### PR TITLE
Update GenerateDocs script

### DIFF
--- a/generate-docs/GenerateDocs.cmd
+++ b/generate-docs/GenerateDocs.cmd
@@ -1,3 +1,7 @@
+IF EXIST "node_modules" (
+    rmdir "node_modules" /s /q
+)
+
 call npm install
 
 pushd scripts


### PR DESCRIPTION
Add logic to remove the `node_modules` folder at the very start of the script, since this step seems necessary in order to reliably pick up any changes that have been made to API Documenter and API Extractor.