### PR TITLE
Update preprocessor script

### DIFF
--- a/generate-docs/scripts/preprocessor.ts
+++ b/generate-docs/scripts/preprocessor.ts
@@ -212,6 +212,8 @@ tryCatch(async () => {
 
     console.log("\nWriting snippets to: " + path.resolve("../json/snippets.yaml"));
 
+    fsx.writeFileSync("../json/snippets.yaml", yaml.dump(snippets));
+
     console.log("\nPreprocessor script complete!");
 
     process.exit(0);

--- a/generate-docs/scripts/preprocessor.ts
+++ b/generate-docs/scripts/preprocessor.ts
@@ -12,7 +12,7 @@ tryCatch(async () => {
     // ----
     console.log('\n\n');
     const urlToCopyOfficeJsFrom = await promptFromList({
-        message: `What is the source of the office.d.ts file that should be used to generate the docs?`,
+        message: `What is the source of the Office-js TypeScript definition file that should be used to generate the docs?`,
         choices: [
             { name: "DefinitelyTyped", value: "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/master/types/office-js/index.d.ts" },
             { name: "Prod CDN", value: "https://appsforoffice.officeapps.live.com/lib/1.1/hosted/office.d.ts" },


### PR DESCRIPTION
Updated preprocessor script to clean up recent changes that were implemented to add processing logic for Custom Functions and Office Runtime d.ts files.

- updated initial prompt (for the source of d.ts) to clarify that it's asking for the source of **office.d.ts**
- removed prompts about whether to process Custom Functions d.ts file and Office Runtime d.ts file (they'll be processed by **GenerateDocs.cmd** regardless of how the user answers these prompts, so the prompts are useless)
- added prompts to confirm source of the Custom Functions d.ts file and the Office Runtime d.ts file
- refactored/simplified logic for processing the Custom Functions d.ts file and Office Runtime d.ts file
- moved the logic for processing the Custom Functions and Office Runtime d.ts files to immediately follow processing of Office d.ts file (i.e., before snippet processing logic)
- moved 'common' regex logic into function (instead of repeating the same lines of code 3x in the script)
- added comments to identify main sections of logic within the code

**Note**: This PR only contains changes to the preprocessor script. I've tested/verified these changes by running **GenerateDocs.cmd** locally, and everything works as intended. I'm intentionally not submitting any doc updates as part of this PR, since I'm not certain that those doc changes are ready to be published (a handful of changes due to recent updates to Excel, Custom Functions, and Office Runtime d.ts files) -- the owners of those areas can decide when those doc updates should be published.