### PR TITLE
Renaming "open specification" in the ref docs ToC

### DIFF
--- a/docs/docs-ref-conceptual/openspec.md
+++ b/docs/docs-ref-conceptual/openspec.md
@@ -1,6 +1,6 @@
 # Preview API documentation
 
-The Office JavaScript API open specifications provide information about new JavaScript APIs that are being designed for Excel, Word, and other host applications. You can review the open specifications in [branches](https://github.com/OfficeDev/office-js-docs/branches/all) of the **OfficeDev/office-js-docs** GitHub repository to learn about APIs that are planned for future releases and can provide feedback about the planned API features and design by logging issues in the GitHub repository.
+Preview documentation for Office JavaScript APIs is presented as a series of open specifications. These open specifications provide information about new JavaScript APIs that are being designed for Excel, Word, and other host applications. You can review the open specifications in [branches](https://github.com/OfficeDev/office-js-docs/branches/all) of the **OfficeDev/office-js-docs** GitHub repository to learn about APIs that are planned for future releases and can provide feedback about the planned API features and design by logging issues in the GitHub repository.
 
 > [!IMPORTANT]
 > Features described in the API open specifications may be in various stages of development, such as early design or public preview, and are subject to change. When an API feature becomes generally available, related documentation is removed from the open specification and added to the [Office Add-ins documentation](https://docs.microsoft.com/office/dev/add-ins/). 

--- a/docs/docs-ref-conceptual/openspec.md
+++ b/docs/docs-ref-conceptual/openspec.md
@@ -1,4 +1,4 @@
-# API open specifications
+# Preview API documentation
 
 The Office JavaScript API open specifications provide information about new JavaScript APIs that are being designed for Excel, Word, and other host applications. You can review the open specifications in [branches](https://github.com/OfficeDev/office-js-docs/branches/all) of the **OfficeDev/office-js-docs** GitHub repository to learn about APIs that are planned for future releases and can provide feedback about the planned API features and design by logging issues in the GitHub repository.
 

--- a/docs/docs-ref-conceptual/toc.yml
+++ b/docs/docs-ref-conceptual/toc.yml
@@ -173,7 +173,7 @@ items:
           href: javascript-api-for-office-error-codes.md
         - name: API Reference
           uid: office
-  - name: API open specifications
+  - name: Preview API documentation
     href: openspec.md
   - name: Office Add-in manifest reference
     items:


### PR DESCRIPTION
This is based on feedback from Tristan the term "open specification" is too jargon-y. Eventually, we'll move away from our current open spec story and this issue will resolve itself. For now, the easy solution is to provide a clear ToC entry and define the term in the page. 