### PR TITLE
Changing Visio run pattern for snippets

### DIFF
--- a/docs/code-snippets/visio-snippets.yaml
+++ b/docs/code-snippets/visio-snippets.yaml
@@ -1,6 +1,6 @@
 Visio.Application.load:
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var application = ctx.document.application;
         application.showToolbars = false;
         application.showBorders = false;
@@ -13,7 +13,7 @@ Visio.Application.load:
     });
 Visio.Comment.load:
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var activePage = ctx.document.getActivePage();
         var shapeName = "Position Belt.41";
         var shape = activePage.shapes.getItem(shapeName);
@@ -36,7 +36,7 @@ Visio.Comment.load:
     });
 Visio.CommentCollection.load:
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var activePage = ctx.document.getActivePage();
         var shapeName = "Position Belt.41";
         var shape = activePage.shapes.getItem(shapeName);
@@ -59,7 +59,7 @@ Visio.CommentCollection.load:
     });
 Visio.DataRefreshCompleteEventArgs.load:
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
       var document1= ctx.document;
                    var page = document1.getActivePage();
              eventResult1 = document1.onDataRefreshComplete.add(
@@ -78,7 +78,7 @@ Visio.DataRefreshCompleteEventArgs.load:
     });
 Visio.Document.getActivePage:
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var document = ctx.document;
         var activePage = document.getActivePage();
         activePage.load();
@@ -93,7 +93,7 @@ Visio.Document.getActivePage:
     });
 Visio.Document.setActivePage:
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var document = ctx.document;
         var pageName = "Page-1";
         document.setActivePage(pageName);
@@ -106,7 +106,7 @@ Visio.Document.setActivePage:
     });
 Visio.Document.startDataRefresh:
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var document = ctx.document;
         document.startDataRefresh();
         return ctx.sync();
@@ -118,7 +118,7 @@ Visio.Document.startDataRefresh:
     });
 Visio.Document.load:
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var pages = ctx.document.pages;
         var pageCount = pages.getCount();
         return ctx.sync().then(function () {
@@ -131,7 +131,7 @@ Visio.Document.load:
         }
     });
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var documentView = ctx.document.view;
         documentView.disableHyperlinks();
         return ctx.sync();
@@ -142,7 +142,7 @@ Visio.Document.load:
         }
     });
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var application = ctx.document.application;
         application.showToolbars = false;
         return ctx.sync();
@@ -154,7 +154,7 @@ Visio.Document.load:
     });
 Visio.DocumentLoadCompleteEventArgs.load:
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var document1 = ctx.document;
         eventResult1 = document1.onDocumentLoadComplete.add(
             function (args){
@@ -172,7 +172,7 @@ Visio.DocumentLoadCompleteEventArgs.load:
     });
 Visio.Highlight.load:
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var activePage = ctx.document.getActivePage();
         var shape = activePage.shapes.getItem(0);
         shape.view.highlight = { color: "#E7E7E7", width: 100 };
@@ -185,7 +185,7 @@ Visio.Highlight.load:
     });
 Visio.Hyperlink.load:
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var activePage = ctx.document.getActivePage();
         var shape = activePage.shapes.getItem(0);
         var hyperlink = shape.hyperlinks.getItem(0);
@@ -204,7 +204,7 @@ Visio.Hyperlink.load:
     });
 Visio.HyperlinkCollection.load:
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var activePage = ctx.document.getActivePage();
         var shapeName = "Manager Belt";
         var shape = activePage.shapes.getItem(shapeName);
@@ -225,7 +225,7 @@ Visio.HyperlinkCollection.load:
     });
 Visio.PageCollection.getItem:
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var pageName = 'Page-1';
         var page = ctx.document.pages.getItem(pageName);
         page.activate();
@@ -238,7 +238,7 @@ Visio.PageCollection.getItem:
     });
 Visio.PageLoadCompleteEventArgs.load:
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var document1= ctx.document;
         var page = document1.getActivePage();
         eventResult1 = document1.onPageLoadComplete.add(
@@ -257,7 +257,7 @@ Visio.PageLoadCompleteEventArgs.load:
     });
 Visio.PageView.centerViewportOnShape:
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var activePage = ctx.document.getActivePage();
         var shape = activePage.shapes.getItem(0);
         activePage.view.centerViewportOnShape(shape.Id);
@@ -270,7 +270,7 @@ Visio.PageView.centerViewportOnShape:
     });
 Visio.PageView.load:
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var activePage = ctx.document.getActivePage();
         activePage.view.zoom = 300;
         return ctx.sync();
@@ -333,7 +333,7 @@ Visio.SelectionChangedEventArgs.load:
     }
 Visio.Shape.load:
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var activePage = ctx.document.getActivePage();
         var shapeName = "Sample Name";
         var shape = activePage.shapes.getItem(shapeName);
@@ -351,7 +351,7 @@ Visio.Shape.load:
         }
     });
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var activePage = ctx.document.getActivePage();
         var shape = activePage.shapes.getItem(0);
         shape.view.highlight = { color: "#E7E7E7", width: 100 };
@@ -364,7 +364,7 @@ Visio.Shape.load:
     });
 Visio.ShapeCollection.getCount:
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var activePage = ctx.document.getActivePage();
         var numShapesActivePage = activePage.shapes.getCount();
         return ctx.sync().then(function () {
@@ -378,7 +378,7 @@ Visio.ShapeCollection.getCount:
     });
 Visio.ShapeDataItem.load:
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var activePage = ctx.document.getActivePage();
         var shape = activePage.shapes.getItem(0);
         var shapeDataItem = shape.shapeDataItems.getItem(0);
@@ -395,7 +395,7 @@ Visio.ShapeDataItem.load:
     });
 Visio.ShapeDataItemCollection.load:
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var activePage = ctx.document.getActivePage();
         var shape = activePage.shapes.getItem(0);
         var shapeDataItems = shape.shapeDataItems;
@@ -415,7 +415,7 @@ Visio.ShapeDataItemCollection.load:
     });
 Visio.ShapeMouseEnterEventArgs.load:
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var document1= ctx.document;
         var page = document1.getActivePage();
         eventResult2 = document1.onShapeMouseEnter.add(
@@ -433,7 +433,7 @@ Visio.ShapeMouseEnterEventArgs.load:
     });
 Visio.ShapeMouseLeaveEventArgs.load:
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var document1= ctx.document;
         var page = document1.getActivePage();
         eventResult2 = document1.onShapeMouseLeave.add(
@@ -451,7 +451,7 @@ Visio.ShapeMouseLeaveEventArgs.load:
     });
 Visio.ShapeView.load:
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var activePage = ctx.document.getActivePage();
         var shape = activePage.shapes.getItem(0);
         shape.view.highlight = { color: "#E7E7E7", width: 100 };
@@ -463,7 +463,7 @@ Visio.ShapeView.load:
         }
     });
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var activePage = ctx.document.getActivePage();
         var shape = activePage.shapes.getItem(0);
         var overlayId=shape.view.addOverlay(1, "Visio Online", 2, 2, 50, 50);
@@ -475,7 +475,7 @@ Visio.ShapeView.load:
         }
     });
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var activePage = ctx.document.getActivePage();
         var shape = activePage.shapes.getItem(0);
         shape.view.removeOverlay(1);

--- a/docs/docs-ref-autogen/visio/visio.application.yml
+++ b/docs/docs-ref-autogen/visio/visio.application.yml
@@ -43,7 +43,7 @@ items:
 
       ```javascript
 
-      Visio.run(function (ctx) { 
+      Visio.run(session, function (ctx) {
           var application = ctx.document.application;
           application.showToolbars = false;
           application.showBorders = false;

--- a/docs/docs-ref-autogen/visio/visio.comment.yml
+++ b/docs/docs-ref-autogen/visio/visio.comment.yml
@@ -73,7 +73,7 @@ items:
 
       ```javascript
 
-      Visio.run(function (ctx) { 
+      Visio.run(session, function (ctx) {
           var activePage = ctx.document.getActivePage();
           var shapeName = "Position Belt.41";
           var shape = activePage.shapes.getItem(shapeName);

--- a/docs/docs-ref-autogen/visio/visio.commentcollection.yml
+++ b/docs/docs-ref-autogen/visio/visio.commentcollection.yml
@@ -92,7 +92,7 @@ items:
 
       ```javascript
 
-      Visio.run(function (ctx) { 
+      Visio.run(session, function (ctx) {
           var activePage = ctx.document.getActivePage();
           var shapeName = "Position Belt.41";
           var shape = activePage.shapes.getItem(shapeName);

--- a/docs/docs-ref-autogen/visio/visio.document.yml
+++ b/docs/docs-ref-autogen/visio/visio.document.yml
@@ -63,7 +63,7 @@ items:
           #### Examples
 
           ```javascript
-          Visio.run(function (ctx) { 
+          Visio.run(session, function (ctx) {
               var document = ctx.document;
               var activePage = document.getActivePage();
               activePage.load();
@@ -101,7 +101,7 @@ items:
 
       ```javascript
 
-      Visio.run(function (ctx) { 
+      Visio.run(session, function (ctx) {
           var pages = ctx.document.pages;
           var pageCount = pages.getCount();
           return ctx.sync().then(function () {
@@ -118,7 +118,7 @@ items:
 
       ```javascript
 
-      Visio.run(function (ctx) { 
+      Visio.run(session, function (ctx) {
           var documentView = ctx.document.view;
           documentView.disableHyperlinks();
           return ctx.sync();
@@ -133,7 +133,7 @@ items:
 
       ```javascript
 
-      Visio.run(function (ctx) { 
+      Visio.run(session, function (ctx) {
           var application = ctx.document.application;
           application.showToolbars = false;
           return ctx.sync();
@@ -286,7 +286,7 @@ items:
           #### Examples
 
           ```javascript
-          Visio.run(function (ctx) { 
+          Visio.run(session, function (ctx) {
               var document = ctx.document;
               var pageName = "Page-1";
               document.setActivePage(pageName);
@@ -323,7 +323,7 @@ items:
           #### Examples
 
           ```javascript
-          Visio.run(function (ctx) { 
+          Visio.run(session, function (ctx) {
               var document = ctx.document;
               document.startDataRefresh();
               return ctx.sync();

--- a/docs/docs-ref-autogen/visio/visio.hyperlink.yml
+++ b/docs/docs-ref-autogen/visio/visio.hyperlink.yml
@@ -89,7 +89,7 @@ items:
 
       ```javascript
 
-      Visio.run(function (ctx) { 
+      Visio.run(session, function (ctx) {
           var activePage = ctx.document.getActivePage();
           var shape = activePage.shapes.getItem(0);
           var hyperlink = shape.hyperlinks.getItem(0);

--- a/docs/docs-ref-autogen/visio/visio.hyperlinkcollection.yml
+++ b/docs/docs-ref-autogen/visio/visio.hyperlinkcollection.yml
@@ -92,7 +92,7 @@ items:
 
       ```javascript
 
-      Visio.run(function (ctx) { 
+      Visio.run(session, function (ctx) {
           var activePage = ctx.document.getActivePage();
           var shapeName = "Manager Belt";
           var shape = activePage.shapes.getItem(shapeName);

--- a/docs/docs-ref-autogen/visio/visio.pagecollection.yml
+++ b/docs/docs-ref-autogen/visio/visio.pagecollection.yml
@@ -55,7 +55,7 @@ items:
           #### Examples
 
           ```javascript
-          Visio.run(function (ctx) { 
+          Visio.run(session, function (ctx) {
               var pageName = 'Page-1';
               var page = ctx.document.pages.getItem(pageName);
               page.activate();

--- a/docs/docs-ref-autogen/visio/visio.pageview.yml
+++ b/docs/docs-ref-autogen/visio/visio.pageview.yml
@@ -43,7 +43,7 @@ items:
           #### Examples
 
           ```javascript
-          Visio.run(function (ctx) { 
+          Visio.run(session, function (ctx) {
               var activePage = ctx.document.getActivePage();
               var shape = activePage.shapes.getItem(0);
               activePage.view.centerViewportOnShape(shape.Id);
@@ -153,7 +153,7 @@ items:
 
       ```javascript
 
-      Visio.run(function (ctx) { 
+      Visio.run(session, function (ctx) {
           var activePage = ctx.document.getActivePage();
           activePage.view.zoom = 300;
           return ctx.sync();

--- a/docs/docs-ref-autogen/visio/visio.shape.yml
+++ b/docs/docs-ref-autogen/visio/visio.shape.yml
@@ -111,7 +111,7 @@ items:
 
       ```javascript
 
-      Visio.run(function (ctx) { 
+      Visio.run(session, function (ctx) {
           var activePage = ctx.document.getActivePage();
           var shapeName = "Sample Name";
           var shape = activePage.shapes.getItem(shapeName);
@@ -133,7 +133,7 @@ items:
 
       ```javascript
 
-      Visio.run(function (ctx) { 
+      Visio.run(session, function (ctx) {
           var activePage = ctx.document.getActivePage();
           var shape = activePage.shapes.getItem(0);
           shape.view.highlight = { color: "#E7E7E7", width: 100 };

--- a/docs/docs-ref-autogen/visio/visio.shapecollection.yml
+++ b/docs/docs-ref-autogen/visio/visio.shapecollection.yml
@@ -39,7 +39,7 @@ items:
           #### Examples
 
           ```javascript
-          Visio.run(function (ctx) { 
+          Visio.run(session, function (ctx) {
               var activePage = ctx.document.getActivePage();
               var numShapesActivePage = activePage.shapes.getCount();
               return ctx.sync().then(function () {

--- a/docs/docs-ref-autogen/visio/visio.shapedataitem.yml
+++ b/docs/docs-ref-autogen/visio/visio.shapedataitem.yml
@@ -89,7 +89,7 @@ items:
 
       ```javascript
 
-      Visio.run(function (ctx) { 
+      Visio.run(session, function (ctx) {
           var activePage = ctx.document.getActivePage();
           var shape = activePage.shapes.getItem(0);
           var shapeDataItem = shape.shapeDataItems.getItem(0);

--- a/docs/docs-ref-autogen/visio/visio.shapedataitemcollection.yml
+++ b/docs/docs-ref-autogen/visio/visio.shapedataitemcollection.yml
@@ -92,7 +92,7 @@ items:
 
       ```javascript
 
-      Visio.run(function (ctx) { 
+      Visio.run(session, function (ctx) {
           var activePage = ctx.document.getActivePage();
           var shape = activePage.shapes.getItem(0);
           var shapeDataItems = shape.shapeDataItems;

--- a/docs/docs-ref-autogen/visio/visio.shapeview.yml
+++ b/docs/docs-ref-autogen/visio/visio.shapeview.yml
@@ -102,7 +102,7 @@ items:
 
       ```javascript
 
-      Visio.run(function (ctx) { 
+      Visio.run(session, function (ctx) {
           var activePage = ctx.document.getActivePage();
           var shape = activePage.shapes.getItem(0);
           shape.view.highlight = { color: "#E7E7E7", width: 100 };
@@ -118,7 +118,7 @@ items:
 
       ```javascript
 
-      Visio.run(function (ctx) { 
+      Visio.run(session, function (ctx) {
           var activePage = ctx.document.getActivePage();
           var shape = activePage.shapes.getItem(0);
           var overlayId=shape.view.addOverlay(1, "Visio Online", 2, 2, 50, 50);
@@ -134,7 +134,7 @@ items:
 
       ```javascript
 
-      Visio.run(function (ctx) { 
+      Visio.run(session, function (ctx) {
           var activePage = ctx.document.getActivePage();
           var shape = activePage.shapes.getItem(0);
           shape.view.removeOverlay(1);

--- a/generate-docs/json/snippets.yaml
+++ b/generate-docs/json/snippets.yaml
@@ -9255,7 +9255,7 @@ Office.Time.setAsync:
     });
 Visio.Application.load:
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var application = ctx.document.application;
         application.showToolbars = false;
         application.showBorders = false;
@@ -9268,7 +9268,7 @@ Visio.Application.load:
     });
 Visio.Comment.load:
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var activePage = ctx.document.getActivePage();
         var shapeName = "Position Belt.41";
         var shape = activePage.shapes.getItem(shapeName);
@@ -9291,7 +9291,7 @@ Visio.Comment.load:
     });
 Visio.CommentCollection.load:
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var activePage = ctx.document.getActivePage();
         var shapeName = "Position Belt.41";
         var shape = activePage.shapes.getItem(shapeName);
@@ -9314,7 +9314,7 @@ Visio.CommentCollection.load:
     });
 Visio.DataRefreshCompleteEventArgs.load:
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
       var document1= ctx.document;
                    var page = document1.getActivePage();
              eventResult1 = document1.onDataRefreshComplete.add(
@@ -9333,7 +9333,7 @@ Visio.DataRefreshCompleteEventArgs.load:
     });
 Visio.Document.getActivePage:
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var document = ctx.document;
         var activePage = document.getActivePage();
         activePage.load();
@@ -9348,7 +9348,7 @@ Visio.Document.getActivePage:
     });
 Visio.Document.setActivePage:
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var document = ctx.document;
         var pageName = "Page-1";
         document.setActivePage(pageName);
@@ -9361,7 +9361,7 @@ Visio.Document.setActivePage:
     });
 Visio.Document.startDataRefresh:
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var document = ctx.document;
         document.startDataRefresh();
         return ctx.sync();
@@ -9373,7 +9373,7 @@ Visio.Document.startDataRefresh:
     });
 Visio.Document.load:
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var pages = ctx.document.pages;
         var pageCount = pages.getCount();
         return ctx.sync().then(function () {
@@ -9386,7 +9386,7 @@ Visio.Document.load:
         }
     });
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var documentView = ctx.document.view;
         documentView.disableHyperlinks();
         return ctx.sync();
@@ -9397,7 +9397,7 @@ Visio.Document.load:
         }
     });
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var application = ctx.document.application;
         application.showToolbars = false;
         return ctx.sync();
@@ -9409,7 +9409,7 @@ Visio.Document.load:
     });
 Visio.DocumentLoadCompleteEventArgs.load:
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var document1 = ctx.document;
         eventResult1 = document1.onDocumentLoadComplete.add(
             function (args){
@@ -9427,7 +9427,7 @@ Visio.DocumentLoadCompleteEventArgs.load:
     });
 Visio.Highlight.load:
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var activePage = ctx.document.getActivePage();
         var shape = activePage.shapes.getItem(0);
         shape.view.highlight = { color: "#E7E7E7", width: 100 };
@@ -9440,7 +9440,7 @@ Visio.Highlight.load:
     });
 Visio.Hyperlink.load:
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var activePage = ctx.document.getActivePage();
         var shape = activePage.shapes.getItem(0);
         var hyperlink = shape.hyperlinks.getItem(0);
@@ -9459,7 +9459,7 @@ Visio.Hyperlink.load:
     });
 Visio.HyperlinkCollection.load:
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var activePage = ctx.document.getActivePage();
         var shapeName = "Manager Belt";
         var shape = activePage.shapes.getItem(shapeName);
@@ -9480,7 +9480,7 @@ Visio.HyperlinkCollection.load:
     });
 Visio.PageCollection.getItem:
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var pageName = 'Page-1';
         var page = ctx.document.pages.getItem(pageName);
         page.activate();
@@ -9493,7 +9493,7 @@ Visio.PageCollection.getItem:
     });
 Visio.PageLoadCompleteEventArgs.load:
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var document1= ctx.document;
         var page = document1.getActivePage();
         eventResult1 = document1.onPageLoadComplete.add(
@@ -9512,7 +9512,7 @@ Visio.PageLoadCompleteEventArgs.load:
     });
 Visio.PageView.centerViewportOnShape:
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var activePage = ctx.document.getActivePage();
         var shape = activePage.shapes.getItem(0);
         activePage.view.centerViewportOnShape(shape.Id);
@@ -9525,7 +9525,7 @@ Visio.PageView.centerViewportOnShape:
     });
 Visio.PageView.load:
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var activePage = ctx.document.getActivePage();
         activePage.view.zoom = 300;
         return ctx.sync();
@@ -9593,7 +9593,7 @@ Visio.SelectionChangedEventArgs.load:
     }
 Visio.Shape.load:
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var activePage = ctx.document.getActivePage();
         var shapeName = "Sample Name";
         var shape = activePage.shapes.getItem(shapeName);
@@ -9611,7 +9611,7 @@ Visio.Shape.load:
         }
     });
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var activePage = ctx.document.getActivePage();
         var shape = activePage.shapes.getItem(0);
         shape.view.highlight = { color: "#E7E7E7", width: 100 };
@@ -9624,7 +9624,7 @@ Visio.Shape.load:
     });
 Visio.ShapeCollection.getCount:
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var activePage = ctx.document.getActivePage();
         var numShapesActivePage = activePage.shapes.getCount();
         return ctx.sync().then(function () {
@@ -9638,7 +9638,7 @@ Visio.ShapeCollection.getCount:
     });
 Visio.ShapeDataItem.load:
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var activePage = ctx.document.getActivePage();
         var shape = activePage.shapes.getItem(0);
         var shapeDataItem = shape.shapeDataItems.getItem(0);
@@ -9655,7 +9655,7 @@ Visio.ShapeDataItem.load:
     });
 Visio.ShapeDataItemCollection.load:
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var activePage = ctx.document.getActivePage();
         var shape = activePage.shapes.getItem(0);
         var shapeDataItems = shape.shapeDataItems;
@@ -9675,7 +9675,7 @@ Visio.ShapeDataItemCollection.load:
     });
 Visio.ShapeMouseEnterEventArgs.load:
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var document1= ctx.document;
         var page = document1.getActivePage();
         eventResult2 = document1.onShapeMouseEnter.add(
@@ -9693,7 +9693,7 @@ Visio.ShapeMouseEnterEventArgs.load:
     });
 Visio.ShapeMouseLeaveEventArgs.load:
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var document1= ctx.document;
         var page = document1.getActivePage();
         eventResult2 = document1.onShapeMouseLeave.add(
@@ -9711,7 +9711,7 @@ Visio.ShapeMouseLeaveEventArgs.load:
     });
 Visio.ShapeView.load:
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var activePage = ctx.document.getActivePage();
         var shape = activePage.shapes.getItem(0);
         shape.view.highlight = { color: "#E7E7E7", width: 100 };
@@ -9723,7 +9723,7 @@ Visio.ShapeView.load:
         }
     });
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var activePage = ctx.document.getActivePage();
         var shape = activePage.shapes.getItem(0);
         var overlayId=shape.view.addOverlay(1, "Visio Online", 2, 2, 50, 50);
@@ -9735,7 +9735,7 @@ Visio.ShapeView.load:
         }
     });
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var activePage = ctx.document.getActivePage();
         var shape = activePage.shapes.getItem(0);
         shape.view.removeOverlay(1);

--- a/generate-docs/script-inputs/local-repo-snippets.yaml
+++ b/generate-docs/script-inputs/local-repo-snippets.yaml
@@ -8411,7 +8411,7 @@ Office.Time.setAsync:
     });
 Visio.Application.load:
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var application = ctx.document.application;
         application.showToolbars = false;
         application.showBorders = false;
@@ -8424,7 +8424,7 @@ Visio.Application.load:
     });
 Visio.Comment.load:
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var activePage = ctx.document.getActivePage();
         var shapeName = "Position Belt.41";
         var shape = activePage.shapes.getItem(shapeName);
@@ -8447,7 +8447,7 @@ Visio.Comment.load:
     });
 Visio.CommentCollection.load:
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var activePage = ctx.document.getActivePage();
         var shapeName = "Position Belt.41";
         var shape = activePage.shapes.getItem(shapeName);
@@ -8470,7 +8470,7 @@ Visio.CommentCollection.load:
     });
 Visio.DataRefreshCompleteEventArgs.load:
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
       var document1= ctx.document;
                    var page = document1.getActivePage();
              eventResult1 = document1.onDataRefreshComplete.add(
@@ -8489,7 +8489,7 @@ Visio.DataRefreshCompleteEventArgs.load:
     });
 Visio.Document.getActivePage:
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var document = ctx.document;
         var activePage = document.getActivePage();
         activePage.load();
@@ -8504,7 +8504,7 @@ Visio.Document.getActivePage:
     });
 Visio.Document.setActivePage:
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var document = ctx.document;
         var pageName = "Page-1";
         document.setActivePage(pageName);
@@ -8517,7 +8517,7 @@ Visio.Document.setActivePage:
     });
 Visio.Document.startDataRefresh:
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var document = ctx.document;
         document.startDataRefresh();
         return ctx.sync();
@@ -8529,7 +8529,7 @@ Visio.Document.startDataRefresh:
     });
 Visio.Document.load:
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var pages = ctx.document.pages;
         var pageCount = pages.getCount();
         return ctx.sync().then(function () {
@@ -8542,7 +8542,7 @@ Visio.Document.load:
         }
     });
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var documentView = ctx.document.view;
         documentView.disableHyperlinks();
         return ctx.sync();
@@ -8553,7 +8553,7 @@ Visio.Document.load:
         }
     });
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var application = ctx.document.application;
         application.showToolbars = false;
         return ctx.sync();
@@ -8565,7 +8565,7 @@ Visio.Document.load:
     });
 Visio.DocumentLoadCompleteEventArgs.load:
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var document1 = ctx.document;
         eventResult1 = document1.onDocumentLoadComplete.add(
             function (args){
@@ -8583,7 +8583,7 @@ Visio.DocumentLoadCompleteEventArgs.load:
     });
 Visio.Highlight.load:
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var activePage = ctx.document.getActivePage();
         var shape = activePage.shapes.getItem(0);
         shape.view.highlight = { color: "#E7E7E7", width: 100 };
@@ -8596,7 +8596,7 @@ Visio.Highlight.load:
     });
 Visio.Hyperlink.load:
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var activePage = ctx.document.getActivePage();
         var shape = activePage.shapes.getItem(0);
         var hyperlink = shape.hyperlinks.getItem(0);
@@ -8615,7 +8615,7 @@ Visio.Hyperlink.load:
     });
 Visio.HyperlinkCollection.load:
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var activePage = ctx.document.getActivePage();
         var shapeName = "Manager Belt";
         var shape = activePage.shapes.getItem(shapeName);
@@ -8636,7 +8636,7 @@ Visio.HyperlinkCollection.load:
     });
 Visio.PageCollection.getItem:
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var pageName = 'Page-1';
         var page = ctx.document.pages.getItem(pageName);
         page.activate();
@@ -8649,7 +8649,7 @@ Visio.PageCollection.getItem:
     });
 Visio.PageLoadCompleteEventArgs.load:
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var document1= ctx.document;
         var page = document1.getActivePage();
         eventResult1 = document1.onPageLoadComplete.add(
@@ -8668,7 +8668,7 @@ Visio.PageLoadCompleteEventArgs.load:
     });
 Visio.PageView.centerViewportOnShape:
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var activePage = ctx.document.getActivePage();
         var shape = activePage.shapes.getItem(0);
         activePage.view.centerViewportOnShape(shape.Id);
@@ -8681,7 +8681,7 @@ Visio.PageView.centerViewportOnShape:
     });
 Visio.PageView.load:
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var activePage = ctx.document.getActivePage();
         activePage.view.zoom = 300;
         return ctx.sync();
@@ -8744,7 +8744,7 @@ Visio.SelectionChangedEventArgs.load:
     }
 Visio.Shape.load:
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var activePage = ctx.document.getActivePage();
         var shapeName = "Sample Name";
         var shape = activePage.shapes.getItem(shapeName);
@@ -8762,7 +8762,7 @@ Visio.Shape.load:
         }
     });
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var activePage = ctx.document.getActivePage();
         var shape = activePage.shapes.getItem(0);
         shape.view.highlight = { color: "#E7E7E7", width: 100 };
@@ -8775,7 +8775,7 @@ Visio.Shape.load:
     });
 Visio.ShapeCollection.getCount:
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var activePage = ctx.document.getActivePage();
         var numShapesActivePage = activePage.shapes.getCount();
         return ctx.sync().then(function () {
@@ -8789,7 +8789,7 @@ Visio.ShapeCollection.getCount:
     });
 Visio.ShapeDataItem.load:
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var activePage = ctx.document.getActivePage();
         var shape = activePage.shapes.getItem(0);
         var shapeDataItem = shape.shapeDataItems.getItem(0);
@@ -8806,7 +8806,7 @@ Visio.ShapeDataItem.load:
     });
 Visio.ShapeDataItemCollection.load:
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var activePage = ctx.document.getActivePage();
         var shape = activePage.shapes.getItem(0);
         var shapeDataItems = shape.shapeDataItems;
@@ -8826,7 +8826,7 @@ Visio.ShapeDataItemCollection.load:
     });
 Visio.ShapeMouseEnterEventArgs.load:
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var document1= ctx.document;
         var page = document1.getActivePage();
         eventResult2 = document1.onShapeMouseEnter.add(
@@ -8844,7 +8844,7 @@ Visio.ShapeMouseEnterEventArgs.load:
     });
 Visio.ShapeMouseLeaveEventArgs.load:
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var document1= ctx.document;
         var page = document1.getActivePage();
         eventResult2 = document1.onShapeMouseLeave.add(
@@ -8862,7 +8862,7 @@ Visio.ShapeMouseLeaveEventArgs.load:
     });
 Visio.ShapeView.load:
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var activePage = ctx.document.getActivePage();
         var shape = activePage.shapes.getItem(0);
         shape.view.highlight = { color: "#E7E7E7", width: 100 };
@@ -8874,7 +8874,7 @@ Visio.ShapeView.load:
         }
     });
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var activePage = ctx.document.getActivePage();
         var shape = activePage.shapes.getItem(0);
         var overlayId=shape.view.addOverlay(1, "Visio Online", 2, 2, 50, 50);
@@ -8886,7 +8886,7 @@ Visio.ShapeView.load:
         }
     });
   - |-
-    Visio.run(function (ctx) { 
+    Visio.run(session, function (ctx) {
         var activePage = ctx.document.getActivePage();
         var shape = activePage.shapes.getItem(0);
         shape.view.removeOverlay(1);


### PR DESCRIPTION
Changing Visio snippets based on guidance from Visio team. Based on [this series of PRs](https://github.com/OfficeDev/office-js-docs/pull/1490) and the following email exchange.

"Visio JS APIs cater to different scenarios when compared to Office Add-ins. Visio APIs are used for embedded Visio diagrams in SPO pages. https://dev.office.com/reference/add-ins/visio/visio-javascript-reference-overview

The session overload is not needed everywhere but it becomes important for scenarios with multiple Visio embeddings in the same SPO page, or if there is a file change on the go for the same embedded iframe.

Therefore we think it is good to add it everywhere so that developers pass specific session object for which they want to run that particular code snippet."