### PR TITLE
Adding whitespace around commented links in snippets

### DIFF
--- a/docs/code-snippets/onenote-snippets.yaml
+++ b/docs/code-snippets/onenote-snippets.yaml
@@ -674,8 +674,10 @@ OneNote.Notebook.getRestApiId:
         return ctx.sync().
             then(function(){
                 console.log("The REST API ID is " + restApiId.value);
-                // Note that the REST API ID isn't all you need to interact with the OneNote REST API. For SharePoint notebooks, the notebook baseUrl should be used to talk to the OneNote REST API according to [OneNote Development Blog](https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/)
-                // (this is only required for SharePoint notebooks, baseUrl will be null for OneDrive notebooks)
+                // Note that the REST API ID isn't all you need to interact with the OneNote REST API. 
+                // This is only required for SharePoint notebooks. baseUrl will be null for OneDrive notebooks.
+                // For SharePoint notebooks, the notebook baseUrl should be used to talk to the OneNote REST API according to the OneNote Development Blog.
+                // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
             });
     });
 OneNote.Notebook.load:
@@ -693,7 +695,9 @@ OneNote.Notebook.load:
         return context.sync()
             .then(function () {
                 console.log("Base url: " + notebook.baseUrl);
-                // This baseUrl should be used to talk to OneNote REST APIs according to https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/ (only required for SharePoint notebooks, will be null for OneDrive notebooks)
+                // This is only required for SharePoint notebooks, and will be null for OneDrive notebooks.
+                // This baseUrl should be used to talk to OneNote REST APIs according to the OneNote Development Blog.
+                // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
             });
     })
     .catch(function(error) {
@@ -1007,8 +1011,10 @@ OneNote.Page.getRestApiId:
         return ctx.sync().
             then(function(){
                 console.log("The REST API ID is " + restApiId.value);
-                // Note that the REST API ID isn't all you need to interact with the OneNote REST API. For SharePoint notebooks, the notebook baseUrl should be used to talk to the OneNote REST API according to [OneNote Development Blog](https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/)
-                // (this is only required for SharePoint notebooks, baseUrl will be null for OneDrive notebooks)
+                // Note that the REST API ID isn't all you need to interact with the OneNote REST API.
+                // This is only required for SharePoint notebooks. baseUrl will be null for OneDrive notebooks.
+                // For SharePoint notebooks, the notebook baseUrl should be used to talk to the OneNote REST API according to the OneNote Development Blog.
+                // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
             });
     });
 OneNote.Page.insertPageAsSibling:
@@ -1782,8 +1788,10 @@ OneNote.Section.getRestApiId:
         return ctx.sync().
             then(function(){
                 console.log("The REST API ID is " + restApiId.value);
-                // Note that the REST API ID isn't all you need to interact with the OneNote REST API. For SharePoint notebooks, the notebook baseUrl should be used to talk to the OneNote REST API according to [OneNote Development Blog](https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/)
-                // (this is only required for SharePoint notebooks, baseUrl will be null for OneDrive notebooks)
+                // Note that the REST API ID isn't all you need to interact with the OneNote REST API. 
+                // This is only required for SharePoint notebooks. baseUrl will be null for OneDrive notebooks.
+                // For SharePoint notebooks, the notebook baseUrl should be used to talk to the OneNote REST API according to the OneNote Development Blog.
+                // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
             });
     });
 OneNote.Section.load:

--- a/docs/code-snippets/word-snippets.yaml
+++ b/docs/code-snippets/word-snippets.yaml
@@ -21,6 +21,7 @@ Word.Body.clear:
             console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
     });
+
     // The Silly stories add-in sample shows how the clear method can be used to clear the contents of a document.
     // https://aka.ms/sillystorywordaddin
 Word.Body.getHtml:
@@ -185,8 +186,10 @@ Word.Body.insertInlinePictureFromBase64:
             console.log('Debug info: ' + JSON.stringify(error.debugInfo));
         }
     });
+
     // Read "Create better add-ins for Word with Office Open XML" for guidance on working with OOXML.
     // https://docs.microsoft.com/office/dev/add-ins/word/create-better-add-ins-for-word-with-office-open-xml
+
     // The Word-Add-in-DocumentAssembly sample shows how you can use this API to assemble a document.
     // https://github.com/OfficeDev/Word-Add-in-DocumentAssembly
 Word.Body.insertParagraph:
@@ -212,6 +215,7 @@ Word.Body.insertParagraph:
             console.log('Debug info: ' + JSON.stringify(error.debugInfo));
         }
     });
+
     // The Word-Add-in-DocumentAssembly sample shows how you can use the insertParagraph method to assemble a document.
     // https://github.com/OfficeDev/Word-Add-in-DocumentAssembly
 Word.Body.insertText:
@@ -277,6 +281,7 @@ Word.Body.search:
             console.log('Debug info: ' + JSON.stringify(error.debugInfo));
         }
     });
+
     // The Word-Add-in-DocumentAssembly sample provides another example of how to search a document.
     // https://github.com/OfficeDev/Word-Add-in-DocumentAssembly
 Word.Body.select:
@@ -612,6 +617,7 @@ Word.ContentControl.insertInlinePictureFromBase64:
             console.log('Debug info: ' + JSON.stringify(error.debugInfo));
         }
     });
+
     // Read "Create better add-ins for Word with Office Open XML" for guidance on working with OOXML.
     // https://docs.microsoft.com/office/dev/add-ins/word/create-better-add-ins-for-word-with-office-open-xml
 Word.ContentControl.insertParagraph:
@@ -686,6 +692,7 @@ Word.ContentControl.insertText:
             console.log('Debug info: ' + JSON.stringify(error.debugInfo));
         }
     });
+
     // The Silly stories add-in sample shows how to use the insertText method.
     // https://aka.ms/sillystorywordaddin
 Word.ContentControl.load:
@@ -923,6 +930,7 @@ Word.ContentControlCollection.getByTag:
             console.log('Debug info: ' + JSON.stringify(error.debugInfo));
         }
     });
+
     // The Word-Add-in-DocumentAssembly sample has another example of using the getByTag method.
     // https://github.com/OfficeDev/Word-Add-in-DocumentAssembly
 Word.ContentControlCollection.getByTitle:
@@ -953,6 +961,7 @@ Word.ContentControlCollection.getByTitle:
             console.log('Debug info: ' + JSON.stringify(error.debugInfo));
         }
     });
+
     // The Word-Add-in-DocumentAssembly sample has another example of using the getByTitle method.
     // https://github.com/OfficeDev/Word-Add-in-DocumentAssembly
 Word.ContentControlCollection.getFirst:
@@ -1046,6 +1055,7 @@ Word.ContentControlCollection.load:
             console.log('Debug info: ' + JSON.stringify(error.debugInfo));
         }
     });
+
     // The Silly stories add-in sample shows how the load method is used to load the content control collection with the tag and title properties.
     // https://aka.ms/sillystorywordaddin
 Word.Document.getSelection:
@@ -2097,6 +2107,7 @@ Word.Range.insertOoxml:
             console.log('Debug info: ' + JSON.stringify(error.debugInfo));
         }
     });
+    
     // Read "Create better add-ins for Word with Office Open XML" for guidance on working with OOXML.
     // https://docs.microsoft.com/office/dev/add-ins/word/create-better-add-ins-for-word-with-office-open-xml
 Word.Range.insertParagraph:

--- a/docs/docs-ref-autogen/onenote/onenote.notebook.yml
+++ b/docs/docs-ref-autogen/onenote/onenote.notebook.yml
@@ -187,8 +187,10 @@ items:
               return ctx.sync().
                   then(function(){
                       console.log("The REST API ID is " + restApiId.value);
-                      // Note that the REST API ID isn't all you need to interact with the OneNote REST API. For SharePoint notebooks, the notebook baseUrl should be used to talk to the OneNote REST API according to [OneNote Development Blog](https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/)
-                      // (this is only required for SharePoint notebooks, baseUrl will be null for OneDrive notebooks)
+                      // Note that the REST API ID isn't all you need to interact with the OneNote REST API. 
+                      // This is only required for SharePoint notebooks. baseUrl will be null for OneDrive notebooks.
+                      // For SharePoint notebooks, the notebook baseUrl should be used to talk to the OneNote REST API according to the OneNote Development Blog.
+                      // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
                   });
           });
           ```
@@ -260,7 +262,9 @@ items:
           return context.sync()
               .then(function () {
                   console.log("Base url: " + notebook.baseUrl);
-                  // This baseUrl should be used to talk to OneNote REST APIs according to https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/ (only required for SharePoint notebooks, will be null for OneDrive notebooks)
+                  // This is only required for SharePoint notebooks, and will be null for OneDrive notebooks.
+                  // This baseUrl should be used to talk to OneNote REST APIs according to the OneNote Development Blog.
+                  // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
               });
       })
 

--- a/docs/docs-ref-autogen/onenote/onenote.page.yml
+++ b/docs/docs-ref-autogen/onenote/onenote.page.yml
@@ -300,8 +300,10 @@ items:
               return ctx.sync().
                   then(function(){
                       console.log("The REST API ID is " + restApiId.value);
-                      // Note that the REST API ID isn't all you need to interact with the OneNote REST API. For SharePoint notebooks, the notebook baseUrl should be used to talk to the OneNote REST API according to [OneNote Development Blog](https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/)
-                      // (this is only required for SharePoint notebooks, baseUrl will be null for OneDrive notebooks)
+                      // Note that the REST API ID isn't all you need to interact with the OneNote REST API.
+                      // This is only required for SharePoint notebooks. baseUrl will be null for OneDrive notebooks.
+                      // For SharePoint notebooks, the notebook baseUrl should be used to talk to the OneNote REST API according to the OneNote Development Blog.
+                      // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
                   });
           });
           ```

--- a/docs/docs-ref-autogen/onenote/onenote.section.yml
+++ b/docs/docs-ref-autogen/onenote/onenote.section.yml
@@ -238,8 +238,10 @@ items:
               return ctx.sync().
                   then(function(){
                       console.log("The REST API ID is " + restApiId.value);
-                      // Note that the REST API ID isn't all you need to interact with the OneNote REST API. For SharePoint notebooks, the notebook baseUrl should be used to talk to the OneNote REST API according to [OneNote Development Blog](https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/)
-                      // (this is only required for SharePoint notebooks, baseUrl will be null for OneDrive notebooks)
+                      // Note that the REST API ID isn't all you need to interact with the OneNote REST API. 
+                      // This is only required for SharePoint notebooks. baseUrl will be null for OneDrive notebooks.
+                      // For SharePoint notebooks, the notebook baseUrl should be used to talk to the OneNote REST API according to the OneNote Development Blog.
+                      // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
                   });
           });
           ```

--- a/docs/docs-ref-autogen/outlook/office.mailbox.yml
+++ b/docs/docs-ref-autogen/outlook/office.mailbox.yml
@@ -485,22 +485,45 @@ items:
             A dictionary containing all values to be filled in for the user in the new form. All parameters are
             optional. toRecipients: An array of strings containing the email addresses or an array containing
             an[Office.EmailAddressDetails](xref:outlook.Office.EmailAddressDetails) object for each of the recipients on
-            the To line. The array is limited to a maximum of 100 entries. ccRecipients: An array of strings containing
-            the email addresses or an array containing an
+            the To line. The array is limited to a maximum of 100 entries.
+
+
+            ccRecipients: An array of strings containing the email addresses or an array containing an
             [Office.EmailAddressDetails](xref:outlook.Office.EmailAddressDetails) object for each of the recipients on
-            the Cc line. The array is limited to a maximum of 100 entries. bccRecipients: An array of strings containing
-            the email addresses or an array containing an
+            the Cc line. The array is limited to a maximum of 100 entries.
+
+
+            bccRecipients: An array of strings containing the email addresses or an array containing an
             [Office.EmailAddressDetails](xref:outlook.Office.EmailAddressDetails) object for each of the recipients on
-            the Bcc line. The array is limited to a maximum of 100 entries. subject: A string containing the subject of
-            the message. The string is limited to a maximum of 255 characters. htmlBody: The HTML body of the message.
-            The body content is limited to a maximum size of 32 KB. attachments: An array of JSON objects that are
-            either file or item attachments. attachments.type: Indicates the type of attachment. Must be file for a file
-            attachment or item for an item attachment. attachments.name: A string that contains the name of the
-            attachment, up to 255 characters in length. attachments.url: Only used if type is set to file. The URI of
-            the location for the file. attachments.isInline: Only used if type is set to file. If true, indicates that
-            the attachment will be shown inline in the message body, and should not be displayed in the attachment list.
-            attachments.itemId: Only used if type is set to item. The EWS item id of the attachment. This is a string up
-            to 100 characters.
+            the Bcc line. The array is limited to a maximum of 100 entries.
+
+
+            subject: A string containing the subject of the message. The string is limited to a maximum of 255
+            characters.
+
+
+            htmlBody: The HTML body of the message. The body content is limited to a maximum size of 32 KB.
+
+
+            attachments: An array of JSON objects that are either file or item attachments.
+
+
+            attachments.type: Indicates the type of attachment. Must be file for a file attachment or item for an item
+            attachment.
+
+
+            attachments.name: A string that contains the name of the attachment, up to 255 characters in length.
+
+
+            attachments.url: Only used if type is set to file. The URI of the location for the file.
+
+
+            attachments.isInline: Only used if type is set to file. If true, indicates that the attachment will be shown
+            inline in the message body, and should not be displayed in the attachment list.
+
+
+            attachments.itemId: Only used if type is set to item. The EWS item id of the existing e-mail you want to
+            attach to the new message. This is a string up to 100 characters.
           type:
             - any
   - uid: outlook.Office.Mailbox.ewsUrl

--- a/docs/docs-ref-autogen/word/word.body.yml
+++ b/docs/docs-ref-autogen/word/word.body.yml
@@ -92,6 +92,7 @@ items:
                   console.log("Debug info: " + JSON.stringify(error.debugInfo));
               }
           });
+
           // The Silly stories add-in sample shows how the clear method can be used to clear the contents of a document.
           // https://aka.ms/sillystorywordaddin
           ```
@@ -495,8 +496,10 @@ items:
                   console.log('Debug info: ' + JSON.stringify(error.debugInfo));
               }
           });
+
           // Read "Create better add-ins for Word with Office Open XML" for guidance on working with OOXML.
           // https://docs.microsoft.com/office/dev/add-ins/word/create-better-add-ins-for-word-with-office-open-xml
+
           // The Word-Add-in-DocumentAssembly sample shows how you can use this API to assemble a document.
           // https://github.com/OfficeDev/Word-Add-in-DocumentAssembly
           ```
@@ -580,6 +583,7 @@ items:
                   console.log('Debug info: ' + JSON.stringify(error.debugInfo));
               }
           });
+
 
           // The Word-Add-in-DocumentAssembly sample shows how you can use the insertParagraph method to assemble a
           document.
@@ -1010,6 +1014,7 @@ items:
                   console.log('Debug info: ' + JSON.stringify(error.debugInfo));
               }
           });
+
           // The Word-Add-in-DocumentAssembly sample provides another example of how to search a document.
           // https://github.com/OfficeDev/Word-Add-in-DocumentAssembly
           ```

--- a/docs/docs-ref-autogen/word/word.contentcontrol.yml
+++ b/docs/docs-ref-autogen/word/word.contentcontrol.yml
@@ -699,6 +699,7 @@ items:
                   console.log('Debug info: ' + JSON.stringify(error.debugInfo));
               }
           });
+
           // Read "Create better add-ins for Word with Office Open XML" for guidance on working with OOXML.
           // https://docs.microsoft.com/office/dev/add-ins/word/create-better-add-ins-for-word-with-office-open-xml
           ```
@@ -907,6 +908,7 @@ items:
                   console.log('Debug info: ' + JSON.stringify(error.debugInfo));
               }
           });
+
           // The Silly stories add-in sample shows how to use the insertText method.
           // https://aka.ms/sillystorywordaddin
           ```

--- a/docs/docs-ref-autogen/word/word.contentcontrolcollection.yml
+++ b/docs/docs-ref-autogen/word/word.contentcontrolcollection.yml
@@ -210,6 +210,7 @@ items:
                   console.log('Debug info: ' + JSON.stringify(error.debugInfo));
               }
           });
+
           // The Word-Add-in-DocumentAssembly sample has another example of using the getByTag method.
           // https://github.com/OfficeDev/Word-Add-in-DocumentAssembly
           ```
@@ -280,6 +281,7 @@ items:
                   console.log('Debug info: ' + JSON.stringify(error.debugInfo));
               }
           });
+
           // The Word-Add-in-DocumentAssembly sample has another example of using the getByTitle method.
           // https://github.com/OfficeDev/Word-Add-in-DocumentAssembly
           ```
@@ -491,6 +493,7 @@ items:
                   console.log('Debug info: ' + JSON.stringify(error.debugInfo));
               }
           });
+
 
           // The Silly stories add-in sample shows how the load method is used to load the content control collection
           with the tag and title properties.

--- a/docs/docs-ref-autogen/word/word.range.yml
+++ b/docs/docs-ref-autogen/word/word.range.yml
@@ -805,6 +805,7 @@ items:
                   console.log('Debug info: ' + JSON.stringify(error.debugInfo));
               }
           });
+
           // Read "Create better add-ins for Word with Office Open XML" for guidance on working with OOXML.
           // https://docs.microsoft.com/office/dev/add-ins/word/create-better-add-ins-for-word-with-office-open-xml
           ```

--- a/generate-docs/api-extractor-inputs-outlook/outlook.d.ts
+++ b/generate-docs/api-extractor-inputs-outlook/outlook.d.ts
@@ -6638,17 +6638,28 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Read</td></tr></table>
          *
          * @param parameters - A dictionary containing all values to be filled in for the user in the new form. All parameters are optional.
+         * 
          *        toRecipients: An array of strings containing the email addresses or an array containing an {@link Office.EmailAddressDetails} object for each of the recipients on the To line. The array is limited to a maximum of 100 entries.
+         * 
          *        ccRecipients: An array of strings containing the email addresses or an array containing an {@link Office.EmailAddressDetails} object for each of the recipients on the Cc line. The array is limited to a maximum of 100 entries.
+         * 
          *        bccRecipients: An array of strings containing the email addresses or an array containing an {@link Office.EmailAddressDetails} object for each of the recipients on the Bcc line. The array is limited to a maximum of 100 entries.
+         * 
          *        subject: A string containing the subject of the message. The string is limited to a maximum of 255 characters.
+         * 
          *        htmlBody: The HTML body of the message. The body content is limited to a maximum size of 32 KB.
+         * 
          *        attachments: An array of JSON objects that are either file or item attachments.
+         * 
          *        attachments.type: Indicates the type of attachment. Must be file for a file attachment or item for an item attachment.
+         * 
          *        attachments.name: A string that contains the name of the attachment, up to 255 characters in length.
+         * 
          *        attachments.url: Only used if type is set to file. The URI of the location for the file.
+         * 
          *        attachments.isInline: Only used if type is set to file. If true, indicates that the attachment will be shown inline in the message body, and should not be displayed in the attachment list.
-         *        attachments.itemId: Only used if type is set to item. The EWS item id of the attachment. This is a string up to 100 characters.
+         * 
+         *        attachments.itemId: Only used if type is set to item. The EWS item id of the existing e-mail you want to attach to the new message. This is a string up to 100 characters.
          */
         displayNewMessageForm(parameters: any): void;
         /**

--- a/generate-docs/json/outlook.api.json
+++ b/generate-docs/json/outlook.api.json
@@ -23683,7 +23683,14 @@
                     },
                     {
                       "kind": "text",
-                      "text": " object for each of the recipients on the To line. The array is limited to a maximum of 100 entries. ccRecipients: An array of strings containing the email addresses or an array containing an "
+                      "text": " object for each of the recipients on the To line. The array is limited to a maximum of 100 entries."
+                    },
+                    {
+                      "kind": "paragraph"
+                    },
+                    {
+                      "kind": "text",
+                      "text": "ccRecipients: An array of strings containing the email addresses or an array containing an "
                     },
                     {
                       "kind": "api-link",
@@ -23702,7 +23709,14 @@
                     },
                     {
                       "kind": "text",
-                      "text": " object for each of the recipients on the Cc line. The array is limited to a maximum of 100 entries. bccRecipients: An array of strings containing the email addresses or an array containing an "
+                      "text": " object for each of the recipients on the Cc line. The array is limited to a maximum of 100 entries."
+                    },
+                    {
+                      "kind": "paragraph"
+                    },
+                    {
+                      "kind": "text",
+                      "text": "bccRecipients: An array of strings containing the email addresses or an array containing an "
                     },
                     {
                       "kind": "api-link",
@@ -23721,7 +23735,63 @@
                     },
                     {
                       "kind": "text",
-                      "text": " object for each of the recipients on the Bcc line. The array is limited to a maximum of 100 entries. subject: A string containing the subject of the message. The string is limited to a maximum of 255 characters. htmlBody: The HTML body of the message. The body content is limited to a maximum size of 32 KB. attachments: An array of JSON objects that are either file or item attachments. attachments.type: Indicates the type of attachment. Must be file for a file attachment or item for an item attachment. attachments.name: A string that contains the name of the attachment, up to 255 characters in length. attachments.url: Only used if type is set to file. The URI of the location for the file. attachments.isInline: Only used if type is set to file. If true, indicates that the attachment will be shown inline in the message body, and should not be displayed in the attachment list. attachments.itemId: Only used if type is set to item. The EWS item id of the attachment. This is a string up to 100 characters."
+                      "text": " object for each of the recipients on the Bcc line. The array is limited to a maximum of 100 entries."
+                    },
+                    {
+                      "kind": "paragraph"
+                    },
+                    {
+                      "kind": "text",
+                      "text": "subject: A string containing the subject of the message. The string is limited to a maximum of 255 characters."
+                    },
+                    {
+                      "kind": "paragraph"
+                    },
+                    {
+                      "kind": "text",
+                      "text": "htmlBody: The HTML body of the message. The body content is limited to a maximum size of 32 KB."
+                    },
+                    {
+                      "kind": "paragraph"
+                    },
+                    {
+                      "kind": "text",
+                      "text": "attachments: An array of JSON objects that are either file or item attachments."
+                    },
+                    {
+                      "kind": "paragraph"
+                    },
+                    {
+                      "kind": "text",
+                      "text": "attachments.type: Indicates the type of attachment. Must be file for a file attachment or item for an item attachment."
+                    },
+                    {
+                      "kind": "paragraph"
+                    },
+                    {
+                      "kind": "text",
+                      "text": "attachments.name: A string that contains the name of the attachment, up to 255 characters in length."
+                    },
+                    {
+                      "kind": "paragraph"
+                    },
+                    {
+                      "kind": "text",
+                      "text": "attachments.url: Only used if type is set to file. The URI of the location for the file."
+                    },
+                    {
+                      "kind": "paragraph"
+                    },
+                    {
+                      "kind": "text",
+                      "text": "attachments.isInline: Only used if type is set to file. If true, indicates that the attachment will be shown inline in the message body, and should not be displayed in the attachment list."
+                    },
+                    {
+                      "kind": "paragraph"
+                    },
+                    {
+                      "kind": "text",
+                      "text": "attachments.itemId: Only used if type is set to item. The EWS item id of the existing e-mail you want to attach to the new message. This is a string up to 100 characters."
                     }
                   ],
                   "isOptional": false,

--- a/generate-docs/json/snippets.yaml
+++ b/generate-docs/json/snippets.yaml
@@ -6854,8 +6854,10 @@ OneNote.Notebook.getRestApiId:
         return ctx.sync().
             then(function(){
                 console.log("The REST API ID is " + restApiId.value);
-                // Note that the REST API ID isn't all you need to interact with the OneNote REST API. For SharePoint notebooks, the notebook baseUrl should be used to talk to the OneNote REST API according to [OneNote Development Blog](https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/)
-                // (this is only required for SharePoint notebooks, baseUrl will be null for OneDrive notebooks)
+                // Note that the REST API ID isn't all you need to interact with the OneNote REST API. 
+                // This is only required for SharePoint notebooks. baseUrl will be null for OneDrive notebooks.
+                // For SharePoint notebooks, the notebook baseUrl should be used to talk to the OneNote REST API according to the OneNote Development Blog.
+                // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
             });
     });
 OneNote.Notebook.load:
@@ -6873,7 +6875,9 @@ OneNote.Notebook.load:
         return context.sync()
             .then(function () {
                 console.log("Base url: " + notebook.baseUrl);
-                // This baseUrl should be used to talk to OneNote REST APIs according to https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/ (only required for SharePoint notebooks, will be null for OneDrive notebooks)
+                // This is only required for SharePoint notebooks, and will be null for OneDrive notebooks.
+                // This baseUrl should be used to talk to OneNote REST APIs according to the OneNote Development Blog.
+                // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
             });
     })
     .catch(function(error) {
@@ -7187,8 +7191,10 @@ OneNote.Page.getRestApiId:
         return ctx.sync().
             then(function(){
                 console.log("The REST API ID is " + restApiId.value);
-                // Note that the REST API ID isn't all you need to interact with the OneNote REST API. For SharePoint notebooks, the notebook baseUrl should be used to talk to the OneNote REST API according to [OneNote Development Blog](https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/)
-                // (this is only required for SharePoint notebooks, baseUrl will be null for OneDrive notebooks)
+                // Note that the REST API ID isn't all you need to interact with the OneNote REST API.
+                // This is only required for SharePoint notebooks. baseUrl will be null for OneDrive notebooks.
+                // For SharePoint notebooks, the notebook baseUrl should be used to talk to the OneNote REST API according to the OneNote Development Blog.
+                // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
             });
     });
 OneNote.Page.insertPageAsSibling:
@@ -7962,8 +7968,10 @@ OneNote.Section.getRestApiId:
         return ctx.sync().
             then(function(){
                 console.log("The REST API ID is " + restApiId.value);
-                // Note that the REST API ID isn't all you need to interact with the OneNote REST API. For SharePoint notebooks, the notebook baseUrl should be used to talk to the OneNote REST API according to [OneNote Development Blog](https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/)
-                // (this is only required for SharePoint notebooks, baseUrl will be null for OneDrive notebooks)
+                // Note that the REST API ID isn't all you need to interact with the OneNote REST API. 
+                // This is only required for SharePoint notebooks. baseUrl will be null for OneDrive notebooks.
+                // For SharePoint notebooks, the notebook baseUrl should be used to talk to the OneNote REST API according to the OneNote Development Blog.
+                // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
             });
     });
 OneNote.Section.load:
@@ -9779,6 +9787,7 @@ Word.Body.clear:
         }
     });
 
+
     // The Silly stories add-in sample shows how the clear method can be used to
     clear the contents of a document.
 
@@ -9948,11 +9957,13 @@ Word.Body.insertInlinePictureFromBase64:
         }
     });
 
+
     // Read "Create better add-ins for Word with Office Open XML" for guidance
     on working with OOXML.
 
     //
     https://docs.microsoft.com/office/dev/add-ins/word/create-better-add-ins-for-word-with-office-open-xml
+
 
     // The Word-Add-in-DocumentAssembly sample shows how you can use this API to
     assemble a document.
@@ -9983,6 +9994,7 @@ Word.Body.insertParagraph:
             console.log('Debug info: ' + JSON.stringify(error.debugInfo));
         }
     });
+
 
     // The Word-Add-in-DocumentAssembly sample shows how you can use the
     insertParagraph method to assemble a document.
@@ -10083,6 +10095,7 @@ Word.Body.search:
             console.log('Debug info: ' + JSON.stringify(error.debugInfo));
         }
     });
+
 
     // The Word-Add-in-DocumentAssembly sample provides another example of how
     to search a document.
@@ -10457,6 +10470,7 @@ Word.ContentControl.insertInlinePictureFromBase64:
         }
     });
 
+
     // Read "Create better add-ins for Word with Office Open XML" for guidance
     on working with OOXML.
 
@@ -10534,6 +10548,7 @@ Word.ContentControl.insertText:
             console.log('Debug info: ' + JSON.stringify(error.debugInfo));
         }
     });
+
     // The Silly stories add-in sample shows how to use the insertText method.
     // https://aka.ms/sillystorywordaddin
 Word.ContentControl.load:
@@ -10774,6 +10789,7 @@ Word.ContentControlCollection.getByTag:
         }
     });
 
+
     // The Word-Add-in-DocumentAssembly sample has another example of using the
     getByTag method.
 
@@ -10821,6 +10837,7 @@ Word.ContentControlCollection.getByTitle:
             console.log('Debug info: ' + JSON.stringify(error.debugInfo));
         }
     });
+
 
     // The Word-Add-in-DocumentAssembly sample has another example of using the
     getByTitle method.
@@ -10919,6 +10936,7 @@ Word.ContentControlCollection.load:
             console.log('Debug info: ' + JSON.stringify(error.debugInfo));
         }
     });
+
 
     // The Silly stories add-in sample shows how the load method is used to load
     the content control collection with the tag and title properties.
@@ -12084,6 +12102,7 @@ Word.Range.insertOoxml:
             console.log('Debug info: ' + JSON.stringify(error.debugInfo));
         }
     });
+
 
     // Read "Create better add-ins for Word with Office Open XML" for guidance
     on working with OOXML.

--- a/generate-docs/script-inputs/local-repo-snippets.yaml
+++ b/generate-docs/script-inputs/local-repo-snippets.yaml
@@ -6089,8 +6089,10 @@ OneNote.Notebook.getRestApiId:
         return ctx.sync().
             then(function(){
                 console.log("The REST API ID is " + restApiId.value);
-                // Note that the REST API ID isn't all you need to interact with the OneNote REST API. For SharePoint notebooks, the notebook baseUrl should be used to talk to the OneNote REST API according to [OneNote Development Blog](https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/)
-                // (this is only required for SharePoint notebooks, baseUrl will be null for OneDrive notebooks)
+                // Note that the REST API ID isn't all you need to interact with the OneNote REST API. 
+                // This is only required for SharePoint notebooks. baseUrl will be null for OneDrive notebooks.
+                // For SharePoint notebooks, the notebook baseUrl should be used to talk to the OneNote REST API according to the OneNote Development Blog.
+                // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
             });
     });
 OneNote.Notebook.load:
@@ -6108,7 +6110,9 @@ OneNote.Notebook.load:
         return context.sync()
             .then(function () {
                 console.log("Base url: " + notebook.baseUrl);
-                // This baseUrl should be used to talk to OneNote REST APIs according to https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/ (only required for SharePoint notebooks, will be null for OneDrive notebooks)
+                // This is only required for SharePoint notebooks, and will be null for OneDrive notebooks.
+                // This baseUrl should be used to talk to OneNote REST APIs according to the OneNote Development Blog.
+                // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
             });
     })
     .catch(function(error) {
@@ -6422,8 +6426,10 @@ OneNote.Page.getRestApiId:
         return ctx.sync().
             then(function(){
                 console.log("The REST API ID is " + restApiId.value);
-                // Note that the REST API ID isn't all you need to interact with the OneNote REST API. For SharePoint notebooks, the notebook baseUrl should be used to talk to the OneNote REST API according to [OneNote Development Blog](https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/)
-                // (this is only required for SharePoint notebooks, baseUrl will be null for OneDrive notebooks)
+                // Note that the REST API ID isn't all you need to interact with the OneNote REST API.
+                // This is only required for SharePoint notebooks. baseUrl will be null for OneDrive notebooks.
+                // For SharePoint notebooks, the notebook baseUrl should be used to talk to the OneNote REST API according to the OneNote Development Blog.
+                // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
             });
     });
 OneNote.Page.insertPageAsSibling:
@@ -7197,8 +7203,10 @@ OneNote.Section.getRestApiId:
         return ctx.sync().
             then(function(){
                 console.log("The REST API ID is " + restApiId.value);
-                // Note that the REST API ID isn't all you need to interact with the OneNote REST API. For SharePoint notebooks, the notebook baseUrl should be used to talk to the OneNote REST API according to [OneNote Development Blog](https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/)
-                // (this is only required for SharePoint notebooks, baseUrl will be null for OneDrive notebooks)
+                // Note that the REST API ID isn't all you need to interact with the OneNote REST API. 
+                // This is only required for SharePoint notebooks. baseUrl will be null for OneDrive notebooks.
+                // For SharePoint notebooks, the notebook baseUrl should be used to talk to the OneNote REST API according to the OneNote Development Blog.
+                // https://blogs.msdn.microsoft.com/onenotedev/2015/06/11/and-sharepoint-makes-three/
             });
     });
 OneNote.Section.load:
@@ -8928,6 +8936,7 @@ Word.Body.clear:
             console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
     });
+
     // The Silly stories add-in sample shows how the clear method can be used to clear the contents of a document.
     // https://aka.ms/sillystorywordaddin
 Word.Body.getHtml:
@@ -9092,8 +9101,10 @@ Word.Body.insertInlinePictureFromBase64:
             console.log('Debug info: ' + JSON.stringify(error.debugInfo));
         }
     });
+
     // Read "Create better add-ins for Word with Office Open XML" for guidance on working with OOXML.
     // https://docs.microsoft.com/office/dev/add-ins/word/create-better-add-ins-for-word-with-office-open-xml
+
     // The Word-Add-in-DocumentAssembly sample shows how you can use this API to assemble a document.
     // https://github.com/OfficeDev/Word-Add-in-DocumentAssembly
 Word.Body.insertParagraph:
@@ -9119,6 +9130,7 @@ Word.Body.insertParagraph:
             console.log('Debug info: ' + JSON.stringify(error.debugInfo));
         }
     });
+
     // The Word-Add-in-DocumentAssembly sample shows how you can use the insertParagraph method to assemble a document.
     // https://github.com/OfficeDev/Word-Add-in-DocumentAssembly
 Word.Body.insertText:
@@ -9184,6 +9196,7 @@ Word.Body.search:
             console.log('Debug info: ' + JSON.stringify(error.debugInfo));
         }
     });
+
     // The Word-Add-in-DocumentAssembly sample provides another example of how to search a document.
     // https://github.com/OfficeDev/Word-Add-in-DocumentAssembly
 Word.Body.select:
@@ -9519,6 +9532,7 @@ Word.ContentControl.insertInlinePictureFromBase64:
             console.log('Debug info: ' + JSON.stringify(error.debugInfo));
         }
     });
+
     // Read "Create better add-ins for Word with Office Open XML" for guidance on working with OOXML.
     // https://docs.microsoft.com/office/dev/add-ins/word/create-better-add-ins-for-word-with-office-open-xml
 Word.ContentControl.insertParagraph:
@@ -9593,6 +9607,7 @@ Word.ContentControl.insertText:
             console.log('Debug info: ' + JSON.stringify(error.debugInfo));
         }
     });
+
     // The Silly stories add-in sample shows how to use the insertText method.
     // https://aka.ms/sillystorywordaddin
 Word.ContentControl.load:
@@ -9830,6 +9845,7 @@ Word.ContentControlCollection.getByTag:
             console.log('Debug info: ' + JSON.stringify(error.debugInfo));
         }
     });
+
     // The Word-Add-in-DocumentAssembly sample has another example of using the getByTag method.
     // https://github.com/OfficeDev/Word-Add-in-DocumentAssembly
 Word.ContentControlCollection.getByTitle:
@@ -9860,6 +9876,7 @@ Word.ContentControlCollection.getByTitle:
             console.log('Debug info: ' + JSON.stringify(error.debugInfo));
         }
     });
+
     // The Word-Add-in-DocumentAssembly sample has another example of using the getByTitle method.
     // https://github.com/OfficeDev/Word-Add-in-DocumentAssembly
 Word.ContentControlCollection.getFirst:
@@ -9953,6 +9970,7 @@ Word.ContentControlCollection.load:
             console.log('Debug info: ' + JSON.stringify(error.debugInfo));
         }
     });
+
     // The Silly stories add-in sample shows how the load method is used to load the content control collection with the tag and title properties.
     // https://aka.ms/sillystorywordaddin
 Word.Document.getSelection:
@@ -11004,6 +11022,7 @@ Word.Range.insertOoxml:
             console.log('Debug info: ' + JSON.stringify(error.debugInfo));
         }
     });
+    
     // Read "Create better add-ins for Word with Office Open XML" for guidance on working with OOXML.
     // https://docs.microsoft.com/office/dev/add-ins/word/create-better-add-ins-for-word-with-office-open-xml
 Word.Range.insertParagraph:

--- a/generate-docs/script-inputs/office.d.ts
+++ b/generate-docs/script-inputs/office.d.ts
@@ -12140,17 +12140,28 @@ declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Read</td></tr></table>
          *
          * @param parameters A dictionary containing all values to be filled in for the user in the new form. All parameters are optional.
+         * 
          *        toRecipients: An array of strings containing the email addresses or an array containing an {@link Office.EmailAddressDetails} object for each of the recipients on the To line. The array is limited to a maximum of 100 entries.
+         * 
          *        ccRecipients: An array of strings containing the email addresses or an array containing an {@link Office.EmailAddressDetails} object for each of the recipients on the Cc line. The array is limited to a maximum of 100 entries.
+         * 
          *        bccRecipients: An array of strings containing the email addresses or an array containing an {@link Office.EmailAddressDetails} object for each of the recipients on the Bcc line. The array is limited to a maximum of 100 entries.
+         * 
          *        subject: A string containing the subject of the message. The string is limited to a maximum of 255 characters.
+         * 
          *        htmlBody: The HTML body of the message. The body content is limited to a maximum size of 32 KB.
+         * 
          *        attachments: An array of JSON objects that are either file or item attachments.
+         * 
          *        attachments.type: Indicates the type of attachment. Must be file for a file attachment or item for an item attachment.
+         * 
          *        attachments.name: A string that contains the name of the attachment, up to 255 characters in length.
+         * 
          *        attachments.url: Only used if type is set to file. The URI of the location for the file.
+         * 
          *        attachments.isInline: Only used if type is set to file. If true, indicates that the attachment will be shown inline in the message body, and should not be displayed in the attachment list.
-         *        attachments.itemId: Only used if type is set to item. The EWS item id of the attachment. This is a string up to 100 characters.
+         * 
+         *        attachments.itemId: Only used if type is set to item. The EWS item id of the existing e-mail you want to attach to the new message. This is a string up to 100 characters.
          */
         displayNewMessageForm(parameters: any): void;
         /**
@@ -58748,4 +58759,22 @@ declare namespace Visio {
 
 ////////////////////////////////////////////////////////////////
 //////////////////////// End Visio APIs ////////////////////////
+////////////////////////////////////////////////////////////////
+
+
+
+
+////////////////////////////////////////////////////////////////
+
+
+
+
+////////////////////////////////////////////////////////////////
+///////////////////// Begin PowerPoint APIs ////////////////////
+////////////////////////////////////////////////////////////////
+
+// Empty placeholder, for now
+
+////////////////////////////////////////////////////////////////
+////////////////////// End PowerPoint APIs /////////////////////
 ////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Also removing the markdown formatting from OneNote snippet comments.

A couple recent changes to DefinitelyTyped are also getting picked up in this change.