### PR TITLE
Removing the term "relationship" from the overviews

### DIFF
--- a/docs/docs-ref-conceptual/overview/excel-add-ins-reference-overview.md
+++ b/docs/docs-ref-conceptual/overview/excel-add-ins-reference-overview.md
@@ -1,8 +1,6 @@
 # Excel JavaScript API overview
 
-You can use the Excel JavaScript API to build add-ins for Excel 2016. The following list shows the high-level Excel objects that are available in the API. Each object page link contains a description of the properties, relationships, and methods that are available on the object. Explore the links from the menu to learn more.
-
-Note that the relationships section within the document lists the properties that are used to navigate from the main object to another related object. These are non-scalar objects that themselves may contain other properties, methods and relationships.
+You can use the Excel JavaScript API to build add-ins for Excel 2016. The following list shows the high-level Excel objects that are available in the API. Each object page link contains a description of the properties, events, and methods that are available on the object. Explore the links from the menu to learn more.
 
 Some of the core Excel objects are listed below for convenience: 
 

--- a/docs/docs-ref-conceptual/overview/onenote-add-ins-javascript-reference.md
+++ b/docs/docs-ref-conceptual/overview/onenote-add-ins-javascript-reference.md
@@ -2,7 +2,7 @@
 
 Applies to: OneNote Online
 
-The following links show the high level OneNote objects available in the API. Each object page link contains a description of the properties, relationships, and methods available on the object. Explore these links to learn more. 
+The following links show the high level OneNote objects available in the API. Each object page link contains a description of the properties, events, and methods available on the object. Explore these links to learn more. 
 	
 - [Application](/javascript/api/onenote/onenote.application): The top-level object used to access all globally addressable OneNote objects, such as the active notebook and the active section.
 

--- a/docs/docs-ref-conceptual/overview/visio-javascript-reference-overview.md
+++ b/docs/docs-ref-conceptual/overview/visio-javascript-reference-overview.md
@@ -73,7 +73,7 @@ The following shows the syntax for the **load()** method.
 object.load(string: properties); //or object.load(array: properties); //or object.load({loadOption});
 ```
 
-1. **properties** is the list of properties and/or relationship names to be loaded, specified as comma-delimited strings or array of names. See **.load()** methods under each object for details.
+1. **properties** is the list of properties names to be loaded, specified as comma-delimited strings or array of names. See **.load()** methods under each object for details.
 
 2. **loadOption** specifies an object that describes the selection, expansion, top, and skip options. See object load [options](/javascript/api/office/officeextension.loadoption) for details.
 

--- a/docs/docs-ref-conceptual/overview/visio-javascript-reference-overview.md
+++ b/docs/docs-ref-conceptual/overview/visio-javascript-reference-overview.md
@@ -73,7 +73,7 @@ The following shows the syntax for the **load()** method.
 object.load(string: properties); //or object.load(array: properties); //or object.load({loadOption});
 ```
 
-1. **properties** is the list of properties names to be loaded, specified as comma-delimited strings or array of names. See **.load()** methods under each object for details.
+1. **properties** is the list of property names to be loaded, specified as comma-delimited strings or array of names. See **.load()** methods under each object for details.
 
 2. **loadOption** specifies an object that describes the selection, expansion, top, and skip options. See object load [options](/javascript/api/office/officeextension.loadoption) for details.
 


### PR DESCRIPTION
Relationships aren't a concept in the new reference docs. Updating the overviews to reflect the information we're now presenting.