### PR TITLE
Revert "set overview page metadata so CATS won't think it needs breadcrumb"

### DIFF
--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -86,12 +86,7 @@
       "feedback_github_repo": "MicrosoftDocs/visualstudio-docs",
       "feedback_product_url": "https://developercommunity.visualstudio.com/"      
     },
-    "fileMetadata": {
-      "ms.topic":
-      {
-        "overview/office.md": "overview"
-      }
-    },
+    "fileMetadata": {},
     "template": [],
     "dest": "office-docs-ref-javascript"
   }


### PR DESCRIPTION
Reverts OfficeDev/office-js-docs-reference#91 because it didn't work