### PR TITLE
Refresh Outlook legacy docs

### DIFF
--- a/docs/docs-ref-autogen/outlook_1_1.yml
+++ b/docs/docs-ref-autogen/outlook_1_1.yml
@@ -29,6 +29,7 @@ items:
       - Outlook_1_1.Office.MailboxEnums.AttachmentType
       - Outlook_1_1.Office.MailboxEnums.EntityType
       - Outlook_1_1.Office.MailboxEnums.ItemType
+      - Outlook_1_1.Office.MailboxEnums.OWAView
       - Outlook_1_1.Office.MailboxEnums.RecipientType
       - Outlook_1_1.Office.MailboxEnums.ResponseType
       - Outlook_1_1.Office.MeetingSuggestion
@@ -90,6 +91,8 @@ references:
     name: Office.MailboxEnums.EntityType
   - uid: Outlook_1_1.Office.MailboxEnums.ItemType
     name: Office.MailboxEnums.ItemType
+  - uid: Outlook_1_1.Office.MailboxEnums.OWAView
+    name: Office.MailboxEnums.OWAView
   - uid: Outlook_1_1.Office.MailboxEnums.RecipientType
     name: Office.MailboxEnums.RecipientType
   - uid: Outlook_1_1.Office.MailboxEnums.ResponseType

--- a/docs/docs-ref-autogen/outlook_1_1/office.appointmentcompose.yml
+++ b/docs/docs-ref-autogen/outlook_1_1/office.appointmentcompose.yml
@@ -2,11 +2,11 @@
 items:
   - uid: Outlook_1_1.Office.AppointmentCompose
     summary: >-
-      The appointment organizer mode of [Office.context.mailbox.item](xref:Outlook_1_1.Office.Item)<!-- -->.
+      The appointment organizer mode of [ Office.context.mailbox.item](xref:Outlook_1_1.Office.Item)<!-- -->.
 
 
       Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat
-      this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
+      this as a mode of `Office.context.mailbox.item`<!-- -->. Refer to the Object Model pages for more information.
     name: Office.AppointmentCompose
     fullName: Outlook_1_1.Office.AppointmentCompose
     langs:
@@ -45,11 +45,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Organizer</td></tr>
 
 
@@ -68,7 +68,8 @@ items:
       `addFileAttachmentAsync(uri: string, attachmentName: string, options: Office.AsyncContextOptions): void;`
 
 
-      `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+      `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void):
+      void;`
     name: 'addFileAttachmentAsync(uri, attachmentName, options, callback)'
     fullName: Outlook_1_1.Office.AppointmentCompose.addFileAttachmentAsync
     langs:
@@ -77,7 +78,7 @@ items:
     syntax:
       content: >-
         addFileAttachmentAsync(uri: string, attachmentName: string, options?: Office.AsyncContextOptions, callback?:
-        (result: AsyncResult) => void): void;
+        (result: AsyncResult<string>) => void): void;
       return:
         type:
           - void
@@ -109,7 +110,7 @@ items:
             property. If uploading the attachment fails, the asyncResult object will contain an Error object that
             provides a description of the error.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<string>) => void'
   - uid: Outlook_1_1.Office.AppointmentCompose.addItemAttachmentAsync
     summary: >-
       Adds an Exchange item, such as a message, as an attachment to the message or appointment.
@@ -125,17 +126,17 @@ items:
       session.
 
 
-      If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items
+      If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items
       other than the item that you are editing; however, this is not supported and is not recommended.
 
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Organizer</td></tr>
 
 
@@ -143,7 +144,7 @@ items:
       attachments.</td></tr></table>
 
 
-      In addition to the main signature, this method also has these signatures:
+      In addition to this signature, this method also has the following signatures:
 
 
       `addItemAttachmentAsync(itemId: any, attachmentName: string): void;`
@@ -152,7 +153,8 @@ items:
       `addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;`
 
 
-      `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+      `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void):
+      void;`
     name: 'addItemAttachmentAsync(itemId, attachmentName, options, callback)'
     fullName: Outlook_1_1.Office.AppointmentCompose.addItemAttachmentAsync
     langs:
@@ -161,7 +163,7 @@ items:
     syntax:
       content: >-
         addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?:
-        (result: AsyncResult) => void): void;
+        (result: AsyncResult<string>) => void): void;
       return:
         type:
           - void
@@ -186,22 +188,22 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value
+            of type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value
             property. If adding the attachment fails, the asyncResult object will contain an Error object that provides
             a description of the error.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<string>) => void'
   - uid: Outlook_1_1.Office.AppointmentCompose.body
     summary: |-
       Gets an object that provides methods for manipulating the body of an item.
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: body
@@ -220,11 +222,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: dateTimeCreated
@@ -243,11 +245,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
 
@@ -279,11 +281,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: end
@@ -307,11 +309,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: itemType
@@ -342,11 +344,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: 'loadCustomPropertiesAsync(callback, userContext)'
@@ -355,7 +357,9 @@ items:
       - typeScript
     type: method
     syntax:
-      content: 'loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;'
+      content: >-
+        loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any):
+        void;
       return:
         type:
           - void
@@ -364,9 +368,9 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult.
+            of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<Office.CustomProperties>) => void'
         - id: userContext
           description: >-
             Optional. Developers can provide any object they wish to access in the callback function. This object can be
@@ -381,11 +385,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: location
@@ -408,11 +412,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: optionalAttendees
@@ -433,17 +437,17 @@ items:
       The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best
       practice, you should use the attachment identifier to remove an attachment only if the same mail app has added
       that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid
-      only within the same session. A session is over when the user closes the app, or if the user starts composing in
-      an inline form and subsequently pops out the inline form to continue in a separate window.
+      only within the same session. A session is over when the user closes the app, or if the user starts composing an
+      inline form then subsequently pops out the form to continue in a separate window.
 
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Organizer</td></tr>
 
 
@@ -459,7 +463,7 @@ items:
       `removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;`
 
 
-      `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;`
+      `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;`
     name: 'removeAttachmentAsync(attachmentIndex, options, callback)'
     fullName: Outlook_1_1.Office.AppointmentCompose.removeAttachmentAsync
     langs:
@@ -468,7 +472,7 @@ items:
     syntax:
       content: >-
         removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result:
-        AsyncResult) => void): void;
+        AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -487,10 +491,10 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain
-            an error code with the reason for the failure.
+            parameter of type Office.AsyncResult. If removing the attachment fails, the asyncResult.error property will
+            contain an error code with the reason for the failure.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_1.Office.AppointmentCompose.requiredAttendees
     summary: >-
       Provides access to the required attendees of an event. The type of object and level of access depends on the mode
@@ -501,11 +505,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: requiredAttendees
@@ -534,11 +538,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: start
@@ -561,11 +565,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: subject

--- a/docs/docs-ref-autogen/outlook_1_1/office.appointmentform.yml
+++ b/docs/docs-ref-autogen/outlook_1_1/office.appointmentform.yml
@@ -6,12 +6,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.AppointmentForm
     fullName: Outlook_1_1.Office.AppointmentForm
     langs:
@@ -33,12 +33,12 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: body
     fullName: Outlook_1_1.Office.AppointmentForm.body
     langs:
@@ -76,12 +76,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: end
     fullName: Outlook_1_1.Office.AppointmentForm.end
     langs:
@@ -112,10 +112,10 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: location
     fullName: Outlook_1_1.Office.AppointmentForm.location
     langs:
@@ -148,12 +148,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: optionalAttendees
     fullName: Outlook_1_1.Office.AppointmentForm.optionalAttendees
     langs:
@@ -186,12 +186,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: requiredAttendees
     fullName: Outlook_1_1.Office.AppointmentForm.requiredAttendees
     langs:
@@ -240,12 +240,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: start
     fullName: Outlook_1_1.Office.AppointmentForm.start
     langs:
@@ -279,12 +279,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: subject
     fullName: Outlook_1_1.Office.AppointmentForm.subject
     langs:

--- a/docs/docs-ref-autogen/outlook_1_1/office.appointmentread.yml
+++ b/docs/docs-ref-autogen/outlook_1_1/office.appointmentread.yml
@@ -2,7 +2,7 @@
 items:
   - uid: Outlook_1_1.Office.AppointmentRead
     summary: >-
-      The appointment attendee mode of [Office.context.mailbox.item](xref:Outlook_1_1.Office.Item)<!-- -->.
+      The appointment attendee mode of [ Office.context.mailbox.item](xref:Outlook_1_1.Office.Item)<!-- -->.
 
 
       Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat
@@ -41,20 +41,20 @@ items:
       - Outlook_1_1.Office.AppointmentRead.subject
   - uid: Outlook_1_1.Office.AppointmentRead.attachments
     summary: |-
-      Gets an array of attachments for the item.
+      Gets the item's attachments as an array.
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
 
 
       Note: Certain types of files are blocked by Outlook due to potential security issues and are therefore not
-      returned. For more information, see [Blocked attachments in
+      returned. For more information, see [ Blocked attachments in
       Outlook](https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519)<!--
       -->.
     name: attachments
@@ -73,11 +73,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: body
     fullName: Outlook_1_1.Office.AppointmentRead.body
@@ -95,11 +95,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: dateTimeCreated
     fullName: Outlook_1_1.Office.AppointmentRead.dateTimeCreated
@@ -117,11 +117,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
 
 
@@ -159,11 +159,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: displayReplyAllForm(formData)
     fullName: Outlook_1_1.Office.AppointmentRead.displayReplyAllForm
@@ -180,7 +180,7 @@ items:
         - id: formData
           description: >-
             A string that contains text and HTML and that represents the body of the reply form. The string is limited
-            to 32 KB OR An[Office.ReplyFormData](xref:Outlook_1_1.Office.ReplyFormData) object that contains body or
+            to 32 KB OR An [Office.ReplyFormData](xref:Outlook_1_1.Office.ReplyFormData) object that contains body or
             attachment data and a callback function
           type:
             - string | ReplyFormData
@@ -207,11 +207,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: displayReplyForm(formData)
     fullName: Outlook_1_1.Office.AppointmentRead.displayReplyForm
@@ -228,7 +228,7 @@ items:
         - id: formData
           description: >-
             A string that contains text and HTML and that represents the body of the reply form. The string is limited
-            to 32 KB. OR An[Office.ReplyFormData](xref:Outlook_1_1.Office.ReplyFormData) object that contains body or
+            to 32 KB. OR An [Office.ReplyFormData](xref:Outlook_1_1.Office.ReplyFormData) object that contains body or
             attachment data and a callback function.
           type:
             - string | ReplyFormData
@@ -247,11 +247,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: end
     fullName: Outlook_1_1.Office.AppointmentRead.end
@@ -265,17 +265,17 @@ items:
           - Date
   - uid: Outlook_1_1.Office.AppointmentRead.getEntities
     summary: |-
-      Gets the entities found in the selected item.
+      Gets the entities found in the selected item's body.
 
       Note: This method is not supported in Outlook for iOS or Outlook for Android.
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: getEntities()
     fullName: Outlook_1_1.Office.AppointmentRead.getEntities
@@ -290,17 +290,17 @@ items:
         description: ''
   - uid: Outlook_1_1.Office.AppointmentRead.getEntitiesByType
     summary: |-
-      Gets an array of all the entities of the specified entity type found in the selected item.
+      Gets an array of all the entities of the specified entity type found in the selected item's body.
 
       Note: This method is not supported in Outlook for iOS or Outlook for Android.
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
 
 
@@ -328,7 +328,7 @@ items:
           - '(string | Contact | MeetingSuggestion | PhoneNumber | TaskSuggestion)[]'
         description: >-
           If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns
-          null. If no entities of the specified type are present on the item, the method returns an empty array.
+          null. If no entities of the specified type are present in the item's body, the method returns an empty array.
           Otherwise, the type of the objects in the returned array depends on the type of entity requested in the
           entityType parameter.
       parameters:
@@ -350,11 +350,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: getFilteredEntitiesByName(name)
     fullName: Outlook_1_1.Office.AppointmentRead.getFilteredEntitiesByName
@@ -399,11 +399,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: getRegExMatches()
     fullName: Outlook_1_1.Office.AppointmentRead.getRegExMatches
@@ -439,11 +439,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: getRegExMatchesByName(name)
     fullName: Outlook_1_1.Office.AppointmentRead.getRegExMatchesByName
@@ -472,11 +472,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
 
 
@@ -514,16 +514,17 @@ items:
       Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The
       itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making
       REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more
-      details, see Use the Outlook REST APIs from an Outlook add-in.
+      details, see [ Use the Outlook REST APIs from an Outlook
+      add-in](https://docs.microsoft.com/outlook/add-ins/use-rest-api#get-the-item-id)<!-- -->.
 
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: itemId
     fullName: Outlook_1_1.Office.AppointmentRead.itemId
@@ -546,11 +547,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: itemType
     fullName: Outlook_1_1.Office.AppointmentRead.itemType
@@ -580,11 +581,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: 'loadCustomPropertiesAsync(callback, userContext)'
     fullName: Outlook_1_1.Office.AppointmentRead.loadCustomPropertiesAsync
@@ -592,7 +593,9 @@ items:
       - typeScript
     type: method
     syntax:
-      content: 'loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;'
+      content: >-
+        loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any):
+        void;
       return:
         type:
           - void
@@ -601,9 +604,9 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult.
+            of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<Office.CustomProperties>) => void'
         - id: userContext
           description: >-
             Optional. Developers can provide any object they wish to access in the callback function. This object can be
@@ -618,11 +621,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: location
     fullName: Outlook_1_1.Office.AppointmentRead.location
@@ -645,11 +648,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: normalizedSubject
     fullName: Outlook_1_1.Office.AppointmentRead.normalizedSubject
@@ -674,11 +677,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: optionalAttendees
     fullName: Outlook_1_1.Office.AppointmentRead.optionalAttendees
@@ -692,15 +695,15 @@ items:
           - 'EmailAddressDetails[]'
   - uid: Outlook_1_1.Office.AppointmentRead.organizer
     summary: |-
-      Gets the email address of the meeting organizer for a specified meeting. Read mode only.
+      Gets the email address of the meeting organizer for a specified meeting.
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: organizer
     fullName: Outlook_1_1.Office.AppointmentRead.organizer
@@ -725,11 +728,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: requiredAttendees
     fullName: Outlook_1_1.Office.AppointmentRead.requiredAttendees
@@ -752,11 +755,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: start
     fullName: Outlook_1_1.Office.AppointmentRead.start
@@ -782,11 +785,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: subject
     fullName: Outlook_1_1.Office.AppointmentRead.subject

--- a/docs/docs-ref-autogen/outlook_1_1/office.attachmentdetails.yml
+++ b/docs/docs-ref-autogen/outlook_1_1/office.attachmentdetails.yml
@@ -8,11 +8,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: Office.AttachmentDetails
     fullName: Outlook_1_1.Office.AttachmentDetails

--- a/docs/docs-ref-autogen/outlook_1_1/office.body.yml
+++ b/docs/docs-ref-autogen/outlook_1_1/office.body.yml
@@ -8,12 +8,12 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.Body
     fullName: Outlook_1_1.Office.Body
     langs:
@@ -30,11 +30,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
     name: 'getTypeAsync(options, callback)'
     fullName: Outlook_1_1.Office.Body.getTypeAsync
@@ -42,7 +42,9 @@ items:
       - typeScript
     type: method
     syntax:
-      content: 'getTypeAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;'
+      content: >-
+        getTypeAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<Office.CoercionType>) =>
+        void): void;
       return:
         type:
           - void
@@ -57,10 +59,10 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. The content type is returned as one of the CoercionType values in the
+            parameter of type Office.AsyncResult. The content type is returned as one of the CoercionType values in the
             asyncResult.value property.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<Office.CoercionType>) => void'
   - uid: Outlook_1_1.Office.Body.prependAsync
     summary: >-
       Adds the specified content to the beginning of the item body.
@@ -76,11 +78,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -88,13 +90,13 @@ items:
       characters.</td></tr></table>
 
 
-      In addition to the main signature, this method also has these signatures:
+      In addition to this signature, this method also has the following signatures:
 
 
-      `prependAsync(data: string, options: Office.AsyncContextOptions &amp; CoercionTypeOptions): void;`
+      `prependAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`
 
 
-      `prependAsync(data: string, callback: (result: AsyncResult) => void): void;`
+      `prependAsync(data: string, callback: (result: AsyncResult<void>) => void): void;`
 
 
       `prependAsync(data: string): void;`
@@ -106,7 +108,7 @@ items:
     syntax:
       content: >-
         prependAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result:
-        AsyncResult) => void): void;
+        AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -126,9 +128,10 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. Any errors encountered will be provided in the asyncResult.error property.
+            parameter of type Office.AsyncResult. Any errors encountered will be provided in the asyncResult.error
+            property.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_1.Office.Body.setSelectedDataAsync
     summary: >-
       Replaces the selection in the body with the specified text.
@@ -146,11 +149,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -159,13 +162,13 @@ items:
       Office.CoercionType.Html and the message body is in plain text.</td></tr></table>
 
 
-      In addition to the main signature, this method also has these signatures:
+      In addition to this signature, this method also has the following signatures:
 
 
-      `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions &amp; CoercionTypeOptions): void;`
+      `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`
 
 
-      `setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;`
+      `setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;`
 
 
       `setSelectedDataAsync(data: string): void;`
@@ -177,7 +180,7 @@ items:
     syntax:
       content: >-
         setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?:
-        (result: AsyncResult) => void): void;
+        (result: AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -197,6 +200,7 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. Any errors encountered will be provided in the asyncResult.error property.
+            parameter of type Office.AsyncResult. Any errors encountered will be provided in the asyncResult.error
+            property.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'

--- a/docs/docs-ref-autogen/outlook_1_1/office.contact.yml
+++ b/docs/docs-ref-autogen/outlook_1_1/office.contact.yml
@@ -12,11 +12,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: Office.Contact
     fullName: Outlook_1_1.Office.Contact

--- a/docs/docs-ref-autogen/outlook_1_1/office.customproperties.yml
+++ b/docs/docs-ref-autogen/outlook_1_1/office.customproperties.yml
@@ -15,12 +15,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.CustomProperties
     fullName: Outlook_1_1.Office.CustomProperties
     langs:
@@ -35,12 +35,12 @@ items:
   - uid: Outlook_1_1.Office.CustomProperties.get
     summary: Returns the value of the specified custom property.
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: get(name)
     fullName: Outlook_1_1.Office.CustomProperties.get
     langs:
@@ -66,12 +66,12 @@ items:
 
       To make the removal of the property permanent, you must call the saveAsync method of the CustomProperties object.
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: remove(name)
     fullName: Outlook_1_1.Office.CustomProperties.remove
     langs:
@@ -85,7 +85,10 @@ items:
         description: ''
       parameters:
         - id: name
-          description: 'The name of the property to be removed. \[Api set: Mailbox 1.0\]'
+          description: |-
+            The name of the property to be removed.
+
+            \[Api set: Mailbox 1.0\]
           type:
             - string
   - uid: Outlook_1_1.Office.CustomProperties.saveAsync
@@ -102,19 +105,19 @@ items:
       becomes disconnected. If the add-in calls saveAsync while in the disconnected state, saveAsync would return an
       error. Your callback method should handle this error accordingly.
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: 'saveAsync(callback, asyncContext)'
     fullName: Outlook_1_1.Office.CustomProperties.saveAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'saveAsync(callback?: (result: AsyncResult) => void, asyncContext?: any): void;'
+      content: 'saveAsync(callback?: (result: AsyncResult<void>) => void, asyncContext?: any): void;'
       return:
         type:
           - void
@@ -123,11 +126,14 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult.
+            parameter of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
         - id: asyncContext
-          description: 'Optional. Any state data that is passed to the callback method. \[Api set: Mailbox 1.0\]'
+          description: |-
+            Optional. Any state data that is passed to the callback method.
+
+            \[Api set: Mailbox 1.0\]
           type:
             - any
   - uid: Outlook_1_1.Office.CustomProperties.set
@@ -146,12 +152,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: 'set(name, value)'
     fullName: Outlook_1_1.Office.CustomProperties.set
     langs:

--- a/docs/docs-ref-autogen/outlook_1_1/office.diagnostics.yml
+++ b/docs/docs-ref-autogen/outlook_1_1/office.diagnostics.yml
@@ -6,12 +6,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.Diagnostics
     fullName: Outlook_1_1.Office.Diagnostics
     langs:
@@ -30,12 +30,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: hostName
     fullName: Outlook_1_1.Office.Diagnostics.hostName
     langs:
@@ -58,12 +58,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: hostVersion
     fullName: Outlook_1_1.Office.Diagnostics.hostVersion
     langs:
@@ -102,19 +102,19 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: OWAView
     fullName: Outlook_1_1.Office.Diagnostics.OWAView
     langs:
       - typeScript
     type: property
     syntax:
-      content: 'OWAView: "string";'
+      content: 'OWAView: MailboxEnums.OWAView | "OneColumn" | "TwoColumns" | "ThreeColumns";'
       return:
         type:
-          - '"string"'
+          - MailboxEnums.OWAView | "OneColumn" | "TwoColumns" | "ThreeColumns"

--- a/docs/docs-ref-autogen/outlook_1_1/office.emailaddressdetails.yml
+++ b/docs/docs-ref-autogen/outlook_1_1/office.emailaddressdetails.yml
@@ -6,12 +6,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.EmailAddressDetails
     fullName: Outlook_1_1.Office.EmailAddressDetails
     langs:

--- a/docs/docs-ref-autogen/outlook_1_1/office.emailuser.yml
+++ b/docs/docs-ref-autogen/outlook_1_1/office.emailuser.yml
@@ -6,11 +6,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: Office.EmailUser
     fullName: Outlook_1_1.Office.EmailUser

--- a/docs/docs-ref-autogen/outlook_1_1/office.entities.yml
+++ b/docs/docs-ref-autogen/outlook_1_1/office.entities.yml
@@ -34,11 +34,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: Office.Entities
     fullName: Outlook_1_1.Office.Entities

--- a/docs/docs-ref-autogen/outlook_1_1/office.item.yml
+++ b/docs/docs-ref-autogen/outlook_1_1/office.item.yml
@@ -8,12 +8,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.Item
     fullName: Outlook_1_1.Office.Item
     langs:
@@ -32,12 +32,12 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: body
     fullName: Outlook_1_1.Office.Item.body
     langs:
@@ -54,11 +54,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: dateTimeCreated
     fullName: Outlook_1_1.Office.Item.dateTimeCreated
@@ -76,11 +76,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
 
 
@@ -106,12 +106,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: itemType
     fullName: Outlook_1_1.Office.Item.itemType
     langs:
@@ -140,19 +140,21 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: 'loadCustomPropertiesAsync(callback, userContext)'
     fullName: Outlook_1_1.Office.Item.loadCustomPropertiesAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;'
+      content: >-
+        loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any):
+        void;
       return:
         type:
           - void
@@ -161,9 +163,9 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult.
+            of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<Office.CustomProperties>) => void'
         - id: userContext
           description: >-
             Optional. Developers can provide any object they wish to access in the callback function. This object can be

--- a/docs/docs-ref-autogen/outlook_1_1/office.itemcompose.yml
+++ b/docs/docs-ref-autogen/outlook_1_1/office.itemcompose.yml
@@ -2,11 +2,11 @@
 items:
   - uid: Outlook_1_1.Office.ItemCompose
     summary: >-
-      The compose mode of [Office.context.mailbox.item](xref:Outlook_1_1.Office.Item)<!-- -->.
+      The compose mode of [ Office.context.mailbox.item](xref:Outlook_1_1.Office.Item)<!-- -->.
 
 
       Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat
-      this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
+      this as a mode of `Office.context.mailbox.item`<!-- -->. Refer to the Object Model pages for more information.
     name: Office.ItemCompose
     fullName: Outlook_1_1.Office.ItemCompose
     langs:
@@ -35,11 +35,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -58,7 +58,8 @@ items:
       `addFileAttachmentAsync(uri: string, attachmentName: string, options: Office.AsyncContextOptions): void;`
 
 
-      `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+      `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void):
+      void;`
     name: 'addFileAttachmentAsync(uri, attachmentName, options, callback)'
     fullName: Outlook_1_1.Office.ItemCompose.addFileAttachmentAsync
     langs:
@@ -67,7 +68,7 @@ items:
     syntax:
       content: >-
         addFileAttachmentAsync(uri: string, attachmentName: string, options?: Office.AsyncContextOptions, callback?:
-        (result: AsyncResult) => void): void;
+        (result: AsyncResult<string>) => void): void;
       return:
         type:
           - void
@@ -99,7 +100,7 @@ items:
             property. If uploading the attachment fails, the asyncResult object will contain an Error object that
             provides a description of the error.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<string>) => void'
   - uid: Outlook_1_1.Office.ItemCompose.addItemAttachmentAsync
     summary: >-
       Adds an Exchange item, such as a message, as an attachment to the message or appointment.
@@ -115,17 +116,17 @@ items:
       session.
 
 
-      If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items
+      If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items
       other than the item that you are editing; however, this is not supported and is not recommended.
 
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -133,7 +134,7 @@ items:
       attachments.</td></tr></table>
 
 
-      In addition to the main signature, this method also has these signatures:
+      In addition to this signature, this method also has the following signatures:
 
 
       `addItemAttachmentAsync(itemId: any, attachmentName: string): void;`
@@ -142,7 +143,8 @@ items:
       `addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;`
 
 
-      `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+      `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void):
+      void;`
     name: 'addItemAttachmentAsync(itemId, attachmentName, options, callback)'
     fullName: Outlook_1_1.Office.ItemCompose.addItemAttachmentAsync
     langs:
@@ -151,7 +153,7 @@ items:
     syntax:
       content: >-
         addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?:
-        (result: AsyncResult) => void): void;
+        (result: AsyncResult<string>) => void): void;
       return:
         type:
           - void
@@ -176,11 +178,11 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value
+            of type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value
             property. If adding the attachment fails, the asyncResult object will contain an Error object that provides
             a description of the error.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<string>) => void'
   - uid: Outlook_1_1.Office.ItemCompose.removeAttachmentAsync
     summary: >-
       Removes an attachment from a message or appointment.
@@ -189,17 +191,17 @@ items:
       The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best
       practice, you should use the attachment identifier to remove an attachment only if the same mail app has added
       that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid
-      only within the same session. A session is over when the user closes the app, or if the user starts composing in
-      an inline form and subsequently pops out the inline form to continue in a separate window.
+      only within the same session. A session is over when the user closes the app, or if the user starts composing an
+      inline form then subsequently pops out the form to continue in a separate window.
 
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -215,7 +217,7 @@ items:
       `removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;`
 
 
-      `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;`
+      `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;`
     name: 'removeAttachmentAsync(attachmentIndex, options, callback)'
     fullName: Outlook_1_1.Office.ItemCompose.removeAttachmentAsync
     langs:
@@ -224,7 +226,7 @@ items:
     syntax:
       content: >-
         removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result:
-        AsyncResult) => void): void;
+        AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -243,10 +245,10 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain
-            an error code with the reason for the failure.
+            parameter of type Office.AsyncResult. If removing the attachment fails, the asyncResult.error property will
+            contain an error code with the reason for the failure.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_1.Office.ItemCompose.subject
     summary: |-
       Gets or sets the description that appears in the subject field of an item.
@@ -257,12 +259,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: subject
     fullName: Outlook_1_1.Office.ItemCompose.subject
     langs:

--- a/docs/docs-ref-autogen/outlook_1_1/office.itemread.yml
+++ b/docs/docs-ref-autogen/outlook_1_1/office.itemread.yml
@@ -2,11 +2,11 @@
 items:
   - uid: Outlook_1_1.Office.ItemRead
     summary: >-
-      The read mode of [Office.context.mailbox.item](xref:Outlook_1_1.Office.Item)<!-- -->.
+      The read mode of [ Office.context.mailbox.item](xref:Outlook_1_1.Office.Item)<!-- -->.
 
 
       Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat
-      this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
+      this as a mode of `Office.context.mailbox.item`<!-- -->. Refer to the Object Model pages for more information.
     name: Office.ItemRead
     fullName: Outlook_1_1.Office.ItemRead
     langs:
@@ -30,20 +30,20 @@ items:
       - Outlook_1_1.Office.ItemRead.subject
   - uid: Outlook_1_1.Office.ItemRead.attachments
     summary: |-
-      Gets an array of attachments for the item.
+      Gets the item's attachments as an array.
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
 
 
       Note: Certain types of files are blocked by Outlook due to potential security issues and are therefore not
-      returned. For more information, see [Blocked attachments in
+      returned. For more information, see [ Blocked attachments in
       Outlook](https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519)<!--
       -->.
     name: attachments
@@ -79,11 +79,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: displayReplyAllForm(formData)
     fullName: Outlook_1_1.Office.ItemRead.displayReplyAllForm
@@ -100,7 +100,7 @@ items:
         - id: formData
           description: >-
             A string that contains text and HTML and that represents the body of the reply form. The string is limited
-            to 32 KB OR An[Office.ReplyFormData](xref:Outlook_1_1.Office.ReplyFormData) object that contains body or
+            to 32 KB OR An [Office.ReplyFormData](xref:Outlook_1_1.Office.ReplyFormData) object that contains body or
             attachment data and a callback function
           type:
             - string | ReplyFormData
@@ -127,11 +127,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: displayReplyForm(formData)
     fullName: Outlook_1_1.Office.ItemRead.displayReplyForm
@@ -148,23 +148,23 @@ items:
         - id: formData
           description: >-
             A string that contains text and HTML and that represents the body of the reply form. The string is limited
-            to 32 KB. OR An[Office.ReplyFormData](xref:Outlook_1_1.Office.ReplyFormData) object that contains body or
+            to 32 KB. OR An [Office.ReplyFormData](xref:Outlook_1_1.Office.ReplyFormData) object that contains body or
             attachment data and a callback function.
           type:
             - string | ReplyFormData
   - uid: Outlook_1_1.Office.ItemRead.getEntities
     summary: |-
-      Gets the entities found in the selected item.
+      Gets the entities found in the selected item's body.
 
       Note: This method is not supported in Outlook for iOS or Outlook for Android.
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: getEntities()
     fullName: Outlook_1_1.Office.ItemRead.getEntities
@@ -179,17 +179,17 @@ items:
         description: ''
   - uid: Outlook_1_1.Office.ItemRead.getEntitiesByType
     summary: |-
-      Gets an array of all the entities of the specified entity type found in the selected item.
+      Gets an array of all the entities of the specified entity type found in the selected item's body.
 
       Note: This method is not supported in Outlook for iOS or Outlook for Android.
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
 
 
@@ -217,7 +217,7 @@ items:
           - '(string | Contact | MeetingSuggestion | PhoneNumber | TaskSuggestion)[]'
         description: >-
           If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns
-          null. If no entities of the specified type are present on the item, the method returns an empty array.
+          null. If no entities of the specified type are present in the item's body, the method returns an empty array.
           Otherwise, the type of the objects in the returned array depends on the type of entity requested in the
           entityType parameter.
       parameters:
@@ -239,11 +239,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: getFilteredEntitiesByName(name)
     fullName: Outlook_1_1.Office.ItemRead.getFilteredEntitiesByName
@@ -288,11 +288,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: getRegExMatches()
     fullName: Outlook_1_1.Office.ItemRead.getRegExMatches
@@ -328,11 +328,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: getRegExMatchesByName(name)
     fullName: Outlook_1_1.Office.ItemRead.getRegExMatchesByName
@@ -361,11 +361,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
 
 
@@ -403,16 +403,17 @@ items:
       Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The
       itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making
       REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more
-      details, see Use the Outlook REST APIs from an Outlook add-in.
+      details, see [ Use the Outlook REST APIs from an Outlook
+      add-in](https://docs.microsoft.com/outlook/add-ins/use-rest-api#get-the-item-id)<!-- -->.
 
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: itemId
     fullName: Outlook_1_1.Office.ItemRead.itemId
@@ -435,11 +436,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: normalizedSubject
     fullName: Outlook_1_1.Office.ItemRead.normalizedSubject
@@ -465,12 +466,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: subject
     fullName: Outlook_1_1.Office.ItemRead.subject
     langs:

--- a/docs/docs-ref-autogen/outlook_1_1/office.localclienttime.yml
+++ b/docs/docs-ref-autogen/outlook_1_1/office.localclienttime.yml
@@ -6,11 +6,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: Office.LocalClientTime
     fullName: Outlook_1_1.Office.LocalClientTime

--- a/docs/docs-ref-autogen/outlook_1_1/office.location.yml
+++ b/docs/docs-ref-autogen/outlook_1_1/office.location.yml
@@ -6,11 +6,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
     name: Office.Location
     fullName: Outlook_1_1.Office.Location
@@ -29,25 +29,25 @@ items:
       The getAsync method starts an asynchronous call to the Exchange server to get the location of an appointment. The
       location of the appointment is provided as a string in the asyncResult.value property.
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
 
 
       In addition to this signature, the method also has the following signature:
 
 
-      `getAsync(callback: (result: AsyncResult) => void): void;`
+      `getAsync(callback: (result: AsyncResult<string>) => void): void;`
     name: 'getAsync(options, callback)'
     fullName: Outlook_1_1.Office.Location.getAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'getAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;'
+      content: 'getAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;'
       return:
         type:
           - void
@@ -62,9 +62,12 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. \[Api set: Mailbox 1.1\]
+            parameter of type Office.AsyncResult.
+
+
+            \[Api set: Mailbox 1.1\]
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<string>) => void'
   - uid: Outlook_1_1.Office.Location.setAsync
     summary: >-
       Sets the location of an appointment.
@@ -73,11 +76,11 @@ items:
       The setAsync method starts an asynchronous call to the Exchange server to set the location of an appointment.
       Setting the location of an appointment overwrites the current location.
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -94,7 +97,7 @@ items:
       `setAsync(location: string, options: Office.AsyncContextOptions): void;`
 
 
-      `setAsync(location: string, callback: (result: AsyncResult) => void): void;`
+      `setAsync(location: string, callback: (result: AsyncResult<void>) => void): void;`
     name: 'setAsync(location, options, callback)'
     fullName: Outlook_1_1.Office.Location.setAsync
     langs:
@@ -102,8 +105,8 @@ items:
     type: method
     syntax:
       content: >-
-        setAsync(location: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void):
-        void;
+        setAsync(location: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) =>
+        void): void;
       return:
         type:
           - void
@@ -122,7 +125,10 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. If setting the location fails, the asyncResult.error property will contain an
-            error code. \[Api set: Mailbox 1.1\]
+            parameter of type Office.AsyncResult. If setting the location fails, the asyncResult.error property will
+            contain an error code.
+
+
+            \[Api set: Mailbox 1.1\]
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'

--- a/docs/docs-ref-autogen/outlook_1_1/office.mailbox.yml
+++ b/docs/docs-ref-autogen/outlook_1_1/office.mailbox.yml
@@ -2,7 +2,7 @@
 items:
   - uid: Outlook_1_1.Office.Mailbox
     summary: |-
-      Provides access to the Outlook add-in object model for Microsoft Outlook and Microsoft Outlook on the web.
+      Provides access to the Outlook Add-in object model for Microsoft Outlook and Microsoft Outlook on the web.
 
       Namespaces:
 
@@ -14,12 +14,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.Mailbox
     fullName: Outlook_1_1.Office.Mailbox
     langs:
@@ -57,12 +57,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: convertToLocalClientTime(timeValue)
     fullName: Outlook_1_1.Office.Mailbox.convertToLocalClientTime
     langs:
@@ -90,12 +90,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: convertToUtcClientTime(input)
     fullName: Outlook_1_1.Office.Mailbox.convertToUtcClientTime
     langs:
@@ -130,11 +130,11 @@ items:
       Exchange Server. An example is the string 15.0.468.0.
 
 
-      - OWAView (string): A string that represents the current view of Outlook Web App. If the host application is not
-      Outlook Web App, then accessing this property results in undefined. Outlook Web App has three views (OneColumn -
-      displayed when the screen is narrow, TwoColumns - displayed when the screen is wider, and ThreeColumns - displayed
-      when the screen is wide.) that correspond to the width of the screen and the window, and the number of columns
-      that can be displayed.
+      - OWAView (MailboxEnums.OWAView or string): An enum (or string literal) that represents the current view of
+      Outlook Web App. If the host application is not Outlook Web App, then accessing this property results in
+      undefined. Outlook Web App has three views (OneColumn - displayed when the screen is narrow, TwoColumns -
+      displayed when the screen is wider, and ThreeColumns - displayed when the screen is wide) that correspond to the
+      width of the screen and the window, and the number of columns that can be displayed.
 
 
       More information is under [Office.Diagnostics](xref:Outlook_1_1.Office.Diagnostics)<!-- -->.
@@ -142,12 +142,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: diagnostics
     fullName: Outlook_1_1.Office.Mailbox.diagnostics
     langs:
@@ -186,12 +186,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: displayAppointmentForm(itemId)
     fullName: Outlook_1_1.Office.Mailbox.displayAppointmentForm
     langs:
@@ -235,12 +235,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: displayMessageForm(itemId)
     fullName: Outlook_1_1.Office.Mailbox.displayMessageForm
     langs:
@@ -286,11 +286,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: displayNewAppointmentForm(parameters)
     fullName: Outlook_1_1.Office.Mailbox.displayNewAppointmentForm
@@ -322,16 +322,16 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
 
 
       The ewsUrl value can be used by a remote service to make EWS calls to the user's mailbox. For example, you can
-      create a remote service to [get attachments from the selected
+      create a remote service to [ get attachments from the selected
       item](https://docs.microsoft.com/outlook/add-ins/get-attachments-of-an-outlook-item)<!-- -->.
 
 
@@ -354,23 +354,23 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
       and read</td></tr></table>
 
 
-      The getUserIdentityTokenAsync method returns a token that you can use to identify and [authenticate the add-in and
-      user with a third-party system](https://docs.microsoft.com/outlook/add-ins/authentication)<!-- -->.
+      The getUserIdentityTokenAsync method returns a token that you can use to identify and [ authenticate the add-in
+      and user with a third-party system](https://docs.microsoft.com/outlook/add-ins/authentication)<!-- -->.
     name: 'getUserIdentityTokenAsync(callback, userContext)'
     fullName: Outlook_1_1.Office.Mailbox.getUserIdentityTokenAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'getUserIdentityTokenAsync(callback: (result: AsyncResult) => void, userContext?: any): void;'
+      content: 'getUserIdentityTokenAsync(callback: (result: AsyncResult<string>) => void, userContext?: any): void;'
       return:
         type:
           - void
@@ -379,9 +379,9 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult.
+            of type Office.AsyncResult. The token is provided as a string in the asyncResult.value property.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<string>) => void'
         - id: userContext
           description: Optional. Any state data that is passed to the asynchronous method.\|
           type:
@@ -390,7 +390,8 @@ items:
     summary: >-
       The mailbox item. Depending on the context in which the add-in opened, the item may be of any number of types. If
       you want to see IntelliSense for only a specific type, you should cast this item to one of the following:
-      `ItemCompose`, `ItemRead`, `MessageCompose`, `MessageRead`, `AppointmentCompose`, `AppointmentRead`
+      `ItemCompose`<!-- -->, `ItemRead`<!-- -->, `MessageCompose`<!-- -->, `MessageRead`<!-- -->,
+      `AppointmentCompose`<!-- -->, `AppointmentRead`
     name: item
     fullName: Outlook_1_1.Office.Mailbox.item
     langs:
@@ -421,15 +422,21 @@ items:
 
       Your add-in must have the ReadWriteMailbox permission to use the makeEwsRequestAsync method. For information about
       using the ReadWriteMailbox permission and the EWS operations that you can call with the makeEwsRequestAsync
-      method, see Specify permissions for mail add-in access to the user's mailbox.
+      method, see [ Specify permissions for mail add-in access to the user's
+      mailbox](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)<!-- -->.
 
 
       The XML result of the EWS call is provided as a string in the asyncResult.value property. If the result exceeds 1
       MB in size, an error message is returned instead.
 
 
-      Note: This method is not supported in the following scenarios. - In Outlook for iOS or Outlook for Android - When
-      the add-in is loaded in a Gmail mailbox
+      Note: This method is not supported in the following scenarios:
+
+
+      - In Outlook for iOS or Outlook for Android.
+
+
+      - When the add-in is loaded in a Gmail mailbox.
 
 
       Note: The server administrator must set OAuthAuthentication to true on the Client Access Server EWS directory to
@@ -443,7 +450,7 @@ items:
       15.0.4535.1004, you should set the encoding value to ISO-8859-1.
 
 
-      `&lt;?xml version="1.0" encoding="iso-8859-1"?&gt;`
+      `<?xml version="1.0" encoding="iso-8859-1"?>`
 
 
       You do not need to set the encoding value when your mail app is running in Outlook on the web. You can determine
@@ -454,11 +461,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteMailbox</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
       and read</td></tr></table>
     name: 'makeEwsRequestAsync(data, callback, userContext)'
     fullName: Outlook_1_1.Office.Mailbox.makeEwsRequestAsync
@@ -466,7 +473,7 @@ items:
       - typeScript
     type: method
     syntax:
-      content: 'makeEwsRequestAsync(data: any, callback: (result: AsyncResult) => void, userContext?: any): void;'
+      content: 'makeEwsRequestAsync(data: any, callback: (result: AsyncResult<string>) => void, userContext?: any): void;'
       return:
         type:
           - void
@@ -479,9 +486,10 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult.
+            of type Office.AsyncResult. The `value` property of the result is the XML of the EWS request provided as a
+            string. If the result exceeds 1 MB in size, an error message is returned instead.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<string>) => void'
         - id: userContext
           description: Optional. Any state data that is passed to the asynchronous method.
           type:
@@ -489,7 +497,7 @@ items:
   - uid: Outlook_1_1.Office.Mailbox.userProfile
     summary: >-
       Information about the user associated with the mailbox. This includes their account type, display name, email
-      adddress, and time zone.
+      address, and time zone.
 
 
       More information is under [Office.UserProfile](xref:Outlook_1_1.Office.UserProfile)

--- a/docs/docs-ref-autogen/outlook_1_1/office.mailboxenums.attachmenttype.yml
+++ b/docs/docs-ref-autogen/outlook_1_1/office.mailboxenums.attachmenttype.yml
@@ -6,7 +6,7 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td> [Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
+      <table><tr><td> [ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
       </td><td>Compose or read</td></tr></table>
     name: Office.MailboxEnums.AttachmentType
     fullName: Outlook_1_1.Office.MailboxEnums.AttachmentType

--- a/docs/docs-ref-autogen/outlook_1_1/office.mailboxenums.entitytype.yml
+++ b/docs/docs-ref-autogen/outlook_1_1/office.mailboxenums.entitytype.yml
@@ -6,7 +6,7 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td> [Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
+      <table><tr><td> [ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
       </td><td>Compose or read</td></tr></table>
     name: Office.MailboxEnums.EntityType
     fullName: Outlook_1_1.Office.MailboxEnums.EntityType

--- a/docs/docs-ref-autogen/outlook_1_1/office.mailboxenums.itemtype.yml
+++ b/docs/docs-ref-autogen/outlook_1_1/office.mailboxenums.itemtype.yml
@@ -6,7 +6,7 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td> [Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
+      <table><tr><td> [ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
       </td><td>Compose or read</td></tr></table>
     name: Office.MailboxEnums.ItemType
     fullName: Outlook_1_1.Office.MailboxEnums.ItemType

--- a/docs/docs-ref-autogen/outlook_1_1/office.mailboxenums.owaview.yml
+++ b/docs/docs-ref-autogen/outlook_1_1/office.mailboxenums.owaview.yml
@@ -1,0 +1,42 @@
+### YamlMime:UniversalReference
+items:
+  - uid: Outlook_1_1.Office.MailboxEnums.OWAView
+    summary: Represents the current view of Outlook Web App.
+    name: Office.MailboxEnums.OWAView
+    fullName: Outlook_1_1.Office.MailboxEnums.OWAView
+    langs:
+      - typeScript
+    type: enum
+    package: Outlook_1_1
+    children:
+      - Outlook_1_1.Office.MailboxEnums.OWAView.OneColumn
+      - Outlook_1_1.Office.MailboxEnums.OWAView.ThreeColumns
+      - Outlook_1_1.Office.MailboxEnums.OWAView.TwoColumns
+  - uid: Outlook_1_1.Office.MailboxEnums.OWAView.OneColumn
+    summary: >-
+      One column view. Displayed when the screen is narrow. Outlook Web App uses this single-column layout on the entire
+      screen of a smartphone.
+    name: OneColumn
+    fullName: Outlook_1_1.Office.MailboxEnums.OWAView.OneColumn
+    langs:
+      - typeScript
+    type: field
+    numericValue: '"OneColumn"'
+  - uid: Outlook_1_1.Office.MailboxEnums.OWAView.ThreeColumns
+    summary: >-
+      Three column view. Displayed when the screen is wide. For example, Outlook Web App uses this view in a full screen
+      window on a desktop computer.
+    name: ThreeColumns
+    fullName: Outlook_1_1.Office.MailboxEnums.OWAView.ThreeColumns
+    langs:
+      - typeScript
+    type: field
+    numericValue: '"ThreeColumns"'
+  - uid: Outlook_1_1.Office.MailboxEnums.OWAView.TwoColumns
+    summary: Two column view. Displayed when the screen is wider. Outlook Web App uses this view on most tablets.
+    name: TwoColumns
+    fullName: Outlook_1_1.Office.MailboxEnums.OWAView.TwoColumns
+    langs:
+      - typeScript
+    type: field
+    numericValue: '"TwoColumns"'

--- a/docs/docs-ref-autogen/outlook_1_1/office.mailboxenums.recipienttype.yml
+++ b/docs/docs-ref-autogen/outlook_1_1/office.mailboxenums.recipienttype.yml
@@ -6,7 +6,7 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td> [Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
+      <table><tr><td> [ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
       </td><td>Compose or read</td></tr></table>
     name: Office.MailboxEnums.RecipientType
     fullName: Outlook_1_1.Office.MailboxEnums.RecipientType

--- a/docs/docs-ref-autogen/outlook_1_1/office.mailboxenums.responsetype.yml
+++ b/docs/docs-ref-autogen/outlook_1_1/office.mailboxenums.responsetype.yml
@@ -6,7 +6,7 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td> [Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
+      <table><tr><td> [ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
       </td><td>Compose or read</td></tr></table>
     name: Office.MailboxEnums.ResponseType
     fullName: Outlook_1_1.Office.MailboxEnums.ResponseType

--- a/docs/docs-ref-autogen/outlook_1_1/office.meetingsuggestion.yml
+++ b/docs/docs-ref-autogen/outlook_1_1/office.meetingsuggestion.yml
@@ -15,11 +15,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: Office.MeetingSuggestion
     fullName: Outlook_1_1.Office.MeetingSuggestion

--- a/docs/docs-ref-autogen/outlook_1_1/office.message.yml
+++ b/docs/docs-ref-autogen/outlook_1_1/office.message.yml
@@ -6,7 +6,7 @@ items:
 
 
       Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat
-      this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
+      this as a mode of `Office.context.mailbox.item`<!-- -->. Refer to the Object Model pages for more information.
     name: Office.Message
     fullName: Outlook_1_1.Office.Message
     langs:
@@ -33,12 +33,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: conversationId
     fullName: Outlook_1_1.Office.Message.conversationId
     langs:

--- a/docs/docs-ref-autogen/outlook_1_1/office.messagecompose.yml
+++ b/docs/docs-ref-autogen/outlook_1_1/office.messagecompose.yml
@@ -2,11 +2,11 @@
 items:
   - uid: Outlook_1_1.Office.MessageCompose
     summary: >-
-      The message compose mode of [Office.context.mailbox.item](xref:Outlook_1_1.Office.Item)<!-- -->.
+      The message compose mode of [ Office.context.mailbox.item](xref:Outlook_1_1.Office.Item)<!-- -->.
 
 
       Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat
-      this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
+      this as a mode of `Office.context.mailbox.item`<!-- -->. Refer to the Object Model pages for more information.
     name: Office.MessageCompose
     fullName: Outlook_1_1.Office.MessageCompose
     langs:
@@ -44,11 +44,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr>
 
 
@@ -67,7 +67,8 @@ items:
       `addFileAttachmentAsync(uri: string, attachmentName: string, options: AsyncContextOptions): void;`
 
 
-      `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+      `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void):
+      void;`
     name: 'addFileAttachmentAsync(uri, attachmentName, options, callback)'
     fullName: Outlook_1_1.Office.MessageCompose.addFileAttachmentAsync
     langs:
@@ -76,7 +77,7 @@ items:
     syntax:
       content: >-
         addFileAttachmentAsync(uri: string, attachmentName: string, options?: AsyncContextOptions, callback?: (result:
-        AsyncResult) => void): void;
+        AsyncResult<string>) => void): void;
       return:
         type:
           - void
@@ -104,11 +105,11 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type asyncResult. On success, the attachment identifier will be provided in the asyncResult.value
+            of type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value
             property. If uploading the attachment fails, the asyncResult object will contain an Error object that
             provides a description of the error.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<string>) => void'
   - uid: Outlook_1_1.Office.MessageCompose.addItemAttachmentAsync
     summary: >-
       Adds an Exchange item, such as a message, as an attachment to the message or appointment.
@@ -124,17 +125,17 @@ items:
       session.
 
 
-      If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items
+      If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items
       other than the item that you are editing; however, this is not supported and is not recommended.
 
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr>
 
 
@@ -142,7 +143,7 @@ items:
       attachments.</td></tr></table>
 
 
-      In addition to the main signature, this method also has these signatures:
+      In addition to this signature, this method also has the following signatures:
 
 
       `addItemAttachmentAsync(itemId: any, attachmentName: string): void;`
@@ -151,7 +152,8 @@ items:
       `addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;`
 
 
-      `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+      `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void):
+      void;`
     name: 'addItemAttachmentAsync(itemId, attachmentName, options, callback)'
     fullName: Outlook_1_1.Office.MessageCompose.addItemAttachmentAsync
     langs:
@@ -160,7 +162,7 @@ items:
     syntax:
       content: >-
         addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?:
-        (result: AsyncResult) => void): void;
+        (result: AsyncResult<string>) => void): void;
       return:
         type:
           - void
@@ -189,7 +191,7 @@ items:
             property. If adding the attachment fails, the asyncResult object will contain an Error object that provides
             a description of the error.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<string>) => void'
   - uid: Outlook_1_1.Office.MessageCompose.bcc
     summary: >-
       Gets an object that provides methods to get or update the recipients on the Bcc (blind carbon copy) line of a
@@ -198,11 +200,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: bcc
     fullName: Outlook_1_1.Office.MessageCompose.bcc
@@ -220,11 +222,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: body
     fullName: Outlook_1_1.Office.MessageCompose.body
@@ -248,11 +250,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: cc
     fullName: Outlook_1_1.Office.MessageCompose.cc
@@ -280,11 +282,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: conversationId
     fullName: Outlook_1_1.Office.MessageCompose.conversationId
@@ -302,11 +304,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: dateTimeCreated
     fullName: Outlook_1_1.Office.MessageCompose.dateTimeCreated
@@ -324,11 +326,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
 
 
@@ -354,11 +356,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: itemType
     fullName: Outlook_1_1.Office.MessageCompose.itemType
@@ -388,11 +390,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: 'loadCustomPropertiesAsync(callback, userContext)'
     fullName: Outlook_1_1.Office.MessageCompose.loadCustomPropertiesAsync
@@ -400,7 +402,9 @@ items:
       - typeScript
     type: method
     syntax:
-      content: 'loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;'
+      content: >-
+        loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any):
+        void;
       return:
         type:
           - void
@@ -409,9 +413,9 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult.
+            of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<Office.CustomProperties>) => void'
         - id: userContext
           description: >-
             Optional. Developers can provide any object they wish to access in the callback function. This object can be
@@ -426,17 +430,17 @@ items:
       The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best
       practice, you should use the attachment identifier to remove an attachment only if the same mail app has added
       that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid
-      only within the same session. A session is over when the user closes the app, or if the user starts composing in
-      an inline form and subsequently pops out the inline form to continue in a separate window.
+      only within the same session. A session is over when the user closes the app, or if the user starts composing an
+      inline form then subsequently pops out the form to continue in a separate window.
 
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr>
 
 
@@ -452,7 +456,7 @@ items:
       `removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;`
 
 
-      `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;`
+      `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;`
     name: 'removeAttachmentAsync(attachmentIndex, options, callback)'
     fullName: Outlook_1_1.Office.MessageCompose.removeAttachmentAsync
     langs:
@@ -461,7 +465,7 @@ items:
     syntax:
       content: >-
         removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result:
-        AsyncResult) => void): void;
+        AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -480,10 +484,10 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain
-            an error code with the reason for the failure.
+            parameter of type Office.AsyncResult. If removing the attachment fails, the asyncResult.error property will
+            contain an error code with the reason for the failure.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_1.Office.MessageCompose.subject
     summary: |-
       Gets or sets the description that appears in the subject field of an item.
@@ -494,11 +498,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: subject
     fullName: Outlook_1_1.Office.MessageCompose.subject
@@ -522,11 +526,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: to
     fullName: Outlook_1_1.Office.MessageCompose.to

--- a/docs/docs-ref-autogen/outlook_1_1/office.messageread.yml
+++ b/docs/docs-ref-autogen/outlook_1_1/office.messageread.yml
@@ -2,7 +2,7 @@
 items:
   - uid: Outlook_1_1.Office.MessageRead
     summary: >-
-      The message read mode of [Office.context.mailbox.item](xref:Outlook_1_1.Office.Item)<!-- -->.
+      The message read mode of [ Office.context.mailbox.item](xref:Outlook_1_1.Office.Item)<!-- -->.
 
 
       Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat
@@ -41,20 +41,20 @@ items:
       - Outlook_1_1.Office.MessageRead.to
   - uid: Outlook_1_1.Office.MessageRead.attachments
     summary: |-
-      Gets an array of attachments for the item.
+      Gets the item's attachments as an array.
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
 
 
       Note: Certain types of files are blocked by Outlook due to potential security issues and are therefore not
-      returned. For more information, see [Blocked attachments in
+      returned. For more information, see [ Blocked attachments in
       Outlook](https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519)<!--
       -->.
     name: attachments
@@ -73,11 +73,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: body
     fullName: Outlook_1_1.Office.MessageRead.body
@@ -101,11 +101,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: cc
     fullName: Outlook_1_1.Office.MessageRead.cc
@@ -133,11 +133,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: conversationId
     fullName: Outlook_1_1.Office.MessageRead.conversationId
@@ -155,11 +155,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: dateTimeCreated
     fullName: Outlook_1_1.Office.MessageRead.dateTimeCreated
@@ -177,11 +177,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
 
 
@@ -219,11 +219,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: displayReplyAllForm(formData)
     fullName: Outlook_1_1.Office.MessageRead.displayReplyAllForm
@@ -240,7 +240,7 @@ items:
         - id: formData
           description: >-
             A string that contains text and HTML and that represents the body of the reply form. The string is limited
-            to 32 KB OR An[Office.ReplyFormData](xref:Outlook_1_1.Office.ReplyFormData) object that contains body or
+            to 32 KB OR An [Office.ReplyFormData](xref:Outlook_1_1.Office.ReplyFormData) object that contains body or
             attachment data and a callback function
           type:
             - string | ReplyFormData
@@ -267,11 +267,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: displayReplyForm(formData)
     fullName: Outlook_1_1.Office.MessageRead.displayReplyForm
@@ -288,7 +288,7 @@ items:
         - id: formData
           description: >-
             A string that contains text and HTML and that represents the body of the reply form. The string is limited
-            to 32 KB. OR An[Office.ReplyFormData](xref:Outlook_1_1.Office.ReplyFormData) object that contains body or
+            to 32 KB. OR An [Office.ReplyFormData](xref:Outlook_1_1.Office.ReplyFormData) object that contains body or
             attachment data and a callback function.
           type:
             - string | ReplyFormData
@@ -309,11 +309,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: from
     fullName: Outlook_1_1.Office.MessageRead.from
@@ -327,17 +327,17 @@ items:
           - EmailAddressDetails
   - uid: Outlook_1_1.Office.MessageRead.getEntities
     summary: |-
-      Gets the entities found in the selected item.
+      Gets the entities found in the selected item's body.
 
       Note: This method is not supported in Outlook for iOS or Outlook for Android.
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: getEntities()
     fullName: Outlook_1_1.Office.MessageRead.getEntities
@@ -352,17 +352,17 @@ items:
         description: ''
   - uid: Outlook_1_1.Office.MessageRead.getEntitiesByType
     summary: |-
-      Gets an array of all the entities of the specified entity type found in the selected item.
+      Gets an array of all the entities of the specified entity type found in the selected item's body.
 
       Note: This method is not supported in Outlook for iOS or Outlook for Android.
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
 
 
@@ -390,7 +390,7 @@ items:
           - '(string | Contact | MeetingSuggestion | PhoneNumber | TaskSuggestion)[]'
         description: >-
           If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns
-          null. If no entities of the specified type are present on the item, the method returns an empty array.
+          null. If no entities of the specified type are present in the item's body, the method returns an empty array.
           Otherwise, the type of the objects in the returned array depends on the type of entity requested in the
           entityType parameter.
       parameters:
@@ -412,11 +412,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: getFilteredEntitiesByName(name)
     fullName: Outlook_1_1.Office.MessageRead.getFilteredEntitiesByName
@@ -461,11 +461,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: getRegExMatches()
     fullName: Outlook_1_1.Office.MessageRead.getRegExMatches
@@ -501,11 +501,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: getRegExMatchesByName(name)
     fullName: Outlook_1_1.Office.MessageRead.getRegExMatchesByName
@@ -529,11 +529,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: internetMessageId
     fullName: Outlook_1_1.Office.MessageRead.internetMessageId
@@ -556,11 +556,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
 
 
@@ -598,16 +598,17 @@ items:
       Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The
       itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making
       REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more
-      details, see Use the Outlook REST APIs from an Outlook add-in.
+      details, see [ Use the Outlook REST APIs from an Outlook
+      add-in](https://docs.microsoft.com/outlook/add-ins/use-rest-api#get-the-item-id)<!-- -->.
 
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: itemId
     fullName: Outlook_1_1.Office.MessageRead.itemId
@@ -630,11 +631,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: itemType
     fullName: Outlook_1_1.Office.MessageRead.itemType
@@ -664,11 +665,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: 'loadCustomPropertiesAsync(callback, userContext)'
     fullName: Outlook_1_1.Office.MessageRead.loadCustomPropertiesAsync
@@ -676,7 +677,9 @@ items:
       - typeScript
     type: method
     syntax:
-      content: 'loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;'
+      content: >-
+        loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any):
+        void;
       return:
         type:
           - void
@@ -685,9 +688,9 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult.
+            of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<Office.CustomProperties>) => void'
         - id: userContext
           description: >-
             Optional. Developers can provide any object they wish to access in the callback function. This object can be
@@ -705,11 +708,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: normalizedSubject
     fullName: Outlook_1_1.Office.MessageRead.normalizedSubject
@@ -735,11 +738,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: sender
     fullName: Outlook_1_1.Office.MessageRead.sender
@@ -765,11 +768,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: subject
     fullName: Outlook_1_1.Office.MessageRead.subject
@@ -793,11 +796,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: to
     fullName: Outlook_1_1.Office.MessageRead.to

--- a/docs/docs-ref-autogen/outlook_1_1/office.phonenumber.yml
+++ b/docs/docs-ref-autogen/outlook_1_1/office.phonenumber.yml
@@ -12,11 +12,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: Office.PhoneNumber
     fullName: Outlook_1_1.Office.PhoneNumber

--- a/docs/docs-ref-autogen/outlook_1_1/office.recipients.yml
+++ b/docs/docs-ref-autogen/outlook_1_1/office.recipients.yml
@@ -3,11 +3,11 @@ items:
   - uid: Outlook_1_1.Office.Recipients
     summary: '\[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]'
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
     name: Office.Recipients
     fullName: Outlook_1_1.Office.Recipients
@@ -33,11 +33,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -45,7 +45,7 @@ items:
       entries.</td></tr></table>
 
 
-      In addition to the main signature, this method also has these signatures:
+      In addition to this signature, this method also has the following signatures:
 
 
       `addAsync(recipients: (string | EmailUser | EmailAddressDetails)[]): void;`
@@ -54,8 +54,8 @@ items:
       `addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options: Office.AsyncContextOptions): void;`
 
 
-      `addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult) => void):
-      void;`
+      `addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult<void>) =>
+      void): void;`
     name: 'addAsync(recipients, options, callback)'
     fullName: Outlook_1_1.Office.Recipients.addAsync
     langs:
@@ -64,7 +64,7 @@ items:
     syntax:
       content: >-
         addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options?: Office.AsyncContextOptions,
-        callback?: (result: AsyncResult) => void): void;
+        callback?: (result: AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -83,40 +83,42 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. If adding the recipients fails, the asyncResult.error property will contain
-            an error code.
+            parameter of type Office.AsyncResult. If adding the recipients fails, the asyncResult.error property will
+            contain an error code.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_1.Office.Recipients.getAsync
     summary: >-
       Gets a recipient list for an appointment or message.
 
 
-      When the call completes, the asyncResult.value property will contain an array
-      of[Office.EmailAddressDetails](xref:Outlook_1_1.Office.EmailAddressDetails) objects.
+      When the call completes, the asyncResult.value property will contain an array of
+      [Office.EmailAddressDetails](xref:Outlook_1_1.Office.EmailAddressDetails) objects.
 
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
 
 
-      In addition to the main signature, this method also has this signature:
+      In addition to this signature, this method also has the following signature:
 
 
-      `getAsync(callback: (result: AsyncResult) => void): void;`
+      `getAsync(callback: (result: AsyncResult<Office.EmailAddressDetails[]>) => void): void;`
     name: 'getAsync(options, callback)'
     fullName: Outlook_1_1.Office.Recipients.getAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;'
+      content: >-
+        getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult<Office.EmailAddressDetails[]>) =>
+        void): void;
       return:
         type:
           - void
@@ -131,9 +133,9 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult.
+            of type Office.AsyncResult. The `value` property of the result is an array of EmailAddressDetails objects.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<Office.EmailAddressDetails[]>) => void'
   - uid: Outlook_1_1.Office.Recipients.setAsync
     summary: |-
       Sets a recipient list for an appointment or message.
@@ -150,11 +152,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -162,7 +164,7 @@ items:
       entries.</td></tr></table>
 
 
-      In addition to the main signature, this method also has these signatures:
+      In addition to this signature, this method also has the following signatures:
 
 
       `setAsync(recipients: (string | EmailUser | EmailAddressDetails)[]): void;`
@@ -171,8 +173,8 @@ items:
       `setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options: Office.AsyncContextOptions): void;`
 
 
-      `setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult) => void):
-      void;`
+      `setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult<void>) =>
+      void): void;`
     name: 'setAsync(recipients, options, callback)'
     fullName: Outlook_1_1.Office.Recipients.setAsync
     langs:
@@ -181,7 +183,7 @@ items:
     syntax:
       content: >-
         setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options?: Office.AsyncContextOptions,
-        callback?: (result: AsyncResult) => void): void;
+        callback?: (result: AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -200,7 +202,7 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. If setting the recipients fails the asyncResult.error property will contain a
-            code that indicates any error that occurred while adding the data.
+            parameter of type Office.AsyncResult. If setting the recipients fails the asyncResult.error property will
+            contain a code that indicates any error that occurred while adding the data.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'

--- a/docs/docs-ref-autogen/outlook_1_1/office.replyformdata.yml
+++ b/docs/docs-ref-autogen/outlook_1_1/office.replyformdata.yml
@@ -31,17 +31,17 @@ items:
   - uid: Outlook_1_1.Office.ReplyFormData.callback
     summary: >-
       When the reply display call completes, the function passed in the callback parameter is called with a single
-      parameter, asyncResult, which is an AsyncResult object.
+      parameter, asyncResult, which is an Office.AsyncResult object.
     name: callback
     fullName: Outlook_1_1.Office.ReplyFormData.callback
     langs:
       - typeScript
     type: property
     syntax:
-      content: 'callback?: (result: AsyncResult) => void;'
+      content: 'callback?: (result: AsyncResult<any>) => void;'
       return:
         type:
-          - '(result: AsyncResult) => void'
+          - '(result: AsyncResult<any>) => void'
   - uid: Outlook_1_1.Office.ReplyFormData.htmlBody
     summary: >-
       A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32

--- a/docs/docs-ref-autogen/outlook_1_1/office.roamingsettings.yml
+++ b/docs/docs-ref-autogen/outlook_1_1/office.roamingsettings.yml
@@ -7,7 +7,7 @@ items:
       saved.
 
 
-      While the Outlook add-in API limits access to these settings to only the add-in that created them, these settings
+      While the Outlook Add-in API limits access to these settings to only the add-in that created them, these settings
       should not be considered secure storage. They can be accessed by Exchange Web Services or Extended MAPI. They
       should not be used to store sensitive information such as user credentials or security tokens.
 
@@ -27,12 +27,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.RoamingSettings
     fullName: Outlook_1_1.Office.RoamingSettings
     langs:
@@ -50,12 +50,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: get(name)
     fullName: Outlook_1_1.Office.RoamingSettings.get
     langs:
@@ -78,12 +78,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: remove(name)
     fullName: Outlook_1_1.Office.RoamingSettings.remove
     langs:
@@ -113,19 +113,19 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: saveAsync(callback)
     fullName: Outlook_1_1.Office.RoamingSettings.saveAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'saveAsync(callback?: (result: AsyncResult) => void): void;'
+      content: 'saveAsync(callback?: (result: AsyncResult<void>) => void): void;'
       return:
         type:
           - void
@@ -133,10 +133,10 @@ items:
       parameters:
         - id: callback
           description: >-
-            Optional? When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult.
+            Optional. When the method completes, the function passed in the callback parameter is called with a single
+            parameter of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_1.Office.RoamingSettings.set
     summary: >-
       Sets or creates the specified setting.
@@ -156,12 +156,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: 'set(name, value)'
     fullName: Outlook_1_1.Office.RoamingSettings.set
     langs:

--- a/docs/docs-ref-autogen/outlook_1_1/office.subject.yml
+++ b/docs/docs-ref-autogen/outlook_1_1/office.subject.yml
@@ -6,11 +6,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
     name: Office.Subject
     fullName: Outlook_1_1.Office.Subject
@@ -32,25 +32,25 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
 
 
-      In addition to the main signature, this method also has this signature:
+      In addition to this signature, this method also has the following signature:
 
 
-      `getAsync(callback: (result: AsyncResult) => void): void;`
+      `getAsync(callback: (result: AsyncResult<string>) => void): void;`
     name: 'getAsync(options, callback)'
     fullName: Outlook_1_1.Office.Subject.getAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;'
+      content: 'getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult<string>) => void): void;'
       return:
         type:
           - void
@@ -65,9 +65,9 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult.
+            of type Office.AsyncResult. The `value` property of the result is the subject of the item.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<string>) => void'
   - uid: Outlook_1_1.Office.Subject.setAsync
     summary: >-
       Sets the subject of an appointment or message.
@@ -80,11 +80,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -92,7 +92,7 @@ items:
       characters.</td></tr></table>
 
 
-      In addition to the main signature, this method also has these signatures:
+      In addition to this signature, this method also has the following signatures:
 
 
       `setAsync(subject: string): void;`
@@ -101,14 +101,16 @@ items:
       `setAsync(subject: string, options: Office.AsyncContextOptions): void;`
 
 
-      `setAsync(subject: string, callback: (result: AsyncResult) => void): void;`
+      `setAsync(subject: string, callback: (result: AsyncResult<void>) => void): void;`
     name: 'setAsync(subject, options, callback)'
     fullName: Outlook_1_1.Office.Subject.setAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'setAsync(subject: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;'
+      content: >-
+        setAsync(subject: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void):
+        void;
       return:
         type:
           - void
@@ -127,7 +129,7 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult. If setting the subject fails, the asyncResult.error property will contain an error
-            code.
+            of type Office.AsyncResult. If setting the subject fails, the asyncResult.error property will contain an
+            error code.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'

--- a/docs/docs-ref-autogen/outlook_1_1/office.tasksuggestion.yml
+++ b/docs/docs-ref-autogen/outlook_1_1/office.tasksuggestion.yml
@@ -5,18 +5,18 @@ items:
       Represents a suggested task identified in an item. Read mode only.
 
 
-      The list of tasks suggested in an email message is returned in the taskSuggestions property of the
-      \[Entities\]Entities object that is returned when the getEntities or getEntitiesByType method is called on the
-      active item.
+      The list of tasks suggested in an email message is returned in the taskSuggestions property of the [
+      Entities](xref:Outlook_1_1.Office.Entities) object that is returned when the getEntities or getEntitiesByType
+      method is called on the active item.
 
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: Office.TaskSuggestion
     fullName: Outlook_1_1.Office.TaskSuggestion

--- a/docs/docs-ref-autogen/outlook_1_1/office.time.yml
+++ b/docs/docs-ref-autogen/outlook_1_1/office.time.yml
@@ -6,11 +6,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
     name: Office.Time
     fullName: Outlook_1_1.Office.Time
@@ -33,25 +33,25 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
 
 
-      In addition to the main signature, this method also has this signature:
+      In addition to this signature, this method also has the following signature:
 
 
-      `getAsync(callback: (result: AsyncResult) => void): void;`
+      `getAsync(callback: (result: AsyncResult<Date>) => void): void;`
     name: 'getAsync(options, callback)'
     fullName: Outlook_1_1.Office.Time.getAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;'
+      content: 'getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult<Date>) => void): void;'
       return:
         type:
           - void
@@ -66,9 +66,9 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult.
+            of type AsyncResult. The `value` property of the result is a Date object.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<Date>) => void'
   - uid: Outlook_1_1.Office.Time.setAsync
     summary: >-
       Sets the start or end time of an appointment.
@@ -84,11 +84,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -96,7 +96,7 @@ items:
       time.</td></tr></table>
 
 
-      In addition to the main signature, this method also has these signatures:
+      In addition to this signature, this method also has the following signatures:
 
 
       `setAsync(dateTime: Date): void;`
@@ -105,14 +105,16 @@ items:
       `setAsync(dateTime: Date, options: Office.AsyncContextOptions): void;`
 
 
-      `setAsync(dateTime: Date, callback: (result: AsyncResult) => void): void;`
+      `setAsync(dateTime: Date, callback: (result: AsyncResult<void>) => void): void;`
     name: 'setAsync(dateTime, options, callback)'
     fullName: Outlook_1_1.Office.Time.setAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'setAsync(dateTime: Date, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;'
+      content: >-
+        setAsync(dateTime: Date, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void):
+        void;
       return:
         type:
           - void
@@ -131,7 +133,7 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult. If setting the date and time fails, the asyncResult.error property will contain an
-            error code.
+            of type Office.AsyncResult. If setting the date and time fails, the asyncResult.error property will contain
+            an error code.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'

--- a/docs/docs-ref-autogen/outlook_1_1/office.userprofile.yml
+++ b/docs/docs-ref-autogen/outlook_1_1/office.userprofile.yml
@@ -8,12 +8,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.UserProfile
     fullName: Outlook_1_1.Office.UserProfile
     langs:
@@ -30,12 +30,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: displayName
     fullName: Outlook_1_1.Office.UserProfile.displayName
     langs:
@@ -52,12 +52,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: emailAddress
     fullName: Outlook_1_1.Office.UserProfile.emailAddress
     langs:
@@ -74,12 +74,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: timeZone
     fullName: Outlook_1_1.Office.UserProfile.timeZone
     langs:

--- a/docs/docs-ref-autogen/outlook_1_2.yml
+++ b/docs/docs-ref-autogen/outlook_1_2.yml
@@ -29,6 +29,7 @@ items:
       - Outlook_1_2.Office.MailboxEnums.AttachmentType
       - Outlook_1_2.Office.MailboxEnums.EntityType
       - Outlook_1_2.Office.MailboxEnums.ItemType
+      - Outlook_1_2.Office.MailboxEnums.OWAView
       - Outlook_1_2.Office.MailboxEnums.RecipientType
       - Outlook_1_2.Office.MailboxEnums.ResponseType
       - Outlook_1_2.Office.MeetingSuggestion
@@ -90,6 +91,8 @@ references:
     name: Office.MailboxEnums.EntityType
   - uid: Outlook_1_2.Office.MailboxEnums.ItemType
     name: Office.MailboxEnums.ItemType
+  - uid: Outlook_1_2.Office.MailboxEnums.OWAView
+    name: Office.MailboxEnums.OWAView
   - uid: Outlook_1_2.Office.MailboxEnums.RecipientType
     name: Office.MailboxEnums.RecipientType
   - uid: Outlook_1_2.Office.MailboxEnums.ResponseType

--- a/docs/docs-ref-autogen/outlook_1_2/office.appointmentcompose.yml
+++ b/docs/docs-ref-autogen/outlook_1_2/office.appointmentcompose.yml
@@ -2,11 +2,11 @@
 items:
   - uid: Outlook_1_2.Office.AppointmentCompose
     summary: >-
-      The appointment organizer mode of [Office.context.mailbox.item](xref:Outlook_1_2.Office.Item)<!-- -->.
+      The appointment organizer mode of [ Office.context.mailbox.item](xref:Outlook_1_2.Office.Item)<!-- -->.
 
 
       Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat
-      this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
+      this as a mode of `Office.context.mailbox.item`<!-- -->. Refer to the Object Model pages for more information.
     name: Office.AppointmentCompose
     fullName: Outlook_1_2.Office.AppointmentCompose
     langs:
@@ -47,11 +47,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Organizer</td></tr>
 
 
@@ -70,7 +70,8 @@ items:
       `addFileAttachmentAsync(uri: string, attachmentName: string, options: Office.AsyncContextOptions): void;`
 
 
-      `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+      `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void):
+      void;`
     name: 'addFileAttachmentAsync(uri, attachmentName, options, callback)'
     fullName: Outlook_1_2.Office.AppointmentCompose.addFileAttachmentAsync
     langs:
@@ -79,7 +80,7 @@ items:
     syntax:
       content: >-
         addFileAttachmentAsync(uri: string, attachmentName: string, options?: Office.AsyncContextOptions, callback?:
-        (result: AsyncResult) => void): void;
+        (result: AsyncResult<string>) => void): void;
       return:
         type:
           - void
@@ -111,7 +112,7 @@ items:
             property. If uploading the attachment fails, the asyncResult object will contain an Error object that
             provides a description of the error.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<string>) => void'
   - uid: Outlook_1_2.Office.AppointmentCompose.addItemAttachmentAsync
     summary: >-
       Adds an Exchange item, such as a message, as an attachment to the message or appointment.
@@ -127,17 +128,17 @@ items:
       session.
 
 
-      If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items
+      If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items
       other than the item that you are editing; however, this is not supported and is not recommended.
 
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Organizer</td></tr>
 
 
@@ -145,7 +146,7 @@ items:
       attachments.</td></tr></table>
 
 
-      In addition to the main signature, this method also has these signatures:
+      In addition to this signature, this method also has the following signatures:
 
 
       `addItemAttachmentAsync(itemId: any, attachmentName: string): void;`
@@ -154,7 +155,8 @@ items:
       `addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;`
 
 
-      `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+      `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void):
+      void;`
     name: 'addItemAttachmentAsync(itemId, attachmentName, options, callback)'
     fullName: Outlook_1_2.Office.AppointmentCompose.addItemAttachmentAsync
     langs:
@@ -163,7 +165,7 @@ items:
     syntax:
       content: >-
         addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?:
-        (result: AsyncResult) => void): void;
+        (result: AsyncResult<string>) => void): void;
       return:
         type:
           - void
@@ -188,22 +190,22 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value
+            of type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value
             property. If adding the attachment fails, the asyncResult object will contain an Error object that provides
             a description of the error.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<string>) => void'
   - uid: Outlook_1_2.Office.AppointmentCompose.body
     summary: |-
       Gets an object that provides methods for manipulating the body of an item.
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: body
@@ -222,11 +224,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: dateTimeCreated
@@ -245,11 +247,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
 
@@ -281,11 +283,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: end
@@ -313,11 +315,11 @@ items:
 
       \[ [API set: Mailbox 1.2](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: 'getSelectedDataAsync(coerciontype, options, callback)'
@@ -328,7 +330,7 @@ items:
     syntax:
       content: >-
         getSelectedDataAsync(coerciontype: Office.CoercionType, options: Office.AsyncContextOptions, callback: (result:
-        AsyncResult) => void): void;
+        AsyncResult<any>) => void): void;
       return:
         type:
           - void
@@ -349,7 +351,7 @@ items:
             When the method completes, the function passed in the callback parameter is called with a single parameter
             of type AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<any>) => void'
   - uid: Outlook_1_2.Office.AppointmentCompose.itemType
     summary: >-
       Gets the type of item that an instance represents.
@@ -361,11 +363,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: itemType
@@ -396,11 +398,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: 'loadCustomPropertiesAsync(callback, userContext)'
@@ -409,7 +411,9 @@ items:
       - typeScript
     type: method
     syntax:
-      content: 'loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;'
+      content: >-
+        loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any):
+        void;
       return:
         type:
           - void
@@ -418,9 +422,9 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult.
+            of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<Office.CustomProperties>) => void'
         - id: userContext
           description: >-
             Optional. Developers can provide any object they wish to access in the callback function. This object can be
@@ -435,11 +439,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: location
@@ -462,11 +466,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: optionalAttendees
@@ -487,17 +491,17 @@ items:
       The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best
       practice, you should use the attachment identifier to remove an attachment only if the same mail app has added
       that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid
-      only within the same session. A session is over when the user closes the app, or if the user starts composing in
-      an inline form and subsequently pops out the inline form to continue in a separate window.
+      only within the same session. A session is over when the user closes the app, or if the user starts composing an
+      inline form then subsequently pops out the form to continue in a separate window.
 
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Organizer</td></tr>
 
 
@@ -513,7 +517,7 @@ items:
       `removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;`
 
 
-      `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;`
+      `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;`
     name: 'removeAttachmentAsync(attachmentIndex, options, callback)'
     fullName: Outlook_1_2.Office.AppointmentCompose.removeAttachmentAsync
     langs:
@@ -522,7 +526,7 @@ items:
     syntax:
       content: >-
         removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result:
-        AsyncResult) => void): void;
+        AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -541,10 +545,10 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain
-            an error code with the reason for the failure.
+            parameter of type Office.AsyncResult. If removing the attachment fails, the asyncResult.error property will
+            contain an error code with the reason for the failure.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_2.Office.AppointmentCompose.requiredAttendees
     summary: >-
       Provides access to the required attendees of an event. The type of object and level of access depends on the mode
@@ -555,11 +559,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: requiredAttendees
@@ -584,11 +588,11 @@ items:
 
       \[ [API set: Mailbox 1.2](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Organizer</td></tr>
 
 
@@ -601,10 +605,10 @@ items:
       `setSelectedDataAsync(data: string): void;`
 
 
-      `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions &amp; CoercionTypeOptions): void;`
+      `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`
 
 
-      `setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;`
+      `setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;`
     name: 'setSelectedDataAsync(data, options, callback)'
     fullName: Outlook_1_2.Office.AppointmentCompose.setSelectedDataAsync
     langs:
@@ -613,7 +617,7 @@ items:
     syntax:
       content: >-
         setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?:
-        (result: AsyncResult) => void): void;
+        (result: AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -639,10 +643,9 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain
-            an error code with the reason for the failure.
+            parameter of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_2.Office.AppointmentCompose.start
     summary: >-
       Gets or sets the date and time that the appointment is to begin.
@@ -659,11 +662,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: start
@@ -686,11 +689,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: subject

--- a/docs/docs-ref-autogen/outlook_1_2/office.appointmentform.yml
+++ b/docs/docs-ref-autogen/outlook_1_2/office.appointmentform.yml
@@ -6,12 +6,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.AppointmentForm
     fullName: Outlook_1_2.Office.AppointmentForm
     langs:
@@ -33,12 +33,12 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: body
     fullName: Outlook_1_2.Office.AppointmentForm.body
     langs:
@@ -76,12 +76,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: end
     fullName: Outlook_1_2.Office.AppointmentForm.end
     langs:
@@ -112,10 +112,10 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: location
     fullName: Outlook_1_2.Office.AppointmentForm.location
     langs:
@@ -148,12 +148,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: optionalAttendees
     fullName: Outlook_1_2.Office.AppointmentForm.optionalAttendees
     langs:
@@ -186,12 +186,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: requiredAttendees
     fullName: Outlook_1_2.Office.AppointmentForm.requiredAttendees
     langs:
@@ -240,12 +240,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: start
     fullName: Outlook_1_2.Office.AppointmentForm.start
     langs:
@@ -279,12 +279,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: subject
     fullName: Outlook_1_2.Office.AppointmentForm.subject
     langs:

--- a/docs/docs-ref-autogen/outlook_1_2/office.appointmentread.yml
+++ b/docs/docs-ref-autogen/outlook_1_2/office.appointmentread.yml
@@ -2,7 +2,7 @@
 items:
   - uid: Outlook_1_2.Office.AppointmentRead
     summary: >-
-      The appointment attendee mode of [Office.context.mailbox.item](xref:Outlook_1_2.Office.Item)<!-- -->.
+      The appointment attendee mode of [ Office.context.mailbox.item](xref:Outlook_1_2.Office.Item)<!-- -->.
 
 
       Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat
@@ -41,20 +41,20 @@ items:
       - Outlook_1_2.Office.AppointmentRead.subject
   - uid: Outlook_1_2.Office.AppointmentRead.attachments
     summary: |-
-      Gets an array of attachments for the item.
+      Gets the item's attachments as an array.
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
 
 
       Note: Certain types of files are blocked by Outlook due to potential security issues and are therefore not
-      returned. For more information, see [Blocked attachments in
+      returned. For more information, see [ Blocked attachments in
       Outlook](https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519)<!--
       -->.
     name: attachments
@@ -73,11 +73,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: body
     fullName: Outlook_1_2.Office.AppointmentRead.body
@@ -95,11 +95,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: dateTimeCreated
     fullName: Outlook_1_2.Office.AppointmentRead.dateTimeCreated
@@ -117,11 +117,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
 
 
@@ -159,11 +159,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: displayReplyAllForm(formData)
     fullName: Outlook_1_2.Office.AppointmentRead.displayReplyAllForm
@@ -180,7 +180,7 @@ items:
         - id: formData
           description: >-
             A string that contains text and HTML and that represents the body of the reply form. The string is limited
-            to 32 KB OR An[Office.ReplyFormData](xref:Outlook_1_2.Office.ReplyFormData) object that contains body or
+            to 32 KB OR An [Office.ReplyFormData](xref:Outlook_1_2.Office.ReplyFormData) object that contains body or
             attachment data and a callback function
           type:
             - string | ReplyFormData
@@ -207,11 +207,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: displayReplyForm(formData)
     fullName: Outlook_1_2.Office.AppointmentRead.displayReplyForm
@@ -228,7 +228,7 @@ items:
         - id: formData
           description: >-
             A string that contains text and HTML and that represents the body of the reply form. The string is limited
-            to 32 KB. OR An[Office.ReplyFormData](xref:Outlook_1_2.Office.ReplyFormData) object that contains body or
+            to 32 KB. OR An [Office.ReplyFormData](xref:Outlook_1_2.Office.ReplyFormData) object that contains body or
             attachment data and a callback function.
           type:
             - string | ReplyFormData
@@ -247,11 +247,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: end
     fullName: Outlook_1_2.Office.AppointmentRead.end
@@ -265,17 +265,17 @@ items:
           - Date
   - uid: Outlook_1_2.Office.AppointmentRead.getEntities
     summary: |-
-      Gets the entities found in the selected item.
+      Gets the entities found in the selected item's body.
 
       Note: This method is not supported in Outlook for iOS or Outlook for Android.
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: getEntities()
     fullName: Outlook_1_2.Office.AppointmentRead.getEntities
@@ -290,17 +290,17 @@ items:
         description: ''
   - uid: Outlook_1_2.Office.AppointmentRead.getEntitiesByType
     summary: |-
-      Gets an array of all the entities of the specified entity type found in the selected item.
+      Gets an array of all the entities of the specified entity type found in the selected item's body.
 
       Note: This method is not supported in Outlook for iOS or Outlook for Android.
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
 
 
@@ -328,7 +328,7 @@ items:
           - '(string | Contact | MeetingSuggestion | PhoneNumber | TaskSuggestion)[]'
         description: >-
           If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns
-          null. If no entities of the specified type are present on the item, the method returns an empty array.
+          null. If no entities of the specified type are present in the item's body, the method returns an empty array.
           Otherwise, the type of the objects in the returned array depends on the type of entity requested in the
           entityType parameter.
       parameters:
@@ -350,11 +350,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: getFilteredEntitiesByName(name)
     fullName: Outlook_1_2.Office.AppointmentRead.getFilteredEntitiesByName
@@ -399,11 +399,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: getRegExMatches()
     fullName: Outlook_1_2.Office.AppointmentRead.getRegExMatches
@@ -439,11 +439,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: getRegExMatchesByName(name)
     fullName: Outlook_1_2.Office.AppointmentRead.getRegExMatchesByName
@@ -472,11 +472,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
 
 
@@ -514,16 +514,17 @@ items:
       Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The
       itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making
       REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more
-      details, see Use the Outlook REST APIs from an Outlook add-in.
+      details, see [ Use the Outlook REST APIs from an Outlook
+      add-in](https://docs.microsoft.com/outlook/add-ins/use-rest-api#get-the-item-id)<!-- -->.
 
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: itemId
     fullName: Outlook_1_2.Office.AppointmentRead.itemId
@@ -546,11 +547,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: itemType
     fullName: Outlook_1_2.Office.AppointmentRead.itemType
@@ -580,11 +581,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: 'loadCustomPropertiesAsync(callback, userContext)'
     fullName: Outlook_1_2.Office.AppointmentRead.loadCustomPropertiesAsync
@@ -592,7 +593,9 @@ items:
       - typeScript
     type: method
     syntax:
-      content: 'loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;'
+      content: >-
+        loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any):
+        void;
       return:
         type:
           - void
@@ -601,9 +604,9 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult.
+            of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<Office.CustomProperties>) => void'
         - id: userContext
           description: >-
             Optional. Developers can provide any object they wish to access in the callback function. This object can be
@@ -618,11 +621,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: location
     fullName: Outlook_1_2.Office.AppointmentRead.location
@@ -645,11 +648,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: normalizedSubject
     fullName: Outlook_1_2.Office.AppointmentRead.normalizedSubject
@@ -674,11 +677,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: optionalAttendees
     fullName: Outlook_1_2.Office.AppointmentRead.optionalAttendees
@@ -692,15 +695,15 @@ items:
           - 'EmailAddressDetails[]'
   - uid: Outlook_1_2.Office.AppointmentRead.organizer
     summary: |-
-      Gets the email address of the meeting organizer for a specified meeting. Read mode only.
+      Gets the email address of the meeting organizer for a specified meeting.
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: organizer
     fullName: Outlook_1_2.Office.AppointmentRead.organizer
@@ -725,11 +728,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: requiredAttendees
     fullName: Outlook_1_2.Office.AppointmentRead.requiredAttendees
@@ -752,11 +755,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: start
     fullName: Outlook_1_2.Office.AppointmentRead.start
@@ -782,11 +785,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: subject
     fullName: Outlook_1_2.Office.AppointmentRead.subject

--- a/docs/docs-ref-autogen/outlook_1_2/office.attachmentdetails.yml
+++ b/docs/docs-ref-autogen/outlook_1_2/office.attachmentdetails.yml
@@ -8,11 +8,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: Office.AttachmentDetails
     fullName: Outlook_1_2.Office.AttachmentDetails

--- a/docs/docs-ref-autogen/outlook_1_2/office.body.yml
+++ b/docs/docs-ref-autogen/outlook_1_2/office.body.yml
@@ -8,12 +8,12 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.Body
     fullName: Outlook_1_2.Office.Body
     langs:
@@ -30,11 +30,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
     name: 'getTypeAsync(options, callback)'
     fullName: Outlook_1_2.Office.Body.getTypeAsync
@@ -42,7 +42,9 @@ items:
       - typeScript
     type: method
     syntax:
-      content: 'getTypeAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;'
+      content: >-
+        getTypeAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<Office.CoercionType>) =>
+        void): void;
       return:
         type:
           - void
@@ -57,10 +59,10 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. The content type is returned as one of the CoercionType values in the
+            parameter of type Office.AsyncResult. The content type is returned as one of the CoercionType values in the
             asyncResult.value property.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<Office.CoercionType>) => void'
   - uid: Outlook_1_2.Office.Body.prependAsync
     summary: >-
       Adds the specified content to the beginning of the item body.
@@ -76,11 +78,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -88,13 +90,13 @@ items:
       characters.</td></tr></table>
 
 
-      In addition to the main signature, this method also has these signatures:
+      In addition to this signature, this method also has the following signatures:
 
 
-      `prependAsync(data: string, options: Office.AsyncContextOptions &amp; CoercionTypeOptions): void;`
+      `prependAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`
 
 
-      `prependAsync(data: string, callback: (result: AsyncResult) => void): void;`
+      `prependAsync(data: string, callback: (result: AsyncResult<void>) => void): void;`
 
 
       `prependAsync(data: string): void;`
@@ -106,7 +108,7 @@ items:
     syntax:
       content: >-
         prependAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result:
-        AsyncResult) => void): void;
+        AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -126,9 +128,10 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. Any errors encountered will be provided in the asyncResult.error property.
+            parameter of type Office.AsyncResult. Any errors encountered will be provided in the asyncResult.error
+            property.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_2.Office.Body.setSelectedDataAsync
     summary: >-
       Replaces the selection in the body with the specified text.
@@ -146,11 +149,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -159,13 +162,13 @@ items:
       Office.CoercionType.Html and the message body is in plain text.</td></tr></table>
 
 
-      In addition to the main signature, this method also has these signatures:
+      In addition to this signature, this method also has the following signatures:
 
 
-      `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions &amp; CoercionTypeOptions): void;`
+      `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`
 
 
-      `setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;`
+      `setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;`
 
 
       `setSelectedDataAsync(data: string): void;`
@@ -177,7 +180,7 @@ items:
     syntax:
       content: >-
         setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?:
-        (result: AsyncResult) => void): void;
+        (result: AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -197,6 +200,7 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. Any errors encountered will be provided in the asyncResult.error property.
+            parameter of type Office.AsyncResult. Any errors encountered will be provided in the asyncResult.error
+            property.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'

--- a/docs/docs-ref-autogen/outlook_1_2/office.contact.yml
+++ b/docs/docs-ref-autogen/outlook_1_2/office.contact.yml
@@ -12,11 +12,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: Office.Contact
     fullName: Outlook_1_2.Office.Contact

--- a/docs/docs-ref-autogen/outlook_1_2/office.customproperties.yml
+++ b/docs/docs-ref-autogen/outlook_1_2/office.customproperties.yml
@@ -15,12 +15,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.CustomProperties
     fullName: Outlook_1_2.Office.CustomProperties
     langs:
@@ -35,12 +35,12 @@ items:
   - uid: Outlook_1_2.Office.CustomProperties.get
     summary: Returns the value of the specified custom property.
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: get(name)
     fullName: Outlook_1_2.Office.CustomProperties.get
     langs:
@@ -66,12 +66,12 @@ items:
 
       To make the removal of the property permanent, you must call the saveAsync method of the CustomProperties object.
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: remove(name)
     fullName: Outlook_1_2.Office.CustomProperties.remove
     langs:
@@ -85,7 +85,10 @@ items:
         description: ''
       parameters:
         - id: name
-          description: 'The name of the property to be removed. \[Api set: Mailbox 1.0\]'
+          description: |-
+            The name of the property to be removed.
+
+            \[Api set: Mailbox 1.0\]
           type:
             - string
   - uid: Outlook_1_2.Office.CustomProperties.saveAsync
@@ -102,19 +105,19 @@ items:
       becomes disconnected. If the add-in calls saveAsync while in the disconnected state, saveAsync would return an
       error. Your callback method should handle this error accordingly.
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: 'saveAsync(callback, asyncContext)'
     fullName: Outlook_1_2.Office.CustomProperties.saveAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'saveAsync(callback?: (result: AsyncResult) => void, asyncContext?: any): void;'
+      content: 'saveAsync(callback?: (result: AsyncResult<void>) => void, asyncContext?: any): void;'
       return:
         type:
           - void
@@ -123,11 +126,14 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult.
+            parameter of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
         - id: asyncContext
-          description: 'Optional. Any state data that is passed to the callback method. \[Api set: Mailbox 1.0\]'
+          description: |-
+            Optional. Any state data that is passed to the callback method.
+
+            \[Api set: Mailbox 1.0\]
           type:
             - any
   - uid: Outlook_1_2.Office.CustomProperties.set
@@ -146,12 +152,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: 'set(name, value)'
     fullName: Outlook_1_2.Office.CustomProperties.set
     langs:

--- a/docs/docs-ref-autogen/outlook_1_2/office.diagnostics.yml
+++ b/docs/docs-ref-autogen/outlook_1_2/office.diagnostics.yml
@@ -6,12 +6,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.Diagnostics
     fullName: Outlook_1_2.Office.Diagnostics
     langs:
@@ -30,12 +30,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: hostName
     fullName: Outlook_1_2.Office.Diagnostics.hostName
     langs:
@@ -58,12 +58,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: hostVersion
     fullName: Outlook_1_2.Office.Diagnostics.hostVersion
     langs:
@@ -102,19 +102,19 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: OWAView
     fullName: Outlook_1_2.Office.Diagnostics.OWAView
     langs:
       - typeScript
     type: property
     syntax:
-      content: 'OWAView: "string";'
+      content: 'OWAView: MailboxEnums.OWAView | "OneColumn" | "TwoColumns" | "ThreeColumns";'
       return:
         type:
-          - '"string"'
+          - MailboxEnums.OWAView | "OneColumn" | "TwoColumns" | "ThreeColumns"

--- a/docs/docs-ref-autogen/outlook_1_2/office.emailaddressdetails.yml
+++ b/docs/docs-ref-autogen/outlook_1_2/office.emailaddressdetails.yml
@@ -6,12 +6,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.EmailAddressDetails
     fullName: Outlook_1_2.Office.EmailAddressDetails
     langs:

--- a/docs/docs-ref-autogen/outlook_1_2/office.emailuser.yml
+++ b/docs/docs-ref-autogen/outlook_1_2/office.emailuser.yml
@@ -6,11 +6,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: Office.EmailUser
     fullName: Outlook_1_2.Office.EmailUser

--- a/docs/docs-ref-autogen/outlook_1_2/office.entities.yml
+++ b/docs/docs-ref-autogen/outlook_1_2/office.entities.yml
@@ -34,11 +34,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: Office.Entities
     fullName: Outlook_1_2.Office.Entities

--- a/docs/docs-ref-autogen/outlook_1_2/office.item.yml
+++ b/docs/docs-ref-autogen/outlook_1_2/office.item.yml
@@ -8,12 +8,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.Item
     fullName: Outlook_1_2.Office.Item
     langs:
@@ -32,12 +32,12 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: body
     fullName: Outlook_1_2.Office.Item.body
     langs:
@@ -54,11 +54,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: dateTimeCreated
     fullName: Outlook_1_2.Office.Item.dateTimeCreated
@@ -76,11 +76,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
 
 
@@ -106,12 +106,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: itemType
     fullName: Outlook_1_2.Office.Item.itemType
     langs:
@@ -140,19 +140,21 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: 'loadCustomPropertiesAsync(callback, userContext)'
     fullName: Outlook_1_2.Office.Item.loadCustomPropertiesAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;'
+      content: >-
+        loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any):
+        void;
       return:
         type:
           - void
@@ -161,9 +163,9 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult.
+            of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<Office.CustomProperties>) => void'
         - id: userContext
           description: >-
             Optional. Developers can provide any object they wish to access in the callback function. This object can be

--- a/docs/docs-ref-autogen/outlook_1_2/office.itemcompose.yml
+++ b/docs/docs-ref-autogen/outlook_1_2/office.itemcompose.yml
@@ -2,11 +2,11 @@
 items:
   - uid: Outlook_1_2.Office.ItemCompose
     summary: >-
-      The compose mode of [Office.context.mailbox.item](xref:Outlook_1_2.Office.Item)<!-- -->.
+      The compose mode of [ Office.context.mailbox.item](xref:Outlook_1_2.Office.Item)<!-- -->.
 
 
       Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat
-      this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
+      this as a mode of `Office.context.mailbox.item`<!-- -->. Refer to the Object Model pages for more information.
     name: Office.ItemCompose
     fullName: Outlook_1_2.Office.ItemCompose
     langs:
@@ -37,11 +37,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -60,7 +60,8 @@ items:
       `addFileAttachmentAsync(uri: string, attachmentName: string, options: Office.AsyncContextOptions): void;`
 
 
-      `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+      `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void):
+      void;`
     name: 'addFileAttachmentAsync(uri, attachmentName, options, callback)'
     fullName: Outlook_1_2.Office.ItemCompose.addFileAttachmentAsync
     langs:
@@ -69,7 +70,7 @@ items:
     syntax:
       content: >-
         addFileAttachmentAsync(uri: string, attachmentName: string, options?: Office.AsyncContextOptions, callback?:
-        (result: AsyncResult) => void): void;
+        (result: AsyncResult<string>) => void): void;
       return:
         type:
           - void
@@ -101,7 +102,7 @@ items:
             property. If uploading the attachment fails, the asyncResult object will contain an Error object that
             provides a description of the error.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<string>) => void'
   - uid: Outlook_1_2.Office.ItemCompose.addItemAttachmentAsync
     summary: >-
       Adds an Exchange item, such as a message, as an attachment to the message or appointment.
@@ -117,17 +118,17 @@ items:
       session.
 
 
-      If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items
+      If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items
       other than the item that you are editing; however, this is not supported and is not recommended.
 
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -135,7 +136,7 @@ items:
       attachments.</td></tr></table>
 
 
-      In addition to the main signature, this method also has these signatures:
+      In addition to this signature, this method also has the following signatures:
 
 
       `addItemAttachmentAsync(itemId: any, attachmentName: string): void;`
@@ -144,7 +145,8 @@ items:
       `addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;`
 
 
-      `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+      `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void):
+      void;`
     name: 'addItemAttachmentAsync(itemId, attachmentName, options, callback)'
     fullName: Outlook_1_2.Office.ItemCompose.addItemAttachmentAsync
     langs:
@@ -153,7 +155,7 @@ items:
     syntax:
       content: >-
         addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?:
-        (result: AsyncResult) => void): void;
+        (result: AsyncResult<string>) => void): void;
       return:
         type:
           - void
@@ -178,11 +180,11 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value
+            of type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value
             property. If adding the attachment fails, the asyncResult object will contain an Error object that provides
             a description of the error.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<string>) => void'
   - uid: Outlook_1_2.Office.ItemCompose.getSelectedDataAsync
     summary: >-
       Asynchronously returns selected data from the subject or body of a message.
@@ -198,11 +200,11 @@ items:
 
       \[ [API set: Mailbox 1.2](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
     name: 'getSelectedDataAsync(coerciontype, callback)'
     fullName: Outlook_1_2.Office.ItemCompose.getSelectedDataAsync
@@ -210,7 +212,7 @@ items:
       - typeScript
     type: method
     syntax:
-      content: 'getSelectedDataAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult) => void): void;'
+      content: 'getSelectedDataAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult<any>) => void): void;'
       return:
         type:
           - void
@@ -223,9 +225,9 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult.
+            of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<any>) => void'
   - uid: Outlook_1_2.Office.ItemCompose.removeAttachmentAsync
     summary: >-
       Removes an attachment from a message or appointment.
@@ -234,17 +236,17 @@ items:
       The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best
       practice, you should use the attachment identifier to remove an attachment only if the same mail app has added
       that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid
-      only within the same session. A session is over when the user closes the app, or if the user starts composing in
-      an inline form and subsequently pops out the inline form to continue in a separate window.
+      only within the same session. A session is over when the user closes the app, or if the user starts composing an
+      inline form then subsequently pops out the form to continue in a separate window.
 
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -260,7 +262,7 @@ items:
       `removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;`
 
 
-      `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;`
+      `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;`
     name: 'removeAttachmentAsync(attachmentIndex, options, callback)'
     fullName: Outlook_1_2.Office.ItemCompose.removeAttachmentAsync
     langs:
@@ -269,7 +271,7 @@ items:
     syntax:
       content: >-
         removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result:
-        AsyncResult) => void): void;
+        AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -288,10 +290,10 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain
-            an error code with the reason for the failure.
+            parameter of type Office.AsyncResult. If removing the attachment fails, the asyncResult.error property will
+            contain an error code with the reason for the failure.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_2.Office.ItemCompose.setSelectedDataAsync
     summary: >-
       Asynchronously inserts data into the body or subject of a message.
@@ -304,11 +306,11 @@ items:
 
       \[ [API set: Mailbox 1.2](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -321,10 +323,10 @@ items:
       `setSelectedDataAsync(data: string): void;`
 
 
-      `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions &amp; CoercionTypeOptions): void;`
+      `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`
 
 
-      `setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;`
+      `setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;`
     name: 'setSelectedDataAsync(data, options, callback)'
     fullName: Outlook_1_2.Office.ItemCompose.setSelectedDataAsync
     langs:
@@ -333,7 +335,7 @@ items:
     syntax:
       content: >-
         setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?:
-        (result: AsyncResult) => void): void;
+        (result: AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -359,10 +361,9 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain
-            an error code with the reason for the failure.
+            parameter of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_2.Office.ItemCompose.subject
     summary: |-
       Gets or sets the description that appears in the subject field of an item.
@@ -373,12 +374,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: subject
     fullName: Outlook_1_2.Office.ItemCompose.subject
     langs:

--- a/docs/docs-ref-autogen/outlook_1_2/office.itemread.yml
+++ b/docs/docs-ref-autogen/outlook_1_2/office.itemread.yml
@@ -2,11 +2,11 @@
 items:
   - uid: Outlook_1_2.Office.ItemRead
     summary: >-
-      The read mode of [Office.context.mailbox.item](xref:Outlook_1_2.Office.Item)<!-- -->.
+      The read mode of [ Office.context.mailbox.item](xref:Outlook_1_2.Office.Item)<!-- -->.
 
 
       Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat
-      this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
+      this as a mode of `Office.context.mailbox.item`<!-- -->. Refer to the Object Model pages for more information.
     name: Office.ItemRead
     fullName: Outlook_1_2.Office.ItemRead
     langs:
@@ -30,20 +30,20 @@ items:
       - Outlook_1_2.Office.ItemRead.subject
   - uid: Outlook_1_2.Office.ItemRead.attachments
     summary: |-
-      Gets an array of attachments for the item.
+      Gets the item's attachments as an array.
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
 
 
       Note: Certain types of files are blocked by Outlook due to potential security issues and are therefore not
-      returned. For more information, see [Blocked attachments in
+      returned. For more information, see [ Blocked attachments in
       Outlook](https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519)<!--
       -->.
     name: attachments
@@ -79,11 +79,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: displayReplyAllForm(formData)
     fullName: Outlook_1_2.Office.ItemRead.displayReplyAllForm
@@ -100,7 +100,7 @@ items:
         - id: formData
           description: >-
             A string that contains text and HTML and that represents the body of the reply form. The string is limited
-            to 32 KB OR An[Office.ReplyFormData](xref:Outlook_1_2.Office.ReplyFormData) object that contains body or
+            to 32 KB OR An [Office.ReplyFormData](xref:Outlook_1_2.Office.ReplyFormData) object that contains body or
             attachment data and a callback function
           type:
             - string | ReplyFormData
@@ -127,11 +127,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: displayReplyForm(formData)
     fullName: Outlook_1_2.Office.ItemRead.displayReplyForm
@@ -148,23 +148,23 @@ items:
         - id: formData
           description: >-
             A string that contains text and HTML and that represents the body of the reply form. The string is limited
-            to 32 KB. OR An[Office.ReplyFormData](xref:Outlook_1_2.Office.ReplyFormData) object that contains body or
+            to 32 KB. OR An [Office.ReplyFormData](xref:Outlook_1_2.Office.ReplyFormData) object that contains body or
             attachment data and a callback function.
           type:
             - string | ReplyFormData
   - uid: Outlook_1_2.Office.ItemRead.getEntities
     summary: |-
-      Gets the entities found in the selected item.
+      Gets the entities found in the selected item's body.
 
       Note: This method is not supported in Outlook for iOS or Outlook for Android.
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: getEntities()
     fullName: Outlook_1_2.Office.ItemRead.getEntities
@@ -179,17 +179,17 @@ items:
         description: ''
   - uid: Outlook_1_2.Office.ItemRead.getEntitiesByType
     summary: |-
-      Gets an array of all the entities of the specified entity type found in the selected item.
+      Gets an array of all the entities of the specified entity type found in the selected item's body.
 
       Note: This method is not supported in Outlook for iOS or Outlook for Android.
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
 
 
@@ -217,7 +217,7 @@ items:
           - '(string | Contact | MeetingSuggestion | PhoneNumber | TaskSuggestion)[]'
         description: >-
           If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns
-          null. If no entities of the specified type are present on the item, the method returns an empty array.
+          null. If no entities of the specified type are present in the item's body, the method returns an empty array.
           Otherwise, the type of the objects in the returned array depends on the type of entity requested in the
           entityType parameter.
       parameters:
@@ -239,11 +239,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: getFilteredEntitiesByName(name)
     fullName: Outlook_1_2.Office.ItemRead.getFilteredEntitiesByName
@@ -288,11 +288,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: getRegExMatches()
     fullName: Outlook_1_2.Office.ItemRead.getRegExMatches
@@ -328,11 +328,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: getRegExMatchesByName(name)
     fullName: Outlook_1_2.Office.ItemRead.getRegExMatchesByName
@@ -361,11 +361,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
 
 
@@ -403,16 +403,17 @@ items:
       Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The
       itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making
       REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more
-      details, see Use the Outlook REST APIs from an Outlook add-in.
+      details, see [ Use the Outlook REST APIs from an Outlook
+      add-in](https://docs.microsoft.com/outlook/add-ins/use-rest-api#get-the-item-id)<!-- -->.
 
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: itemId
     fullName: Outlook_1_2.Office.ItemRead.itemId
@@ -435,11 +436,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: normalizedSubject
     fullName: Outlook_1_2.Office.ItemRead.normalizedSubject
@@ -465,12 +466,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: subject
     fullName: Outlook_1_2.Office.ItemRead.subject
     langs:

--- a/docs/docs-ref-autogen/outlook_1_2/office.localclienttime.yml
+++ b/docs/docs-ref-autogen/outlook_1_2/office.localclienttime.yml
@@ -6,11 +6,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: Office.LocalClientTime
     fullName: Outlook_1_2.Office.LocalClientTime

--- a/docs/docs-ref-autogen/outlook_1_2/office.location.yml
+++ b/docs/docs-ref-autogen/outlook_1_2/office.location.yml
@@ -6,11 +6,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
     name: Office.Location
     fullName: Outlook_1_2.Office.Location
@@ -29,25 +29,25 @@ items:
       The getAsync method starts an asynchronous call to the Exchange server to get the location of an appointment. The
       location of the appointment is provided as a string in the asyncResult.value property.
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
 
 
       In addition to this signature, the method also has the following signature:
 
 
-      `getAsync(callback: (result: AsyncResult) => void): void;`
+      `getAsync(callback: (result: AsyncResult<string>) => void): void;`
     name: 'getAsync(options, callback)'
     fullName: Outlook_1_2.Office.Location.getAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'getAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;'
+      content: 'getAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;'
       return:
         type:
           - void
@@ -62,9 +62,12 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. \[Api set: Mailbox 1.1\]
+            parameter of type Office.AsyncResult.
+
+
+            \[Api set: Mailbox 1.1\]
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<string>) => void'
   - uid: Outlook_1_2.Office.Location.setAsync
     summary: >-
       Sets the location of an appointment.
@@ -73,11 +76,11 @@ items:
       The setAsync method starts an asynchronous call to the Exchange server to set the location of an appointment.
       Setting the location of an appointment overwrites the current location.
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -94,7 +97,7 @@ items:
       `setAsync(location: string, options: Office.AsyncContextOptions): void;`
 
 
-      `setAsync(location: string, callback: (result: AsyncResult) => void): void;`
+      `setAsync(location: string, callback: (result: AsyncResult<void>) => void): void;`
     name: 'setAsync(location, options, callback)'
     fullName: Outlook_1_2.Office.Location.setAsync
     langs:
@@ -102,8 +105,8 @@ items:
     type: method
     syntax:
       content: >-
-        setAsync(location: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void):
-        void;
+        setAsync(location: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) =>
+        void): void;
       return:
         type:
           - void
@@ -122,7 +125,10 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. If setting the location fails, the asyncResult.error property will contain an
-            error code. \[Api set: Mailbox 1.1\]
+            parameter of type Office.AsyncResult. If setting the location fails, the asyncResult.error property will
+            contain an error code.
+
+
+            \[Api set: Mailbox 1.1\]
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'

--- a/docs/docs-ref-autogen/outlook_1_2/office.mailbox.yml
+++ b/docs/docs-ref-autogen/outlook_1_2/office.mailbox.yml
@@ -2,7 +2,7 @@
 items:
   - uid: Outlook_1_2.Office.Mailbox
     summary: |-
-      Provides access to the Outlook add-in object model for Microsoft Outlook and Microsoft Outlook on the web.
+      Provides access to the Outlook Add-in object model for Microsoft Outlook and Microsoft Outlook on the web.
 
       Namespaces:
 
@@ -14,12 +14,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.Mailbox
     fullName: Outlook_1_2.Office.Mailbox
     langs:
@@ -57,12 +57,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: convertToLocalClientTime(timeValue)
     fullName: Outlook_1_2.Office.Mailbox.convertToLocalClientTime
     langs:
@@ -90,12 +90,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: convertToUtcClientTime(input)
     fullName: Outlook_1_2.Office.Mailbox.convertToUtcClientTime
     langs:
@@ -130,11 +130,11 @@ items:
       Exchange Server. An example is the string 15.0.468.0.
 
 
-      - OWAView (string): A string that represents the current view of Outlook Web App. If the host application is not
-      Outlook Web App, then accessing this property results in undefined. Outlook Web App has three views (OneColumn -
-      displayed when the screen is narrow, TwoColumns - displayed when the screen is wider, and ThreeColumns - displayed
-      when the screen is wide.) that correspond to the width of the screen and the window, and the number of columns
-      that can be displayed.
+      - OWAView (MailboxEnums.OWAView or string): An enum (or string literal) that represents the current view of
+      Outlook Web App. If the host application is not Outlook Web App, then accessing this property results in
+      undefined. Outlook Web App has three views (OneColumn - displayed when the screen is narrow, TwoColumns -
+      displayed when the screen is wider, and ThreeColumns - displayed when the screen is wide) that correspond to the
+      width of the screen and the window, and the number of columns that can be displayed.
 
 
       More information is under [Office.Diagnostics](xref:Outlook_1_2.Office.Diagnostics)<!-- -->.
@@ -142,12 +142,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: diagnostics
     fullName: Outlook_1_2.Office.Mailbox.diagnostics
     langs:
@@ -186,12 +186,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: displayAppointmentForm(itemId)
     fullName: Outlook_1_2.Office.Mailbox.displayAppointmentForm
     langs:
@@ -235,12 +235,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: displayMessageForm(itemId)
     fullName: Outlook_1_2.Office.Mailbox.displayMessageForm
     langs:
@@ -286,11 +286,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: displayNewAppointmentForm(parameters)
     fullName: Outlook_1_2.Office.Mailbox.displayNewAppointmentForm
@@ -322,16 +322,16 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
 
 
       The ewsUrl value can be used by a remote service to make EWS calls to the user's mailbox. For example, you can
-      create a remote service to [get attachments from the selected
+      create a remote service to [ get attachments from the selected
       item](https://docs.microsoft.com/outlook/add-ins/get-attachments-of-an-outlook-item)<!-- -->.
 
 
@@ -354,23 +354,23 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
       and read</td></tr></table>
 
 
-      The getUserIdentityTokenAsync method returns a token that you can use to identify and [authenticate the add-in and
-      user with a third-party system](https://docs.microsoft.com/outlook/add-ins/authentication)<!-- -->.
+      The getUserIdentityTokenAsync method returns a token that you can use to identify and [ authenticate the add-in
+      and user with a third-party system](https://docs.microsoft.com/outlook/add-ins/authentication)<!-- -->.
     name: 'getUserIdentityTokenAsync(callback, userContext)'
     fullName: Outlook_1_2.Office.Mailbox.getUserIdentityTokenAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'getUserIdentityTokenAsync(callback: (result: AsyncResult) => void, userContext?: any): void;'
+      content: 'getUserIdentityTokenAsync(callback: (result: AsyncResult<string>) => void, userContext?: any): void;'
       return:
         type:
           - void
@@ -379,9 +379,9 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult.
+            of type Office.AsyncResult. The token is provided as a string in the asyncResult.value property.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<string>) => void'
         - id: userContext
           description: Optional. Any state data that is passed to the asynchronous method.\|
           type:
@@ -390,7 +390,8 @@ items:
     summary: >-
       The mailbox item. Depending on the context in which the add-in opened, the item may be of any number of types. If
       you want to see IntelliSense for only a specific type, you should cast this item to one of the following:
-      `ItemCompose`, `ItemRead`, `MessageCompose`, `MessageRead`, `AppointmentCompose`, `AppointmentRead`
+      `ItemCompose`<!-- -->, `ItemRead`<!-- -->, `MessageCompose`<!-- -->, `MessageRead`<!-- -->,
+      `AppointmentCompose`<!-- -->, `AppointmentRead`
     name: item
     fullName: Outlook_1_2.Office.Mailbox.item
     langs:
@@ -421,15 +422,21 @@ items:
 
       Your add-in must have the ReadWriteMailbox permission to use the makeEwsRequestAsync method. For information about
       using the ReadWriteMailbox permission and the EWS operations that you can call with the makeEwsRequestAsync
-      method, see Specify permissions for mail add-in access to the user's mailbox.
+      method, see [ Specify permissions for mail add-in access to the user's
+      mailbox](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)<!-- -->.
 
 
       The XML result of the EWS call is provided as a string in the asyncResult.value property. If the result exceeds 1
       MB in size, an error message is returned instead.
 
 
-      Note: This method is not supported in the following scenarios. - In Outlook for iOS or Outlook for Android - When
-      the add-in is loaded in a Gmail mailbox
+      Note: This method is not supported in the following scenarios:
+
+
+      - In Outlook for iOS or Outlook for Android.
+
+
+      - When the add-in is loaded in a Gmail mailbox.
 
 
       Note: The server administrator must set OAuthAuthentication to true on the Client Access Server EWS directory to
@@ -443,7 +450,7 @@ items:
       15.0.4535.1004, you should set the encoding value to ISO-8859-1.
 
 
-      `&lt;?xml version="1.0" encoding="iso-8859-1"?&gt;`
+      `<?xml version="1.0" encoding="iso-8859-1"?>`
 
 
       You do not need to set the encoding value when your mail app is running in Outlook on the web. You can determine
@@ -454,11 +461,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteMailbox</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
       and read</td></tr></table>
     name: 'makeEwsRequestAsync(data, callback, userContext)'
     fullName: Outlook_1_2.Office.Mailbox.makeEwsRequestAsync
@@ -466,7 +473,7 @@ items:
       - typeScript
     type: method
     syntax:
-      content: 'makeEwsRequestAsync(data: any, callback: (result: AsyncResult) => void, userContext?: any): void;'
+      content: 'makeEwsRequestAsync(data: any, callback: (result: AsyncResult<string>) => void, userContext?: any): void;'
       return:
         type:
           - void
@@ -479,9 +486,10 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult.
+            of type Office.AsyncResult. The `value` property of the result is the XML of the EWS request provided as a
+            string. If the result exceeds 1 MB in size, an error message is returned instead.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<string>) => void'
         - id: userContext
           description: Optional. Any state data that is passed to the asynchronous method.
           type:
@@ -489,7 +497,7 @@ items:
   - uid: Outlook_1_2.Office.Mailbox.userProfile
     summary: >-
       Information about the user associated with the mailbox. This includes their account type, display name, email
-      adddress, and time zone.
+      address, and time zone.
 
 
       More information is under [Office.UserProfile](xref:Outlook_1_2.Office.UserProfile)

--- a/docs/docs-ref-autogen/outlook_1_2/office.mailboxenums.attachmenttype.yml
+++ b/docs/docs-ref-autogen/outlook_1_2/office.mailboxenums.attachmenttype.yml
@@ -6,7 +6,7 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td> [Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
+      <table><tr><td> [ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
       </td><td>Compose or read</td></tr></table>
     name: Office.MailboxEnums.AttachmentType
     fullName: Outlook_1_2.Office.MailboxEnums.AttachmentType

--- a/docs/docs-ref-autogen/outlook_1_2/office.mailboxenums.entitytype.yml
+++ b/docs/docs-ref-autogen/outlook_1_2/office.mailboxenums.entitytype.yml
@@ -6,7 +6,7 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td> [Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
+      <table><tr><td> [ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
       </td><td>Compose or read</td></tr></table>
     name: Office.MailboxEnums.EntityType
     fullName: Outlook_1_2.Office.MailboxEnums.EntityType

--- a/docs/docs-ref-autogen/outlook_1_2/office.mailboxenums.itemtype.yml
+++ b/docs/docs-ref-autogen/outlook_1_2/office.mailboxenums.itemtype.yml
@@ -6,7 +6,7 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td> [Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
+      <table><tr><td> [ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
       </td><td>Compose or read</td></tr></table>
     name: Office.MailboxEnums.ItemType
     fullName: Outlook_1_2.Office.MailboxEnums.ItemType

--- a/docs/docs-ref-autogen/outlook_1_2/office.mailboxenums.owaview.yml
+++ b/docs/docs-ref-autogen/outlook_1_2/office.mailboxenums.owaview.yml
@@ -1,0 +1,42 @@
+### YamlMime:UniversalReference
+items:
+  - uid: Outlook_1_2.Office.MailboxEnums.OWAView
+    summary: Represents the current view of Outlook Web App.
+    name: Office.MailboxEnums.OWAView
+    fullName: Outlook_1_2.Office.MailboxEnums.OWAView
+    langs:
+      - typeScript
+    type: enum
+    package: Outlook_1_2
+    children:
+      - Outlook_1_2.Office.MailboxEnums.OWAView.OneColumn
+      - Outlook_1_2.Office.MailboxEnums.OWAView.ThreeColumns
+      - Outlook_1_2.Office.MailboxEnums.OWAView.TwoColumns
+  - uid: Outlook_1_2.Office.MailboxEnums.OWAView.OneColumn
+    summary: >-
+      One column view. Displayed when the screen is narrow. Outlook Web App uses this single-column layout on the entire
+      screen of a smartphone.
+    name: OneColumn
+    fullName: Outlook_1_2.Office.MailboxEnums.OWAView.OneColumn
+    langs:
+      - typeScript
+    type: field
+    numericValue: '"OneColumn"'
+  - uid: Outlook_1_2.Office.MailboxEnums.OWAView.ThreeColumns
+    summary: >-
+      Three column view. Displayed when the screen is wide. For example, Outlook Web App uses this view in a full screen
+      window on a desktop computer.
+    name: ThreeColumns
+    fullName: Outlook_1_2.Office.MailboxEnums.OWAView.ThreeColumns
+    langs:
+      - typeScript
+    type: field
+    numericValue: '"ThreeColumns"'
+  - uid: Outlook_1_2.Office.MailboxEnums.OWAView.TwoColumns
+    summary: Two column view. Displayed when the screen is wider. Outlook Web App uses this view on most tablets.
+    name: TwoColumns
+    fullName: Outlook_1_2.Office.MailboxEnums.OWAView.TwoColumns
+    langs:
+      - typeScript
+    type: field
+    numericValue: '"TwoColumns"'

--- a/docs/docs-ref-autogen/outlook_1_2/office.mailboxenums.recipienttype.yml
+++ b/docs/docs-ref-autogen/outlook_1_2/office.mailboxenums.recipienttype.yml
@@ -6,7 +6,7 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td> [Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
+      <table><tr><td> [ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
       </td><td>Compose or read</td></tr></table>
     name: Office.MailboxEnums.RecipientType
     fullName: Outlook_1_2.Office.MailboxEnums.RecipientType

--- a/docs/docs-ref-autogen/outlook_1_2/office.mailboxenums.responsetype.yml
+++ b/docs/docs-ref-autogen/outlook_1_2/office.mailboxenums.responsetype.yml
@@ -6,7 +6,7 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td> [Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
+      <table><tr><td> [ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
       </td><td>Compose or read</td></tr></table>
     name: Office.MailboxEnums.ResponseType
     fullName: Outlook_1_2.Office.MailboxEnums.ResponseType

--- a/docs/docs-ref-autogen/outlook_1_2/office.meetingsuggestion.yml
+++ b/docs/docs-ref-autogen/outlook_1_2/office.meetingsuggestion.yml
@@ -15,11 +15,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: Office.MeetingSuggestion
     fullName: Outlook_1_2.Office.MeetingSuggestion

--- a/docs/docs-ref-autogen/outlook_1_2/office.message.yml
+++ b/docs/docs-ref-autogen/outlook_1_2/office.message.yml
@@ -6,7 +6,7 @@ items:
 
 
       Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat
-      this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
+      this as a mode of `Office.context.mailbox.item`<!-- -->. Refer to the Object Model pages for more information.
     name: Office.Message
     fullName: Outlook_1_2.Office.Message
     langs:
@@ -33,12 +33,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: conversationId
     fullName: Outlook_1_2.Office.Message.conversationId
     langs:

--- a/docs/docs-ref-autogen/outlook_1_2/office.messagecompose.yml
+++ b/docs/docs-ref-autogen/outlook_1_2/office.messagecompose.yml
@@ -2,11 +2,11 @@
 items:
   - uid: Outlook_1_2.Office.MessageCompose
     summary: >-
-      The message compose mode of [Office.context.mailbox.item](xref:Outlook_1_2.Office.Item)<!-- -->.
+      The message compose mode of [ Office.context.mailbox.item](xref:Outlook_1_2.Office.Item)<!-- -->.
 
 
       Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat
-      this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
+      this as a mode of `Office.context.mailbox.item`<!-- -->. Refer to the Object Model pages for more information.
     name: Office.MessageCompose
     fullName: Outlook_1_2.Office.MessageCompose
     langs:
@@ -46,11 +46,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr>
 
 
@@ -69,7 +69,8 @@ items:
       `addFileAttachmentAsync(uri: string, attachmentName: string, options: AsyncContextOptions): void;`
 
 
-      `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+      `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void):
+      void;`
     name: 'addFileAttachmentAsync(uri, attachmentName, options, callback)'
     fullName: Outlook_1_2.Office.MessageCompose.addFileAttachmentAsync
     langs:
@@ -78,7 +79,7 @@ items:
     syntax:
       content: >-
         addFileAttachmentAsync(uri: string, attachmentName: string, options?: AsyncContextOptions, callback?: (result:
-        AsyncResult) => void): void;
+        AsyncResult<string>) => void): void;
       return:
         type:
           - void
@@ -106,11 +107,11 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type asyncResult. On success, the attachment identifier will be provided in the asyncResult.value
+            of type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value
             property. If uploading the attachment fails, the asyncResult object will contain an Error object that
             provides a description of the error.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<string>) => void'
   - uid: Outlook_1_2.Office.MessageCompose.addItemAttachmentAsync
     summary: >-
       Adds an Exchange item, such as a message, as an attachment to the message or appointment.
@@ -126,17 +127,17 @@ items:
       session.
 
 
-      If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items
+      If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items
       other than the item that you are editing; however, this is not supported and is not recommended.
 
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr>
 
 
@@ -144,7 +145,7 @@ items:
       attachments.</td></tr></table>
 
 
-      In addition to the main signature, this method also has these signatures:
+      In addition to this signature, this method also has the following signatures:
 
 
       `addItemAttachmentAsync(itemId: any, attachmentName: string): void;`
@@ -153,7 +154,8 @@ items:
       `addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;`
 
 
-      `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+      `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void):
+      void;`
     name: 'addItemAttachmentAsync(itemId, attachmentName, options, callback)'
     fullName: Outlook_1_2.Office.MessageCompose.addItemAttachmentAsync
     langs:
@@ -162,7 +164,7 @@ items:
     syntax:
       content: >-
         addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?:
-        (result: AsyncResult) => void): void;
+        (result: AsyncResult<string>) => void): void;
       return:
         type:
           - void
@@ -191,7 +193,7 @@ items:
             property. If adding the attachment fails, the asyncResult object will contain an Error object that provides
             a description of the error.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<string>) => void'
   - uid: Outlook_1_2.Office.MessageCompose.bcc
     summary: >-
       Gets an object that provides methods to get or update the recipients on the Bcc (blind carbon copy) line of a
@@ -200,11 +202,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: bcc
     fullName: Outlook_1_2.Office.MessageCompose.bcc
@@ -222,11 +224,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: body
     fullName: Outlook_1_2.Office.MessageCompose.body
@@ -250,11 +252,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: cc
     fullName: Outlook_1_2.Office.MessageCompose.cc
@@ -282,11 +284,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: conversationId
     fullName: Outlook_1_2.Office.MessageCompose.conversationId
@@ -304,11 +306,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: dateTimeCreated
     fullName: Outlook_1_2.Office.MessageCompose.dateTimeCreated
@@ -326,11 +328,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
 
 
@@ -360,11 +362,11 @@ items:
 
       \[ [API set: Mailbox 1.2](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: 'getSelectedDataAsync(coerciontype, callback)'
     fullName: Outlook_1_2.Office.MessageCompose.getSelectedDataAsync
@@ -372,7 +374,7 @@ items:
       - typeScript
     type: method
     syntax:
-      content: 'getSelectedDataAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult) => void): void;'
+      content: 'getSelectedDataAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult<any>) => void): void;'
       return:
         type:
           - void
@@ -385,9 +387,9 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult.
+            of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<any>) => void'
   - uid: Outlook_1_2.Office.MessageCompose.itemType
     summary: >-
       Gets the type of item that an instance represents.
@@ -399,11 +401,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: itemType
     fullName: Outlook_1_2.Office.MessageCompose.itemType
@@ -433,11 +435,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: 'loadCustomPropertiesAsync(callback, userContext)'
     fullName: Outlook_1_2.Office.MessageCompose.loadCustomPropertiesAsync
@@ -445,7 +447,9 @@ items:
       - typeScript
     type: method
     syntax:
-      content: 'loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;'
+      content: >-
+        loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any):
+        void;
       return:
         type:
           - void
@@ -454,9 +458,9 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult.
+            of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<Office.CustomProperties>) => void'
         - id: userContext
           description: >-
             Optional. Developers can provide any object they wish to access in the callback function. This object can be
@@ -471,17 +475,17 @@ items:
       The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best
       practice, you should use the attachment identifier to remove an attachment only if the same mail app has added
       that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid
-      only within the same session. A session is over when the user closes the app, or if the user starts composing in
-      an inline form and subsequently pops out the inline form to continue in a separate window.
+      only within the same session. A session is over when the user closes the app, or if the user starts composing an
+      inline form then subsequently pops out the form to continue in a separate window.
 
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr>
 
 
@@ -497,7 +501,7 @@ items:
       `removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;`
 
 
-      `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;`
+      `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;`
     name: 'removeAttachmentAsync(attachmentIndex, options, callback)'
     fullName: Outlook_1_2.Office.MessageCompose.removeAttachmentAsync
     langs:
@@ -506,7 +510,7 @@ items:
     syntax:
       content: >-
         removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result:
-        AsyncResult) => void): void;
+        AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -525,10 +529,10 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain
-            an error code with the reason for the failure.
+            parameter of type Office.AsyncResult. If removing the attachment fails, the asyncResult.error property will
+            contain an error code with the reason for the failure.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_2.Office.MessageCompose.setSelectedDataAsync
     summary: >-
       Asynchronously inserts data into the body or subject of a message.
@@ -541,11 +545,11 @@ items:
 
       \[ [API set: Mailbox 1.2](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr>
 
 
@@ -558,10 +562,10 @@ items:
       `setSelectedDataAsync(data: string): void;`
 
 
-      `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions &amp; CoercionTypeOptions): void;`
+      `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`
 
 
-      `setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;`
+      `setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;`
     name: 'setSelectedDataAsync(data, options, callback)'
     fullName: Outlook_1_2.Office.MessageCompose.setSelectedDataAsync
     langs:
@@ -570,7 +574,7 @@ items:
     syntax:
       content: >-
         setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?:
-        (result: AsyncResult) => void): void;
+        (result: AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -596,10 +600,9 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain
-            an error code with the reason for the failure.
+            parameter of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_2.Office.MessageCompose.subject
     summary: |-
       Gets or sets the description that appears in the subject field of an item.
@@ -610,11 +613,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: subject
     fullName: Outlook_1_2.Office.MessageCompose.subject
@@ -638,11 +641,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: to
     fullName: Outlook_1_2.Office.MessageCompose.to

--- a/docs/docs-ref-autogen/outlook_1_2/office.messageread.yml
+++ b/docs/docs-ref-autogen/outlook_1_2/office.messageread.yml
@@ -2,7 +2,7 @@
 items:
   - uid: Outlook_1_2.Office.MessageRead
     summary: >-
-      The message read mode of [Office.context.mailbox.item](xref:Outlook_1_2.Office.Item)<!-- -->.
+      The message read mode of [ Office.context.mailbox.item](xref:Outlook_1_2.Office.Item)<!-- -->.
 
 
       Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat
@@ -41,20 +41,20 @@ items:
       - Outlook_1_2.Office.MessageRead.to
   - uid: Outlook_1_2.Office.MessageRead.attachments
     summary: |-
-      Gets an array of attachments for the item.
+      Gets the item's attachments as an array.
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
 
 
       Note: Certain types of files are blocked by Outlook due to potential security issues and are therefore not
-      returned. For more information, see [Blocked attachments in
+      returned. For more information, see [ Blocked attachments in
       Outlook](https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519)<!--
       -->.
     name: attachments
@@ -73,11 +73,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: body
     fullName: Outlook_1_2.Office.MessageRead.body
@@ -101,11 +101,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: cc
     fullName: Outlook_1_2.Office.MessageRead.cc
@@ -133,11 +133,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: conversationId
     fullName: Outlook_1_2.Office.MessageRead.conversationId
@@ -155,11 +155,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: dateTimeCreated
     fullName: Outlook_1_2.Office.MessageRead.dateTimeCreated
@@ -177,11 +177,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
 
 
@@ -219,11 +219,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: displayReplyAllForm(formData)
     fullName: Outlook_1_2.Office.MessageRead.displayReplyAllForm
@@ -240,7 +240,7 @@ items:
         - id: formData
           description: >-
             A string that contains text and HTML and that represents the body of the reply form. The string is limited
-            to 32 KB OR An[Office.ReplyFormData](xref:Outlook_1_2.Office.ReplyFormData) object that contains body or
+            to 32 KB OR An [Office.ReplyFormData](xref:Outlook_1_2.Office.ReplyFormData) object that contains body or
             attachment data and a callback function
           type:
             - string | ReplyFormData
@@ -267,11 +267,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: displayReplyForm(formData)
     fullName: Outlook_1_2.Office.MessageRead.displayReplyForm
@@ -288,7 +288,7 @@ items:
         - id: formData
           description: >-
             A string that contains text and HTML and that represents the body of the reply form. The string is limited
-            to 32 KB. OR An[Office.ReplyFormData](xref:Outlook_1_2.Office.ReplyFormData) object that contains body or
+            to 32 KB. OR An [Office.ReplyFormData](xref:Outlook_1_2.Office.ReplyFormData) object that contains body or
             attachment data and a callback function.
           type:
             - string | ReplyFormData
@@ -309,11 +309,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: from
     fullName: Outlook_1_2.Office.MessageRead.from
@@ -327,17 +327,17 @@ items:
           - EmailAddressDetails
   - uid: Outlook_1_2.Office.MessageRead.getEntities
     summary: |-
-      Gets the entities found in the selected item.
+      Gets the entities found in the selected item's body.
 
       Note: This method is not supported in Outlook for iOS or Outlook for Android.
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: getEntities()
     fullName: Outlook_1_2.Office.MessageRead.getEntities
@@ -352,17 +352,17 @@ items:
         description: ''
   - uid: Outlook_1_2.Office.MessageRead.getEntitiesByType
     summary: |-
-      Gets an array of all the entities of the specified entity type found in the selected item.
+      Gets an array of all the entities of the specified entity type found in the selected item's body.
 
       Note: This method is not supported in Outlook for iOS or Outlook for Android.
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
 
 
@@ -390,7 +390,7 @@ items:
           - '(string | Contact | MeetingSuggestion | PhoneNumber | TaskSuggestion)[]'
         description: >-
           If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns
-          null. If no entities of the specified type are present on the item, the method returns an empty array.
+          null. If no entities of the specified type are present in the item's body, the method returns an empty array.
           Otherwise, the type of the objects in the returned array depends on the type of entity requested in the
           entityType parameter.
       parameters:
@@ -412,11 +412,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: getFilteredEntitiesByName(name)
     fullName: Outlook_1_2.Office.MessageRead.getFilteredEntitiesByName
@@ -461,11 +461,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: getRegExMatches()
     fullName: Outlook_1_2.Office.MessageRead.getRegExMatches
@@ -501,11 +501,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: getRegExMatchesByName(name)
     fullName: Outlook_1_2.Office.MessageRead.getRegExMatchesByName
@@ -529,11 +529,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: internetMessageId
     fullName: Outlook_1_2.Office.MessageRead.internetMessageId
@@ -556,11 +556,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
 
 
@@ -598,16 +598,17 @@ items:
       Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The
       itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making
       REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more
-      details, see Use the Outlook REST APIs from an Outlook add-in.
+      details, see [ Use the Outlook REST APIs from an Outlook
+      add-in](https://docs.microsoft.com/outlook/add-ins/use-rest-api#get-the-item-id)<!-- -->.
 
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: itemId
     fullName: Outlook_1_2.Office.MessageRead.itemId
@@ -630,11 +631,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: itemType
     fullName: Outlook_1_2.Office.MessageRead.itemType
@@ -664,11 +665,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: 'loadCustomPropertiesAsync(callback, userContext)'
     fullName: Outlook_1_2.Office.MessageRead.loadCustomPropertiesAsync
@@ -676,7 +677,9 @@ items:
       - typeScript
     type: method
     syntax:
-      content: 'loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;'
+      content: >-
+        loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any):
+        void;
       return:
         type:
           - void
@@ -685,9 +688,9 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult.
+            of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<Office.CustomProperties>) => void'
         - id: userContext
           description: >-
             Optional. Developers can provide any object they wish to access in the callback function. This object can be
@@ -705,11 +708,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: normalizedSubject
     fullName: Outlook_1_2.Office.MessageRead.normalizedSubject
@@ -735,11 +738,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: sender
     fullName: Outlook_1_2.Office.MessageRead.sender
@@ -765,11 +768,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: subject
     fullName: Outlook_1_2.Office.MessageRead.subject
@@ -793,11 +796,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: to
     fullName: Outlook_1_2.Office.MessageRead.to

--- a/docs/docs-ref-autogen/outlook_1_2/office.phonenumber.yml
+++ b/docs/docs-ref-autogen/outlook_1_2/office.phonenumber.yml
@@ -12,11 +12,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: Office.PhoneNumber
     fullName: Outlook_1_2.Office.PhoneNumber

--- a/docs/docs-ref-autogen/outlook_1_2/office.recipients.yml
+++ b/docs/docs-ref-autogen/outlook_1_2/office.recipients.yml
@@ -3,11 +3,11 @@ items:
   - uid: Outlook_1_2.Office.Recipients
     summary: '\[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]'
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
     name: Office.Recipients
     fullName: Outlook_1_2.Office.Recipients
@@ -33,11 +33,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -45,7 +45,7 @@ items:
       entries.</td></tr></table>
 
 
-      In addition to the main signature, this method also has these signatures:
+      In addition to this signature, this method also has the following signatures:
 
 
       `addAsync(recipients: (string | EmailUser | EmailAddressDetails)[]): void;`
@@ -54,8 +54,8 @@ items:
       `addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options: Office.AsyncContextOptions): void;`
 
 
-      `addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult) => void):
-      void;`
+      `addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult<void>) =>
+      void): void;`
     name: 'addAsync(recipients, options, callback)'
     fullName: Outlook_1_2.Office.Recipients.addAsync
     langs:
@@ -64,7 +64,7 @@ items:
     syntax:
       content: >-
         addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options?: Office.AsyncContextOptions,
-        callback?: (result: AsyncResult) => void): void;
+        callback?: (result: AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -83,40 +83,42 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. If adding the recipients fails, the asyncResult.error property will contain
-            an error code.
+            parameter of type Office.AsyncResult. If adding the recipients fails, the asyncResult.error property will
+            contain an error code.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_2.Office.Recipients.getAsync
     summary: >-
       Gets a recipient list for an appointment or message.
 
 
-      When the call completes, the asyncResult.value property will contain an array
-      of[Office.EmailAddressDetails](xref:Outlook_1_2.Office.EmailAddressDetails) objects.
+      When the call completes, the asyncResult.value property will contain an array of
+      [Office.EmailAddressDetails](xref:Outlook_1_2.Office.EmailAddressDetails) objects.
 
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
 
 
-      In addition to the main signature, this method also has this signature:
+      In addition to this signature, this method also has the following signature:
 
 
-      `getAsync(callback: (result: AsyncResult) => void): void;`
+      `getAsync(callback: (result: AsyncResult<Office.EmailAddressDetails[]>) => void): void;`
     name: 'getAsync(options, callback)'
     fullName: Outlook_1_2.Office.Recipients.getAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;'
+      content: >-
+        getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult<Office.EmailAddressDetails[]>) =>
+        void): void;
       return:
         type:
           - void
@@ -131,9 +133,9 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult.
+            of type Office.AsyncResult. The `value` property of the result is an array of EmailAddressDetails objects.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<Office.EmailAddressDetails[]>) => void'
   - uid: Outlook_1_2.Office.Recipients.setAsync
     summary: |-
       Sets a recipient list for an appointment or message.
@@ -150,11 +152,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -162,7 +164,7 @@ items:
       entries.</td></tr></table>
 
 
-      In addition to the main signature, this method also has these signatures:
+      In addition to this signature, this method also has the following signatures:
 
 
       `setAsync(recipients: (string | EmailUser | EmailAddressDetails)[]): void;`
@@ -171,8 +173,8 @@ items:
       `setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options: Office.AsyncContextOptions): void;`
 
 
-      `setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult) => void):
-      void;`
+      `setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult<void>) =>
+      void): void;`
     name: 'setAsync(recipients, options, callback)'
     fullName: Outlook_1_2.Office.Recipients.setAsync
     langs:
@@ -181,7 +183,7 @@ items:
     syntax:
       content: >-
         setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options?: Office.AsyncContextOptions,
-        callback?: (result: AsyncResult) => void): void;
+        callback?: (result: AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -200,7 +202,7 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. If setting the recipients fails the asyncResult.error property will contain a
-            code that indicates any error that occurred while adding the data.
+            parameter of type Office.AsyncResult. If setting the recipients fails the asyncResult.error property will
+            contain a code that indicates any error that occurred while adding the data.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'

--- a/docs/docs-ref-autogen/outlook_1_2/office.replyformdata.yml
+++ b/docs/docs-ref-autogen/outlook_1_2/office.replyformdata.yml
@@ -31,17 +31,17 @@ items:
   - uid: Outlook_1_2.Office.ReplyFormData.callback
     summary: >-
       When the reply display call completes, the function passed in the callback parameter is called with a single
-      parameter, asyncResult, which is an AsyncResult object.
+      parameter, asyncResult, which is an Office.AsyncResult object.
     name: callback
     fullName: Outlook_1_2.Office.ReplyFormData.callback
     langs:
       - typeScript
     type: property
     syntax:
-      content: 'callback?: (result: AsyncResult) => void;'
+      content: 'callback?: (result: AsyncResult<any>) => void;'
       return:
         type:
-          - '(result: AsyncResult) => void'
+          - '(result: AsyncResult<any>) => void'
   - uid: Outlook_1_2.Office.ReplyFormData.htmlBody
     summary: >-
       A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32

--- a/docs/docs-ref-autogen/outlook_1_2/office.roamingsettings.yml
+++ b/docs/docs-ref-autogen/outlook_1_2/office.roamingsettings.yml
@@ -7,7 +7,7 @@ items:
       saved.
 
 
-      While the Outlook add-in API limits access to these settings to only the add-in that created them, these settings
+      While the Outlook Add-in API limits access to these settings to only the add-in that created them, these settings
       should not be considered secure storage. They can be accessed by Exchange Web Services or Extended MAPI. They
       should not be used to store sensitive information such as user credentials or security tokens.
 
@@ -27,12 +27,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.RoamingSettings
     fullName: Outlook_1_2.Office.RoamingSettings
     langs:
@@ -50,12 +50,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: get(name)
     fullName: Outlook_1_2.Office.RoamingSettings.get
     langs:
@@ -78,12 +78,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: remove(name)
     fullName: Outlook_1_2.Office.RoamingSettings.remove
     langs:
@@ -113,19 +113,19 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: saveAsync(callback)
     fullName: Outlook_1_2.Office.RoamingSettings.saveAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'saveAsync(callback?: (result: AsyncResult) => void): void;'
+      content: 'saveAsync(callback?: (result: AsyncResult<void>) => void): void;'
       return:
         type:
           - void
@@ -133,10 +133,10 @@ items:
       parameters:
         - id: callback
           description: >-
-            Optional? When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult.
+            Optional. When the method completes, the function passed in the callback parameter is called with a single
+            parameter of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_2.Office.RoamingSettings.set
     summary: >-
       Sets or creates the specified setting.
@@ -156,12 +156,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: 'set(name, value)'
     fullName: Outlook_1_2.Office.RoamingSettings.set
     langs:

--- a/docs/docs-ref-autogen/outlook_1_2/office.subject.yml
+++ b/docs/docs-ref-autogen/outlook_1_2/office.subject.yml
@@ -6,11 +6,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
     name: Office.Subject
     fullName: Outlook_1_2.Office.Subject
@@ -32,25 +32,25 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
 
 
-      In addition to the main signature, this method also has this signature:
+      In addition to this signature, this method also has the following signature:
 
 
-      `getAsync(callback: (result: AsyncResult) => void): void;`
+      `getAsync(callback: (result: AsyncResult<string>) => void): void;`
     name: 'getAsync(options, callback)'
     fullName: Outlook_1_2.Office.Subject.getAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;'
+      content: 'getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult<string>) => void): void;'
       return:
         type:
           - void
@@ -65,9 +65,9 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult.
+            of type Office.AsyncResult. The `value` property of the result is the subject of the item.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<string>) => void'
   - uid: Outlook_1_2.Office.Subject.setAsync
     summary: >-
       Sets the subject of an appointment or message.
@@ -80,11 +80,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -92,7 +92,7 @@ items:
       characters.</td></tr></table>
 
 
-      In addition to the main signature, this method also has these signatures:
+      In addition to this signature, this method also has the following signatures:
 
 
       `setAsync(subject: string): void;`
@@ -101,14 +101,16 @@ items:
       `setAsync(subject: string, options: Office.AsyncContextOptions): void;`
 
 
-      `setAsync(subject: string, callback: (result: AsyncResult) => void): void;`
+      `setAsync(subject: string, callback: (result: AsyncResult<void>) => void): void;`
     name: 'setAsync(subject, options, callback)'
     fullName: Outlook_1_2.Office.Subject.setAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'setAsync(subject: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;'
+      content: >-
+        setAsync(subject: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void):
+        void;
       return:
         type:
           - void
@@ -127,7 +129,7 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult. If setting the subject fails, the asyncResult.error property will contain an error
-            code.
+            of type Office.AsyncResult. If setting the subject fails, the asyncResult.error property will contain an
+            error code.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'

--- a/docs/docs-ref-autogen/outlook_1_2/office.tasksuggestion.yml
+++ b/docs/docs-ref-autogen/outlook_1_2/office.tasksuggestion.yml
@@ -5,18 +5,18 @@ items:
       Represents a suggested task identified in an item. Read mode only.
 
 
-      The list of tasks suggested in an email message is returned in the taskSuggestions property of the
-      \[Entities\]Entities object that is returned when the getEntities or getEntitiesByType method is called on the
-      active item.
+      The list of tasks suggested in an email message is returned in the taskSuggestions property of the [
+      Entities](xref:Outlook_1_2.Office.Entities) object that is returned when the getEntities or getEntitiesByType
+      method is called on the active item.
 
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: Office.TaskSuggestion
     fullName: Outlook_1_2.Office.TaskSuggestion

--- a/docs/docs-ref-autogen/outlook_1_2/office.time.yml
+++ b/docs/docs-ref-autogen/outlook_1_2/office.time.yml
@@ -6,11 +6,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
     name: Office.Time
     fullName: Outlook_1_2.Office.Time
@@ -33,25 +33,25 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
 
 
-      In addition to the main signature, this method also has this signature:
+      In addition to this signature, this method also has the following signature:
 
 
-      `getAsync(callback: (result: AsyncResult) => void): void;`
+      `getAsync(callback: (result: AsyncResult<Date>) => void): void;`
     name: 'getAsync(options, callback)'
     fullName: Outlook_1_2.Office.Time.getAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;'
+      content: 'getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult<Date>) => void): void;'
       return:
         type:
           - void
@@ -66,9 +66,9 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult.
+            of type AsyncResult. The `value` property of the result is a Date object.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<Date>) => void'
   - uid: Outlook_1_2.Office.Time.setAsync
     summary: >-
       Sets the start or end time of an appointment.
@@ -84,11 +84,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -96,7 +96,7 @@ items:
       time.</td></tr></table>
 
 
-      In addition to the main signature, this method also has these signatures:
+      In addition to this signature, this method also has the following signatures:
 
 
       `setAsync(dateTime: Date): void;`
@@ -105,14 +105,16 @@ items:
       `setAsync(dateTime: Date, options: Office.AsyncContextOptions): void;`
 
 
-      `setAsync(dateTime: Date, callback: (result: AsyncResult) => void): void;`
+      `setAsync(dateTime: Date, callback: (result: AsyncResult<void>) => void): void;`
     name: 'setAsync(dateTime, options, callback)'
     fullName: Outlook_1_2.Office.Time.setAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'setAsync(dateTime: Date, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;'
+      content: >-
+        setAsync(dateTime: Date, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void):
+        void;
       return:
         type:
           - void
@@ -131,7 +133,7 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult. If setting the date and time fails, the asyncResult.error property will contain an
-            error code.
+            of type Office.AsyncResult. If setting the date and time fails, the asyncResult.error property will contain
+            an error code.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'

--- a/docs/docs-ref-autogen/outlook_1_2/office.userprofile.yml
+++ b/docs/docs-ref-autogen/outlook_1_2/office.userprofile.yml
@@ -8,12 +8,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.UserProfile
     fullName: Outlook_1_2.Office.UserProfile
     langs:
@@ -30,12 +30,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: displayName
     fullName: Outlook_1_2.Office.UserProfile.displayName
     langs:
@@ -52,12 +52,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: emailAddress
     fullName: Outlook_1_2.Office.UserProfile.emailAddress
     langs:
@@ -74,12 +74,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: timeZone
     fullName: Outlook_1_2.Office.UserProfile.timeZone
     langs:

--- a/docs/docs-ref-autogen/outlook_1_3.yml
+++ b/docs/docs-ref-autogen/outlook_1_3.yml
@@ -30,6 +30,7 @@ items:
       - Outlook_1_3.Office.MailboxEnums.EntityType
       - Outlook_1_3.Office.MailboxEnums.ItemNotificationMessageType
       - Outlook_1_3.Office.MailboxEnums.ItemType
+      - Outlook_1_3.Office.MailboxEnums.OWAView
       - Outlook_1_3.Office.MailboxEnums.RecipientType
       - Outlook_1_3.Office.MailboxEnums.ResponseType
       - Outlook_1_3.Office.MailboxEnums.RestVersion
@@ -96,6 +97,8 @@ references:
     name: Office.MailboxEnums.ItemNotificationMessageType
   - uid: Outlook_1_3.Office.MailboxEnums.ItemType
     name: Office.MailboxEnums.ItemType
+  - uid: Outlook_1_3.Office.MailboxEnums.OWAView
+    name: Office.MailboxEnums.OWAView
   - uid: Outlook_1_3.Office.MailboxEnums.RecipientType
     name: Office.MailboxEnums.RecipientType
   - uid: Outlook_1_3.Office.MailboxEnums.ResponseType

--- a/docs/docs-ref-autogen/outlook_1_3/office.appointmentcompose.yml
+++ b/docs/docs-ref-autogen/outlook_1_3/office.appointmentcompose.yml
@@ -2,11 +2,11 @@
 items:
   - uid: Outlook_1_3.Office.AppointmentCompose
     summary: >-
-      The appointment organizer mode of [Office.context.mailbox.item](xref:Outlook_1_3.Office.Item)<!-- -->.
+      The appointment organizer mode of [ Office.context.mailbox.item](xref:Outlook_1_3.Office.Item)<!-- -->.
 
 
       Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat
-      this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
+      this as a mode of `Office.context.mailbox.item`<!-- -->. Refer to the Object Model pages for more information.
     name: Office.AppointmentCompose
     fullName: Outlook_1_3.Office.AppointmentCompose
     langs:
@@ -50,11 +50,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Organizer</td></tr>
 
 
@@ -73,7 +73,8 @@ items:
       `addFileAttachmentAsync(uri: string, attachmentName: string, options: Office.AsyncContextOptions): void;`
 
 
-      `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+      `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void):
+      void;`
     name: 'addFileAttachmentAsync(uri, attachmentName, options, callback)'
     fullName: Outlook_1_3.Office.AppointmentCompose.addFileAttachmentAsync
     langs:
@@ -82,7 +83,7 @@ items:
     syntax:
       content: >-
         addFileAttachmentAsync(uri: string, attachmentName: string, options?: Office.AsyncContextOptions, callback?:
-        (result: AsyncResult) => void): void;
+        (result: AsyncResult<string>) => void): void;
       return:
         type:
           - void
@@ -114,7 +115,7 @@ items:
             property. If uploading the attachment fails, the asyncResult object will contain an Error object that
             provides a description of the error.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<string>) => void'
   - uid: Outlook_1_3.Office.AppointmentCompose.addItemAttachmentAsync
     summary: >-
       Adds an Exchange item, such as a message, as an attachment to the message or appointment.
@@ -130,17 +131,17 @@ items:
       session.
 
 
-      If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items
+      If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items
       other than the item that you are editing; however, this is not supported and is not recommended.
 
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Organizer</td></tr>
 
 
@@ -148,7 +149,7 @@ items:
       attachments.</td></tr></table>
 
 
-      In addition to the main signature, this method also has these signatures:
+      In addition to this signature, this method also has the following signatures:
 
 
       `addItemAttachmentAsync(itemId: any, attachmentName: string): void;`
@@ -157,7 +158,8 @@ items:
       `addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;`
 
 
-      `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+      `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void):
+      void;`
     name: 'addItemAttachmentAsync(itemId, attachmentName, options, callback)'
     fullName: Outlook_1_3.Office.AppointmentCompose.addItemAttachmentAsync
     langs:
@@ -166,7 +168,7 @@ items:
     syntax:
       content: >-
         addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?:
-        (result: AsyncResult) => void): void;
+        (result: AsyncResult<string>) => void): void;
       return:
         type:
           - void
@@ -191,22 +193,22 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value
+            of type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value
             property. If adding the attachment fails, the asyncResult object will contain an Error object that provides
             a description of the error.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<string>) => void'
   - uid: Outlook_1_3.Office.AppointmentCompose.body
     summary: |-
       Gets an object that provides methods for manipulating the body of an item.
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: body
@@ -237,11 +239,11 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: close()
@@ -261,11 +263,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: dateTimeCreated
@@ -284,11 +286,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
 
@@ -320,11 +322,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: end
@@ -352,11 +354,11 @@ items:
 
       \[ [API set: Mailbox 1.2](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: 'getSelectedDataAsync(coerciontype, options, callback)'
@@ -367,7 +369,7 @@ items:
     syntax:
       content: >-
         getSelectedDataAsync(coerciontype: Office.CoercionType, options: Office.AsyncContextOptions, callback: (result:
-        AsyncResult) => void): void;
+        AsyncResult<any>) => void): void;
       return:
         type:
           - void
@@ -388,7 +390,7 @@ items:
             When the method completes, the function passed in the callback parameter is called with a single parameter
             of type AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<any>) => void'
   - uid: Outlook_1_3.Office.AppointmentCompose.itemType
     summary: >-
       Gets the type of item that an instance represents.
@@ -400,11 +402,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: itemType
@@ -435,11 +437,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: 'loadCustomPropertiesAsync(callback, userContext)'
@@ -448,7 +450,9 @@ items:
       - typeScript
     type: method
     syntax:
-      content: 'loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;'
+      content: >-
+        loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any):
+        void;
       return:
         type:
           - void
@@ -457,9 +461,9 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult.
+            of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<Office.CustomProperties>) => void'
         - id: userContext
           description: >-
             Optional. Developers can provide any object they wish to access in the callback function. This object can be
@@ -474,11 +478,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: location
@@ -497,11 +501,11 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: notificationMessages
@@ -524,11 +528,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: optionalAttendees
@@ -549,17 +553,17 @@ items:
       The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best
       practice, you should use the attachment identifier to remove an attachment only if the same mail app has added
       that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid
-      only within the same session. A session is over when the user closes the app, or if the user starts composing in
-      an inline form and subsequently pops out the inline form to continue in a separate window.
+      only within the same session. A session is over when the user closes the app, or if the user starts composing an
+      inline form then subsequently pops out the form to continue in a separate window.
 
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Organizer</td></tr>
 
 
@@ -575,7 +579,7 @@ items:
       `removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;`
 
 
-      `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;`
+      `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;`
     name: 'removeAttachmentAsync(attachmentIndex, options, callback)'
     fullName: Outlook_1_3.Office.AppointmentCompose.removeAttachmentAsync
     langs:
@@ -584,7 +588,7 @@ items:
     syntax:
       content: >-
         removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result:
-        AsyncResult) => void): void;
+        AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -603,10 +607,10 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain
-            an error code with the reason for the failure.
+            parameter of type Office.AsyncResult. If removing the attachment fails, the asyncResult.error property will
+            contain an error code with the reason for the failure.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_3.Office.AppointmentCompose.requiredAttendees
     summary: >-
       Provides access to the required attendees of an event. The type of object and level of access depends on the mode
@@ -617,11 +621,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: requiredAttendees
@@ -667,11 +671,11 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Organizer</td></tr>
 
 
@@ -687,14 +691,14 @@ items:
       `saveAsync(options: Office.AsyncContextOptions): void;`
 
 
-      `saveAsync(callback: (result: AsyncResult) => void): void;`
+      `saveAsync(callback: (result: AsyncResult<void>) => void): void;`
     name: 'saveAsync(options, callback)'
     fullName: Outlook_1_3.Office.AppointmentCompose.saveAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;'
+      content: 'saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;'
       return:
         type:
           - void
@@ -709,10 +713,9 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain
-            an error code with the reason for the failure.
+            parameter of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_3.Office.AppointmentCompose.setSelectedDataAsync
     summary: >-
       Asynchronously inserts data into the body or subject of a message.
@@ -725,11 +728,11 @@ items:
 
       \[ [API set: Mailbox 1.2](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Organizer</td></tr>
 
 
@@ -742,10 +745,10 @@ items:
       `setSelectedDataAsync(data: string): void;`
 
 
-      `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions &amp; CoercionTypeOptions): void;`
+      `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`
 
 
-      `setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;`
+      `setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;`
     name: 'setSelectedDataAsync(data, options, callback)'
     fullName: Outlook_1_3.Office.AppointmentCompose.setSelectedDataAsync
     langs:
@@ -754,7 +757,7 @@ items:
     syntax:
       content: >-
         setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?:
-        (result: AsyncResult) => void): void;
+        (result: AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -780,10 +783,9 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain
-            an error code with the reason for the failure.
+            parameter of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_3.Office.AppointmentCompose.start
     summary: >-
       Gets or sets the date and time that the appointment is to begin.
@@ -800,11 +802,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: start
@@ -827,11 +829,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: subject

--- a/docs/docs-ref-autogen/outlook_1_3/office.appointmentform.yml
+++ b/docs/docs-ref-autogen/outlook_1_3/office.appointmentform.yml
@@ -6,12 +6,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.AppointmentForm
     fullName: Outlook_1_3.Office.AppointmentForm
     langs:
@@ -33,12 +33,12 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: body
     fullName: Outlook_1_3.Office.AppointmentForm.body
     langs:
@@ -76,12 +76,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: end
     fullName: Outlook_1_3.Office.AppointmentForm.end
     langs:
@@ -112,10 +112,10 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: location
     fullName: Outlook_1_3.Office.AppointmentForm.location
     langs:
@@ -148,12 +148,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: optionalAttendees
     fullName: Outlook_1_3.Office.AppointmentForm.optionalAttendees
     langs:
@@ -186,12 +186,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: requiredAttendees
     fullName: Outlook_1_3.Office.AppointmentForm.requiredAttendees
     langs:
@@ -240,12 +240,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: start
     fullName: Outlook_1_3.Office.AppointmentForm.start
     langs:
@@ -279,12 +279,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: subject
     fullName: Outlook_1_3.Office.AppointmentForm.subject
     langs:

--- a/docs/docs-ref-autogen/outlook_1_3/office.appointmentread.yml
+++ b/docs/docs-ref-autogen/outlook_1_3/office.appointmentread.yml
@@ -2,7 +2,7 @@
 items:
   - uid: Outlook_1_3.Office.AppointmentRead
     summary: >-
-      The appointment attendee mode of [Office.context.mailbox.item](xref:Outlook_1_3.Office.Item)<!-- -->.
+      The appointment attendee mode of [ Office.context.mailbox.item](xref:Outlook_1_3.Office.Item)<!-- -->.
 
 
       Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat
@@ -42,20 +42,20 @@ items:
       - Outlook_1_3.Office.AppointmentRead.subject
   - uid: Outlook_1_3.Office.AppointmentRead.attachments
     summary: |-
-      Gets an array of attachments for the item.
+      Gets the item's attachments as an array.
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
 
 
       Note: Certain types of files are blocked by Outlook due to potential security issues and are therefore not
-      returned. For more information, see [Blocked attachments in
+      returned. For more information, see [ Blocked attachments in
       Outlook](https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519)<!--
       -->.
     name: attachments
@@ -74,11 +74,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: body
     fullName: Outlook_1_3.Office.AppointmentRead.body
@@ -96,11 +96,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: dateTimeCreated
     fullName: Outlook_1_3.Office.AppointmentRead.dateTimeCreated
@@ -118,11 +118,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
 
 
@@ -160,11 +160,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: displayReplyAllForm(formData)
     fullName: Outlook_1_3.Office.AppointmentRead.displayReplyAllForm
@@ -181,7 +181,7 @@ items:
         - id: formData
           description: >-
             A string that contains text and HTML and that represents the body of the reply form. The string is limited
-            to 32 KB OR An[Office.ReplyFormData](xref:Outlook_1_3.Office.ReplyFormData) object that contains body or
+            to 32 KB OR An [Office.ReplyFormData](xref:Outlook_1_3.Office.ReplyFormData) object that contains body or
             attachment data and a callback function
           type:
             - string | ReplyFormData
@@ -208,11 +208,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: displayReplyForm(formData)
     fullName: Outlook_1_3.Office.AppointmentRead.displayReplyForm
@@ -229,7 +229,7 @@ items:
         - id: formData
           description: >-
             A string that contains text and HTML and that represents the body of the reply form. The string is limited
-            to 32 KB. OR An[Office.ReplyFormData](xref:Outlook_1_3.Office.ReplyFormData) object that contains body or
+            to 32 KB. OR An [Office.ReplyFormData](xref:Outlook_1_3.Office.ReplyFormData) object that contains body or
             attachment data and a callback function.
           type:
             - string | ReplyFormData
@@ -248,11 +248,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: end
     fullName: Outlook_1_3.Office.AppointmentRead.end
@@ -266,17 +266,17 @@ items:
           - Date
   - uid: Outlook_1_3.Office.AppointmentRead.getEntities
     summary: |-
-      Gets the entities found in the selected item.
+      Gets the entities found in the selected item's body.
 
       Note: This method is not supported in Outlook for iOS or Outlook for Android.
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: getEntities()
     fullName: Outlook_1_3.Office.AppointmentRead.getEntities
@@ -291,17 +291,17 @@ items:
         description: ''
   - uid: Outlook_1_3.Office.AppointmentRead.getEntitiesByType
     summary: |-
-      Gets an array of all the entities of the specified entity type found in the selected item.
+      Gets an array of all the entities of the specified entity type found in the selected item's body.
 
       Note: This method is not supported in Outlook for iOS or Outlook for Android.
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
 
 
@@ -329,7 +329,7 @@ items:
           - '(string | Contact | MeetingSuggestion | PhoneNumber | TaskSuggestion)[]'
         description: >-
           If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns
-          null. If no entities of the specified type are present on the item, the method returns an empty array.
+          null. If no entities of the specified type are present in the item's body, the method returns an empty array.
           Otherwise, the type of the objects in the returned array depends on the type of entity requested in the
           entityType parameter.
       parameters:
@@ -351,11 +351,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: getFilteredEntitiesByName(name)
     fullName: Outlook_1_3.Office.AppointmentRead.getFilteredEntitiesByName
@@ -400,11 +400,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: getRegExMatches()
     fullName: Outlook_1_3.Office.AppointmentRead.getRegExMatches
@@ -440,11 +440,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: getRegExMatchesByName(name)
     fullName: Outlook_1_3.Office.AppointmentRead.getRegExMatchesByName
@@ -473,11 +473,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
 
 
@@ -515,16 +515,17 @@ items:
       Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The
       itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making
       REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more
-      details, see Use the Outlook REST APIs from an Outlook add-in.
+      details, see [ Use the Outlook REST APIs from an Outlook
+      add-in](https://docs.microsoft.com/outlook/add-ins/use-rest-api#get-the-item-id)<!-- -->.
 
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: itemId
     fullName: Outlook_1_3.Office.AppointmentRead.itemId
@@ -547,11 +548,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: itemType
     fullName: Outlook_1_3.Office.AppointmentRead.itemType
@@ -581,11 +582,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: 'loadCustomPropertiesAsync(callback, userContext)'
     fullName: Outlook_1_3.Office.AppointmentRead.loadCustomPropertiesAsync
@@ -593,7 +594,9 @@ items:
       - typeScript
     type: method
     syntax:
-      content: 'loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;'
+      content: >-
+        loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any):
+        void;
       return:
         type:
           - void
@@ -602,9 +605,9 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult.
+            of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<Office.CustomProperties>) => void'
         - id: userContext
           description: >-
             Optional. Developers can provide any object they wish to access in the callback function. This object can be
@@ -619,11 +622,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: location
     fullName: Outlook_1_3.Office.AppointmentRead.location
@@ -646,11 +649,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: normalizedSubject
     fullName: Outlook_1_3.Office.AppointmentRead.normalizedSubject
@@ -668,11 +671,11 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: notificationMessages
     fullName: Outlook_1_3.Office.AppointmentRead.notificationMessages
@@ -697,11 +700,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: optionalAttendees
     fullName: Outlook_1_3.Office.AppointmentRead.optionalAttendees
@@ -715,15 +718,15 @@ items:
           - 'EmailAddressDetails[]'
   - uid: Outlook_1_3.Office.AppointmentRead.organizer
     summary: |-
-      Gets the email address of the meeting organizer for a specified meeting. Read mode only.
+      Gets the email address of the meeting organizer for a specified meeting.
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: organizer
     fullName: Outlook_1_3.Office.AppointmentRead.organizer
@@ -748,11 +751,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: requiredAttendees
     fullName: Outlook_1_3.Office.AppointmentRead.requiredAttendees
@@ -775,11 +778,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: start
     fullName: Outlook_1_3.Office.AppointmentRead.start
@@ -805,11 +808,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: subject
     fullName: Outlook_1_3.Office.AppointmentRead.subject

--- a/docs/docs-ref-autogen/outlook_1_3/office.attachmentdetails.yml
+++ b/docs/docs-ref-autogen/outlook_1_3/office.attachmentdetails.yml
@@ -8,11 +8,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: Office.AttachmentDetails
     fullName: Outlook_1_3.Office.AttachmentDetails

--- a/docs/docs-ref-autogen/outlook_1_3/office.body.yml
+++ b/docs/docs-ref-autogen/outlook_1_3/office.body.yml
@@ -8,12 +8,12 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.Body
     fullName: Outlook_1_3.Office.Body
     langs:
@@ -42,18 +42,18 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
 
 
-      In addition to the main signature, this method also has this signature:
+      In addition to this signature, this method also has the following signature:
 
 
-      `getAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult) => void): void;`
+      `getAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult<Office.Body>) => void): void;`
     name: 'getAsync(coerciontype, options, callback)'
     fullName: Outlook_1_3.Office.Body.getAsync
     langs:
@@ -62,7 +62,7 @@ items:
     syntax:
       content: >-
         getAsync(coerciontype: Office.CoercionType, options?: Office.AsyncContextOptions, callback?: (result:
-        AsyncResult) => void): void;
+        AsyncResult<Office.Body>) => void): void;
       return:
         type:
           - void
@@ -84,18 +84,18 @@ items:
             parameter of type AsyncResult. The body is provided in the requested format in the asyncResult.value
             property.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<Office.Body>) => void'
   - uid: Outlook_1_3.Office.Body.getTypeAsync
     summary: |-
       Gets a value that indicates whether the content is in HTML or text format.
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
     name: 'getTypeAsync(options, callback)'
     fullName: Outlook_1_3.Office.Body.getTypeAsync
@@ -103,7 +103,9 @@ items:
       - typeScript
     type: method
     syntax:
-      content: 'getTypeAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;'
+      content: >-
+        getTypeAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<Office.CoercionType>) =>
+        void): void;
       return:
         type:
           - void
@@ -118,10 +120,10 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. The content type is returned as one of the CoercionType values in the
+            parameter of type Office.AsyncResult. The content type is returned as one of the CoercionType values in the
             asyncResult.value property.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<Office.CoercionType>) => void'
   - uid: Outlook_1_3.Office.Body.prependAsync
     summary: >-
       Adds the specified content to the beginning of the item body.
@@ -137,11 +139,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -149,13 +151,13 @@ items:
       characters.</td></tr></table>
 
 
-      In addition to the main signature, this method also has these signatures:
+      In addition to this signature, this method also has the following signatures:
 
 
-      `prependAsync(data: string, options: Office.AsyncContextOptions &amp; CoercionTypeOptions): void;`
+      `prependAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`
 
 
-      `prependAsync(data: string, callback: (result: AsyncResult) => void): void;`
+      `prependAsync(data: string, callback: (result: AsyncResult<void>) => void): void;`
 
 
       `prependAsync(data: string): void;`
@@ -167,7 +169,7 @@ items:
     syntax:
       content: >-
         prependAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result:
-        AsyncResult) => void): void;
+        AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -187,9 +189,10 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. Any errors encountered will be provided in the asyncResult.error property.
+            parameter of type Office.AsyncResult. Any errors encountered will be provided in the asyncResult.error
+            property.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_3.Office.Body.setAsync
     summary: >-
       Replaces the entire body with the specified text.
@@ -207,11 +210,11 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -220,13 +223,13 @@ items:
       Office.CoercionType.Html and the message body is in plain text.</td></tr></table>
 
 
-      In addition to the main signature, this method also has these signatures:
+      In addition to this signature, this method also has the following signatures:
 
 
-      `setAsync(data: string, options: Office.AsyncContextOptions &amp; CoercionTypeOptions): void;`
+      `setAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`
 
 
-      `setAsync(data: string, callback: (result: AsyncResult) => void): void;`
+      `setAsync(data: string, callback: (result: AsyncResult<void>) => void): void;`
 
 
       `setAsync(data: string): void;`
@@ -238,7 +241,7 @@ items:
     syntax:
       content: >-
         setAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result:
-        AsyncResult) => void): void;
+        AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -258,9 +261,10 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. Any errors encountered will be provided in the asyncResult.error property.
+            parameter of type Office.AsyncResult. Any errors encountered will be provided in the asyncResult.error
+            property.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_3.Office.Body.setSelectedDataAsync
     summary: >-
       Replaces the selection in the body with the specified text.
@@ -278,11 +282,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -291,13 +295,13 @@ items:
       Office.CoercionType.Html and the message body is in plain text.</td></tr></table>
 
 
-      In addition to the main signature, this method also has these signatures:
+      In addition to this signature, this method also has the following signatures:
 
 
-      `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions &amp; CoercionTypeOptions): void;`
+      `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`
 
 
-      `setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;`
+      `setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;`
 
 
       `setSelectedDataAsync(data: string): void;`
@@ -309,7 +313,7 @@ items:
     syntax:
       content: >-
         setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?:
-        (result: AsyncResult) => void): void;
+        (result: AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -329,6 +333,7 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. Any errors encountered will be provided in the asyncResult.error property.
+            parameter of type Office.AsyncResult. Any errors encountered will be provided in the asyncResult.error
+            property.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'

--- a/docs/docs-ref-autogen/outlook_1_3/office.contact.yml
+++ b/docs/docs-ref-autogen/outlook_1_3/office.contact.yml
@@ -12,11 +12,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: Office.Contact
     fullName: Outlook_1_3.Office.Contact

--- a/docs/docs-ref-autogen/outlook_1_3/office.customproperties.yml
+++ b/docs/docs-ref-autogen/outlook_1_3/office.customproperties.yml
@@ -15,12 +15,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.CustomProperties
     fullName: Outlook_1_3.Office.CustomProperties
     langs:
@@ -35,12 +35,12 @@ items:
   - uid: Outlook_1_3.Office.CustomProperties.get
     summary: Returns the value of the specified custom property.
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: get(name)
     fullName: Outlook_1_3.Office.CustomProperties.get
     langs:
@@ -66,12 +66,12 @@ items:
 
       To make the removal of the property permanent, you must call the saveAsync method of the CustomProperties object.
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: remove(name)
     fullName: Outlook_1_3.Office.CustomProperties.remove
     langs:
@@ -85,7 +85,10 @@ items:
         description: ''
       parameters:
         - id: name
-          description: 'The name of the property to be removed. \[Api set: Mailbox 1.0\]'
+          description: |-
+            The name of the property to be removed.
+
+            \[Api set: Mailbox 1.0\]
           type:
             - string
   - uid: Outlook_1_3.Office.CustomProperties.saveAsync
@@ -102,19 +105,19 @@ items:
       becomes disconnected. If the add-in calls saveAsync while in the disconnected state, saveAsync would return an
       error. Your callback method should handle this error accordingly.
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: 'saveAsync(callback, asyncContext)'
     fullName: Outlook_1_3.Office.CustomProperties.saveAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'saveAsync(callback?: (result: AsyncResult) => void, asyncContext?: any): void;'
+      content: 'saveAsync(callback?: (result: AsyncResult<void>) => void, asyncContext?: any): void;'
       return:
         type:
           - void
@@ -123,11 +126,14 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult.
+            parameter of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
         - id: asyncContext
-          description: 'Optional. Any state data that is passed to the callback method. \[Api set: Mailbox 1.0\]'
+          description: |-
+            Optional. Any state data that is passed to the callback method.
+
+            \[Api set: Mailbox 1.0\]
           type:
             - any
   - uid: Outlook_1_3.Office.CustomProperties.set
@@ -146,12 +152,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: 'set(name, value)'
     fullName: Outlook_1_3.Office.CustomProperties.set
     langs:

--- a/docs/docs-ref-autogen/outlook_1_3/office.diagnostics.yml
+++ b/docs/docs-ref-autogen/outlook_1_3/office.diagnostics.yml
@@ -6,12 +6,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.Diagnostics
     fullName: Outlook_1_3.Office.Diagnostics
     langs:
@@ -30,12 +30,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: hostName
     fullName: Outlook_1_3.Office.Diagnostics.hostName
     langs:
@@ -58,12 +58,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: hostVersion
     fullName: Outlook_1_3.Office.Diagnostics.hostVersion
     langs:
@@ -102,19 +102,19 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: OWAView
     fullName: Outlook_1_3.Office.Diagnostics.OWAView
     langs:
       - typeScript
     type: property
     syntax:
-      content: 'OWAView: "string";'
+      content: 'OWAView: MailboxEnums.OWAView | "OneColumn" | "TwoColumns" | "ThreeColumns";'
       return:
         type:
-          - '"string"'
+          - MailboxEnums.OWAView | "OneColumn" | "TwoColumns" | "ThreeColumns"

--- a/docs/docs-ref-autogen/outlook_1_3/office.emailaddressdetails.yml
+++ b/docs/docs-ref-autogen/outlook_1_3/office.emailaddressdetails.yml
@@ -6,12 +6,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.EmailAddressDetails
     fullName: Outlook_1_3.Office.EmailAddressDetails
     langs:

--- a/docs/docs-ref-autogen/outlook_1_3/office.emailuser.yml
+++ b/docs/docs-ref-autogen/outlook_1_3/office.emailuser.yml
@@ -6,11 +6,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: Office.EmailUser
     fullName: Outlook_1_3.Office.EmailUser

--- a/docs/docs-ref-autogen/outlook_1_3/office.entities.yml
+++ b/docs/docs-ref-autogen/outlook_1_3/office.entities.yml
@@ -34,11 +34,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: Office.Entities
     fullName: Outlook_1_3.Office.Entities

--- a/docs/docs-ref-autogen/outlook_1_3/office.item.yml
+++ b/docs/docs-ref-autogen/outlook_1_3/office.item.yml
@@ -8,12 +8,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.Item
     fullName: Outlook_1_3.Office.Item
     langs:
@@ -33,12 +33,12 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: body
     fullName: Outlook_1_3.Office.Item.body
     langs:
@@ -55,11 +55,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: dateTimeCreated
     fullName: Outlook_1_3.Office.Item.dateTimeCreated
@@ -77,11 +77,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
 
 
@@ -107,12 +107,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: itemType
     fullName: Outlook_1_3.Office.Item.itemType
     langs:
@@ -141,19 +141,21 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: 'loadCustomPropertiesAsync(callback, userContext)'
     fullName: Outlook_1_3.Office.Item.loadCustomPropertiesAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;'
+      content: >-
+        loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any):
+        void;
       return:
         type:
           - void
@@ -162,9 +164,9 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult.
+            of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<Office.CustomProperties>) => void'
         - id: userContext
           description: >-
             Optional. Developers can provide any object they wish to access in the callback function. This object can be
@@ -177,12 +179,12 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: notificationMessages
     fullName: Outlook_1_3.Office.Item.notificationMessages
     langs:

--- a/docs/docs-ref-autogen/outlook_1_3/office.itemcompose.yml
+++ b/docs/docs-ref-autogen/outlook_1_3/office.itemcompose.yml
@@ -2,11 +2,11 @@
 items:
   - uid: Outlook_1_3.Office.ItemCompose
     summary: >-
-      The compose mode of [Office.context.mailbox.item](xref:Outlook_1_3.Office.Item)<!-- -->.
+      The compose mode of [ Office.context.mailbox.item](xref:Outlook_1_3.Office.Item)<!-- -->.
 
 
       Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat
-      this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
+      this as a mode of `Office.context.mailbox.item`<!-- -->. Refer to the Object Model pages for more information.
     name: Office.ItemCompose
     fullName: Outlook_1_3.Office.ItemCompose
     langs:
@@ -39,11 +39,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -62,7 +62,8 @@ items:
       `addFileAttachmentAsync(uri: string, attachmentName: string, options: Office.AsyncContextOptions): void;`
 
 
-      `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+      `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void):
+      void;`
     name: 'addFileAttachmentAsync(uri, attachmentName, options, callback)'
     fullName: Outlook_1_3.Office.ItemCompose.addFileAttachmentAsync
     langs:
@@ -71,7 +72,7 @@ items:
     syntax:
       content: >-
         addFileAttachmentAsync(uri: string, attachmentName: string, options?: Office.AsyncContextOptions, callback?:
-        (result: AsyncResult) => void): void;
+        (result: AsyncResult<string>) => void): void;
       return:
         type:
           - void
@@ -103,7 +104,7 @@ items:
             property. If uploading the attachment fails, the asyncResult object will contain an Error object that
             provides a description of the error.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<string>) => void'
   - uid: Outlook_1_3.Office.ItemCompose.addItemAttachmentAsync
     summary: >-
       Adds an Exchange item, such as a message, as an attachment to the message or appointment.
@@ -119,17 +120,17 @@ items:
       session.
 
 
-      If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items
+      If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items
       other than the item that you are editing; however, this is not supported and is not recommended.
 
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -137,7 +138,7 @@ items:
       attachments.</td></tr></table>
 
 
-      In addition to the main signature, this method also has these signatures:
+      In addition to this signature, this method also has the following signatures:
 
 
       `addItemAttachmentAsync(itemId: any, attachmentName: string): void;`
@@ -146,7 +147,8 @@ items:
       `addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;`
 
 
-      `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+      `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void):
+      void;`
     name: 'addItemAttachmentAsync(itemId, attachmentName, options, callback)'
     fullName: Outlook_1_3.Office.ItemCompose.addItemAttachmentAsync
     langs:
@@ -155,7 +157,7 @@ items:
     syntax:
       content: >-
         addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?:
-        (result: AsyncResult) => void): void;
+        (result: AsyncResult<string>) => void): void;
       return:
         type:
           - void
@@ -180,11 +182,11 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value
+            of type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value
             property. If adding the attachment fails, the asyncResult object will contain an Error object that provides
             a description of the error.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<string>) => void'
   - uid: Outlook_1_3.Office.ItemCompose.close
     summary: >-
       Closes the current item that is being composed
@@ -203,11 +205,11 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
     name: close()
     fullName: Outlook_1_3.Office.ItemCompose.close
@@ -235,11 +237,11 @@ items:
 
       \[ [API set: Mailbox 1.2](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
     name: 'getSelectedDataAsync(coerciontype, callback)'
     fullName: Outlook_1_3.Office.ItemCompose.getSelectedDataAsync
@@ -247,7 +249,7 @@ items:
       - typeScript
     type: method
     syntax:
-      content: 'getSelectedDataAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult) => void): void;'
+      content: 'getSelectedDataAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult<any>) => void): void;'
       return:
         type:
           - void
@@ -260,9 +262,9 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult.
+            of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<any>) => void'
   - uid: Outlook_1_3.Office.ItemCompose.removeAttachmentAsync
     summary: >-
       Removes an attachment from a message or appointment.
@@ -271,17 +273,17 @@ items:
       The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best
       practice, you should use the attachment identifier to remove an attachment only if the same mail app has added
       that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid
-      only within the same session. A session is over when the user closes the app, or if the user starts composing in
-      an inline form and subsequently pops out the inline form to continue in a separate window.
+      only within the same session. A session is over when the user closes the app, or if the user starts composing an
+      inline form then subsequently pops out the form to continue in a separate window.
 
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -297,7 +299,7 @@ items:
       `removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;`
 
 
-      `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;`
+      `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;`
     name: 'removeAttachmentAsync(attachmentIndex, options, callback)'
     fullName: Outlook_1_3.Office.ItemCompose.removeAttachmentAsync
     langs:
@@ -306,7 +308,7 @@ items:
     syntax:
       content: >-
         removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result:
-        AsyncResult) => void): void;
+        AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -325,10 +327,10 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain
-            an error code with the reason for the failure.
+            parameter of type Office.AsyncResult. If removing the attachment fails, the asyncResult.error property will
+            contain an error code with the reason for the failure.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_3.Office.ItemCompose.saveAsync
     summary: >-
       Asynchronously saves an item.
@@ -362,11 +364,11 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -382,14 +384,14 @@ items:
       `saveAsync(options: Office.AsyncContextOptions): void;`
 
 
-      `saveAsync(callback: (result: AsyncResult) => void): void;`
+      `saveAsync(callback: (result: AsyncResult<void>) => void): void;`
     name: 'saveAsync(options, callback)'
     fullName: Outlook_1_3.Office.ItemCompose.saveAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;'
+      content: 'saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;'
       return:
         type:
           - void
@@ -404,10 +406,10 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain
-            an error code with the reason for the failure.
+            parameter of type Office.AsyncResult. If removing the attachment fails, the asyncResult.error property will
+            contain an error code with the reason for the failure.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_3.Office.ItemCompose.setSelectedDataAsync
     summary: >-
       Asynchronously inserts data into the body or subject of a message.
@@ -420,11 +422,11 @@ items:
 
       \[ [API set: Mailbox 1.2](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -437,10 +439,10 @@ items:
       `setSelectedDataAsync(data: string): void;`
 
 
-      `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions &amp; CoercionTypeOptions): void;`
+      `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`
 
 
-      `setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;`
+      `setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;`
     name: 'setSelectedDataAsync(data, options, callback)'
     fullName: Outlook_1_3.Office.ItemCompose.setSelectedDataAsync
     langs:
@@ -449,7 +451,7 @@ items:
     syntax:
       content: >-
         setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?:
-        (result: AsyncResult) => void): void;
+        (result: AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -475,10 +477,9 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain
-            an error code with the reason for the failure.
+            parameter of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_3.Office.ItemCompose.subject
     summary: |-
       Gets or sets the description that appears in the subject field of an item.
@@ -489,12 +490,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: subject
     fullName: Outlook_1_3.Office.ItemCompose.subject
     langs:

--- a/docs/docs-ref-autogen/outlook_1_3/office.itemread.yml
+++ b/docs/docs-ref-autogen/outlook_1_3/office.itemread.yml
@@ -2,11 +2,11 @@
 items:
   - uid: Outlook_1_3.Office.ItemRead
     summary: >-
-      The read mode of [Office.context.mailbox.item](xref:Outlook_1_3.Office.Item)<!-- -->.
+      The read mode of [ Office.context.mailbox.item](xref:Outlook_1_3.Office.Item)<!-- -->.
 
 
       Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat
-      this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
+      this as a mode of `Office.context.mailbox.item`<!-- -->. Refer to the Object Model pages for more information.
     name: Office.ItemRead
     fullName: Outlook_1_3.Office.ItemRead
     langs:
@@ -30,20 +30,20 @@ items:
       - Outlook_1_3.Office.ItemRead.subject
   - uid: Outlook_1_3.Office.ItemRead.attachments
     summary: |-
-      Gets an array of attachments for the item.
+      Gets the item's attachments as an array.
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
 
 
       Note: Certain types of files are blocked by Outlook due to potential security issues and are therefore not
-      returned. For more information, see [Blocked attachments in
+      returned. For more information, see [ Blocked attachments in
       Outlook](https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519)<!--
       -->.
     name: attachments
@@ -79,11 +79,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: displayReplyAllForm(formData)
     fullName: Outlook_1_3.Office.ItemRead.displayReplyAllForm
@@ -100,7 +100,7 @@ items:
         - id: formData
           description: >-
             A string that contains text and HTML and that represents the body of the reply form. The string is limited
-            to 32 KB OR An[Office.ReplyFormData](xref:Outlook_1_3.Office.ReplyFormData) object that contains body or
+            to 32 KB OR An [Office.ReplyFormData](xref:Outlook_1_3.Office.ReplyFormData) object that contains body or
             attachment data and a callback function
           type:
             - string | ReplyFormData
@@ -127,11 +127,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: displayReplyForm(formData)
     fullName: Outlook_1_3.Office.ItemRead.displayReplyForm
@@ -148,23 +148,23 @@ items:
         - id: formData
           description: >-
             A string that contains text and HTML and that represents the body of the reply form. The string is limited
-            to 32 KB. OR An[Office.ReplyFormData](xref:Outlook_1_3.Office.ReplyFormData) object that contains body or
+            to 32 KB. OR An [Office.ReplyFormData](xref:Outlook_1_3.Office.ReplyFormData) object that contains body or
             attachment data and a callback function.
           type:
             - string | ReplyFormData
   - uid: Outlook_1_3.Office.ItemRead.getEntities
     summary: |-
-      Gets the entities found in the selected item.
+      Gets the entities found in the selected item's body.
 
       Note: This method is not supported in Outlook for iOS or Outlook for Android.
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: getEntities()
     fullName: Outlook_1_3.Office.ItemRead.getEntities
@@ -179,17 +179,17 @@ items:
         description: ''
   - uid: Outlook_1_3.Office.ItemRead.getEntitiesByType
     summary: |-
-      Gets an array of all the entities of the specified entity type found in the selected item.
+      Gets an array of all the entities of the specified entity type found in the selected item's body.
 
       Note: This method is not supported in Outlook for iOS or Outlook for Android.
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
 
 
@@ -217,7 +217,7 @@ items:
           - '(string | Contact | MeetingSuggestion | PhoneNumber | TaskSuggestion)[]'
         description: >-
           If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns
-          null. If no entities of the specified type are present on the item, the method returns an empty array.
+          null. If no entities of the specified type are present in the item's body, the method returns an empty array.
           Otherwise, the type of the objects in the returned array depends on the type of entity requested in the
           entityType parameter.
       parameters:
@@ -239,11 +239,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: getFilteredEntitiesByName(name)
     fullName: Outlook_1_3.Office.ItemRead.getFilteredEntitiesByName
@@ -288,11 +288,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: getRegExMatches()
     fullName: Outlook_1_3.Office.ItemRead.getRegExMatches
@@ -328,11 +328,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: getRegExMatchesByName(name)
     fullName: Outlook_1_3.Office.ItemRead.getRegExMatchesByName
@@ -361,11 +361,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
 
 
@@ -403,16 +403,17 @@ items:
       Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The
       itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making
       REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more
-      details, see Use the Outlook REST APIs from an Outlook add-in.
+      details, see [ Use the Outlook REST APIs from an Outlook
+      add-in](https://docs.microsoft.com/outlook/add-ins/use-rest-api#get-the-item-id)<!-- -->.
 
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: itemId
     fullName: Outlook_1_3.Office.ItemRead.itemId
@@ -435,11 +436,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: normalizedSubject
     fullName: Outlook_1_3.Office.ItemRead.normalizedSubject
@@ -465,12 +466,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: subject
     fullName: Outlook_1_3.Office.ItemRead.subject
     langs:

--- a/docs/docs-ref-autogen/outlook_1_3/office.localclienttime.yml
+++ b/docs/docs-ref-autogen/outlook_1_3/office.localclienttime.yml
@@ -6,11 +6,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: Office.LocalClientTime
     fullName: Outlook_1_3.Office.LocalClientTime

--- a/docs/docs-ref-autogen/outlook_1_3/office.location.yml
+++ b/docs/docs-ref-autogen/outlook_1_3/office.location.yml
@@ -6,11 +6,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
     name: Office.Location
     fullName: Outlook_1_3.Office.Location
@@ -29,25 +29,25 @@ items:
       The getAsync method starts an asynchronous call to the Exchange server to get the location of an appointment. The
       location of the appointment is provided as a string in the asyncResult.value property.
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
 
 
       In addition to this signature, the method also has the following signature:
 
 
-      `getAsync(callback: (result: AsyncResult) => void): void;`
+      `getAsync(callback: (result: AsyncResult<string>) => void): void;`
     name: 'getAsync(options, callback)'
     fullName: Outlook_1_3.Office.Location.getAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'getAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;'
+      content: 'getAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;'
       return:
         type:
           - void
@@ -62,9 +62,12 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. \[Api set: Mailbox 1.1\]
+            parameter of type Office.AsyncResult.
+
+
+            \[Api set: Mailbox 1.1\]
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<string>) => void'
   - uid: Outlook_1_3.Office.Location.setAsync
     summary: >-
       Sets the location of an appointment.
@@ -73,11 +76,11 @@ items:
       The setAsync method starts an asynchronous call to the Exchange server to set the location of an appointment.
       Setting the location of an appointment overwrites the current location.
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -94,7 +97,7 @@ items:
       `setAsync(location: string, options: Office.AsyncContextOptions): void;`
 
 
-      `setAsync(location: string, callback: (result: AsyncResult) => void): void;`
+      `setAsync(location: string, callback: (result: AsyncResult<void>) => void): void;`
     name: 'setAsync(location, options, callback)'
     fullName: Outlook_1_3.Office.Location.setAsync
     langs:
@@ -102,8 +105,8 @@ items:
     type: method
     syntax:
       content: >-
-        setAsync(location: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void):
-        void;
+        setAsync(location: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) =>
+        void): void;
       return:
         type:
           - void
@@ -122,7 +125,10 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. If setting the location fails, the asyncResult.error property will contain an
-            error code. \[Api set: Mailbox 1.1\]
+            parameter of type Office.AsyncResult. If setting the location fails, the asyncResult.error property will
+            contain an error code.
+
+
+            \[Api set: Mailbox 1.1\]
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'

--- a/docs/docs-ref-autogen/outlook_1_3/office.mailbox.yml
+++ b/docs/docs-ref-autogen/outlook_1_3/office.mailbox.yml
@@ -2,7 +2,7 @@
 items:
   - uid: Outlook_1_3.Office.Mailbox
     summary: |-
-      Provides access to the Outlook add-in object model for Microsoft Outlook and Microsoft Outlook on the web.
+      Provides access to the Outlook Add-in object model for Microsoft Outlook and Microsoft Outlook on the web.
 
       Namespaces:
 
@@ -14,12 +14,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.Mailbox
     fullName: Outlook_1_3.Office.Mailbox
     langs:
@@ -56,12 +56,12 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: 'convertToEwsId(itemId, restVersion)'
     fullName: Outlook_1_3.Office.Mailbox.convertToEwsId
     langs:
@@ -101,12 +101,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: convertToLocalClientTime(timeValue)
     fullName: Outlook_1_3.Office.Mailbox.convertToLocalClientTime
     langs:
@@ -131,19 +131,19 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
 
 
       Item IDs retrieved via EWS or via the itemId property use a different format than the format used by REST APIs
-      (such as the [Outlook Mail
+      (such as the [ Outlook Mail
       API](https://docs.microsoft.com/previous-versions/office/office-365-api/api/version-2.0/mail-rest-operations) or
-      the [Microsoft Graph](http://graph.microsoft.io/)<!-- -->. The convertToRestId method converts an EWS-formatted ID
-      into the proper format for REST.
+      the [ Microsoft Graph](http://graph.microsoft.io/)<!-- -->. The convertToRestId method converts an EWS-formatted
+      ID into the proper format for REST.
     name: 'convertToRestId(itemId, restVersion)'
     fullName: Outlook_1_3.Office.Mailbox.convertToRestId
     langs:
@@ -175,12 +175,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: convertToUtcClientTime(input)
     fullName: Outlook_1_3.Office.Mailbox.convertToUtcClientTime
     langs:
@@ -215,11 +215,11 @@ items:
       Exchange Server. An example is the string 15.0.468.0.
 
 
-      - OWAView (string): A string that represents the current view of Outlook Web App. If the host application is not
-      Outlook Web App, then accessing this property results in undefined. Outlook Web App has three views (OneColumn -
-      displayed when the screen is narrow, TwoColumns - displayed when the screen is wider, and ThreeColumns - displayed
-      when the screen is wide.) that correspond to the width of the screen and the window, and the number of columns
-      that can be displayed.
+      - OWAView (MailboxEnums.OWAView or string): An enum (or string literal) that represents the current view of
+      Outlook Web App. If the host application is not Outlook Web App, then accessing this property results in
+      undefined. Outlook Web App has three views (OneColumn - displayed when the screen is narrow, TwoColumns -
+      displayed when the screen is wider, and ThreeColumns - displayed when the screen is wide) that correspond to the
+      width of the screen and the window, and the number of columns that can be displayed.
 
 
       More information is under [Office.Diagnostics](xref:Outlook_1_3.Office.Diagnostics)<!-- -->.
@@ -227,12 +227,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: diagnostics
     fullName: Outlook_1_3.Office.Mailbox.diagnostics
     langs:
@@ -271,12 +271,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: displayAppointmentForm(itemId)
     fullName: Outlook_1_3.Office.Mailbox.displayAppointmentForm
     langs:
@@ -320,12 +320,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: displayMessageForm(itemId)
     fullName: Outlook_1_3.Office.Mailbox.displayMessageForm
     langs:
@@ -371,11 +371,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: displayNewAppointmentForm(parameters)
     fullName: Outlook_1_3.Office.Mailbox.displayNewAppointmentForm
@@ -407,16 +407,16 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
 
 
       The ewsUrl value can be used by a remote service to make EWS calls to the user's mailbox. For example, you can
-      create a remote service to [get attachments from the selected
+      create a remote service to [ get attachments from the selected
       item](https://docs.microsoft.com/outlook/add-ins/get-attachments-of-an-outlook-item)<!-- -->.
 
 
@@ -456,11 +456,11 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
       and read</td></tr></table>
     name: 'getCallbackTokenAsync(callback, userContext)'
     fullName: Outlook_1_3.Office.Mailbox.getCallbackTokenAsync
@@ -468,7 +468,7 @@ items:
       - typeScript
     type: method
     syntax:
-      content: 'getCallbackTokenAsync(callback: (result: AsyncResult) => void, userContext?: any): void;'
+      content: 'getCallbackTokenAsync(callback: (result: AsyncResult<string>) => void, userContext?: any): void;'
       return:
         type:
           - void
@@ -477,9 +477,9 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult. The token is provided as a string in the asyncResult.value property.
+            of type Office.AsyncResult. The token is provided as a string in the asyncResult.value property.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<string>) => void'
         - id: userContext
           description: Optional. Any state data that is passed to the asynchronous method.
           type:
@@ -492,23 +492,23 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
       and read</td></tr></table>
 
 
-      The getUserIdentityTokenAsync method returns a token that you can use to identify and [authenticate the add-in and
-      user with a third-party system](https://docs.microsoft.com/outlook/add-ins/authentication)<!-- -->.
+      The getUserIdentityTokenAsync method returns a token that you can use to identify and [ authenticate the add-in
+      and user with a third-party system](https://docs.microsoft.com/outlook/add-ins/authentication)<!-- -->.
     name: 'getUserIdentityTokenAsync(callback, userContext)'
     fullName: Outlook_1_3.Office.Mailbox.getUserIdentityTokenAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'getUserIdentityTokenAsync(callback: (result: AsyncResult) => void, userContext?: any): void;'
+      content: 'getUserIdentityTokenAsync(callback: (result: AsyncResult<string>) => void, userContext?: any): void;'
       return:
         type:
           - void
@@ -517,9 +517,9 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult.
+            of type Office.AsyncResult. The token is provided as a string in the asyncResult.value property.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<string>) => void'
         - id: userContext
           description: Optional. Any state data that is passed to the asynchronous method.\|
           type:
@@ -528,7 +528,8 @@ items:
     summary: >-
       The mailbox item. Depending on the context in which the add-in opened, the item may be of any number of types. If
       you want to see IntelliSense for only a specific type, you should cast this item to one of the following:
-      `ItemCompose`, `ItemRead`, `MessageCompose`, `MessageRead`, `AppointmentCompose`, `AppointmentRead`
+      `ItemCompose`<!-- -->, `ItemRead`<!-- -->, `MessageCompose`<!-- -->, `MessageRead`<!-- -->,
+      `AppointmentCompose`<!-- -->, `AppointmentRead`
     name: item
     fullName: Outlook_1_3.Office.Mailbox.item
     langs:
@@ -559,15 +560,21 @@ items:
 
       Your add-in must have the ReadWriteMailbox permission to use the makeEwsRequestAsync method. For information about
       using the ReadWriteMailbox permission and the EWS operations that you can call with the makeEwsRequestAsync
-      method, see Specify permissions for mail add-in access to the user's mailbox.
+      method, see [ Specify permissions for mail add-in access to the user's
+      mailbox](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)<!-- -->.
 
 
       The XML result of the EWS call is provided as a string in the asyncResult.value property. If the result exceeds 1
       MB in size, an error message is returned instead.
 
 
-      Note: This method is not supported in the following scenarios. - In Outlook for iOS or Outlook for Android - When
-      the add-in is loaded in a Gmail mailbox
+      Note: This method is not supported in the following scenarios:
+
+
+      - In Outlook for iOS or Outlook for Android.
+
+
+      - When the add-in is loaded in a Gmail mailbox.
 
 
       Note: The server administrator must set OAuthAuthentication to true on the Client Access Server EWS directory to
@@ -581,7 +588,7 @@ items:
       15.0.4535.1004, you should set the encoding value to ISO-8859-1.
 
 
-      `&lt;?xml version="1.0" encoding="iso-8859-1"?&gt;`
+      `<?xml version="1.0" encoding="iso-8859-1"?>`
 
 
       You do not need to set the encoding value when your mail app is running in Outlook on the web. You can determine
@@ -592,11 +599,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteMailbox</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
       and read</td></tr></table>
     name: 'makeEwsRequestAsync(data, callback, userContext)'
     fullName: Outlook_1_3.Office.Mailbox.makeEwsRequestAsync
@@ -604,7 +611,7 @@ items:
       - typeScript
     type: method
     syntax:
-      content: 'makeEwsRequestAsync(data: any, callback: (result: AsyncResult) => void, userContext?: any): void;'
+      content: 'makeEwsRequestAsync(data: any, callback: (result: AsyncResult<string>) => void, userContext?: any): void;'
       return:
         type:
           - void
@@ -617,9 +624,10 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult.
+            of type Office.AsyncResult. The `value` property of the result is the XML of the EWS request provided as a
+            string. If the result exceeds 1 MB in size, an error message is returned instead.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<string>) => void'
         - id: userContext
           description: Optional. Any state data that is passed to the asynchronous method.
           type:
@@ -627,7 +635,7 @@ items:
   - uid: Outlook_1_3.Office.Mailbox.userProfile
     summary: >-
       Information about the user associated with the mailbox. This includes their account type, display name, email
-      adddress, and time zone.
+      address, and time zone.
 
 
       More information is under [Office.UserProfile](xref:Outlook_1_3.Office.UserProfile)

--- a/docs/docs-ref-autogen/outlook_1_3/office.mailboxenums.attachmenttype.yml
+++ b/docs/docs-ref-autogen/outlook_1_3/office.mailboxenums.attachmenttype.yml
@@ -6,7 +6,7 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td> [Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
+      <table><tr><td> [ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
       </td><td>Compose or read</td></tr></table>
     name: Office.MailboxEnums.AttachmentType
     fullName: Outlook_1_3.Office.MailboxEnums.AttachmentType

--- a/docs/docs-ref-autogen/outlook_1_3/office.mailboxenums.entitytype.yml
+++ b/docs/docs-ref-autogen/outlook_1_3/office.mailboxenums.entitytype.yml
@@ -6,7 +6,7 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td> [Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
+      <table><tr><td> [ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
       </td><td>Compose or read</td></tr></table>
     name: Office.MailboxEnums.EntityType
     fullName: Outlook_1_3.Office.MailboxEnums.EntityType

--- a/docs/docs-ref-autogen/outlook_1_3/office.mailboxenums.itemnotificationmessagetype.yml
+++ b/docs/docs-ref-autogen/outlook_1_3/office.mailboxenums.itemnotificationmessagetype.yml
@@ -6,7 +6,7 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td> [Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
+      <table><tr><td> [ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
       </td><td>Compose or read</td></tr></table>
     name: Office.MailboxEnums.ItemNotificationMessageType
     fullName: Outlook_1_3.Office.MailboxEnums.ItemNotificationMessageType

--- a/docs/docs-ref-autogen/outlook_1_3/office.mailboxenums.itemtype.yml
+++ b/docs/docs-ref-autogen/outlook_1_3/office.mailboxenums.itemtype.yml
@@ -6,7 +6,7 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td> [Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
+      <table><tr><td> [ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
       </td><td>Compose or read</td></tr></table>
     name: Office.MailboxEnums.ItemType
     fullName: Outlook_1_3.Office.MailboxEnums.ItemType

--- a/docs/docs-ref-autogen/outlook_1_3/office.mailboxenums.owaview.yml
+++ b/docs/docs-ref-autogen/outlook_1_3/office.mailboxenums.owaview.yml
@@ -1,0 +1,42 @@
+### YamlMime:UniversalReference
+items:
+  - uid: Outlook_1_3.Office.MailboxEnums.OWAView
+    summary: Represents the current view of Outlook Web App.
+    name: Office.MailboxEnums.OWAView
+    fullName: Outlook_1_3.Office.MailboxEnums.OWAView
+    langs:
+      - typeScript
+    type: enum
+    package: Outlook_1_3
+    children:
+      - Outlook_1_3.Office.MailboxEnums.OWAView.OneColumn
+      - Outlook_1_3.Office.MailboxEnums.OWAView.ThreeColumns
+      - Outlook_1_3.Office.MailboxEnums.OWAView.TwoColumns
+  - uid: Outlook_1_3.Office.MailboxEnums.OWAView.OneColumn
+    summary: >-
+      One column view. Displayed when the screen is narrow. Outlook Web App uses this single-column layout on the entire
+      screen of a smartphone.
+    name: OneColumn
+    fullName: Outlook_1_3.Office.MailboxEnums.OWAView.OneColumn
+    langs:
+      - typeScript
+    type: field
+    numericValue: '"OneColumn"'
+  - uid: Outlook_1_3.Office.MailboxEnums.OWAView.ThreeColumns
+    summary: >-
+      Three column view. Displayed when the screen is wide. For example, Outlook Web App uses this view in a full screen
+      window on a desktop computer.
+    name: ThreeColumns
+    fullName: Outlook_1_3.Office.MailboxEnums.OWAView.ThreeColumns
+    langs:
+      - typeScript
+    type: field
+    numericValue: '"ThreeColumns"'
+  - uid: Outlook_1_3.Office.MailboxEnums.OWAView.TwoColumns
+    summary: Two column view. Displayed when the screen is wider. Outlook Web App uses this view on most tablets.
+    name: TwoColumns
+    fullName: Outlook_1_3.Office.MailboxEnums.OWAView.TwoColumns
+    langs:
+      - typeScript
+    type: field
+    numericValue: '"TwoColumns"'

--- a/docs/docs-ref-autogen/outlook_1_3/office.mailboxenums.recipienttype.yml
+++ b/docs/docs-ref-autogen/outlook_1_3/office.mailboxenums.recipienttype.yml
@@ -6,7 +6,7 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td> [Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
+      <table><tr><td> [ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
       </td><td>Compose or read</td></tr></table>
     name: Office.MailboxEnums.RecipientType
     fullName: Outlook_1_3.Office.MailboxEnums.RecipientType

--- a/docs/docs-ref-autogen/outlook_1_3/office.mailboxenums.responsetype.yml
+++ b/docs/docs-ref-autogen/outlook_1_3/office.mailboxenums.responsetype.yml
@@ -6,7 +6,7 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td> [Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
+      <table><tr><td> [ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
       </td><td>Compose or read</td></tr></table>
     name: Office.MailboxEnums.ResponseType
     fullName: Outlook_1_3.Office.MailboxEnums.ResponseType

--- a/docs/docs-ref-autogen/outlook_1_3/office.mailboxenums.restversion.yml
+++ b/docs/docs-ref-autogen/outlook_1_3/office.mailboxenums.restversion.yml
@@ -6,7 +6,7 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td> [Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
+      <table><tr><td> [ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
       </td><td>Compose or read</td></tr></table>
     name: Office.MailboxEnums.RestVersion
     fullName: Outlook_1_3.Office.MailboxEnums.RestVersion

--- a/docs/docs-ref-autogen/outlook_1_3/office.meetingsuggestion.yml
+++ b/docs/docs-ref-autogen/outlook_1_3/office.meetingsuggestion.yml
@@ -15,11 +15,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: Office.MeetingSuggestion
     fullName: Outlook_1_3.Office.MeetingSuggestion

--- a/docs/docs-ref-autogen/outlook_1_3/office.message.yml
+++ b/docs/docs-ref-autogen/outlook_1_3/office.message.yml
@@ -6,7 +6,7 @@ items:
 
 
       Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat
-      this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
+      this as a mode of `Office.context.mailbox.item`<!-- -->. Refer to the Object Model pages for more information.
     name: Office.Message
     fullName: Outlook_1_3.Office.Message
     langs:
@@ -33,12 +33,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: conversationId
     fullName: Outlook_1_3.Office.Message.conversationId
     langs:

--- a/docs/docs-ref-autogen/outlook_1_3/office.messagecompose.yml
+++ b/docs/docs-ref-autogen/outlook_1_3/office.messagecompose.yml
@@ -2,11 +2,11 @@
 items:
   - uid: Outlook_1_3.Office.MessageCompose
     summary: >-
-      The message compose mode of [Office.context.mailbox.item](xref:Outlook_1_3.Office.Item)<!-- -->.
+      The message compose mode of [ Office.context.mailbox.item](xref:Outlook_1_3.Office.Item)<!-- -->.
 
 
       Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat
-      this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
+      this as a mode of `Office.context.mailbox.item`<!-- -->. Refer to the Object Model pages for more information.
     name: Office.MessageCompose
     fullName: Outlook_1_3.Office.MessageCompose
     langs:
@@ -49,11 +49,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr>
 
 
@@ -72,7 +72,8 @@ items:
       `addFileAttachmentAsync(uri: string, attachmentName: string, options: AsyncContextOptions): void;`
 
 
-      `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+      `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void):
+      void;`
     name: 'addFileAttachmentAsync(uri, attachmentName, options, callback)'
     fullName: Outlook_1_3.Office.MessageCompose.addFileAttachmentAsync
     langs:
@@ -81,7 +82,7 @@ items:
     syntax:
       content: >-
         addFileAttachmentAsync(uri: string, attachmentName: string, options?: AsyncContextOptions, callback?: (result:
-        AsyncResult) => void): void;
+        AsyncResult<string>) => void): void;
       return:
         type:
           - void
@@ -109,11 +110,11 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type asyncResult. On success, the attachment identifier will be provided in the asyncResult.value
+            of type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value
             property. If uploading the attachment fails, the asyncResult object will contain an Error object that
             provides a description of the error.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<string>) => void'
   - uid: Outlook_1_3.Office.MessageCompose.addItemAttachmentAsync
     summary: >-
       Adds an Exchange item, such as a message, as an attachment to the message or appointment.
@@ -129,17 +130,17 @@ items:
       session.
 
 
-      If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items
+      If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items
       other than the item that you are editing; however, this is not supported and is not recommended.
 
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr>
 
 
@@ -147,7 +148,7 @@ items:
       attachments.</td></tr></table>
 
 
-      In addition to the main signature, this method also has these signatures:
+      In addition to this signature, this method also has the following signatures:
 
 
       `addItemAttachmentAsync(itemId: any, attachmentName: string): void;`
@@ -156,7 +157,8 @@ items:
       `addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;`
 
 
-      `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+      `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void):
+      void;`
     name: 'addItemAttachmentAsync(itemId, attachmentName, options, callback)'
     fullName: Outlook_1_3.Office.MessageCompose.addItemAttachmentAsync
     langs:
@@ -165,7 +167,7 @@ items:
     syntax:
       content: >-
         addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?:
-        (result: AsyncResult) => void): void;
+        (result: AsyncResult<string>) => void): void;
       return:
         type:
           - void
@@ -194,7 +196,7 @@ items:
             property. If adding the attachment fails, the asyncResult object will contain an Error object that provides
             a description of the error.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<string>) => void'
   - uid: Outlook_1_3.Office.MessageCompose.bcc
     summary: >-
       Gets an object that provides methods to get or update the recipients on the Bcc (blind carbon copy) line of a
@@ -203,11 +205,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: bcc
     fullName: Outlook_1_3.Office.MessageCompose.bcc
@@ -225,11 +227,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: body
     fullName: Outlook_1_3.Office.MessageCompose.body
@@ -253,11 +255,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: cc
     fullName: Outlook_1_3.Office.MessageCompose.cc
@@ -287,11 +289,11 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: close()
     fullName: Outlook_1_3.Office.MessageCompose.close
@@ -320,11 +322,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: conversationId
     fullName: Outlook_1_3.Office.MessageCompose.conversationId
@@ -342,11 +344,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: dateTimeCreated
     fullName: Outlook_1_3.Office.MessageCompose.dateTimeCreated
@@ -364,11 +366,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
 
 
@@ -398,11 +400,11 @@ items:
 
       \[ [API set: Mailbox 1.2](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: 'getSelectedDataAsync(coerciontype, callback)'
     fullName: Outlook_1_3.Office.MessageCompose.getSelectedDataAsync
@@ -410,7 +412,7 @@ items:
       - typeScript
     type: method
     syntax:
-      content: 'getSelectedDataAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult) => void): void;'
+      content: 'getSelectedDataAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult<any>) => void): void;'
       return:
         type:
           - void
@@ -423,9 +425,9 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult.
+            of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<any>) => void'
   - uid: Outlook_1_3.Office.MessageCompose.itemType
     summary: >-
       Gets the type of item that an instance represents.
@@ -437,11 +439,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: itemType
     fullName: Outlook_1_3.Office.MessageCompose.itemType
@@ -471,11 +473,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: 'loadCustomPropertiesAsync(callback, userContext)'
     fullName: Outlook_1_3.Office.MessageCompose.loadCustomPropertiesAsync
@@ -483,7 +485,9 @@ items:
       - typeScript
     type: method
     syntax:
-      content: 'loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;'
+      content: >-
+        loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any):
+        void;
       return:
         type:
           - void
@@ -492,9 +496,9 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult.
+            of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<Office.CustomProperties>) => void'
         - id: userContext
           description: >-
             Optional. Developers can provide any object they wish to access in the callback function. This object can be
@@ -507,11 +511,11 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: notificationMessages
     fullName: Outlook_1_3.Office.MessageCompose.notificationMessages
@@ -531,17 +535,17 @@ items:
       The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best
       practice, you should use the attachment identifier to remove an attachment only if the same mail app has added
       that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid
-      only within the same session. A session is over when the user closes the app, or if the user starts composing in
-      an inline form and subsequently pops out the inline form to continue in a separate window.
+      only within the same session. A session is over when the user closes the app, or if the user starts composing an
+      inline form then subsequently pops out the form to continue in a separate window.
 
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr>
 
 
@@ -557,7 +561,7 @@ items:
       `removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;`
 
 
-      `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;`
+      `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;`
     name: 'removeAttachmentAsync(attachmentIndex, options, callback)'
     fullName: Outlook_1_3.Office.MessageCompose.removeAttachmentAsync
     langs:
@@ -566,7 +570,7 @@ items:
     syntax:
       content: >-
         removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result:
-        AsyncResult) => void): void;
+        AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -585,10 +589,10 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain
-            an error code with the reason for the failure.
+            parameter of type Office.AsyncResult. If removing the attachment fails, the asyncResult.error property will
+            contain an error code with the reason for the failure.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_3.Office.MessageCompose.saveAsync
     summary: >-
       Asynchronously saves an item.
@@ -622,11 +626,11 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr>
 
 
@@ -642,14 +646,14 @@ items:
       `saveAsync(options: Office.AsyncContextOptions): void;`
 
 
-      `saveAsync(callback: (result: AsyncResult) => void): void;`
+      `saveAsync(callback: (result: AsyncResult<void>) => void): void;`
     name: 'saveAsync(options, callback)'
     fullName: Outlook_1_3.Office.MessageCompose.saveAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;'
+      content: 'saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;'
       return:
         type:
           - void
@@ -664,10 +668,9 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain
-            an error code with the reason for the failure.
+            parameter of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_3.Office.MessageCompose.setSelectedDataAsync
     summary: >-
       Asynchronously inserts data into the body or subject of a message.
@@ -680,11 +683,11 @@ items:
 
       \[ [API set: Mailbox 1.2](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr>
 
 
@@ -697,10 +700,10 @@ items:
       `setSelectedDataAsync(data: string): void;`
 
 
-      `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions &amp; CoercionTypeOptions): void;`
+      `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`
 
 
-      `setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;`
+      `setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;`
     name: 'setSelectedDataAsync(data, options, callback)'
     fullName: Outlook_1_3.Office.MessageCompose.setSelectedDataAsync
     langs:
@@ -709,7 +712,7 @@ items:
     syntax:
       content: >-
         setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?:
-        (result: AsyncResult) => void): void;
+        (result: AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -735,10 +738,9 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain
-            an error code with the reason for the failure.
+            parameter of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_3.Office.MessageCompose.subject
     summary: |-
       Gets or sets the description that appears in the subject field of an item.
@@ -749,11 +751,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: subject
     fullName: Outlook_1_3.Office.MessageCompose.subject
@@ -777,11 +779,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: to
     fullName: Outlook_1_3.Office.MessageCompose.to

--- a/docs/docs-ref-autogen/outlook_1_3/office.messageread.yml
+++ b/docs/docs-ref-autogen/outlook_1_3/office.messageread.yml
@@ -2,7 +2,7 @@
 items:
   - uid: Outlook_1_3.Office.MessageRead
     summary: >-
-      The message read mode of [Office.context.mailbox.item](xref:Outlook_1_3.Office.Item)<!-- -->.
+      The message read mode of [ Office.context.mailbox.item](xref:Outlook_1_3.Office.Item)<!-- -->.
 
 
       Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat
@@ -42,20 +42,20 @@ items:
       - Outlook_1_3.Office.MessageRead.to
   - uid: Outlook_1_3.Office.MessageRead.attachments
     summary: |-
-      Gets an array of attachments for the item.
+      Gets the item's attachments as an array.
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
 
 
       Note: Certain types of files are blocked by Outlook due to potential security issues and are therefore not
-      returned. For more information, see [Blocked attachments in
+      returned. For more information, see [ Blocked attachments in
       Outlook](https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519)<!--
       -->.
     name: attachments
@@ -74,11 +74,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: body
     fullName: Outlook_1_3.Office.MessageRead.body
@@ -102,11 +102,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: cc
     fullName: Outlook_1_3.Office.MessageRead.cc
@@ -134,11 +134,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: conversationId
     fullName: Outlook_1_3.Office.MessageRead.conversationId
@@ -156,11 +156,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: dateTimeCreated
     fullName: Outlook_1_3.Office.MessageRead.dateTimeCreated
@@ -178,11 +178,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
 
 
@@ -220,11 +220,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: displayReplyAllForm(formData)
     fullName: Outlook_1_3.Office.MessageRead.displayReplyAllForm
@@ -241,7 +241,7 @@ items:
         - id: formData
           description: >-
             A string that contains text and HTML and that represents the body of the reply form. The string is limited
-            to 32 KB OR An[Office.ReplyFormData](xref:Outlook_1_3.Office.ReplyFormData) object that contains body or
+            to 32 KB OR An [Office.ReplyFormData](xref:Outlook_1_3.Office.ReplyFormData) object that contains body or
             attachment data and a callback function
           type:
             - string | ReplyFormData
@@ -268,11 +268,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: displayReplyForm(formData)
     fullName: Outlook_1_3.Office.MessageRead.displayReplyForm
@@ -289,7 +289,7 @@ items:
         - id: formData
           description: >-
             A string that contains text and HTML and that represents the body of the reply form. The string is limited
-            to 32 KB. OR An[Office.ReplyFormData](xref:Outlook_1_3.Office.ReplyFormData) object that contains body or
+            to 32 KB. OR An [Office.ReplyFormData](xref:Outlook_1_3.Office.ReplyFormData) object that contains body or
             attachment data and a callback function.
           type:
             - string | ReplyFormData
@@ -310,11 +310,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: from
     fullName: Outlook_1_3.Office.MessageRead.from
@@ -328,17 +328,17 @@ items:
           - EmailAddressDetails
   - uid: Outlook_1_3.Office.MessageRead.getEntities
     summary: |-
-      Gets the entities found in the selected item.
+      Gets the entities found in the selected item's body.
 
       Note: This method is not supported in Outlook for iOS or Outlook for Android.
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: getEntities()
     fullName: Outlook_1_3.Office.MessageRead.getEntities
@@ -353,17 +353,17 @@ items:
         description: ''
   - uid: Outlook_1_3.Office.MessageRead.getEntitiesByType
     summary: |-
-      Gets an array of all the entities of the specified entity type found in the selected item.
+      Gets an array of all the entities of the specified entity type found in the selected item's body.
 
       Note: This method is not supported in Outlook for iOS or Outlook for Android.
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
 
 
@@ -391,7 +391,7 @@ items:
           - '(string | Contact | MeetingSuggestion | PhoneNumber | TaskSuggestion)[]'
         description: >-
           If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns
-          null. If no entities of the specified type are present on the item, the method returns an empty array.
+          null. If no entities of the specified type are present in the item's body, the method returns an empty array.
           Otherwise, the type of the objects in the returned array depends on the type of entity requested in the
           entityType parameter.
       parameters:
@@ -413,11 +413,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: getFilteredEntitiesByName(name)
     fullName: Outlook_1_3.Office.MessageRead.getFilteredEntitiesByName
@@ -462,11 +462,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: getRegExMatches()
     fullName: Outlook_1_3.Office.MessageRead.getRegExMatches
@@ -502,11 +502,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: getRegExMatchesByName(name)
     fullName: Outlook_1_3.Office.MessageRead.getRegExMatchesByName
@@ -530,11 +530,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: internetMessageId
     fullName: Outlook_1_3.Office.MessageRead.internetMessageId
@@ -557,11 +557,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
 
 
@@ -599,16 +599,17 @@ items:
       Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The
       itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making
       REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more
-      details, see Use the Outlook REST APIs from an Outlook add-in.
+      details, see [ Use the Outlook REST APIs from an Outlook
+      add-in](https://docs.microsoft.com/outlook/add-ins/use-rest-api#get-the-item-id)<!-- -->.
 
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: itemId
     fullName: Outlook_1_3.Office.MessageRead.itemId
@@ -631,11 +632,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: itemType
     fullName: Outlook_1_3.Office.MessageRead.itemType
@@ -665,11 +666,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: 'loadCustomPropertiesAsync(callback, userContext)'
     fullName: Outlook_1_3.Office.MessageRead.loadCustomPropertiesAsync
@@ -677,7 +678,9 @@ items:
       - typeScript
     type: method
     syntax:
-      content: 'loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;'
+      content: >-
+        loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any):
+        void;
       return:
         type:
           - void
@@ -686,9 +689,9 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult.
+            of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<Office.CustomProperties>) => void'
         - id: userContext
           description: >-
             Optional. Developers can provide any object they wish to access in the callback function. This object can be
@@ -706,11 +709,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: normalizedSubject
     fullName: Outlook_1_3.Office.MessageRead.normalizedSubject
@@ -728,12 +731,12 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: notificationMessages
     fullName: Outlook_1_3.Office.MessageRead.notificationMessages
     langs:
@@ -758,11 +761,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: sender
     fullName: Outlook_1_3.Office.MessageRead.sender
@@ -788,11 +791,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: subject
     fullName: Outlook_1_3.Office.MessageRead.subject
@@ -816,11 +819,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: to
     fullName: Outlook_1_3.Office.MessageRead.to

--- a/docs/docs-ref-autogen/outlook_1_3/office.notificationmessagedetails.yml
+++ b/docs/docs-ref-autogen/outlook_1_3/office.notificationmessagedetails.yml
@@ -6,12 +6,12 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.NotificationMessageDetails
     fullName: Outlook_1_3.Office.NotificationMessageDetails
     langs:

--- a/docs/docs-ref-autogen/outlook_1_3/office.notificationmessages.yml
+++ b/docs/docs-ref-autogen/outlook_1_3/office.notificationmessages.yml
@@ -6,12 +6,12 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.NotificationMessages
     fullName: Outlook_1_3.Office.NotificationMessages
     langs:
@@ -31,12 +31,12 @@ items:
       There are a maximum of 5 notifications per message. Setting more will return a
       NumberOfNotificationMessagesExceeded error.
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
 
 
       In addition to this signature, the method also has the following signatures:
@@ -48,7 +48,8 @@ items:
       `addAsync(key: string, JSONmessage: NotificationMessageDetails, options: Office.AsyncContextOptions): void;`
 
 
-      `addAsync(key: string, JSONmessage: NotificationMessageDetails, callback: (result: AsyncResult) => void): void;`
+      `addAsync(key: string, JSONmessage: NotificationMessageDetails, callback: (result: AsyncResult<void>) => void):
+      void;`
     name: 'addAsync(key, JSONmessage, options, callback)'
     fullName: Outlook_1_3.Office.NotificationMessages.addAsync
     langs:
@@ -57,7 +58,7 @@ items:
     syntax:
       content: >-
         addAsync(key: string, JSONmessage: NotificationMessageDetails, options?: Office.AsyncContextOptions, callback?:
-        (result: AsyncResult) => void): void;
+        (result: AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -84,34 +85,39 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. \[Api set: Mailbox 1.3\]
+            parameter of type Office.AsyncResult.
+
+
+            \[Api set: Mailbox 1.3\]
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_3.Office.NotificationMessages.getAllAsync
     summary: |-
       Returns all keys and messages for an item.
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
 
 
-      In addition to the main signature, this method also has this signature:
+      In addition to this signature, this method also has the following signature:
 
 
-      `getAllAsync(callback: (result: AsyncResult) => void): void;`
+      `getAllAsync(callback: (result: AsyncResult<Office.NotificationMessageDetails[]>) => void): void;`
     name: 'getAllAsync(options, callback)'
     fullName: Outlook_1_3.Office.NotificationMessages.getAllAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'getAllAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;'
+      content: >-
+        getAllAsync(options?: Office.AsyncContextOptions, callback?: (result:
+        AsyncResult<Office.NotificationMessageDetails[]>) => void): void;
       return:
         type:
           - void
@@ -126,24 +132,25 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult.
+            parameter of type Office.AsyncResult. The `value` property of the result is an array of
+            NotificationMessageDetails objects.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<Office.NotificationMessageDetails[]>) => void'
   - uid: Outlook_1_3.Office.NotificationMessages.removeAsync
     summary: |-
       Removes a notification message for an item.
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
 
 
-      In addition to the main signature, this method also has these signatures:
+      In addition to this signature, this method also has the following signatures:
 
 
       `removeAsync(key: string): void;`
@@ -152,14 +159,16 @@ items:
       `removeAsync(key: string, options: Office.AsyncContextOptions): void;`
 
 
-      `removeAsync(key: string, callback: (result: AsyncResult) => void): void;`
+      `removeAsync(key: string, callback: (result: AsyncResult<void>) => void): void;`
     name: 'removeAsync(key, options, callback)'
     fullName: Outlook_1_3.Office.NotificationMessages.removeAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'removeAsync(key: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;'
+      content: >-
+        removeAsync(key: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void):
+        void;
       return:
         type:
           - void
@@ -178,9 +187,9 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult.
+            parameter of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_3.Office.NotificationMessages.replaceAsync
     summary: |-
       Replaces a notification message that has a given key with another message.
@@ -189,15 +198,15 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
 
 
-      In addition to the main signature, this method also has these signatures:
+      In addition to this signature, this method also has the following signatures:
 
 
       `replaceAsync(key: string, JSONmessage: NotificationMessageDetails): void;`
@@ -206,8 +215,8 @@ items:
       `replaceAsync(key: string, JSONmessage: NotificationMessageDetails, options: Office.AsyncContextOptions): void;`
 
 
-      `replaceAsync(key: string, JSONmessage: NotificationMessageDetails, callback: (result: AsyncResult) => void):
-      void;`
+      `replaceAsync(key: string, JSONmessage: NotificationMessageDetails, callback: (result: AsyncResult<void>) =>
+      void): void;`
     name: 'replaceAsync(key, JSONmessage, options, callback)'
     fullName: Outlook_1_3.Office.NotificationMessages.replaceAsync
     langs:
@@ -216,7 +225,7 @@ items:
     syntax:
       content: >-
         replaceAsync(key: string, JSONmessage: NotificationMessageDetails, options?: Office.AsyncContextOptions,
-        callback?: (result: AsyncResult) => void): void;
+        callback?: (result: AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -241,6 +250,6 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult.
+            parameter of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'

--- a/docs/docs-ref-autogen/outlook_1_3/office.phonenumber.yml
+++ b/docs/docs-ref-autogen/outlook_1_3/office.phonenumber.yml
@@ -12,11 +12,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: Office.PhoneNumber
     fullName: Outlook_1_3.Office.PhoneNumber

--- a/docs/docs-ref-autogen/outlook_1_3/office.recipients.yml
+++ b/docs/docs-ref-autogen/outlook_1_3/office.recipients.yml
@@ -3,11 +3,11 @@ items:
   - uid: Outlook_1_3.Office.Recipients
     summary: '\[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]'
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
     name: Office.Recipients
     fullName: Outlook_1_3.Office.Recipients
@@ -33,11 +33,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -45,7 +45,7 @@ items:
       entries.</td></tr></table>
 
 
-      In addition to the main signature, this method also has these signatures:
+      In addition to this signature, this method also has the following signatures:
 
 
       `addAsync(recipients: (string | EmailUser | EmailAddressDetails)[]): void;`
@@ -54,8 +54,8 @@ items:
       `addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options: Office.AsyncContextOptions): void;`
 
 
-      `addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult) => void):
-      void;`
+      `addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult<void>) =>
+      void): void;`
     name: 'addAsync(recipients, options, callback)'
     fullName: Outlook_1_3.Office.Recipients.addAsync
     langs:
@@ -64,7 +64,7 @@ items:
     syntax:
       content: >-
         addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options?: Office.AsyncContextOptions,
-        callback?: (result: AsyncResult) => void): void;
+        callback?: (result: AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -83,40 +83,42 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. If adding the recipients fails, the asyncResult.error property will contain
-            an error code.
+            parameter of type Office.AsyncResult. If adding the recipients fails, the asyncResult.error property will
+            contain an error code.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_3.Office.Recipients.getAsync
     summary: >-
       Gets a recipient list for an appointment or message.
 
 
-      When the call completes, the asyncResult.value property will contain an array
-      of[Office.EmailAddressDetails](xref:Outlook_1_3.Office.EmailAddressDetails) objects.
+      When the call completes, the asyncResult.value property will contain an array of
+      [Office.EmailAddressDetails](xref:Outlook_1_3.Office.EmailAddressDetails) objects.
 
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
 
 
-      In addition to the main signature, this method also has this signature:
+      In addition to this signature, this method also has the following signature:
 
 
-      `getAsync(callback: (result: AsyncResult) => void): void;`
+      `getAsync(callback: (result: AsyncResult<Office.EmailAddressDetails[]>) => void): void;`
     name: 'getAsync(options, callback)'
     fullName: Outlook_1_3.Office.Recipients.getAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;'
+      content: >-
+        getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult<Office.EmailAddressDetails[]>) =>
+        void): void;
       return:
         type:
           - void
@@ -131,9 +133,9 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult.
+            of type Office.AsyncResult. The `value` property of the result is an array of EmailAddressDetails objects.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<Office.EmailAddressDetails[]>) => void'
   - uid: Outlook_1_3.Office.Recipients.setAsync
     summary: |-
       Sets a recipient list for an appointment or message.
@@ -150,11 +152,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -162,7 +164,7 @@ items:
       entries.</td></tr></table>
 
 
-      In addition to the main signature, this method also has these signatures:
+      In addition to this signature, this method also has the following signatures:
 
 
       `setAsync(recipients: (string | EmailUser | EmailAddressDetails)[]): void;`
@@ -171,8 +173,8 @@ items:
       `setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options: Office.AsyncContextOptions): void;`
 
 
-      `setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult) => void):
-      void;`
+      `setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult<void>) =>
+      void): void;`
     name: 'setAsync(recipients, options, callback)'
     fullName: Outlook_1_3.Office.Recipients.setAsync
     langs:
@@ -181,7 +183,7 @@ items:
     syntax:
       content: >-
         setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options?: Office.AsyncContextOptions,
-        callback?: (result: AsyncResult) => void): void;
+        callback?: (result: AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -200,7 +202,7 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. If setting the recipients fails the asyncResult.error property will contain a
-            code that indicates any error that occurred while adding the data.
+            parameter of type Office.AsyncResult. If setting the recipients fails the asyncResult.error property will
+            contain a code that indicates any error that occurred while adding the data.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'

--- a/docs/docs-ref-autogen/outlook_1_3/office.replyformdata.yml
+++ b/docs/docs-ref-autogen/outlook_1_3/office.replyformdata.yml
@@ -31,17 +31,17 @@ items:
   - uid: Outlook_1_3.Office.ReplyFormData.callback
     summary: >-
       When the reply display call completes, the function passed in the callback parameter is called with a single
-      parameter, asyncResult, which is an AsyncResult object.
+      parameter, asyncResult, which is an Office.AsyncResult object.
     name: callback
     fullName: Outlook_1_3.Office.ReplyFormData.callback
     langs:
       - typeScript
     type: property
     syntax:
-      content: 'callback?: (result: AsyncResult) => void;'
+      content: 'callback?: (result: AsyncResult<any>) => void;'
       return:
         type:
-          - '(result: AsyncResult) => void'
+          - '(result: AsyncResult<any>) => void'
   - uid: Outlook_1_3.Office.ReplyFormData.htmlBody
     summary: >-
       A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32

--- a/docs/docs-ref-autogen/outlook_1_3/office.roamingsettings.yml
+++ b/docs/docs-ref-autogen/outlook_1_3/office.roamingsettings.yml
@@ -7,7 +7,7 @@ items:
       saved.
 
 
-      While the Outlook add-in API limits access to these settings to only the add-in that created them, these settings
+      While the Outlook Add-in API limits access to these settings to only the add-in that created them, these settings
       should not be considered secure storage. They can be accessed by Exchange Web Services or Extended MAPI. They
       should not be used to store sensitive information such as user credentials or security tokens.
 
@@ -27,12 +27,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.RoamingSettings
     fullName: Outlook_1_3.Office.RoamingSettings
     langs:
@@ -50,12 +50,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: get(name)
     fullName: Outlook_1_3.Office.RoamingSettings.get
     langs:
@@ -78,12 +78,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: remove(name)
     fullName: Outlook_1_3.Office.RoamingSettings.remove
     langs:
@@ -113,19 +113,19 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: saveAsync(callback)
     fullName: Outlook_1_3.Office.RoamingSettings.saveAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'saveAsync(callback?: (result: AsyncResult) => void): void;'
+      content: 'saveAsync(callback?: (result: AsyncResult<void>) => void): void;'
       return:
         type:
           - void
@@ -133,10 +133,10 @@ items:
       parameters:
         - id: callback
           description: >-
-            Optional? When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult.
+            Optional. When the method completes, the function passed in the callback parameter is called with a single
+            parameter of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_3.Office.RoamingSettings.set
     summary: >-
       Sets or creates the specified setting.
@@ -156,12 +156,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: 'set(name, value)'
     fullName: Outlook_1_3.Office.RoamingSettings.set
     langs:

--- a/docs/docs-ref-autogen/outlook_1_3/office.subject.yml
+++ b/docs/docs-ref-autogen/outlook_1_3/office.subject.yml
@@ -6,11 +6,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
     name: Office.Subject
     fullName: Outlook_1_3.Office.Subject
@@ -32,25 +32,25 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
 
 
-      In addition to the main signature, this method also has this signature:
+      In addition to this signature, this method also has the following signature:
 
 
-      `getAsync(callback: (result: AsyncResult) => void): void;`
+      `getAsync(callback: (result: AsyncResult<string>) => void): void;`
     name: 'getAsync(options, callback)'
     fullName: Outlook_1_3.Office.Subject.getAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;'
+      content: 'getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult<string>) => void): void;'
       return:
         type:
           - void
@@ -65,9 +65,9 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult.
+            of type Office.AsyncResult. The `value` property of the result is the subject of the item.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<string>) => void'
   - uid: Outlook_1_3.Office.Subject.setAsync
     summary: >-
       Sets the subject of an appointment or message.
@@ -80,11 +80,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -92,7 +92,7 @@ items:
       characters.</td></tr></table>
 
 
-      In addition to the main signature, this method also has these signatures:
+      In addition to this signature, this method also has the following signatures:
 
 
       `setAsync(subject: string): void;`
@@ -101,14 +101,16 @@ items:
       `setAsync(subject: string, options: Office.AsyncContextOptions): void;`
 
 
-      `setAsync(subject: string, callback: (result: AsyncResult) => void): void;`
+      `setAsync(subject: string, callback: (result: AsyncResult<void>) => void): void;`
     name: 'setAsync(subject, options, callback)'
     fullName: Outlook_1_3.Office.Subject.setAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'setAsync(subject: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;'
+      content: >-
+        setAsync(subject: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void):
+        void;
       return:
         type:
           - void
@@ -127,7 +129,7 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult. If setting the subject fails, the asyncResult.error property will contain an error
-            code.
+            of type Office.AsyncResult. If setting the subject fails, the asyncResult.error property will contain an
+            error code.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'

--- a/docs/docs-ref-autogen/outlook_1_3/office.tasksuggestion.yml
+++ b/docs/docs-ref-autogen/outlook_1_3/office.tasksuggestion.yml
@@ -5,18 +5,18 @@ items:
       Represents a suggested task identified in an item. Read mode only.
 
 
-      The list of tasks suggested in an email message is returned in the taskSuggestions property of the
-      \[Entities\]Entities object that is returned when the getEntities or getEntitiesByType method is called on the
-      active item.
+      The list of tasks suggested in an email message is returned in the taskSuggestions property of the [
+      Entities](xref:Outlook_1_3.Office.Entities) object that is returned when the getEntities or getEntitiesByType
+      method is called on the active item.
 
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: Office.TaskSuggestion
     fullName: Outlook_1_3.Office.TaskSuggestion

--- a/docs/docs-ref-autogen/outlook_1_3/office.time.yml
+++ b/docs/docs-ref-autogen/outlook_1_3/office.time.yml
@@ -6,11 +6,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
     name: Office.Time
     fullName: Outlook_1_3.Office.Time
@@ -33,25 +33,25 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
 
 
-      In addition to the main signature, this method also has this signature:
+      In addition to this signature, this method also has the following signature:
 
 
-      `getAsync(callback: (result: AsyncResult) => void): void;`
+      `getAsync(callback: (result: AsyncResult<Date>) => void): void;`
     name: 'getAsync(options, callback)'
     fullName: Outlook_1_3.Office.Time.getAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;'
+      content: 'getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult<Date>) => void): void;'
       return:
         type:
           - void
@@ -66,9 +66,9 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult.
+            of type AsyncResult. The `value` property of the result is a Date object.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<Date>) => void'
   - uid: Outlook_1_3.Office.Time.setAsync
     summary: >-
       Sets the start or end time of an appointment.
@@ -84,11 +84,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -96,7 +96,7 @@ items:
       time.</td></tr></table>
 
 
-      In addition to the main signature, this method also has these signatures:
+      In addition to this signature, this method also has the following signatures:
 
 
       `setAsync(dateTime: Date): void;`
@@ -105,14 +105,16 @@ items:
       `setAsync(dateTime: Date, options: Office.AsyncContextOptions): void;`
 
 
-      `setAsync(dateTime: Date, callback: (result: AsyncResult) => void): void;`
+      `setAsync(dateTime: Date, callback: (result: AsyncResult<void>) => void): void;`
     name: 'setAsync(dateTime, options, callback)'
     fullName: Outlook_1_3.Office.Time.setAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'setAsync(dateTime: Date, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;'
+      content: >-
+        setAsync(dateTime: Date, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void):
+        void;
       return:
         type:
           - void
@@ -131,7 +133,7 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult. If setting the date and time fails, the asyncResult.error property will contain an
-            error code.
+            of type Office.AsyncResult. If setting the date and time fails, the asyncResult.error property will contain
+            an error code.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'

--- a/docs/docs-ref-autogen/outlook_1_3/office.userprofile.yml
+++ b/docs/docs-ref-autogen/outlook_1_3/office.userprofile.yml
@@ -8,12 +8,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.UserProfile
     fullName: Outlook_1_3.Office.UserProfile
     langs:
@@ -30,12 +30,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: displayName
     fullName: Outlook_1_3.Office.UserProfile.displayName
     langs:
@@ -52,12 +52,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: emailAddress
     fullName: Outlook_1_3.Office.UserProfile.emailAddress
     langs:
@@ -74,12 +74,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: timeZone
     fullName: Outlook_1_3.Office.UserProfile.timeZone
     langs:

--- a/docs/docs-ref-autogen/outlook_1_4.yml
+++ b/docs/docs-ref-autogen/outlook_1_4.yml
@@ -30,6 +30,7 @@ items:
       - Outlook_1_4.Office.MailboxEnums.EntityType
       - Outlook_1_4.Office.MailboxEnums.ItemNotificationMessageType
       - Outlook_1_4.Office.MailboxEnums.ItemType
+      - Outlook_1_4.Office.MailboxEnums.OWAView
       - Outlook_1_4.Office.MailboxEnums.RecipientType
       - Outlook_1_4.Office.MailboxEnums.ResponseType
       - Outlook_1_4.Office.MailboxEnums.RestVersion
@@ -96,6 +97,8 @@ references:
     name: Office.MailboxEnums.ItemNotificationMessageType
   - uid: Outlook_1_4.Office.MailboxEnums.ItemType
     name: Office.MailboxEnums.ItemType
+  - uid: Outlook_1_4.Office.MailboxEnums.OWAView
+    name: Office.MailboxEnums.OWAView
   - uid: Outlook_1_4.Office.MailboxEnums.RecipientType
     name: Office.MailboxEnums.RecipientType
   - uid: Outlook_1_4.Office.MailboxEnums.ResponseType

--- a/docs/docs-ref-autogen/outlook_1_4/office.appointmentcompose.yml
+++ b/docs/docs-ref-autogen/outlook_1_4/office.appointmentcompose.yml
@@ -2,11 +2,11 @@
 items:
   - uid: Outlook_1_4.Office.AppointmentCompose
     summary: >-
-      The appointment organizer mode of [Office.context.mailbox.item](xref:Outlook_1_4.Office.Item)<!-- -->.
+      The appointment organizer mode of [ Office.context.mailbox.item](xref:Outlook_1_4.Office.Item)<!-- -->.
 
 
       Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat
-      this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
+      this as a mode of `Office.context.mailbox.item`<!-- -->. Refer to the Object Model pages for more information.
     name: Office.AppointmentCompose
     fullName: Outlook_1_4.Office.AppointmentCompose
     langs:
@@ -50,11 +50,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Organizer</td></tr>
 
 
@@ -73,7 +73,8 @@ items:
       `addFileAttachmentAsync(uri: string, attachmentName: string, options: Office.AsyncContextOptions): void;`
 
 
-      `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+      `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void):
+      void;`
     name: 'addFileAttachmentAsync(uri, attachmentName, options, callback)'
     fullName: Outlook_1_4.Office.AppointmentCompose.addFileAttachmentAsync
     langs:
@@ -82,7 +83,7 @@ items:
     syntax:
       content: >-
         addFileAttachmentAsync(uri: string, attachmentName: string, options?: Office.AsyncContextOptions, callback?:
-        (result: AsyncResult) => void): void;
+        (result: AsyncResult<string>) => void): void;
       return:
         type:
           - void
@@ -114,7 +115,7 @@ items:
             property. If uploading the attachment fails, the asyncResult object will contain an Error object that
             provides a description of the error.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<string>) => void'
   - uid: Outlook_1_4.Office.AppointmentCompose.addItemAttachmentAsync
     summary: >-
       Adds an Exchange item, such as a message, as an attachment to the message or appointment.
@@ -130,17 +131,17 @@ items:
       session.
 
 
-      If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items
+      If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items
       other than the item that you are editing; however, this is not supported and is not recommended.
 
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Organizer</td></tr>
 
 
@@ -148,7 +149,7 @@ items:
       attachments.</td></tr></table>
 
 
-      In addition to the main signature, this method also has these signatures:
+      In addition to this signature, this method also has the following signatures:
 
 
       `addItemAttachmentAsync(itemId: any, attachmentName: string): void;`
@@ -157,7 +158,8 @@ items:
       `addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;`
 
 
-      `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+      `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void):
+      void;`
     name: 'addItemAttachmentAsync(itemId, attachmentName, options, callback)'
     fullName: Outlook_1_4.Office.AppointmentCompose.addItemAttachmentAsync
     langs:
@@ -166,7 +168,7 @@ items:
     syntax:
       content: >-
         addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?:
-        (result: AsyncResult) => void): void;
+        (result: AsyncResult<string>) => void): void;
       return:
         type:
           - void
@@ -191,22 +193,22 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value
+            of type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value
             property. If adding the attachment fails, the asyncResult object will contain an Error object that provides
             a description of the error.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<string>) => void'
   - uid: Outlook_1_4.Office.AppointmentCompose.body
     summary: |-
       Gets an object that provides methods for manipulating the body of an item.
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: body
@@ -237,11 +239,11 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: close()
@@ -261,11 +263,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: dateTimeCreated
@@ -284,11 +286,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
 
@@ -320,11 +322,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: end
@@ -352,11 +354,11 @@ items:
 
       \[ [API set: Mailbox 1.2](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: 'getSelectedDataAsync(coerciontype, options, callback)'
@@ -367,7 +369,7 @@ items:
     syntax:
       content: >-
         getSelectedDataAsync(coerciontype: Office.CoercionType, options: Office.AsyncContextOptions, callback: (result:
-        AsyncResult) => void): void;
+        AsyncResult<any>) => void): void;
       return:
         type:
           - void
@@ -388,7 +390,7 @@ items:
             When the method completes, the function passed in the callback parameter is called with a single parameter
             of type AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<any>) => void'
   - uid: Outlook_1_4.Office.AppointmentCompose.itemType
     summary: >-
       Gets the type of item that an instance represents.
@@ -400,11 +402,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: itemType
@@ -435,11 +437,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: 'loadCustomPropertiesAsync(callback, userContext)'
@@ -448,7 +450,9 @@ items:
       - typeScript
     type: method
     syntax:
-      content: 'loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;'
+      content: >-
+        loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any):
+        void;
       return:
         type:
           - void
@@ -457,9 +461,9 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult.
+            of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<Office.CustomProperties>) => void'
         - id: userContext
           description: >-
             Optional. Developers can provide any object they wish to access in the callback function. This object can be
@@ -474,11 +478,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: location
@@ -497,11 +501,11 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: notificationMessages
@@ -524,11 +528,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: optionalAttendees
@@ -549,17 +553,17 @@ items:
       The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best
       practice, you should use the attachment identifier to remove an attachment only if the same mail app has added
       that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid
-      only within the same session. A session is over when the user closes the app, or if the user starts composing in
-      an inline form and subsequently pops out the inline form to continue in a separate window.
+      only within the same session. A session is over when the user closes the app, or if the user starts composing an
+      inline form then subsequently pops out the form to continue in a separate window.
 
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Organizer</td></tr>
 
 
@@ -575,7 +579,7 @@ items:
       `removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;`
 
 
-      `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;`
+      `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;`
     name: 'removeAttachmentAsync(attachmentIndex, options, callback)'
     fullName: Outlook_1_4.Office.AppointmentCompose.removeAttachmentAsync
     langs:
@@ -584,7 +588,7 @@ items:
     syntax:
       content: >-
         removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result:
-        AsyncResult) => void): void;
+        AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -603,10 +607,10 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain
-            an error code with the reason for the failure.
+            parameter of type Office.AsyncResult. If removing the attachment fails, the asyncResult.error property will
+            contain an error code with the reason for the failure.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_4.Office.AppointmentCompose.requiredAttendees
     summary: >-
       Provides access to the required attendees of an event. The type of object and level of access depends on the mode
@@ -617,11 +621,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: requiredAttendees
@@ -667,11 +671,11 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Organizer</td></tr>
 
 
@@ -687,14 +691,14 @@ items:
       `saveAsync(options: Office.AsyncContextOptions): void;`
 
 
-      `saveAsync(callback: (result: AsyncResult) => void): void;`
+      `saveAsync(callback: (result: AsyncResult<void>) => void): void;`
     name: 'saveAsync(options, callback)'
     fullName: Outlook_1_4.Office.AppointmentCompose.saveAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;'
+      content: 'saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;'
       return:
         type:
           - void
@@ -709,10 +713,9 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain
-            an error code with the reason for the failure.
+            parameter of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_4.Office.AppointmentCompose.setSelectedDataAsync
     summary: >-
       Asynchronously inserts data into the body or subject of a message.
@@ -725,11 +728,11 @@ items:
 
       \[ [API set: Mailbox 1.2](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Organizer</td></tr>
 
 
@@ -742,10 +745,10 @@ items:
       `setSelectedDataAsync(data: string): void;`
 
 
-      `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions &amp; CoercionTypeOptions): void;`
+      `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`
 
 
-      `setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;`
+      `setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;`
     name: 'setSelectedDataAsync(data, options, callback)'
     fullName: Outlook_1_4.Office.AppointmentCompose.setSelectedDataAsync
     langs:
@@ -754,7 +757,7 @@ items:
     syntax:
       content: >-
         setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?:
-        (result: AsyncResult) => void): void;
+        (result: AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -780,10 +783,9 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain
-            an error code with the reason for the failure.
+            parameter of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_4.Office.AppointmentCompose.start
     summary: >-
       Gets or sets the date and time that the appointment is to begin.
@@ -800,11 +802,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: start
@@ -827,11 +829,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: subject

--- a/docs/docs-ref-autogen/outlook_1_4/office.appointmentform.yml
+++ b/docs/docs-ref-autogen/outlook_1_4/office.appointmentform.yml
@@ -6,12 +6,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.AppointmentForm
     fullName: Outlook_1_4.Office.AppointmentForm
     langs:
@@ -33,12 +33,12 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: body
     fullName: Outlook_1_4.Office.AppointmentForm.body
     langs:
@@ -76,12 +76,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: end
     fullName: Outlook_1_4.Office.AppointmentForm.end
     langs:
@@ -112,10 +112,10 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: location
     fullName: Outlook_1_4.Office.AppointmentForm.location
     langs:
@@ -148,12 +148,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: optionalAttendees
     fullName: Outlook_1_4.Office.AppointmentForm.optionalAttendees
     langs:
@@ -186,12 +186,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: requiredAttendees
     fullName: Outlook_1_4.Office.AppointmentForm.requiredAttendees
     langs:
@@ -240,12 +240,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: start
     fullName: Outlook_1_4.Office.AppointmentForm.start
     langs:
@@ -279,12 +279,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: subject
     fullName: Outlook_1_4.Office.AppointmentForm.subject
     langs:

--- a/docs/docs-ref-autogen/outlook_1_4/office.appointmentread.yml
+++ b/docs/docs-ref-autogen/outlook_1_4/office.appointmentread.yml
@@ -2,7 +2,7 @@
 items:
   - uid: Outlook_1_4.Office.AppointmentRead
     summary: >-
-      The appointment attendee mode of [Office.context.mailbox.item](xref:Outlook_1_4.Office.Item)<!-- -->.
+      The appointment attendee mode of [ Office.context.mailbox.item](xref:Outlook_1_4.Office.Item)<!-- -->.
 
 
       Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat
@@ -42,20 +42,20 @@ items:
       - Outlook_1_4.Office.AppointmentRead.subject
   - uid: Outlook_1_4.Office.AppointmentRead.attachments
     summary: |-
-      Gets an array of attachments for the item.
+      Gets the item's attachments as an array.
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
 
 
       Note: Certain types of files are blocked by Outlook due to potential security issues and are therefore not
-      returned. For more information, see [Blocked attachments in
+      returned. For more information, see [ Blocked attachments in
       Outlook](https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519)<!--
       -->.
     name: attachments
@@ -74,11 +74,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: body
     fullName: Outlook_1_4.Office.AppointmentRead.body
@@ -96,11 +96,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: dateTimeCreated
     fullName: Outlook_1_4.Office.AppointmentRead.dateTimeCreated
@@ -118,11 +118,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
 
 
@@ -160,11 +160,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: displayReplyAllForm(formData)
     fullName: Outlook_1_4.Office.AppointmentRead.displayReplyAllForm
@@ -181,7 +181,7 @@ items:
         - id: formData
           description: >-
             A string that contains text and HTML and that represents the body of the reply form. The string is limited
-            to 32 KB OR An[Office.ReplyFormData](xref:Outlook_1_4.Office.ReplyFormData) object that contains body or
+            to 32 KB OR An [Office.ReplyFormData](xref:Outlook_1_4.Office.ReplyFormData) object that contains body or
             attachment data and a callback function
           type:
             - string | ReplyFormData
@@ -208,11 +208,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: displayReplyForm(formData)
     fullName: Outlook_1_4.Office.AppointmentRead.displayReplyForm
@@ -229,7 +229,7 @@ items:
         - id: formData
           description: >-
             A string that contains text and HTML and that represents the body of the reply form. The string is limited
-            to 32 KB. OR An[Office.ReplyFormData](xref:Outlook_1_4.Office.ReplyFormData) object that contains body or
+            to 32 KB. OR An [Office.ReplyFormData](xref:Outlook_1_4.Office.ReplyFormData) object that contains body or
             attachment data and a callback function.
           type:
             - string | ReplyFormData
@@ -248,11 +248,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: end
     fullName: Outlook_1_4.Office.AppointmentRead.end
@@ -266,17 +266,17 @@ items:
           - Date
   - uid: Outlook_1_4.Office.AppointmentRead.getEntities
     summary: |-
-      Gets the entities found in the selected item.
+      Gets the entities found in the selected item's body.
 
       Note: This method is not supported in Outlook for iOS or Outlook for Android.
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: getEntities()
     fullName: Outlook_1_4.Office.AppointmentRead.getEntities
@@ -291,17 +291,17 @@ items:
         description: ''
   - uid: Outlook_1_4.Office.AppointmentRead.getEntitiesByType
     summary: |-
-      Gets an array of all the entities of the specified entity type found in the selected item.
+      Gets an array of all the entities of the specified entity type found in the selected item's body.
 
       Note: This method is not supported in Outlook for iOS or Outlook for Android.
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
 
 
@@ -329,7 +329,7 @@ items:
           - '(string | Contact | MeetingSuggestion | PhoneNumber | TaskSuggestion)[]'
         description: >-
           If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns
-          null. If no entities of the specified type are present on the item, the method returns an empty array.
+          null. If no entities of the specified type are present in the item's body, the method returns an empty array.
           Otherwise, the type of the objects in the returned array depends on the type of entity requested in the
           entityType parameter.
       parameters:
@@ -351,11 +351,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: getFilteredEntitiesByName(name)
     fullName: Outlook_1_4.Office.AppointmentRead.getFilteredEntitiesByName
@@ -400,11 +400,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: getRegExMatches()
     fullName: Outlook_1_4.Office.AppointmentRead.getRegExMatches
@@ -440,11 +440,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: getRegExMatchesByName(name)
     fullName: Outlook_1_4.Office.AppointmentRead.getRegExMatchesByName
@@ -473,11 +473,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
 
 
@@ -515,16 +515,17 @@ items:
       Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The
       itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making
       REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more
-      details, see Use the Outlook REST APIs from an Outlook add-in.
+      details, see [ Use the Outlook REST APIs from an Outlook
+      add-in](https://docs.microsoft.com/outlook/add-ins/use-rest-api#get-the-item-id)<!-- -->.
 
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: itemId
     fullName: Outlook_1_4.Office.AppointmentRead.itemId
@@ -547,11 +548,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: itemType
     fullName: Outlook_1_4.Office.AppointmentRead.itemType
@@ -581,11 +582,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: 'loadCustomPropertiesAsync(callback, userContext)'
     fullName: Outlook_1_4.Office.AppointmentRead.loadCustomPropertiesAsync
@@ -593,7 +594,9 @@ items:
       - typeScript
     type: method
     syntax:
-      content: 'loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;'
+      content: >-
+        loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any):
+        void;
       return:
         type:
           - void
@@ -602,9 +605,9 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult.
+            of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<Office.CustomProperties>) => void'
         - id: userContext
           description: >-
             Optional. Developers can provide any object they wish to access in the callback function. This object can be
@@ -619,11 +622,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: location
     fullName: Outlook_1_4.Office.AppointmentRead.location
@@ -646,11 +649,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: normalizedSubject
     fullName: Outlook_1_4.Office.AppointmentRead.normalizedSubject
@@ -668,11 +671,11 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: notificationMessages
     fullName: Outlook_1_4.Office.AppointmentRead.notificationMessages
@@ -697,11 +700,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: optionalAttendees
     fullName: Outlook_1_4.Office.AppointmentRead.optionalAttendees
@@ -715,15 +718,15 @@ items:
           - 'EmailAddressDetails[]'
   - uid: Outlook_1_4.Office.AppointmentRead.organizer
     summary: |-
-      Gets the email address of the meeting organizer for a specified meeting. Read mode only.
+      Gets the email address of the meeting organizer for a specified meeting.
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: organizer
     fullName: Outlook_1_4.Office.AppointmentRead.organizer
@@ -748,11 +751,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: requiredAttendees
     fullName: Outlook_1_4.Office.AppointmentRead.requiredAttendees
@@ -775,11 +778,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: start
     fullName: Outlook_1_4.Office.AppointmentRead.start
@@ -805,11 +808,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: subject
     fullName: Outlook_1_4.Office.AppointmentRead.subject

--- a/docs/docs-ref-autogen/outlook_1_4/office.attachmentdetails.yml
+++ b/docs/docs-ref-autogen/outlook_1_4/office.attachmentdetails.yml
@@ -8,11 +8,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: Office.AttachmentDetails
     fullName: Outlook_1_4.Office.AttachmentDetails

--- a/docs/docs-ref-autogen/outlook_1_4/office.body.yml
+++ b/docs/docs-ref-autogen/outlook_1_4/office.body.yml
@@ -8,12 +8,12 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.Body
     fullName: Outlook_1_4.Office.Body
     langs:
@@ -42,18 +42,18 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
 
 
-      In addition to the main signature, this method also has this signature:
+      In addition to this signature, this method also has the following signature:
 
 
-      `getAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult) => void): void;`
+      `getAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult<Office.Body>) => void): void;`
     name: 'getAsync(coerciontype, options, callback)'
     fullName: Outlook_1_4.Office.Body.getAsync
     langs:
@@ -62,7 +62,7 @@ items:
     syntax:
       content: >-
         getAsync(coerciontype: Office.CoercionType, options?: Office.AsyncContextOptions, callback?: (result:
-        AsyncResult) => void): void;
+        AsyncResult<Office.Body>) => void): void;
       return:
         type:
           - void
@@ -84,18 +84,18 @@ items:
             parameter of type AsyncResult. The body is provided in the requested format in the asyncResult.value
             property.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<Office.Body>) => void'
   - uid: Outlook_1_4.Office.Body.getTypeAsync
     summary: |-
       Gets a value that indicates whether the content is in HTML or text format.
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
     name: 'getTypeAsync(options, callback)'
     fullName: Outlook_1_4.Office.Body.getTypeAsync
@@ -103,7 +103,9 @@ items:
       - typeScript
     type: method
     syntax:
-      content: 'getTypeAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;'
+      content: >-
+        getTypeAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<Office.CoercionType>) =>
+        void): void;
       return:
         type:
           - void
@@ -118,10 +120,10 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. The content type is returned as one of the CoercionType values in the
+            parameter of type Office.AsyncResult. The content type is returned as one of the CoercionType values in the
             asyncResult.value property.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<Office.CoercionType>) => void'
   - uid: Outlook_1_4.Office.Body.prependAsync
     summary: >-
       Adds the specified content to the beginning of the item body.
@@ -137,11 +139,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -149,13 +151,13 @@ items:
       characters.</td></tr></table>
 
 
-      In addition to the main signature, this method also has these signatures:
+      In addition to this signature, this method also has the following signatures:
 
 
-      `prependAsync(data: string, options: Office.AsyncContextOptions &amp; CoercionTypeOptions): void;`
+      `prependAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`
 
 
-      `prependAsync(data: string, callback: (result: AsyncResult) => void): void;`
+      `prependAsync(data: string, callback: (result: AsyncResult<void>) => void): void;`
 
 
       `prependAsync(data: string): void;`
@@ -167,7 +169,7 @@ items:
     syntax:
       content: >-
         prependAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result:
-        AsyncResult) => void): void;
+        AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -187,9 +189,10 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. Any errors encountered will be provided in the asyncResult.error property.
+            parameter of type Office.AsyncResult. Any errors encountered will be provided in the asyncResult.error
+            property.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_4.Office.Body.setAsync
     summary: >-
       Replaces the entire body with the specified text.
@@ -207,11 +210,11 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -220,13 +223,13 @@ items:
       Office.CoercionType.Html and the message body is in plain text.</td></tr></table>
 
 
-      In addition to the main signature, this method also has these signatures:
+      In addition to this signature, this method also has the following signatures:
 
 
-      `setAsync(data: string, options: Office.AsyncContextOptions &amp; CoercionTypeOptions): void;`
+      `setAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`
 
 
-      `setAsync(data: string, callback: (result: AsyncResult) => void): void;`
+      `setAsync(data: string, callback: (result: AsyncResult<void>) => void): void;`
 
 
       `setAsync(data: string): void;`
@@ -238,7 +241,7 @@ items:
     syntax:
       content: >-
         setAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result:
-        AsyncResult) => void): void;
+        AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -258,9 +261,10 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. Any errors encountered will be provided in the asyncResult.error property.
+            parameter of type Office.AsyncResult. Any errors encountered will be provided in the asyncResult.error
+            property.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_4.Office.Body.setSelectedDataAsync
     summary: >-
       Replaces the selection in the body with the specified text.
@@ -278,11 +282,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -291,13 +295,13 @@ items:
       Office.CoercionType.Html and the message body is in plain text.</td></tr></table>
 
 
-      In addition to the main signature, this method also has these signatures:
+      In addition to this signature, this method also has the following signatures:
 
 
-      `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions &amp; CoercionTypeOptions): void;`
+      `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`
 
 
-      `setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;`
+      `setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;`
 
 
       `setSelectedDataAsync(data: string): void;`
@@ -309,7 +313,7 @@ items:
     syntax:
       content: >-
         setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?:
-        (result: AsyncResult) => void): void;
+        (result: AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -329,6 +333,7 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. Any errors encountered will be provided in the asyncResult.error property.
+            parameter of type Office.AsyncResult. Any errors encountered will be provided in the asyncResult.error
+            property.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'

--- a/docs/docs-ref-autogen/outlook_1_4/office.contact.yml
+++ b/docs/docs-ref-autogen/outlook_1_4/office.contact.yml
@@ -12,11 +12,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: Office.Contact
     fullName: Outlook_1_4.Office.Contact

--- a/docs/docs-ref-autogen/outlook_1_4/office.customproperties.yml
+++ b/docs/docs-ref-autogen/outlook_1_4/office.customproperties.yml
@@ -15,12 +15,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.CustomProperties
     fullName: Outlook_1_4.Office.CustomProperties
     langs:
@@ -35,12 +35,12 @@ items:
   - uid: Outlook_1_4.Office.CustomProperties.get
     summary: Returns the value of the specified custom property.
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: get(name)
     fullName: Outlook_1_4.Office.CustomProperties.get
     langs:
@@ -66,12 +66,12 @@ items:
 
       To make the removal of the property permanent, you must call the saveAsync method of the CustomProperties object.
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: remove(name)
     fullName: Outlook_1_4.Office.CustomProperties.remove
     langs:
@@ -85,7 +85,10 @@ items:
         description: ''
       parameters:
         - id: name
-          description: 'The name of the property to be removed. \[Api set: Mailbox 1.0\]'
+          description: |-
+            The name of the property to be removed.
+
+            \[Api set: Mailbox 1.0\]
           type:
             - string
   - uid: Outlook_1_4.Office.CustomProperties.saveAsync
@@ -102,19 +105,19 @@ items:
       becomes disconnected. If the add-in calls saveAsync while in the disconnected state, saveAsync would return an
       error. Your callback method should handle this error accordingly.
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: 'saveAsync(callback, asyncContext)'
     fullName: Outlook_1_4.Office.CustomProperties.saveAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'saveAsync(callback?: (result: AsyncResult) => void, asyncContext?: any): void;'
+      content: 'saveAsync(callback?: (result: AsyncResult<void>) => void, asyncContext?: any): void;'
       return:
         type:
           - void
@@ -123,11 +126,14 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult.
+            parameter of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
         - id: asyncContext
-          description: 'Optional. Any state data that is passed to the callback method. \[Api set: Mailbox 1.0\]'
+          description: |-
+            Optional. Any state data that is passed to the callback method.
+
+            \[Api set: Mailbox 1.0\]
           type:
             - any
   - uid: Outlook_1_4.Office.CustomProperties.set
@@ -146,12 +152,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: 'set(name, value)'
     fullName: Outlook_1_4.Office.CustomProperties.set
     langs:

--- a/docs/docs-ref-autogen/outlook_1_4/office.diagnostics.yml
+++ b/docs/docs-ref-autogen/outlook_1_4/office.diagnostics.yml
@@ -6,12 +6,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.Diagnostics
     fullName: Outlook_1_4.Office.Diagnostics
     langs:
@@ -30,12 +30,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: hostName
     fullName: Outlook_1_4.Office.Diagnostics.hostName
     langs:
@@ -58,12 +58,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: hostVersion
     fullName: Outlook_1_4.Office.Diagnostics.hostVersion
     langs:
@@ -102,19 +102,19 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: OWAView
     fullName: Outlook_1_4.Office.Diagnostics.OWAView
     langs:
       - typeScript
     type: property
     syntax:
-      content: 'OWAView: "string";'
+      content: 'OWAView: MailboxEnums.OWAView | "OneColumn" | "TwoColumns" | "ThreeColumns";'
       return:
         type:
-          - '"string"'
+          - MailboxEnums.OWAView | "OneColumn" | "TwoColumns" | "ThreeColumns"

--- a/docs/docs-ref-autogen/outlook_1_4/office.emailaddressdetails.yml
+++ b/docs/docs-ref-autogen/outlook_1_4/office.emailaddressdetails.yml
@@ -6,12 +6,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.EmailAddressDetails
     fullName: Outlook_1_4.Office.EmailAddressDetails
     langs:

--- a/docs/docs-ref-autogen/outlook_1_4/office.emailuser.yml
+++ b/docs/docs-ref-autogen/outlook_1_4/office.emailuser.yml
@@ -6,11 +6,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: Office.EmailUser
     fullName: Outlook_1_4.Office.EmailUser

--- a/docs/docs-ref-autogen/outlook_1_4/office.entities.yml
+++ b/docs/docs-ref-autogen/outlook_1_4/office.entities.yml
@@ -34,11 +34,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: Office.Entities
     fullName: Outlook_1_4.Office.Entities

--- a/docs/docs-ref-autogen/outlook_1_4/office.item.yml
+++ b/docs/docs-ref-autogen/outlook_1_4/office.item.yml
@@ -8,12 +8,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.Item
     fullName: Outlook_1_4.Office.Item
     langs:
@@ -33,12 +33,12 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: body
     fullName: Outlook_1_4.Office.Item.body
     langs:
@@ -55,11 +55,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: dateTimeCreated
     fullName: Outlook_1_4.Office.Item.dateTimeCreated
@@ -77,11 +77,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
 
 
@@ -107,12 +107,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: itemType
     fullName: Outlook_1_4.Office.Item.itemType
     langs:
@@ -141,19 +141,21 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: 'loadCustomPropertiesAsync(callback, userContext)'
     fullName: Outlook_1_4.Office.Item.loadCustomPropertiesAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;'
+      content: >-
+        loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any):
+        void;
       return:
         type:
           - void
@@ -162,9 +164,9 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult.
+            of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<Office.CustomProperties>) => void'
         - id: userContext
           description: >-
             Optional. Developers can provide any object they wish to access in the callback function. This object can be
@@ -177,12 +179,12 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: notificationMessages
     fullName: Outlook_1_4.Office.Item.notificationMessages
     langs:

--- a/docs/docs-ref-autogen/outlook_1_4/office.itemcompose.yml
+++ b/docs/docs-ref-autogen/outlook_1_4/office.itemcompose.yml
@@ -2,11 +2,11 @@
 items:
   - uid: Outlook_1_4.Office.ItemCompose
     summary: >-
-      The compose mode of [Office.context.mailbox.item](xref:Outlook_1_4.Office.Item)<!-- -->.
+      The compose mode of [ Office.context.mailbox.item](xref:Outlook_1_4.Office.Item)<!-- -->.
 
 
       Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat
-      this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
+      this as a mode of `Office.context.mailbox.item`<!-- -->. Refer to the Object Model pages for more information.
     name: Office.ItemCompose
     fullName: Outlook_1_4.Office.ItemCompose
     langs:
@@ -39,11 +39,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -62,7 +62,8 @@ items:
       `addFileAttachmentAsync(uri: string, attachmentName: string, options: Office.AsyncContextOptions): void;`
 
 
-      `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+      `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void):
+      void;`
     name: 'addFileAttachmentAsync(uri, attachmentName, options, callback)'
     fullName: Outlook_1_4.Office.ItemCompose.addFileAttachmentAsync
     langs:
@@ -71,7 +72,7 @@ items:
     syntax:
       content: >-
         addFileAttachmentAsync(uri: string, attachmentName: string, options?: Office.AsyncContextOptions, callback?:
-        (result: AsyncResult) => void): void;
+        (result: AsyncResult<string>) => void): void;
       return:
         type:
           - void
@@ -103,7 +104,7 @@ items:
             property. If uploading the attachment fails, the asyncResult object will contain an Error object that
             provides a description of the error.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<string>) => void'
   - uid: Outlook_1_4.Office.ItemCompose.addItemAttachmentAsync
     summary: >-
       Adds an Exchange item, such as a message, as an attachment to the message or appointment.
@@ -119,17 +120,17 @@ items:
       session.
 
 
-      If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items
+      If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items
       other than the item that you are editing; however, this is not supported and is not recommended.
 
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -137,7 +138,7 @@ items:
       attachments.</td></tr></table>
 
 
-      In addition to the main signature, this method also has these signatures:
+      In addition to this signature, this method also has the following signatures:
 
 
       `addItemAttachmentAsync(itemId: any, attachmentName: string): void;`
@@ -146,7 +147,8 @@ items:
       `addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;`
 
 
-      `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+      `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void):
+      void;`
     name: 'addItemAttachmentAsync(itemId, attachmentName, options, callback)'
     fullName: Outlook_1_4.Office.ItemCompose.addItemAttachmentAsync
     langs:
@@ -155,7 +157,7 @@ items:
     syntax:
       content: >-
         addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?:
-        (result: AsyncResult) => void): void;
+        (result: AsyncResult<string>) => void): void;
       return:
         type:
           - void
@@ -180,11 +182,11 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value
+            of type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value
             property. If adding the attachment fails, the asyncResult object will contain an Error object that provides
             a description of the error.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<string>) => void'
   - uid: Outlook_1_4.Office.ItemCompose.close
     summary: >-
       Closes the current item that is being composed
@@ -203,11 +205,11 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
     name: close()
     fullName: Outlook_1_4.Office.ItemCompose.close
@@ -235,11 +237,11 @@ items:
 
       \[ [API set: Mailbox 1.2](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
     name: 'getSelectedDataAsync(coerciontype, callback)'
     fullName: Outlook_1_4.Office.ItemCompose.getSelectedDataAsync
@@ -247,7 +249,7 @@ items:
       - typeScript
     type: method
     syntax:
-      content: 'getSelectedDataAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult) => void): void;'
+      content: 'getSelectedDataAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult<any>) => void): void;'
       return:
         type:
           - void
@@ -260,9 +262,9 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult.
+            of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<any>) => void'
   - uid: Outlook_1_4.Office.ItemCompose.removeAttachmentAsync
     summary: >-
       Removes an attachment from a message or appointment.
@@ -271,17 +273,17 @@ items:
       The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best
       practice, you should use the attachment identifier to remove an attachment only if the same mail app has added
       that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid
-      only within the same session. A session is over when the user closes the app, or if the user starts composing in
-      an inline form and subsequently pops out the inline form to continue in a separate window.
+      only within the same session. A session is over when the user closes the app, or if the user starts composing an
+      inline form then subsequently pops out the form to continue in a separate window.
 
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -297,7 +299,7 @@ items:
       `removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;`
 
 
-      `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;`
+      `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;`
     name: 'removeAttachmentAsync(attachmentIndex, options, callback)'
     fullName: Outlook_1_4.Office.ItemCompose.removeAttachmentAsync
     langs:
@@ -306,7 +308,7 @@ items:
     syntax:
       content: >-
         removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result:
-        AsyncResult) => void): void;
+        AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -325,10 +327,10 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain
-            an error code with the reason for the failure.
+            parameter of type Office.AsyncResult. If removing the attachment fails, the asyncResult.error property will
+            contain an error code with the reason for the failure.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_4.Office.ItemCompose.saveAsync
     summary: >-
       Asynchronously saves an item.
@@ -362,11 +364,11 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -382,14 +384,14 @@ items:
       `saveAsync(options: Office.AsyncContextOptions): void;`
 
 
-      `saveAsync(callback: (result: AsyncResult) => void): void;`
+      `saveAsync(callback: (result: AsyncResult<void>) => void): void;`
     name: 'saveAsync(options, callback)'
     fullName: Outlook_1_4.Office.ItemCompose.saveAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;'
+      content: 'saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;'
       return:
         type:
           - void
@@ -404,10 +406,10 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain
-            an error code with the reason for the failure.
+            parameter of type Office.AsyncResult. If removing the attachment fails, the asyncResult.error property will
+            contain an error code with the reason for the failure.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_4.Office.ItemCompose.setSelectedDataAsync
     summary: >-
       Asynchronously inserts data into the body or subject of a message.
@@ -420,11 +422,11 @@ items:
 
       \[ [API set: Mailbox 1.2](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -437,10 +439,10 @@ items:
       `setSelectedDataAsync(data: string): void;`
 
 
-      `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions &amp; CoercionTypeOptions): void;`
+      `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`
 
 
-      `setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;`
+      `setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;`
     name: 'setSelectedDataAsync(data, options, callback)'
     fullName: Outlook_1_4.Office.ItemCompose.setSelectedDataAsync
     langs:
@@ -449,7 +451,7 @@ items:
     syntax:
       content: >-
         setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?:
-        (result: AsyncResult) => void): void;
+        (result: AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -475,10 +477,9 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain
-            an error code with the reason for the failure.
+            parameter of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_4.Office.ItemCompose.subject
     summary: |-
       Gets or sets the description that appears in the subject field of an item.
@@ -489,12 +490,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: subject
     fullName: Outlook_1_4.Office.ItemCompose.subject
     langs:

--- a/docs/docs-ref-autogen/outlook_1_4/office.itemread.yml
+++ b/docs/docs-ref-autogen/outlook_1_4/office.itemread.yml
@@ -2,11 +2,11 @@
 items:
   - uid: Outlook_1_4.Office.ItemRead
     summary: >-
-      The read mode of [Office.context.mailbox.item](xref:Outlook_1_4.Office.Item)<!-- -->.
+      The read mode of [ Office.context.mailbox.item](xref:Outlook_1_4.Office.Item)<!-- -->.
 
 
       Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat
-      this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
+      this as a mode of `Office.context.mailbox.item`<!-- -->. Refer to the Object Model pages for more information.
     name: Office.ItemRead
     fullName: Outlook_1_4.Office.ItemRead
     langs:
@@ -30,20 +30,20 @@ items:
       - Outlook_1_4.Office.ItemRead.subject
   - uid: Outlook_1_4.Office.ItemRead.attachments
     summary: |-
-      Gets an array of attachments for the item.
+      Gets the item's attachments as an array.
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
 
 
       Note: Certain types of files are blocked by Outlook due to potential security issues and are therefore not
-      returned. For more information, see [Blocked attachments in
+      returned. For more information, see [ Blocked attachments in
       Outlook](https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519)<!--
       -->.
     name: attachments
@@ -79,11 +79,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: displayReplyAllForm(formData)
     fullName: Outlook_1_4.Office.ItemRead.displayReplyAllForm
@@ -100,7 +100,7 @@ items:
         - id: formData
           description: >-
             A string that contains text and HTML and that represents the body of the reply form. The string is limited
-            to 32 KB OR An[Office.ReplyFormData](xref:Outlook_1_4.Office.ReplyFormData) object that contains body or
+            to 32 KB OR An [Office.ReplyFormData](xref:Outlook_1_4.Office.ReplyFormData) object that contains body or
             attachment data and a callback function
           type:
             - string | ReplyFormData
@@ -127,11 +127,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: displayReplyForm(formData)
     fullName: Outlook_1_4.Office.ItemRead.displayReplyForm
@@ -148,23 +148,23 @@ items:
         - id: formData
           description: >-
             A string that contains text and HTML and that represents the body of the reply form. The string is limited
-            to 32 KB. OR An[Office.ReplyFormData](xref:Outlook_1_4.Office.ReplyFormData) object that contains body or
+            to 32 KB. OR An [Office.ReplyFormData](xref:Outlook_1_4.Office.ReplyFormData) object that contains body or
             attachment data and a callback function.
           type:
             - string | ReplyFormData
   - uid: Outlook_1_4.Office.ItemRead.getEntities
     summary: |-
-      Gets the entities found in the selected item.
+      Gets the entities found in the selected item's body.
 
       Note: This method is not supported in Outlook for iOS or Outlook for Android.
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: getEntities()
     fullName: Outlook_1_4.Office.ItemRead.getEntities
@@ -179,17 +179,17 @@ items:
         description: ''
   - uid: Outlook_1_4.Office.ItemRead.getEntitiesByType
     summary: |-
-      Gets an array of all the entities of the specified entity type found in the selected item.
+      Gets an array of all the entities of the specified entity type found in the selected item's body.
 
       Note: This method is not supported in Outlook for iOS or Outlook for Android.
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
 
 
@@ -217,7 +217,7 @@ items:
           - '(string | Contact | MeetingSuggestion | PhoneNumber | TaskSuggestion)[]'
         description: >-
           If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns
-          null. If no entities of the specified type are present on the item, the method returns an empty array.
+          null. If no entities of the specified type are present in the item's body, the method returns an empty array.
           Otherwise, the type of the objects in the returned array depends on the type of entity requested in the
           entityType parameter.
       parameters:
@@ -239,11 +239,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: getFilteredEntitiesByName(name)
     fullName: Outlook_1_4.Office.ItemRead.getFilteredEntitiesByName
@@ -288,11 +288,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: getRegExMatches()
     fullName: Outlook_1_4.Office.ItemRead.getRegExMatches
@@ -328,11 +328,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: getRegExMatchesByName(name)
     fullName: Outlook_1_4.Office.ItemRead.getRegExMatchesByName
@@ -361,11 +361,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
 
 
@@ -403,16 +403,17 @@ items:
       Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The
       itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making
       REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more
-      details, see Use the Outlook REST APIs from an Outlook add-in.
+      details, see [ Use the Outlook REST APIs from an Outlook
+      add-in](https://docs.microsoft.com/outlook/add-ins/use-rest-api#get-the-item-id)<!-- -->.
 
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: itemId
     fullName: Outlook_1_4.Office.ItemRead.itemId
@@ -435,11 +436,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: normalizedSubject
     fullName: Outlook_1_4.Office.ItemRead.normalizedSubject
@@ -465,12 +466,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: subject
     fullName: Outlook_1_4.Office.ItemRead.subject
     langs:

--- a/docs/docs-ref-autogen/outlook_1_4/office.localclienttime.yml
+++ b/docs/docs-ref-autogen/outlook_1_4/office.localclienttime.yml
@@ -6,11 +6,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: Office.LocalClientTime
     fullName: Outlook_1_4.Office.LocalClientTime

--- a/docs/docs-ref-autogen/outlook_1_4/office.location.yml
+++ b/docs/docs-ref-autogen/outlook_1_4/office.location.yml
@@ -6,11 +6,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
     name: Office.Location
     fullName: Outlook_1_4.Office.Location
@@ -29,25 +29,25 @@ items:
       The getAsync method starts an asynchronous call to the Exchange server to get the location of an appointment. The
       location of the appointment is provided as a string in the asyncResult.value property.
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
 
 
       In addition to this signature, the method also has the following signature:
 
 
-      `getAsync(callback: (result: AsyncResult) => void): void;`
+      `getAsync(callback: (result: AsyncResult<string>) => void): void;`
     name: 'getAsync(options, callback)'
     fullName: Outlook_1_4.Office.Location.getAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'getAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;'
+      content: 'getAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;'
       return:
         type:
           - void
@@ -62,9 +62,12 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. \[Api set: Mailbox 1.1\]
+            parameter of type Office.AsyncResult.
+
+
+            \[Api set: Mailbox 1.1\]
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<string>) => void'
   - uid: Outlook_1_4.Office.Location.setAsync
     summary: >-
       Sets the location of an appointment.
@@ -73,11 +76,11 @@ items:
       The setAsync method starts an asynchronous call to the Exchange server to set the location of an appointment.
       Setting the location of an appointment overwrites the current location.
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -94,7 +97,7 @@ items:
       `setAsync(location: string, options: Office.AsyncContextOptions): void;`
 
 
-      `setAsync(location: string, callback: (result: AsyncResult) => void): void;`
+      `setAsync(location: string, callback: (result: AsyncResult<void>) => void): void;`
     name: 'setAsync(location, options, callback)'
     fullName: Outlook_1_4.Office.Location.setAsync
     langs:
@@ -102,8 +105,8 @@ items:
     type: method
     syntax:
       content: >-
-        setAsync(location: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void):
-        void;
+        setAsync(location: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) =>
+        void): void;
       return:
         type:
           - void
@@ -122,7 +125,10 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. If setting the location fails, the asyncResult.error property will contain an
-            error code. \[Api set: Mailbox 1.1\]
+            parameter of type Office.AsyncResult. If setting the location fails, the asyncResult.error property will
+            contain an error code.
+
+
+            \[Api set: Mailbox 1.1\]
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'

--- a/docs/docs-ref-autogen/outlook_1_4/office.mailbox.yml
+++ b/docs/docs-ref-autogen/outlook_1_4/office.mailbox.yml
@@ -2,7 +2,7 @@
 items:
   - uid: Outlook_1_4.Office.Mailbox
     summary: |-
-      Provides access to the Outlook add-in object model for Microsoft Outlook and Microsoft Outlook on the web.
+      Provides access to the Outlook Add-in object model for Microsoft Outlook and Microsoft Outlook on the web.
 
       Namespaces:
 
@@ -14,12 +14,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.Mailbox
     fullName: Outlook_1_4.Office.Mailbox
     langs:
@@ -56,12 +56,12 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: 'convertToEwsId(itemId, restVersion)'
     fullName: Outlook_1_4.Office.Mailbox.convertToEwsId
     langs:
@@ -101,12 +101,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: convertToLocalClientTime(timeValue)
     fullName: Outlook_1_4.Office.Mailbox.convertToLocalClientTime
     langs:
@@ -131,19 +131,19 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
 
 
       Item IDs retrieved via EWS or via the itemId property use a different format than the format used by REST APIs
-      (such as the [Outlook Mail
+      (such as the [ Outlook Mail
       API](https://docs.microsoft.com/previous-versions/office/office-365-api/api/version-2.0/mail-rest-operations) or
-      the [Microsoft Graph](http://graph.microsoft.io/)<!-- -->. The convertToRestId method converts an EWS-formatted ID
-      into the proper format for REST.
+      the [ Microsoft Graph](http://graph.microsoft.io/)<!-- -->. The convertToRestId method converts an EWS-formatted
+      ID into the proper format for REST.
     name: 'convertToRestId(itemId, restVersion)'
     fullName: Outlook_1_4.Office.Mailbox.convertToRestId
     langs:
@@ -175,12 +175,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: convertToUtcClientTime(input)
     fullName: Outlook_1_4.Office.Mailbox.convertToUtcClientTime
     langs:
@@ -215,11 +215,11 @@ items:
       Exchange Server. An example is the string 15.0.468.0.
 
 
-      - OWAView (string): A string that represents the current view of Outlook Web App. If the host application is not
-      Outlook Web App, then accessing this property results in undefined. Outlook Web App has three views (OneColumn -
-      displayed when the screen is narrow, TwoColumns - displayed when the screen is wider, and ThreeColumns - displayed
-      when the screen is wide.) that correspond to the width of the screen and the window, and the number of columns
-      that can be displayed.
+      - OWAView (MailboxEnums.OWAView or string): An enum (or string literal) that represents the current view of
+      Outlook Web App. If the host application is not Outlook Web App, then accessing this property results in
+      undefined. Outlook Web App has three views (OneColumn - displayed when the screen is narrow, TwoColumns -
+      displayed when the screen is wider, and ThreeColumns - displayed when the screen is wide) that correspond to the
+      width of the screen and the window, and the number of columns that can be displayed.
 
 
       More information is under [Office.Diagnostics](xref:Outlook_1_4.Office.Diagnostics)<!-- -->.
@@ -227,12 +227,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: diagnostics
     fullName: Outlook_1_4.Office.Mailbox.diagnostics
     langs:
@@ -271,12 +271,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: displayAppointmentForm(itemId)
     fullName: Outlook_1_4.Office.Mailbox.displayAppointmentForm
     langs:
@@ -320,12 +320,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: displayMessageForm(itemId)
     fullName: Outlook_1_4.Office.Mailbox.displayMessageForm
     langs:
@@ -371,11 +371,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: displayNewAppointmentForm(parameters)
     fullName: Outlook_1_4.Office.Mailbox.displayNewAppointmentForm
@@ -407,16 +407,16 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
 
 
       The ewsUrl value can be used by a remote service to make EWS calls to the user's mailbox. For example, you can
-      create a remote service to [get attachments from the selected
+      create a remote service to [ get attachments from the selected
       item](https://docs.microsoft.com/outlook/add-ins/get-attachments-of-an-outlook-item)<!-- -->.
 
 
@@ -456,11 +456,11 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
       and read</td></tr></table>
     name: 'getCallbackTokenAsync(callback, userContext)'
     fullName: Outlook_1_4.Office.Mailbox.getCallbackTokenAsync
@@ -468,7 +468,7 @@ items:
       - typeScript
     type: method
     syntax:
-      content: 'getCallbackTokenAsync(callback: (result: AsyncResult) => void, userContext?: any): void;'
+      content: 'getCallbackTokenAsync(callback: (result: AsyncResult<string>) => void, userContext?: any): void;'
       return:
         type:
           - void
@@ -477,9 +477,9 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult. The token is provided as a string in the asyncResult.value property.
+            of type Office.AsyncResult. The token is provided as a string in the asyncResult.value property.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<string>) => void'
         - id: userContext
           description: Optional. Any state data that is passed to the asynchronous method.
           type:
@@ -492,23 +492,23 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
       and read</td></tr></table>
 
 
-      The getUserIdentityTokenAsync method returns a token that you can use to identify and [authenticate the add-in and
-      user with a third-party system](https://docs.microsoft.com/outlook/add-ins/authentication)<!-- -->.
+      The getUserIdentityTokenAsync method returns a token that you can use to identify and [ authenticate the add-in
+      and user with a third-party system](https://docs.microsoft.com/outlook/add-ins/authentication)<!-- -->.
     name: 'getUserIdentityTokenAsync(callback, userContext)'
     fullName: Outlook_1_4.Office.Mailbox.getUserIdentityTokenAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'getUserIdentityTokenAsync(callback: (result: AsyncResult) => void, userContext?: any): void;'
+      content: 'getUserIdentityTokenAsync(callback: (result: AsyncResult<string>) => void, userContext?: any): void;'
       return:
         type:
           - void
@@ -517,9 +517,9 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult.
+            of type Office.AsyncResult. The token is provided as a string in the asyncResult.value property.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<string>) => void'
         - id: userContext
           description: Optional. Any state data that is passed to the asynchronous method.\|
           type:
@@ -528,7 +528,8 @@ items:
     summary: >-
       The mailbox item. Depending on the context in which the add-in opened, the item may be of any number of types. If
       you want to see IntelliSense for only a specific type, you should cast this item to one of the following:
-      `ItemCompose`, `ItemRead`, `MessageCompose`, `MessageRead`, `AppointmentCompose`, `AppointmentRead`
+      `ItemCompose`<!-- -->, `ItemRead`<!-- -->, `MessageCompose`<!-- -->, `MessageRead`<!-- -->,
+      `AppointmentCompose`<!-- -->, `AppointmentRead`
     name: item
     fullName: Outlook_1_4.Office.Mailbox.item
     langs:
@@ -559,15 +560,21 @@ items:
 
       Your add-in must have the ReadWriteMailbox permission to use the makeEwsRequestAsync method. For information about
       using the ReadWriteMailbox permission and the EWS operations that you can call with the makeEwsRequestAsync
-      method, see Specify permissions for mail add-in access to the user's mailbox.
+      method, see [ Specify permissions for mail add-in access to the user's
+      mailbox](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)<!-- -->.
 
 
       The XML result of the EWS call is provided as a string in the asyncResult.value property. If the result exceeds 1
       MB in size, an error message is returned instead.
 
 
-      Note: This method is not supported in the following scenarios. - In Outlook for iOS or Outlook for Android - When
-      the add-in is loaded in a Gmail mailbox
+      Note: This method is not supported in the following scenarios:
+
+
+      - In Outlook for iOS or Outlook for Android.
+
+
+      - When the add-in is loaded in a Gmail mailbox.
 
 
       Note: The server administrator must set OAuthAuthentication to true on the Client Access Server EWS directory to
@@ -581,7 +588,7 @@ items:
       15.0.4535.1004, you should set the encoding value to ISO-8859-1.
 
 
-      `&lt;?xml version="1.0" encoding="iso-8859-1"?&gt;`
+      `<?xml version="1.0" encoding="iso-8859-1"?>`
 
 
       You do not need to set the encoding value when your mail app is running in Outlook on the web. You can determine
@@ -592,11 +599,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteMailbox</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
       and read</td></tr></table>
     name: 'makeEwsRequestAsync(data, callback, userContext)'
     fullName: Outlook_1_4.Office.Mailbox.makeEwsRequestAsync
@@ -604,7 +611,7 @@ items:
       - typeScript
     type: method
     syntax:
-      content: 'makeEwsRequestAsync(data: any, callback: (result: AsyncResult) => void, userContext?: any): void;'
+      content: 'makeEwsRequestAsync(data: any, callback: (result: AsyncResult<string>) => void, userContext?: any): void;'
       return:
         type:
           - void
@@ -617,9 +624,10 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult.
+            of type Office.AsyncResult. The `value` property of the result is the XML of the EWS request provided as a
+            string. If the result exceeds 1 MB in size, an error message is returned instead.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<string>) => void'
         - id: userContext
           description: Optional. Any state data that is passed to the asynchronous method.
           type:
@@ -627,7 +635,7 @@ items:
   - uid: Outlook_1_4.Office.Mailbox.userProfile
     summary: >-
       Information about the user associated with the mailbox. This includes their account type, display name, email
-      adddress, and time zone.
+      address, and time zone.
 
 
       More information is under [Office.UserProfile](xref:Outlook_1_4.Office.UserProfile)

--- a/docs/docs-ref-autogen/outlook_1_4/office.mailboxenums.attachmenttype.yml
+++ b/docs/docs-ref-autogen/outlook_1_4/office.mailboxenums.attachmenttype.yml
@@ -6,7 +6,7 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td> [Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
+      <table><tr><td> [ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
       </td><td>Compose or read</td></tr></table>
     name: Office.MailboxEnums.AttachmentType
     fullName: Outlook_1_4.Office.MailboxEnums.AttachmentType

--- a/docs/docs-ref-autogen/outlook_1_4/office.mailboxenums.entitytype.yml
+++ b/docs/docs-ref-autogen/outlook_1_4/office.mailboxenums.entitytype.yml
@@ -6,7 +6,7 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td> [Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
+      <table><tr><td> [ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
       </td><td>Compose or read</td></tr></table>
     name: Office.MailboxEnums.EntityType
     fullName: Outlook_1_4.Office.MailboxEnums.EntityType

--- a/docs/docs-ref-autogen/outlook_1_4/office.mailboxenums.itemnotificationmessagetype.yml
+++ b/docs/docs-ref-autogen/outlook_1_4/office.mailboxenums.itemnotificationmessagetype.yml
@@ -6,7 +6,7 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td> [Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
+      <table><tr><td> [ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
       </td><td>Compose or read</td></tr></table>
     name: Office.MailboxEnums.ItemNotificationMessageType
     fullName: Outlook_1_4.Office.MailboxEnums.ItemNotificationMessageType

--- a/docs/docs-ref-autogen/outlook_1_4/office.mailboxenums.itemtype.yml
+++ b/docs/docs-ref-autogen/outlook_1_4/office.mailboxenums.itemtype.yml
@@ -6,7 +6,7 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td> [Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
+      <table><tr><td> [ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
       </td><td>Compose or read</td></tr></table>
     name: Office.MailboxEnums.ItemType
     fullName: Outlook_1_4.Office.MailboxEnums.ItemType

--- a/docs/docs-ref-autogen/outlook_1_4/office.mailboxenums.owaview.yml
+++ b/docs/docs-ref-autogen/outlook_1_4/office.mailboxenums.owaview.yml
@@ -1,0 +1,42 @@
+### YamlMime:UniversalReference
+items:
+  - uid: Outlook_1_4.Office.MailboxEnums.OWAView
+    summary: Represents the current view of Outlook Web App.
+    name: Office.MailboxEnums.OWAView
+    fullName: Outlook_1_4.Office.MailboxEnums.OWAView
+    langs:
+      - typeScript
+    type: enum
+    package: Outlook_1_4
+    children:
+      - Outlook_1_4.Office.MailboxEnums.OWAView.OneColumn
+      - Outlook_1_4.Office.MailboxEnums.OWAView.ThreeColumns
+      - Outlook_1_4.Office.MailboxEnums.OWAView.TwoColumns
+  - uid: Outlook_1_4.Office.MailboxEnums.OWAView.OneColumn
+    summary: >-
+      One column view. Displayed when the screen is narrow. Outlook Web App uses this single-column layout on the entire
+      screen of a smartphone.
+    name: OneColumn
+    fullName: Outlook_1_4.Office.MailboxEnums.OWAView.OneColumn
+    langs:
+      - typeScript
+    type: field
+    numericValue: '"OneColumn"'
+  - uid: Outlook_1_4.Office.MailboxEnums.OWAView.ThreeColumns
+    summary: >-
+      Three column view. Displayed when the screen is wide. For example, Outlook Web App uses this view in a full screen
+      window on a desktop computer.
+    name: ThreeColumns
+    fullName: Outlook_1_4.Office.MailboxEnums.OWAView.ThreeColumns
+    langs:
+      - typeScript
+    type: field
+    numericValue: '"ThreeColumns"'
+  - uid: Outlook_1_4.Office.MailboxEnums.OWAView.TwoColumns
+    summary: Two column view. Displayed when the screen is wider. Outlook Web App uses this view on most tablets.
+    name: TwoColumns
+    fullName: Outlook_1_4.Office.MailboxEnums.OWAView.TwoColumns
+    langs:
+      - typeScript
+    type: field
+    numericValue: '"TwoColumns"'

--- a/docs/docs-ref-autogen/outlook_1_4/office.mailboxenums.recipienttype.yml
+++ b/docs/docs-ref-autogen/outlook_1_4/office.mailboxenums.recipienttype.yml
@@ -6,7 +6,7 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td> [Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
+      <table><tr><td> [ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
       </td><td>Compose or read</td></tr></table>
     name: Office.MailboxEnums.RecipientType
     fullName: Outlook_1_4.Office.MailboxEnums.RecipientType

--- a/docs/docs-ref-autogen/outlook_1_4/office.mailboxenums.responsetype.yml
+++ b/docs/docs-ref-autogen/outlook_1_4/office.mailboxenums.responsetype.yml
@@ -6,7 +6,7 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td> [Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
+      <table><tr><td> [ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
       </td><td>Compose or read</td></tr></table>
     name: Office.MailboxEnums.ResponseType
     fullName: Outlook_1_4.Office.MailboxEnums.ResponseType

--- a/docs/docs-ref-autogen/outlook_1_4/office.mailboxenums.restversion.yml
+++ b/docs/docs-ref-autogen/outlook_1_4/office.mailboxenums.restversion.yml
@@ -6,7 +6,7 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td> [Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
+      <table><tr><td> [ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
       </td><td>Compose or read</td></tr></table>
     name: Office.MailboxEnums.RestVersion
     fullName: Outlook_1_4.Office.MailboxEnums.RestVersion

--- a/docs/docs-ref-autogen/outlook_1_4/office.meetingsuggestion.yml
+++ b/docs/docs-ref-autogen/outlook_1_4/office.meetingsuggestion.yml
@@ -15,11 +15,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: Office.MeetingSuggestion
     fullName: Outlook_1_4.Office.MeetingSuggestion

--- a/docs/docs-ref-autogen/outlook_1_4/office.message.yml
+++ b/docs/docs-ref-autogen/outlook_1_4/office.message.yml
@@ -6,7 +6,7 @@ items:
 
 
       Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat
-      this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
+      this as a mode of `Office.context.mailbox.item`<!-- -->. Refer to the Object Model pages for more information.
     name: Office.Message
     fullName: Outlook_1_4.Office.Message
     langs:
@@ -33,12 +33,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: conversationId
     fullName: Outlook_1_4.Office.Message.conversationId
     langs:

--- a/docs/docs-ref-autogen/outlook_1_4/office.messagecompose.yml
+++ b/docs/docs-ref-autogen/outlook_1_4/office.messagecompose.yml
@@ -2,11 +2,11 @@
 items:
   - uid: Outlook_1_4.Office.MessageCompose
     summary: >-
-      The message compose mode of [Office.context.mailbox.item](xref:Outlook_1_4.Office.Item)<!-- -->.
+      The message compose mode of [ Office.context.mailbox.item](xref:Outlook_1_4.Office.Item)<!-- -->.
 
 
       Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat
-      this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
+      this as a mode of `Office.context.mailbox.item`<!-- -->. Refer to the Object Model pages for more information.
     name: Office.MessageCompose
     fullName: Outlook_1_4.Office.MessageCompose
     langs:
@@ -49,11 +49,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr>
 
 
@@ -72,7 +72,8 @@ items:
       `addFileAttachmentAsync(uri: string, attachmentName: string, options: AsyncContextOptions): void;`
 
 
-      `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+      `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void):
+      void;`
     name: 'addFileAttachmentAsync(uri, attachmentName, options, callback)'
     fullName: Outlook_1_4.Office.MessageCompose.addFileAttachmentAsync
     langs:
@@ -81,7 +82,7 @@ items:
     syntax:
       content: >-
         addFileAttachmentAsync(uri: string, attachmentName: string, options?: AsyncContextOptions, callback?: (result:
-        AsyncResult) => void): void;
+        AsyncResult<string>) => void): void;
       return:
         type:
           - void
@@ -109,11 +110,11 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type asyncResult. On success, the attachment identifier will be provided in the asyncResult.value
+            of type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value
             property. If uploading the attachment fails, the asyncResult object will contain an Error object that
             provides a description of the error.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<string>) => void'
   - uid: Outlook_1_4.Office.MessageCompose.addItemAttachmentAsync
     summary: >-
       Adds an Exchange item, such as a message, as an attachment to the message or appointment.
@@ -129,17 +130,17 @@ items:
       session.
 
 
-      If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items
+      If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items
       other than the item that you are editing; however, this is not supported and is not recommended.
 
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr>
 
 
@@ -147,7 +148,7 @@ items:
       attachments.</td></tr></table>
 
 
-      In addition to the main signature, this method also has these signatures:
+      In addition to this signature, this method also has the following signatures:
 
 
       `addItemAttachmentAsync(itemId: any, attachmentName: string): void;`
@@ -156,7 +157,8 @@ items:
       `addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;`
 
 
-      `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+      `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void):
+      void;`
     name: 'addItemAttachmentAsync(itemId, attachmentName, options, callback)'
     fullName: Outlook_1_4.Office.MessageCompose.addItemAttachmentAsync
     langs:
@@ -165,7 +167,7 @@ items:
     syntax:
       content: >-
         addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?:
-        (result: AsyncResult) => void): void;
+        (result: AsyncResult<string>) => void): void;
       return:
         type:
           - void
@@ -194,7 +196,7 @@ items:
             property. If adding the attachment fails, the asyncResult object will contain an Error object that provides
             a description of the error.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<string>) => void'
   - uid: Outlook_1_4.Office.MessageCompose.bcc
     summary: >-
       Gets an object that provides methods to get or update the recipients on the Bcc (blind carbon copy) line of a
@@ -203,11 +205,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: bcc
     fullName: Outlook_1_4.Office.MessageCompose.bcc
@@ -225,11 +227,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: body
     fullName: Outlook_1_4.Office.MessageCompose.body
@@ -253,11 +255,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: cc
     fullName: Outlook_1_4.Office.MessageCompose.cc
@@ -287,11 +289,11 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: close()
     fullName: Outlook_1_4.Office.MessageCompose.close
@@ -320,11 +322,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: conversationId
     fullName: Outlook_1_4.Office.MessageCompose.conversationId
@@ -342,11 +344,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: dateTimeCreated
     fullName: Outlook_1_4.Office.MessageCompose.dateTimeCreated
@@ -364,11 +366,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
 
 
@@ -398,11 +400,11 @@ items:
 
       \[ [API set: Mailbox 1.2](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: 'getSelectedDataAsync(coerciontype, callback)'
     fullName: Outlook_1_4.Office.MessageCompose.getSelectedDataAsync
@@ -410,7 +412,7 @@ items:
       - typeScript
     type: method
     syntax:
-      content: 'getSelectedDataAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult) => void): void;'
+      content: 'getSelectedDataAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult<any>) => void): void;'
       return:
         type:
           - void
@@ -423,9 +425,9 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult.
+            of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<any>) => void'
   - uid: Outlook_1_4.Office.MessageCompose.itemType
     summary: >-
       Gets the type of item that an instance represents.
@@ -437,11 +439,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: itemType
     fullName: Outlook_1_4.Office.MessageCompose.itemType
@@ -471,11 +473,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: 'loadCustomPropertiesAsync(callback, userContext)'
     fullName: Outlook_1_4.Office.MessageCompose.loadCustomPropertiesAsync
@@ -483,7 +485,9 @@ items:
       - typeScript
     type: method
     syntax:
-      content: 'loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;'
+      content: >-
+        loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any):
+        void;
       return:
         type:
           - void
@@ -492,9 +496,9 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult.
+            of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<Office.CustomProperties>) => void'
         - id: userContext
           description: >-
             Optional. Developers can provide any object they wish to access in the callback function. This object can be
@@ -507,11 +511,11 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: notificationMessages
     fullName: Outlook_1_4.Office.MessageCompose.notificationMessages
@@ -531,17 +535,17 @@ items:
       The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best
       practice, you should use the attachment identifier to remove an attachment only if the same mail app has added
       that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid
-      only within the same session. A session is over when the user closes the app, or if the user starts composing in
-      an inline form and subsequently pops out the inline form to continue in a separate window.
+      only within the same session. A session is over when the user closes the app, or if the user starts composing an
+      inline form then subsequently pops out the form to continue in a separate window.
 
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr>
 
 
@@ -557,7 +561,7 @@ items:
       `removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;`
 
 
-      `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;`
+      `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;`
     name: 'removeAttachmentAsync(attachmentIndex, options, callback)'
     fullName: Outlook_1_4.Office.MessageCompose.removeAttachmentAsync
     langs:
@@ -566,7 +570,7 @@ items:
     syntax:
       content: >-
         removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result:
-        AsyncResult) => void): void;
+        AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -585,10 +589,10 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain
-            an error code with the reason for the failure.
+            parameter of type Office.AsyncResult. If removing the attachment fails, the asyncResult.error property will
+            contain an error code with the reason for the failure.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_4.Office.MessageCompose.saveAsync
     summary: >-
       Asynchronously saves an item.
@@ -622,11 +626,11 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr>
 
 
@@ -642,14 +646,14 @@ items:
       `saveAsync(options: Office.AsyncContextOptions): void;`
 
 
-      `saveAsync(callback: (result: AsyncResult) => void): void;`
+      `saveAsync(callback: (result: AsyncResult<void>) => void): void;`
     name: 'saveAsync(options, callback)'
     fullName: Outlook_1_4.Office.MessageCompose.saveAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;'
+      content: 'saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;'
       return:
         type:
           - void
@@ -664,10 +668,9 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain
-            an error code with the reason for the failure.
+            parameter of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_4.Office.MessageCompose.setSelectedDataAsync
     summary: >-
       Asynchronously inserts data into the body or subject of a message.
@@ -680,11 +683,11 @@ items:
 
       \[ [API set: Mailbox 1.2](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr>
 
 
@@ -697,10 +700,10 @@ items:
       `setSelectedDataAsync(data: string): void;`
 
 
-      `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions &amp; CoercionTypeOptions): void;`
+      `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`
 
 
-      `setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;`
+      `setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;`
     name: 'setSelectedDataAsync(data, options, callback)'
     fullName: Outlook_1_4.Office.MessageCompose.setSelectedDataAsync
     langs:
@@ -709,7 +712,7 @@ items:
     syntax:
       content: >-
         setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?:
-        (result: AsyncResult) => void): void;
+        (result: AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -735,10 +738,9 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain
-            an error code with the reason for the failure.
+            parameter of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_4.Office.MessageCompose.subject
     summary: |-
       Gets or sets the description that appears in the subject field of an item.
@@ -749,11 +751,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: subject
     fullName: Outlook_1_4.Office.MessageCompose.subject
@@ -777,11 +779,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: to
     fullName: Outlook_1_4.Office.MessageCompose.to

--- a/docs/docs-ref-autogen/outlook_1_4/office.messageread.yml
+++ b/docs/docs-ref-autogen/outlook_1_4/office.messageread.yml
@@ -2,7 +2,7 @@
 items:
   - uid: Outlook_1_4.Office.MessageRead
     summary: >-
-      The message read mode of [Office.context.mailbox.item](xref:Outlook_1_4.Office.Item)<!-- -->.
+      The message read mode of [ Office.context.mailbox.item](xref:Outlook_1_4.Office.Item)<!-- -->.
 
 
       Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat
@@ -42,20 +42,20 @@ items:
       - Outlook_1_4.Office.MessageRead.to
   - uid: Outlook_1_4.Office.MessageRead.attachments
     summary: |-
-      Gets an array of attachments for the item.
+      Gets the item's attachments as an array.
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
 
 
       Note: Certain types of files are blocked by Outlook due to potential security issues and are therefore not
-      returned. For more information, see [Blocked attachments in
+      returned. For more information, see [ Blocked attachments in
       Outlook](https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519)<!--
       -->.
     name: attachments
@@ -74,11 +74,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: body
     fullName: Outlook_1_4.Office.MessageRead.body
@@ -102,11 +102,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: cc
     fullName: Outlook_1_4.Office.MessageRead.cc
@@ -134,11 +134,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: conversationId
     fullName: Outlook_1_4.Office.MessageRead.conversationId
@@ -156,11 +156,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: dateTimeCreated
     fullName: Outlook_1_4.Office.MessageRead.dateTimeCreated
@@ -178,11 +178,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
 
 
@@ -220,11 +220,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: displayReplyAllForm(formData)
     fullName: Outlook_1_4.Office.MessageRead.displayReplyAllForm
@@ -241,7 +241,7 @@ items:
         - id: formData
           description: >-
             A string that contains text and HTML and that represents the body of the reply form. The string is limited
-            to 32 KB OR An[Office.ReplyFormData](xref:Outlook_1_4.Office.ReplyFormData) object that contains body or
+            to 32 KB OR An [Office.ReplyFormData](xref:Outlook_1_4.Office.ReplyFormData) object that contains body or
             attachment data and a callback function
           type:
             - string | ReplyFormData
@@ -268,11 +268,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: displayReplyForm(formData)
     fullName: Outlook_1_4.Office.MessageRead.displayReplyForm
@@ -289,7 +289,7 @@ items:
         - id: formData
           description: >-
             A string that contains text and HTML and that represents the body of the reply form. The string is limited
-            to 32 KB. OR An[Office.ReplyFormData](xref:Outlook_1_4.Office.ReplyFormData) object that contains body or
+            to 32 KB. OR An [Office.ReplyFormData](xref:Outlook_1_4.Office.ReplyFormData) object that contains body or
             attachment data and a callback function.
           type:
             - string | ReplyFormData
@@ -310,11 +310,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: from
     fullName: Outlook_1_4.Office.MessageRead.from
@@ -328,17 +328,17 @@ items:
           - EmailAddressDetails
   - uid: Outlook_1_4.Office.MessageRead.getEntities
     summary: |-
-      Gets the entities found in the selected item.
+      Gets the entities found in the selected item's body.
 
       Note: This method is not supported in Outlook for iOS or Outlook for Android.
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: getEntities()
     fullName: Outlook_1_4.Office.MessageRead.getEntities
@@ -353,17 +353,17 @@ items:
         description: ''
   - uid: Outlook_1_4.Office.MessageRead.getEntitiesByType
     summary: |-
-      Gets an array of all the entities of the specified entity type found in the selected item.
+      Gets an array of all the entities of the specified entity type found in the selected item's body.
 
       Note: This method is not supported in Outlook for iOS or Outlook for Android.
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
 
 
@@ -391,7 +391,7 @@ items:
           - '(string | Contact | MeetingSuggestion | PhoneNumber | TaskSuggestion)[]'
         description: >-
           If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns
-          null. If no entities of the specified type are present on the item, the method returns an empty array.
+          null. If no entities of the specified type are present in the item's body, the method returns an empty array.
           Otherwise, the type of the objects in the returned array depends on the type of entity requested in the
           entityType parameter.
       parameters:
@@ -413,11 +413,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: getFilteredEntitiesByName(name)
     fullName: Outlook_1_4.Office.MessageRead.getFilteredEntitiesByName
@@ -462,11 +462,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: getRegExMatches()
     fullName: Outlook_1_4.Office.MessageRead.getRegExMatches
@@ -502,11 +502,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: getRegExMatchesByName(name)
     fullName: Outlook_1_4.Office.MessageRead.getRegExMatchesByName
@@ -530,11 +530,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: internetMessageId
     fullName: Outlook_1_4.Office.MessageRead.internetMessageId
@@ -557,11 +557,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
 
 
@@ -599,16 +599,17 @@ items:
       Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The
       itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making
       REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more
-      details, see Use the Outlook REST APIs from an Outlook add-in.
+      details, see [ Use the Outlook REST APIs from an Outlook
+      add-in](https://docs.microsoft.com/outlook/add-ins/use-rest-api#get-the-item-id)<!-- -->.
 
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: itemId
     fullName: Outlook_1_4.Office.MessageRead.itemId
@@ -631,11 +632,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: itemType
     fullName: Outlook_1_4.Office.MessageRead.itemType
@@ -665,11 +666,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: 'loadCustomPropertiesAsync(callback, userContext)'
     fullName: Outlook_1_4.Office.MessageRead.loadCustomPropertiesAsync
@@ -677,7 +678,9 @@ items:
       - typeScript
     type: method
     syntax:
-      content: 'loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;'
+      content: >-
+        loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any):
+        void;
       return:
         type:
           - void
@@ -686,9 +689,9 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult.
+            of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<Office.CustomProperties>) => void'
         - id: userContext
           description: >-
             Optional. Developers can provide any object they wish to access in the callback function. This object can be
@@ -706,11 +709,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: normalizedSubject
     fullName: Outlook_1_4.Office.MessageRead.normalizedSubject
@@ -728,12 +731,12 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: notificationMessages
     fullName: Outlook_1_4.Office.MessageRead.notificationMessages
     langs:
@@ -758,11 +761,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: sender
     fullName: Outlook_1_4.Office.MessageRead.sender
@@ -788,11 +791,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: subject
     fullName: Outlook_1_4.Office.MessageRead.subject
@@ -816,11 +819,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: to
     fullName: Outlook_1_4.Office.MessageRead.to

--- a/docs/docs-ref-autogen/outlook_1_4/office.notificationmessagedetails.yml
+++ b/docs/docs-ref-autogen/outlook_1_4/office.notificationmessagedetails.yml
@@ -6,12 +6,12 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.NotificationMessageDetails
     fullName: Outlook_1_4.Office.NotificationMessageDetails
     langs:

--- a/docs/docs-ref-autogen/outlook_1_4/office.notificationmessages.yml
+++ b/docs/docs-ref-autogen/outlook_1_4/office.notificationmessages.yml
@@ -6,12 +6,12 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.NotificationMessages
     fullName: Outlook_1_4.Office.NotificationMessages
     langs:
@@ -31,12 +31,12 @@ items:
       There are a maximum of 5 notifications per message. Setting more will return a
       NumberOfNotificationMessagesExceeded error.
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
 
 
       In addition to this signature, the method also has the following signatures:
@@ -48,7 +48,8 @@ items:
       `addAsync(key: string, JSONmessage: NotificationMessageDetails, options: Office.AsyncContextOptions): void;`
 
 
-      `addAsync(key: string, JSONmessage: NotificationMessageDetails, callback: (result: AsyncResult) => void): void;`
+      `addAsync(key: string, JSONmessage: NotificationMessageDetails, callback: (result: AsyncResult<void>) => void):
+      void;`
     name: 'addAsync(key, JSONmessage, options, callback)'
     fullName: Outlook_1_4.Office.NotificationMessages.addAsync
     langs:
@@ -57,7 +58,7 @@ items:
     syntax:
       content: >-
         addAsync(key: string, JSONmessage: NotificationMessageDetails, options?: Office.AsyncContextOptions, callback?:
-        (result: AsyncResult) => void): void;
+        (result: AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -84,34 +85,39 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. \[Api set: Mailbox 1.3\]
+            parameter of type Office.AsyncResult.
+
+
+            \[Api set: Mailbox 1.3\]
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_4.Office.NotificationMessages.getAllAsync
     summary: |-
       Returns all keys and messages for an item.
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
 
 
-      In addition to the main signature, this method also has this signature:
+      In addition to this signature, this method also has the following signature:
 
 
-      `getAllAsync(callback: (result: AsyncResult) => void): void;`
+      `getAllAsync(callback: (result: AsyncResult<Office.NotificationMessageDetails[]>) => void): void;`
     name: 'getAllAsync(options, callback)'
     fullName: Outlook_1_4.Office.NotificationMessages.getAllAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'getAllAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;'
+      content: >-
+        getAllAsync(options?: Office.AsyncContextOptions, callback?: (result:
+        AsyncResult<Office.NotificationMessageDetails[]>) => void): void;
       return:
         type:
           - void
@@ -126,24 +132,25 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult.
+            parameter of type Office.AsyncResult. The `value` property of the result is an array of
+            NotificationMessageDetails objects.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<Office.NotificationMessageDetails[]>) => void'
   - uid: Outlook_1_4.Office.NotificationMessages.removeAsync
     summary: |-
       Removes a notification message for an item.
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
 
 
-      In addition to the main signature, this method also has these signatures:
+      In addition to this signature, this method also has the following signatures:
 
 
       `removeAsync(key: string): void;`
@@ -152,14 +159,16 @@ items:
       `removeAsync(key: string, options: Office.AsyncContextOptions): void;`
 
 
-      `removeAsync(key: string, callback: (result: AsyncResult) => void): void;`
+      `removeAsync(key: string, callback: (result: AsyncResult<void>) => void): void;`
     name: 'removeAsync(key, options, callback)'
     fullName: Outlook_1_4.Office.NotificationMessages.removeAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'removeAsync(key: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;'
+      content: >-
+        removeAsync(key: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void):
+        void;
       return:
         type:
           - void
@@ -178,9 +187,9 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult.
+            parameter of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_4.Office.NotificationMessages.replaceAsync
     summary: |-
       Replaces a notification message that has a given key with another message.
@@ -189,15 +198,15 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
 
 
-      In addition to the main signature, this method also has these signatures:
+      In addition to this signature, this method also has the following signatures:
 
 
       `replaceAsync(key: string, JSONmessage: NotificationMessageDetails): void;`
@@ -206,8 +215,8 @@ items:
       `replaceAsync(key: string, JSONmessage: NotificationMessageDetails, options: Office.AsyncContextOptions): void;`
 
 
-      `replaceAsync(key: string, JSONmessage: NotificationMessageDetails, callback: (result: AsyncResult) => void):
-      void;`
+      `replaceAsync(key: string, JSONmessage: NotificationMessageDetails, callback: (result: AsyncResult<void>) =>
+      void): void;`
     name: 'replaceAsync(key, JSONmessage, options, callback)'
     fullName: Outlook_1_4.Office.NotificationMessages.replaceAsync
     langs:
@@ -216,7 +225,7 @@ items:
     syntax:
       content: >-
         replaceAsync(key: string, JSONmessage: NotificationMessageDetails, options?: Office.AsyncContextOptions,
-        callback?: (result: AsyncResult) => void): void;
+        callback?: (result: AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -241,6 +250,6 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult.
+            parameter of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'

--- a/docs/docs-ref-autogen/outlook_1_4/office.phonenumber.yml
+++ b/docs/docs-ref-autogen/outlook_1_4/office.phonenumber.yml
@@ -12,11 +12,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: Office.PhoneNumber
     fullName: Outlook_1_4.Office.PhoneNumber

--- a/docs/docs-ref-autogen/outlook_1_4/office.recipients.yml
+++ b/docs/docs-ref-autogen/outlook_1_4/office.recipients.yml
@@ -3,11 +3,11 @@ items:
   - uid: Outlook_1_4.Office.Recipients
     summary: '\[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]'
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
     name: Office.Recipients
     fullName: Outlook_1_4.Office.Recipients
@@ -33,11 +33,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -45,7 +45,7 @@ items:
       entries.</td></tr></table>
 
 
-      In addition to the main signature, this method also has these signatures:
+      In addition to this signature, this method also has the following signatures:
 
 
       `addAsync(recipients: (string | EmailUser | EmailAddressDetails)[]): void;`
@@ -54,8 +54,8 @@ items:
       `addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options: Office.AsyncContextOptions): void;`
 
 
-      `addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult) => void):
-      void;`
+      `addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult<void>) =>
+      void): void;`
     name: 'addAsync(recipients, options, callback)'
     fullName: Outlook_1_4.Office.Recipients.addAsync
     langs:
@@ -64,7 +64,7 @@ items:
     syntax:
       content: >-
         addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options?: Office.AsyncContextOptions,
-        callback?: (result: AsyncResult) => void): void;
+        callback?: (result: AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -83,40 +83,42 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. If adding the recipients fails, the asyncResult.error property will contain
-            an error code.
+            parameter of type Office.AsyncResult. If adding the recipients fails, the asyncResult.error property will
+            contain an error code.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_4.Office.Recipients.getAsync
     summary: >-
       Gets a recipient list for an appointment or message.
 
 
-      When the call completes, the asyncResult.value property will contain an array
-      of[Office.EmailAddressDetails](xref:Outlook_1_4.Office.EmailAddressDetails) objects.
+      When the call completes, the asyncResult.value property will contain an array of
+      [Office.EmailAddressDetails](xref:Outlook_1_4.Office.EmailAddressDetails) objects.
 
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
 
 
-      In addition to the main signature, this method also has this signature:
+      In addition to this signature, this method also has the following signature:
 
 
-      `getAsync(callback: (result: AsyncResult) => void): void;`
+      `getAsync(callback: (result: AsyncResult<Office.EmailAddressDetails[]>) => void): void;`
     name: 'getAsync(options, callback)'
     fullName: Outlook_1_4.Office.Recipients.getAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;'
+      content: >-
+        getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult<Office.EmailAddressDetails[]>) =>
+        void): void;
       return:
         type:
           - void
@@ -131,9 +133,9 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult.
+            of type Office.AsyncResult. The `value` property of the result is an array of EmailAddressDetails objects.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<Office.EmailAddressDetails[]>) => void'
   - uid: Outlook_1_4.Office.Recipients.setAsync
     summary: |-
       Sets a recipient list for an appointment or message.
@@ -150,11 +152,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -162,7 +164,7 @@ items:
       entries.</td></tr></table>
 
 
-      In addition to the main signature, this method also has these signatures:
+      In addition to this signature, this method also has the following signatures:
 
 
       `setAsync(recipients: (string | EmailUser | EmailAddressDetails)[]): void;`
@@ -171,8 +173,8 @@ items:
       `setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options: Office.AsyncContextOptions): void;`
 
 
-      `setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult) => void):
-      void;`
+      `setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult<void>) =>
+      void): void;`
     name: 'setAsync(recipients, options, callback)'
     fullName: Outlook_1_4.Office.Recipients.setAsync
     langs:
@@ -181,7 +183,7 @@ items:
     syntax:
       content: >-
         setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options?: Office.AsyncContextOptions,
-        callback?: (result: AsyncResult) => void): void;
+        callback?: (result: AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -200,7 +202,7 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. If setting the recipients fails the asyncResult.error property will contain a
-            code that indicates any error that occurred while adding the data.
+            parameter of type Office.AsyncResult. If setting the recipients fails the asyncResult.error property will
+            contain a code that indicates any error that occurred while adding the data.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'

--- a/docs/docs-ref-autogen/outlook_1_4/office.replyformdata.yml
+++ b/docs/docs-ref-autogen/outlook_1_4/office.replyformdata.yml
@@ -31,17 +31,17 @@ items:
   - uid: Outlook_1_4.Office.ReplyFormData.callback
     summary: >-
       When the reply display call completes, the function passed in the callback parameter is called with a single
-      parameter, asyncResult, which is an AsyncResult object.
+      parameter, asyncResult, which is an Office.AsyncResult object.
     name: callback
     fullName: Outlook_1_4.Office.ReplyFormData.callback
     langs:
       - typeScript
     type: property
     syntax:
-      content: 'callback?: (result: AsyncResult) => void;'
+      content: 'callback?: (result: AsyncResult<any>) => void;'
       return:
         type:
-          - '(result: AsyncResult) => void'
+          - '(result: AsyncResult<any>) => void'
   - uid: Outlook_1_4.Office.ReplyFormData.htmlBody
     summary: >-
       A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32

--- a/docs/docs-ref-autogen/outlook_1_4/office.roamingsettings.yml
+++ b/docs/docs-ref-autogen/outlook_1_4/office.roamingsettings.yml
@@ -7,7 +7,7 @@ items:
       saved.
 
 
-      While the Outlook add-in API limits access to these settings to only the add-in that created them, these settings
+      While the Outlook Add-in API limits access to these settings to only the add-in that created them, these settings
       should not be considered secure storage. They can be accessed by Exchange Web Services or Extended MAPI. They
       should not be used to store sensitive information such as user credentials or security tokens.
 
@@ -27,12 +27,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.RoamingSettings
     fullName: Outlook_1_4.Office.RoamingSettings
     langs:
@@ -50,12 +50,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: get(name)
     fullName: Outlook_1_4.Office.RoamingSettings.get
     langs:
@@ -78,12 +78,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: remove(name)
     fullName: Outlook_1_4.Office.RoamingSettings.remove
     langs:
@@ -113,19 +113,19 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: saveAsync(callback)
     fullName: Outlook_1_4.Office.RoamingSettings.saveAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'saveAsync(callback?: (result: AsyncResult) => void): void;'
+      content: 'saveAsync(callback?: (result: AsyncResult<void>) => void): void;'
       return:
         type:
           - void
@@ -133,10 +133,10 @@ items:
       parameters:
         - id: callback
           description: >-
-            Optional? When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult.
+            Optional. When the method completes, the function passed in the callback parameter is called with a single
+            parameter of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_4.Office.RoamingSettings.set
     summary: >-
       Sets or creates the specified setting.
@@ -156,12 +156,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: 'set(name, value)'
     fullName: Outlook_1_4.Office.RoamingSettings.set
     langs:

--- a/docs/docs-ref-autogen/outlook_1_4/office.subject.yml
+++ b/docs/docs-ref-autogen/outlook_1_4/office.subject.yml
@@ -6,11 +6,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
     name: Office.Subject
     fullName: Outlook_1_4.Office.Subject
@@ -32,25 +32,25 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
 
 
-      In addition to the main signature, this method also has this signature:
+      In addition to this signature, this method also has the following signature:
 
 
-      `getAsync(callback: (result: AsyncResult) => void): void;`
+      `getAsync(callback: (result: AsyncResult<string>) => void): void;`
     name: 'getAsync(options, callback)'
     fullName: Outlook_1_4.Office.Subject.getAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;'
+      content: 'getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult<string>) => void): void;'
       return:
         type:
           - void
@@ -65,9 +65,9 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult.
+            of type Office.AsyncResult. The `value` property of the result is the subject of the item.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<string>) => void'
   - uid: Outlook_1_4.Office.Subject.setAsync
     summary: >-
       Sets the subject of an appointment or message.
@@ -80,11 +80,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -92,7 +92,7 @@ items:
       characters.</td></tr></table>
 
 
-      In addition to the main signature, this method also has these signatures:
+      In addition to this signature, this method also has the following signatures:
 
 
       `setAsync(subject: string): void;`
@@ -101,14 +101,16 @@ items:
       `setAsync(subject: string, options: Office.AsyncContextOptions): void;`
 
 
-      `setAsync(subject: string, callback: (result: AsyncResult) => void): void;`
+      `setAsync(subject: string, callback: (result: AsyncResult<void>) => void): void;`
     name: 'setAsync(subject, options, callback)'
     fullName: Outlook_1_4.Office.Subject.setAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'setAsync(subject: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;'
+      content: >-
+        setAsync(subject: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void):
+        void;
       return:
         type:
           - void
@@ -127,7 +129,7 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult. If setting the subject fails, the asyncResult.error property will contain an error
-            code.
+            of type Office.AsyncResult. If setting the subject fails, the asyncResult.error property will contain an
+            error code.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'

--- a/docs/docs-ref-autogen/outlook_1_4/office.tasksuggestion.yml
+++ b/docs/docs-ref-autogen/outlook_1_4/office.tasksuggestion.yml
@@ -5,18 +5,18 @@ items:
       Represents a suggested task identified in an item. Read mode only.
 
 
-      The list of tasks suggested in an email message is returned in the taskSuggestions property of the
-      \[Entities\]Entities object that is returned when the getEntities or getEntitiesByType method is called on the
-      active item.
+      The list of tasks suggested in an email message is returned in the taskSuggestions property of the [
+      Entities](xref:Outlook_1_4.Office.Entities) object that is returned when the getEntities or getEntitiesByType
+      method is called on the active item.
 
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: Office.TaskSuggestion
     fullName: Outlook_1_4.Office.TaskSuggestion

--- a/docs/docs-ref-autogen/outlook_1_4/office.time.yml
+++ b/docs/docs-ref-autogen/outlook_1_4/office.time.yml
@@ -6,11 +6,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
     name: Office.Time
     fullName: Outlook_1_4.Office.Time
@@ -33,25 +33,25 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
 
 
-      In addition to the main signature, this method also has this signature:
+      In addition to this signature, this method also has the following signature:
 
 
-      `getAsync(callback: (result: AsyncResult) => void): void;`
+      `getAsync(callback: (result: AsyncResult<Date>) => void): void;`
     name: 'getAsync(options, callback)'
     fullName: Outlook_1_4.Office.Time.getAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;'
+      content: 'getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult<Date>) => void): void;'
       return:
         type:
           - void
@@ -66,9 +66,9 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult.
+            of type AsyncResult. The `value` property of the result is a Date object.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<Date>) => void'
   - uid: Outlook_1_4.Office.Time.setAsync
     summary: >-
       Sets the start or end time of an appointment.
@@ -84,11 +84,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -96,7 +96,7 @@ items:
       time.</td></tr></table>
 
 
-      In addition to the main signature, this method also has these signatures:
+      In addition to this signature, this method also has the following signatures:
 
 
       `setAsync(dateTime: Date): void;`
@@ -105,14 +105,16 @@ items:
       `setAsync(dateTime: Date, options: Office.AsyncContextOptions): void;`
 
 
-      `setAsync(dateTime: Date, callback: (result: AsyncResult) => void): void;`
+      `setAsync(dateTime: Date, callback: (result: AsyncResult<void>) => void): void;`
     name: 'setAsync(dateTime, options, callback)'
     fullName: Outlook_1_4.Office.Time.setAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'setAsync(dateTime: Date, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;'
+      content: >-
+        setAsync(dateTime: Date, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void):
+        void;
       return:
         type:
           - void
@@ -131,7 +133,7 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult. If setting the date and time fails, the asyncResult.error property will contain an
-            error code.
+            of type Office.AsyncResult. If setting the date and time fails, the asyncResult.error property will contain
+            an error code.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'

--- a/docs/docs-ref-autogen/outlook_1_4/office.userprofile.yml
+++ b/docs/docs-ref-autogen/outlook_1_4/office.userprofile.yml
@@ -8,12 +8,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.UserProfile
     fullName: Outlook_1_4.Office.UserProfile
     langs:
@@ -30,12 +30,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: displayName
     fullName: Outlook_1_4.Office.UserProfile.displayName
     langs:
@@ -52,12 +52,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: emailAddress
     fullName: Outlook_1_4.Office.UserProfile.emailAddress
     langs:
@@ -74,12 +74,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: timeZone
     fullName: Outlook_1_4.Office.UserProfile.timeZone
     langs:

--- a/docs/docs-ref-autogen/outlook_1_5.yml
+++ b/docs/docs-ref-autogen/outlook_1_5.yml
@@ -30,6 +30,7 @@ items:
       - Outlook_1_5.Office.MailboxEnums.EntityType
       - Outlook_1_5.Office.MailboxEnums.ItemNotificationMessageType
       - Outlook_1_5.Office.MailboxEnums.ItemType
+      - Outlook_1_5.Office.MailboxEnums.OWAView
       - Outlook_1_5.Office.MailboxEnums.RecipientType
       - Outlook_1_5.Office.MailboxEnums.ResponseType
       - Outlook_1_5.Office.MailboxEnums.RestVersion
@@ -96,6 +97,8 @@ references:
     name: Office.MailboxEnums.ItemNotificationMessageType
   - uid: Outlook_1_5.Office.MailboxEnums.ItemType
     name: Office.MailboxEnums.ItemType
+  - uid: Outlook_1_5.Office.MailboxEnums.OWAView
+    name: Office.MailboxEnums.OWAView
   - uid: Outlook_1_5.Office.MailboxEnums.RecipientType
     name: Office.MailboxEnums.RecipientType
   - uid: Outlook_1_5.Office.MailboxEnums.ResponseType

--- a/docs/docs-ref-autogen/outlook_1_5/office.appointmentcompose.yml
+++ b/docs/docs-ref-autogen/outlook_1_5/office.appointmentcompose.yml
@@ -2,11 +2,11 @@
 items:
   - uid: Outlook_1_5.Office.AppointmentCompose
     summary: >-
-      The appointment organizer mode of [Office.context.mailbox.item](xref:Outlook_1_5.Office.Item)<!-- -->.
+      The appointment organizer mode of [ Office.context.mailbox.item](xref:Outlook_1_5.Office.Item)<!-- -->.
 
 
       Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat
-      this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
+      this as a mode of `Office.context.mailbox.item`<!-- -->. Refer to the Object Model pages for more information.
     name: Office.AppointmentCompose
     fullName: Outlook_1_5.Office.AppointmentCompose
     langs:
@@ -50,11 +50,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Organizer</td></tr>
 
 
@@ -73,7 +73,8 @@ items:
       `addFileAttachmentAsync(uri: string, attachmentName: string, options: Office.AsyncContextOptions): void;`
 
 
-      `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+      `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void):
+      void;`
     name: 'addFileAttachmentAsync(uri, attachmentName, options, callback)'
     fullName: Outlook_1_5.Office.AppointmentCompose.addFileAttachmentAsync
     langs:
@@ -82,7 +83,7 @@ items:
     syntax:
       content: >-
         addFileAttachmentAsync(uri: string, attachmentName: string, options?: Office.AsyncContextOptions, callback?:
-        (result: AsyncResult) => void): void;
+        (result: AsyncResult<string>) => void): void;
       return:
         type:
           - void
@@ -114,7 +115,7 @@ items:
             property. If uploading the attachment fails, the asyncResult object will contain an Error object that
             provides a description of the error.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<string>) => void'
   - uid: Outlook_1_5.Office.AppointmentCompose.addItemAttachmentAsync
     summary: >-
       Adds an Exchange item, such as a message, as an attachment to the message or appointment.
@@ -130,17 +131,17 @@ items:
       session.
 
 
-      If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items
+      If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items
       other than the item that you are editing; however, this is not supported and is not recommended.
 
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Organizer</td></tr>
 
 
@@ -148,7 +149,7 @@ items:
       attachments.</td></tr></table>
 
 
-      In addition to the main signature, this method also has these signatures:
+      In addition to this signature, this method also has the following signatures:
 
 
       `addItemAttachmentAsync(itemId: any, attachmentName: string): void;`
@@ -157,7 +158,8 @@ items:
       `addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;`
 
 
-      `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+      `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void):
+      void;`
     name: 'addItemAttachmentAsync(itemId, attachmentName, options, callback)'
     fullName: Outlook_1_5.Office.AppointmentCompose.addItemAttachmentAsync
     langs:
@@ -166,7 +168,7 @@ items:
     syntax:
       content: >-
         addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?:
-        (result: AsyncResult) => void): void;
+        (result: AsyncResult<string>) => void): void;
       return:
         type:
           - void
@@ -191,22 +193,22 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value
+            of type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value
             property. If adding the attachment fails, the asyncResult object will contain an Error object that provides
             a description of the error.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<string>) => void'
   - uid: Outlook_1_5.Office.AppointmentCompose.body
     summary: |-
       Gets an object that provides methods for manipulating the body of an item.
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: body
@@ -237,11 +239,11 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: close()
@@ -261,11 +263,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: dateTimeCreated
@@ -284,11 +286,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
 
@@ -320,11 +322,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: end
@@ -352,11 +354,11 @@ items:
 
       \[ [API set: Mailbox 1.2](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: 'getSelectedDataAsync(coerciontype, options, callback)'
@@ -367,7 +369,7 @@ items:
     syntax:
       content: >-
         getSelectedDataAsync(coerciontype: Office.CoercionType, options: Office.AsyncContextOptions, callback: (result:
-        AsyncResult) => void): void;
+        AsyncResult<any>) => void): void;
       return:
         type:
           - void
@@ -388,7 +390,7 @@ items:
             When the method completes, the function passed in the callback parameter is called with a single parameter
             of type AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<any>) => void'
   - uid: Outlook_1_5.Office.AppointmentCompose.itemType
     summary: >-
       Gets the type of item that an instance represents.
@@ -400,11 +402,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: itemType
@@ -435,11 +437,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: 'loadCustomPropertiesAsync(callback, userContext)'
@@ -448,7 +450,9 @@ items:
       - typeScript
     type: method
     syntax:
-      content: 'loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;'
+      content: >-
+        loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any):
+        void;
       return:
         type:
           - void
@@ -457,9 +461,9 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult.
+            of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<Office.CustomProperties>) => void'
         - id: userContext
           description: >-
             Optional. Developers can provide any object they wish to access in the callback function. This object can be
@@ -474,11 +478,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: location
@@ -497,11 +501,11 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: notificationMessages
@@ -524,11 +528,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: optionalAttendees
@@ -549,17 +553,17 @@ items:
       The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best
       practice, you should use the attachment identifier to remove an attachment only if the same mail app has added
       that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid
-      only within the same session. A session is over when the user closes the app, or if the user starts composing in
-      an inline form and subsequently pops out the inline form to continue in a separate window.
+      only within the same session. A session is over when the user closes the app, or if the user starts composing an
+      inline form then subsequently pops out the form to continue in a separate window.
 
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Organizer</td></tr>
 
 
@@ -575,7 +579,7 @@ items:
       `removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;`
 
 
-      `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;`
+      `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;`
     name: 'removeAttachmentAsync(attachmentIndex, options, callback)'
     fullName: Outlook_1_5.Office.AppointmentCompose.removeAttachmentAsync
     langs:
@@ -584,7 +588,7 @@ items:
     syntax:
       content: >-
         removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result:
-        AsyncResult) => void): void;
+        AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -603,10 +607,10 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain
-            an error code with the reason for the failure.
+            parameter of type Office.AsyncResult. If removing the attachment fails, the asyncResult.error property will
+            contain an error code with the reason for the failure.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_5.Office.AppointmentCompose.requiredAttendees
     summary: >-
       Provides access to the required attendees of an event. The type of object and level of access depends on the mode
@@ -617,11 +621,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: requiredAttendees
@@ -667,11 +671,11 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Organizer</td></tr>
 
 
@@ -687,14 +691,14 @@ items:
       `saveAsync(options: Office.AsyncContextOptions): void;`
 
 
-      `saveAsync(callback: (result: AsyncResult) => void): void;`
+      `saveAsync(callback: (result: AsyncResult<void>) => void): void;`
     name: 'saveAsync(options, callback)'
     fullName: Outlook_1_5.Office.AppointmentCompose.saveAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;'
+      content: 'saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;'
       return:
         type:
           - void
@@ -709,10 +713,9 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain
-            an error code with the reason for the failure.
+            parameter of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_5.Office.AppointmentCompose.setSelectedDataAsync
     summary: >-
       Asynchronously inserts data into the body or subject of a message.
@@ -725,11 +728,11 @@ items:
 
       \[ [API set: Mailbox 1.2](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Organizer</td></tr>
 
 
@@ -742,10 +745,10 @@ items:
       `setSelectedDataAsync(data: string): void;`
 
 
-      `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions &amp; CoercionTypeOptions): void;`
+      `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`
 
 
-      `setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;`
+      `setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;`
     name: 'setSelectedDataAsync(data, options, callback)'
     fullName: Outlook_1_5.Office.AppointmentCompose.setSelectedDataAsync
     langs:
@@ -754,7 +757,7 @@ items:
     syntax:
       content: >-
         setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?:
-        (result: AsyncResult) => void): void;
+        (result: AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -780,10 +783,9 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain
-            an error code with the reason for the failure.
+            parameter of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_5.Office.AppointmentCompose.start
     summary: >-
       Gets or sets the date and time that the appointment is to begin.
@@ -800,11 +802,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: start
@@ -827,11 +829,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: subject

--- a/docs/docs-ref-autogen/outlook_1_5/office.appointmentform.yml
+++ b/docs/docs-ref-autogen/outlook_1_5/office.appointmentform.yml
@@ -6,12 +6,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.AppointmentForm
     fullName: Outlook_1_5.Office.AppointmentForm
     langs:
@@ -33,12 +33,12 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: body
     fullName: Outlook_1_5.Office.AppointmentForm.body
     langs:
@@ -76,12 +76,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: end
     fullName: Outlook_1_5.Office.AppointmentForm.end
     langs:
@@ -112,10 +112,10 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: location
     fullName: Outlook_1_5.Office.AppointmentForm.location
     langs:
@@ -148,12 +148,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: optionalAttendees
     fullName: Outlook_1_5.Office.AppointmentForm.optionalAttendees
     langs:
@@ -186,12 +186,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: requiredAttendees
     fullName: Outlook_1_5.Office.AppointmentForm.requiredAttendees
     langs:
@@ -240,12 +240,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: start
     fullName: Outlook_1_5.Office.AppointmentForm.start
     langs:
@@ -279,12 +279,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: subject
     fullName: Outlook_1_5.Office.AppointmentForm.subject
     langs:

--- a/docs/docs-ref-autogen/outlook_1_5/office.appointmentread.yml
+++ b/docs/docs-ref-autogen/outlook_1_5/office.appointmentread.yml
@@ -2,7 +2,7 @@
 items:
   - uid: Outlook_1_5.Office.AppointmentRead
     summary: >-
-      The appointment attendee mode of [Office.context.mailbox.item](xref:Outlook_1_5.Office.Item)<!-- -->.
+      The appointment attendee mode of [ Office.context.mailbox.item](xref:Outlook_1_5.Office.Item)<!-- -->.
 
 
       Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat
@@ -42,20 +42,20 @@ items:
       - Outlook_1_5.Office.AppointmentRead.subject
   - uid: Outlook_1_5.Office.AppointmentRead.attachments
     summary: |-
-      Gets an array of attachments for the item.
+      Gets the item's attachments as an array.
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
 
 
       Note: Certain types of files are blocked by Outlook due to potential security issues and are therefore not
-      returned. For more information, see [Blocked attachments in
+      returned. For more information, see [ Blocked attachments in
       Outlook](https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519)<!--
       -->.
     name: attachments
@@ -74,11 +74,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: body
     fullName: Outlook_1_5.Office.AppointmentRead.body
@@ -96,11 +96,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: dateTimeCreated
     fullName: Outlook_1_5.Office.AppointmentRead.dateTimeCreated
@@ -118,11 +118,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
 
 
@@ -160,11 +160,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: displayReplyAllForm(formData)
     fullName: Outlook_1_5.Office.AppointmentRead.displayReplyAllForm
@@ -181,7 +181,7 @@ items:
         - id: formData
           description: >-
             A string that contains text and HTML and that represents the body of the reply form. The string is limited
-            to 32 KB OR An[Office.ReplyFormData](xref:Outlook_1_5.Office.ReplyFormData) object that contains body or
+            to 32 KB OR An [Office.ReplyFormData](xref:Outlook_1_5.Office.ReplyFormData) object that contains body or
             attachment data and a callback function
           type:
             - string | ReplyFormData
@@ -208,11 +208,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: displayReplyForm(formData)
     fullName: Outlook_1_5.Office.AppointmentRead.displayReplyForm
@@ -229,7 +229,7 @@ items:
         - id: formData
           description: >-
             A string that contains text and HTML and that represents the body of the reply form. The string is limited
-            to 32 KB. OR An[Office.ReplyFormData](xref:Outlook_1_5.Office.ReplyFormData) object that contains body or
+            to 32 KB. OR An [Office.ReplyFormData](xref:Outlook_1_5.Office.ReplyFormData) object that contains body or
             attachment data and a callback function.
           type:
             - string | ReplyFormData
@@ -248,11 +248,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: end
     fullName: Outlook_1_5.Office.AppointmentRead.end
@@ -266,17 +266,17 @@ items:
           - Date
   - uid: Outlook_1_5.Office.AppointmentRead.getEntities
     summary: |-
-      Gets the entities found in the selected item.
+      Gets the entities found in the selected item's body.
 
       Note: This method is not supported in Outlook for iOS or Outlook for Android.
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: getEntities()
     fullName: Outlook_1_5.Office.AppointmentRead.getEntities
@@ -291,17 +291,17 @@ items:
         description: ''
   - uid: Outlook_1_5.Office.AppointmentRead.getEntitiesByType
     summary: |-
-      Gets an array of all the entities of the specified entity type found in the selected item.
+      Gets an array of all the entities of the specified entity type found in the selected item's body.
 
       Note: This method is not supported in Outlook for iOS or Outlook for Android.
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
 
 
@@ -329,7 +329,7 @@ items:
           - '(string | Contact | MeetingSuggestion | PhoneNumber | TaskSuggestion)[]'
         description: >-
           If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns
-          null. If no entities of the specified type are present on the item, the method returns an empty array.
+          null. If no entities of the specified type are present in the item's body, the method returns an empty array.
           Otherwise, the type of the objects in the returned array depends on the type of entity requested in the
           entityType parameter.
       parameters:
@@ -351,11 +351,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: getFilteredEntitiesByName(name)
     fullName: Outlook_1_5.Office.AppointmentRead.getFilteredEntitiesByName
@@ -400,11 +400,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: getRegExMatches()
     fullName: Outlook_1_5.Office.AppointmentRead.getRegExMatches
@@ -440,11 +440,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: getRegExMatchesByName(name)
     fullName: Outlook_1_5.Office.AppointmentRead.getRegExMatchesByName
@@ -473,11 +473,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
 
 
@@ -515,16 +515,17 @@ items:
       Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The
       itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making
       REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more
-      details, see Use the Outlook REST APIs from an Outlook add-in.
+      details, see [ Use the Outlook REST APIs from an Outlook
+      add-in](https://docs.microsoft.com/outlook/add-ins/use-rest-api#get-the-item-id)<!-- -->.
 
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: itemId
     fullName: Outlook_1_5.Office.AppointmentRead.itemId
@@ -547,11 +548,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: itemType
     fullName: Outlook_1_5.Office.AppointmentRead.itemType
@@ -581,11 +582,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: 'loadCustomPropertiesAsync(callback, userContext)'
     fullName: Outlook_1_5.Office.AppointmentRead.loadCustomPropertiesAsync
@@ -593,7 +594,9 @@ items:
       - typeScript
     type: method
     syntax:
-      content: 'loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;'
+      content: >-
+        loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any):
+        void;
       return:
         type:
           - void
@@ -602,9 +605,9 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult.
+            of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<Office.CustomProperties>) => void'
         - id: userContext
           description: >-
             Optional. Developers can provide any object they wish to access in the callback function. This object can be
@@ -619,11 +622,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: location
     fullName: Outlook_1_5.Office.AppointmentRead.location
@@ -646,11 +649,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: normalizedSubject
     fullName: Outlook_1_5.Office.AppointmentRead.normalizedSubject
@@ -668,11 +671,11 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: notificationMessages
     fullName: Outlook_1_5.Office.AppointmentRead.notificationMessages
@@ -697,11 +700,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: optionalAttendees
     fullName: Outlook_1_5.Office.AppointmentRead.optionalAttendees
@@ -715,15 +718,15 @@ items:
           - 'EmailAddressDetails[]'
   - uid: Outlook_1_5.Office.AppointmentRead.organizer
     summary: |-
-      Gets the email address of the meeting organizer for a specified meeting. Read mode only.
+      Gets the email address of the meeting organizer for a specified meeting.
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: organizer
     fullName: Outlook_1_5.Office.AppointmentRead.organizer
@@ -748,11 +751,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: requiredAttendees
     fullName: Outlook_1_5.Office.AppointmentRead.requiredAttendees
@@ -775,11 +778,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: start
     fullName: Outlook_1_5.Office.AppointmentRead.start
@@ -805,11 +808,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: subject
     fullName: Outlook_1_5.Office.AppointmentRead.subject

--- a/docs/docs-ref-autogen/outlook_1_5/office.attachmentdetails.yml
+++ b/docs/docs-ref-autogen/outlook_1_5/office.attachmentdetails.yml
@@ -8,11 +8,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: Office.AttachmentDetails
     fullName: Outlook_1_5.Office.AttachmentDetails

--- a/docs/docs-ref-autogen/outlook_1_5/office.body.yml
+++ b/docs/docs-ref-autogen/outlook_1_5/office.body.yml
@@ -8,12 +8,12 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.Body
     fullName: Outlook_1_5.Office.Body
     langs:
@@ -42,18 +42,18 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
 
 
-      In addition to the main signature, this method also has this signature:
+      In addition to this signature, this method also has the following signature:
 
 
-      `getAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult) => void): void;`
+      `getAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult<Office.Body>) => void): void;`
     name: 'getAsync(coerciontype, options, callback)'
     fullName: Outlook_1_5.Office.Body.getAsync
     langs:
@@ -62,7 +62,7 @@ items:
     syntax:
       content: >-
         getAsync(coerciontype: Office.CoercionType, options?: Office.AsyncContextOptions, callback?: (result:
-        AsyncResult) => void): void;
+        AsyncResult<Office.Body>) => void): void;
       return:
         type:
           - void
@@ -84,18 +84,18 @@ items:
             parameter of type AsyncResult. The body is provided in the requested format in the asyncResult.value
             property.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<Office.Body>) => void'
   - uid: Outlook_1_5.Office.Body.getTypeAsync
     summary: |-
       Gets a value that indicates whether the content is in HTML or text format.
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
     name: 'getTypeAsync(options, callback)'
     fullName: Outlook_1_5.Office.Body.getTypeAsync
@@ -103,7 +103,9 @@ items:
       - typeScript
     type: method
     syntax:
-      content: 'getTypeAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;'
+      content: >-
+        getTypeAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<Office.CoercionType>) =>
+        void): void;
       return:
         type:
           - void
@@ -118,10 +120,10 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. The content type is returned as one of the CoercionType values in the
+            parameter of type Office.AsyncResult. The content type is returned as one of the CoercionType values in the
             asyncResult.value property.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<Office.CoercionType>) => void'
   - uid: Outlook_1_5.Office.Body.prependAsync
     summary: >-
       Adds the specified content to the beginning of the item body.
@@ -137,11 +139,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -149,13 +151,13 @@ items:
       characters.</td></tr></table>
 
 
-      In addition to the main signature, this method also has these signatures:
+      In addition to this signature, this method also has the following signatures:
 
 
-      `prependAsync(data: string, options: Office.AsyncContextOptions &amp; CoercionTypeOptions): void;`
+      `prependAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`
 
 
-      `prependAsync(data: string, callback: (result: AsyncResult) => void): void;`
+      `prependAsync(data: string, callback: (result: AsyncResult<void>) => void): void;`
 
 
       `prependAsync(data: string): void;`
@@ -167,7 +169,7 @@ items:
     syntax:
       content: >-
         prependAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result:
-        AsyncResult) => void): void;
+        AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -187,9 +189,10 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. Any errors encountered will be provided in the asyncResult.error property.
+            parameter of type Office.AsyncResult. Any errors encountered will be provided in the asyncResult.error
+            property.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_5.Office.Body.setAsync
     summary: >-
       Replaces the entire body with the specified text.
@@ -207,11 +210,11 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -220,13 +223,13 @@ items:
       Office.CoercionType.Html and the message body is in plain text.</td></tr></table>
 
 
-      In addition to the main signature, this method also has these signatures:
+      In addition to this signature, this method also has the following signatures:
 
 
-      `setAsync(data: string, options: Office.AsyncContextOptions &amp; CoercionTypeOptions): void;`
+      `setAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`
 
 
-      `setAsync(data: string, callback: (result: AsyncResult) => void): void;`
+      `setAsync(data: string, callback: (result: AsyncResult<void>) => void): void;`
 
 
       `setAsync(data: string): void;`
@@ -238,7 +241,7 @@ items:
     syntax:
       content: >-
         setAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result:
-        AsyncResult) => void): void;
+        AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -258,9 +261,10 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. Any errors encountered will be provided in the asyncResult.error property.
+            parameter of type Office.AsyncResult. Any errors encountered will be provided in the asyncResult.error
+            property.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_5.Office.Body.setSelectedDataAsync
     summary: >-
       Replaces the selection in the body with the specified text.
@@ -278,11 +282,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -291,13 +295,13 @@ items:
       Office.CoercionType.Html and the message body is in plain text.</td></tr></table>
 
 
-      In addition to the main signature, this method also has these signatures:
+      In addition to this signature, this method also has the following signatures:
 
 
-      `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions &amp; CoercionTypeOptions): void;`
+      `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`
 
 
-      `setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;`
+      `setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;`
 
 
       `setSelectedDataAsync(data: string): void;`
@@ -309,7 +313,7 @@ items:
     syntax:
       content: >-
         setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?:
-        (result: AsyncResult) => void): void;
+        (result: AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -329,6 +333,7 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. Any errors encountered will be provided in the asyncResult.error property.
+            parameter of type Office.AsyncResult. Any errors encountered will be provided in the asyncResult.error
+            property.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'

--- a/docs/docs-ref-autogen/outlook_1_5/office.contact.yml
+++ b/docs/docs-ref-autogen/outlook_1_5/office.contact.yml
@@ -12,11 +12,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: Office.Contact
     fullName: Outlook_1_5.Office.Contact

--- a/docs/docs-ref-autogen/outlook_1_5/office.customproperties.yml
+++ b/docs/docs-ref-autogen/outlook_1_5/office.customproperties.yml
@@ -15,12 +15,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.CustomProperties
     fullName: Outlook_1_5.Office.CustomProperties
     langs:
@@ -35,12 +35,12 @@ items:
   - uid: Outlook_1_5.Office.CustomProperties.get
     summary: Returns the value of the specified custom property.
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: get(name)
     fullName: Outlook_1_5.Office.CustomProperties.get
     langs:
@@ -66,12 +66,12 @@ items:
 
       To make the removal of the property permanent, you must call the saveAsync method of the CustomProperties object.
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: remove(name)
     fullName: Outlook_1_5.Office.CustomProperties.remove
     langs:
@@ -85,7 +85,10 @@ items:
         description: ''
       parameters:
         - id: name
-          description: 'The name of the property to be removed. \[Api set: Mailbox 1.0\]'
+          description: |-
+            The name of the property to be removed.
+
+            \[Api set: Mailbox 1.0\]
           type:
             - string
   - uid: Outlook_1_5.Office.CustomProperties.saveAsync
@@ -102,19 +105,19 @@ items:
       becomes disconnected. If the add-in calls saveAsync while in the disconnected state, saveAsync would return an
       error. Your callback method should handle this error accordingly.
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: 'saveAsync(callback, asyncContext)'
     fullName: Outlook_1_5.Office.CustomProperties.saveAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'saveAsync(callback?: (result: AsyncResult) => void, asyncContext?: any): void;'
+      content: 'saveAsync(callback?: (result: AsyncResult<void>) => void, asyncContext?: any): void;'
       return:
         type:
           - void
@@ -123,11 +126,14 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult.
+            parameter of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
         - id: asyncContext
-          description: 'Optional. Any state data that is passed to the callback method. \[Api set: Mailbox 1.0\]'
+          description: |-
+            Optional. Any state data that is passed to the callback method.
+
+            \[Api set: Mailbox 1.0\]
           type:
             - any
   - uid: Outlook_1_5.Office.CustomProperties.set
@@ -146,12 +152,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: 'set(name, value)'
     fullName: Outlook_1_5.Office.CustomProperties.set
     langs:

--- a/docs/docs-ref-autogen/outlook_1_5/office.diagnostics.yml
+++ b/docs/docs-ref-autogen/outlook_1_5/office.diagnostics.yml
@@ -6,12 +6,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.Diagnostics
     fullName: Outlook_1_5.Office.Diagnostics
     langs:
@@ -30,12 +30,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: hostName
     fullName: Outlook_1_5.Office.Diagnostics.hostName
     langs:
@@ -58,12 +58,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: hostVersion
     fullName: Outlook_1_5.Office.Diagnostics.hostVersion
     langs:
@@ -102,19 +102,19 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: OWAView
     fullName: Outlook_1_5.Office.Diagnostics.OWAView
     langs:
       - typeScript
     type: property
     syntax:
-      content: 'OWAView: "string";'
+      content: 'OWAView: MailboxEnums.OWAView | "OneColumn" | "TwoColumns" | "ThreeColumns";'
       return:
         type:
-          - '"string"'
+          - MailboxEnums.OWAView | "OneColumn" | "TwoColumns" | "ThreeColumns"

--- a/docs/docs-ref-autogen/outlook_1_5/office.emailaddressdetails.yml
+++ b/docs/docs-ref-autogen/outlook_1_5/office.emailaddressdetails.yml
@@ -6,12 +6,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.EmailAddressDetails
     fullName: Outlook_1_5.Office.EmailAddressDetails
     langs:

--- a/docs/docs-ref-autogen/outlook_1_5/office.emailuser.yml
+++ b/docs/docs-ref-autogen/outlook_1_5/office.emailuser.yml
@@ -6,11 +6,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: Office.EmailUser
     fullName: Outlook_1_5.Office.EmailUser

--- a/docs/docs-ref-autogen/outlook_1_5/office.entities.yml
+++ b/docs/docs-ref-autogen/outlook_1_5/office.entities.yml
@@ -34,11 +34,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: Office.Entities
     fullName: Outlook_1_5.Office.Entities

--- a/docs/docs-ref-autogen/outlook_1_5/office.item.yml
+++ b/docs/docs-ref-autogen/outlook_1_5/office.item.yml
@@ -8,12 +8,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.Item
     fullName: Outlook_1_5.Office.Item
     langs:
@@ -33,12 +33,12 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: body
     fullName: Outlook_1_5.Office.Item.body
     langs:
@@ -55,11 +55,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: dateTimeCreated
     fullName: Outlook_1_5.Office.Item.dateTimeCreated
@@ -77,11 +77,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
 
 
@@ -107,12 +107,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: itemType
     fullName: Outlook_1_5.Office.Item.itemType
     langs:
@@ -141,19 +141,21 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: 'loadCustomPropertiesAsync(callback, userContext)'
     fullName: Outlook_1_5.Office.Item.loadCustomPropertiesAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;'
+      content: >-
+        loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any):
+        void;
       return:
         type:
           - void
@@ -162,9 +164,9 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult.
+            of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<Office.CustomProperties>) => void'
         - id: userContext
           description: >-
             Optional. Developers can provide any object they wish to access in the callback function. This object can be
@@ -177,12 +179,12 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: notificationMessages
     fullName: Outlook_1_5.Office.Item.notificationMessages
     langs:

--- a/docs/docs-ref-autogen/outlook_1_5/office.itemcompose.yml
+++ b/docs/docs-ref-autogen/outlook_1_5/office.itemcompose.yml
@@ -2,11 +2,11 @@
 items:
   - uid: Outlook_1_5.Office.ItemCompose
     summary: >-
-      The compose mode of [Office.context.mailbox.item](xref:Outlook_1_5.Office.Item)<!-- -->.
+      The compose mode of [ Office.context.mailbox.item](xref:Outlook_1_5.Office.Item)<!-- -->.
 
 
       Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat
-      this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
+      this as a mode of `Office.context.mailbox.item`<!-- -->. Refer to the Object Model pages for more information.
     name: Office.ItemCompose
     fullName: Outlook_1_5.Office.ItemCompose
     langs:
@@ -39,11 +39,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -62,7 +62,8 @@ items:
       `addFileAttachmentAsync(uri: string, attachmentName: string, options: Office.AsyncContextOptions): void;`
 
 
-      `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+      `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void):
+      void;`
     name: 'addFileAttachmentAsync(uri, attachmentName, options, callback)'
     fullName: Outlook_1_5.Office.ItemCompose.addFileAttachmentAsync
     langs:
@@ -71,7 +72,7 @@ items:
     syntax:
       content: >-
         addFileAttachmentAsync(uri: string, attachmentName: string, options?: Office.AsyncContextOptions, callback?:
-        (result: AsyncResult) => void): void;
+        (result: AsyncResult<string>) => void): void;
       return:
         type:
           - void
@@ -103,7 +104,7 @@ items:
             property. If uploading the attachment fails, the asyncResult object will contain an Error object that
             provides a description of the error.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<string>) => void'
   - uid: Outlook_1_5.Office.ItemCompose.addItemAttachmentAsync
     summary: >-
       Adds an Exchange item, such as a message, as an attachment to the message or appointment.
@@ -119,17 +120,17 @@ items:
       session.
 
 
-      If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items
+      If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items
       other than the item that you are editing; however, this is not supported and is not recommended.
 
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -137,7 +138,7 @@ items:
       attachments.</td></tr></table>
 
 
-      In addition to the main signature, this method also has these signatures:
+      In addition to this signature, this method also has the following signatures:
 
 
       `addItemAttachmentAsync(itemId: any, attachmentName: string): void;`
@@ -146,7 +147,8 @@ items:
       `addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;`
 
 
-      `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+      `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void):
+      void;`
     name: 'addItemAttachmentAsync(itemId, attachmentName, options, callback)'
     fullName: Outlook_1_5.Office.ItemCompose.addItemAttachmentAsync
     langs:
@@ -155,7 +157,7 @@ items:
     syntax:
       content: >-
         addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?:
-        (result: AsyncResult) => void): void;
+        (result: AsyncResult<string>) => void): void;
       return:
         type:
           - void
@@ -180,11 +182,11 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value
+            of type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value
             property. If adding the attachment fails, the asyncResult object will contain an Error object that provides
             a description of the error.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<string>) => void'
   - uid: Outlook_1_5.Office.ItemCompose.close
     summary: >-
       Closes the current item that is being composed
@@ -203,11 +205,11 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
     name: close()
     fullName: Outlook_1_5.Office.ItemCompose.close
@@ -235,11 +237,11 @@ items:
 
       \[ [API set: Mailbox 1.2](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
     name: 'getSelectedDataAsync(coerciontype, callback)'
     fullName: Outlook_1_5.Office.ItemCompose.getSelectedDataAsync
@@ -247,7 +249,7 @@ items:
       - typeScript
     type: method
     syntax:
-      content: 'getSelectedDataAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult) => void): void;'
+      content: 'getSelectedDataAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult<any>) => void): void;'
       return:
         type:
           - void
@@ -260,9 +262,9 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult.
+            of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<any>) => void'
   - uid: Outlook_1_5.Office.ItemCompose.removeAttachmentAsync
     summary: >-
       Removes an attachment from a message or appointment.
@@ -271,17 +273,17 @@ items:
       The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best
       practice, you should use the attachment identifier to remove an attachment only if the same mail app has added
       that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid
-      only within the same session. A session is over when the user closes the app, or if the user starts composing in
-      an inline form and subsequently pops out the inline form to continue in a separate window.
+      only within the same session. A session is over when the user closes the app, or if the user starts composing an
+      inline form then subsequently pops out the form to continue in a separate window.
 
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -297,7 +299,7 @@ items:
       `removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;`
 
 
-      `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;`
+      `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;`
     name: 'removeAttachmentAsync(attachmentIndex, options, callback)'
     fullName: Outlook_1_5.Office.ItemCompose.removeAttachmentAsync
     langs:
@@ -306,7 +308,7 @@ items:
     syntax:
       content: >-
         removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result:
-        AsyncResult) => void): void;
+        AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -325,10 +327,10 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain
-            an error code with the reason for the failure.
+            parameter of type Office.AsyncResult. If removing the attachment fails, the asyncResult.error property will
+            contain an error code with the reason for the failure.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_5.Office.ItemCompose.saveAsync
     summary: >-
       Asynchronously saves an item.
@@ -362,11 +364,11 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -382,14 +384,14 @@ items:
       `saveAsync(options: Office.AsyncContextOptions): void;`
 
 
-      `saveAsync(callback: (result: AsyncResult) => void): void;`
+      `saveAsync(callback: (result: AsyncResult<void>) => void): void;`
     name: 'saveAsync(options, callback)'
     fullName: Outlook_1_5.Office.ItemCompose.saveAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;'
+      content: 'saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;'
       return:
         type:
           - void
@@ -404,10 +406,10 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain
-            an error code with the reason for the failure.
+            parameter of type Office.AsyncResult. If removing the attachment fails, the asyncResult.error property will
+            contain an error code with the reason for the failure.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_5.Office.ItemCompose.setSelectedDataAsync
     summary: >-
       Asynchronously inserts data into the body or subject of a message.
@@ -420,11 +422,11 @@ items:
 
       \[ [API set: Mailbox 1.2](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -437,10 +439,10 @@ items:
       `setSelectedDataAsync(data: string): void;`
 
 
-      `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions &amp; CoercionTypeOptions): void;`
+      `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`
 
 
-      `setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;`
+      `setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;`
     name: 'setSelectedDataAsync(data, options, callback)'
     fullName: Outlook_1_5.Office.ItemCompose.setSelectedDataAsync
     langs:
@@ -449,7 +451,7 @@ items:
     syntax:
       content: >-
         setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?:
-        (result: AsyncResult) => void): void;
+        (result: AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -475,10 +477,9 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain
-            an error code with the reason for the failure.
+            parameter of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_5.Office.ItemCompose.subject
     summary: |-
       Gets or sets the description that appears in the subject field of an item.
@@ -489,12 +490,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: subject
     fullName: Outlook_1_5.Office.ItemCompose.subject
     langs:

--- a/docs/docs-ref-autogen/outlook_1_5/office.itemread.yml
+++ b/docs/docs-ref-autogen/outlook_1_5/office.itemread.yml
@@ -2,11 +2,11 @@
 items:
   - uid: Outlook_1_5.Office.ItemRead
     summary: >-
-      The read mode of [Office.context.mailbox.item](xref:Outlook_1_5.Office.Item)<!-- -->.
+      The read mode of [ Office.context.mailbox.item](xref:Outlook_1_5.Office.Item)<!-- -->.
 
 
       Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat
-      this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
+      this as a mode of `Office.context.mailbox.item`<!-- -->. Refer to the Object Model pages for more information.
     name: Office.ItemRead
     fullName: Outlook_1_5.Office.ItemRead
     langs:
@@ -30,20 +30,20 @@ items:
       - Outlook_1_5.Office.ItemRead.subject
   - uid: Outlook_1_5.Office.ItemRead.attachments
     summary: |-
-      Gets an array of attachments for the item.
+      Gets the item's attachments as an array.
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
 
 
       Note: Certain types of files are blocked by Outlook due to potential security issues and are therefore not
-      returned. For more information, see [Blocked attachments in
+      returned. For more information, see [ Blocked attachments in
       Outlook](https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519)<!--
       -->.
     name: attachments
@@ -79,11 +79,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: displayReplyAllForm(formData)
     fullName: Outlook_1_5.Office.ItemRead.displayReplyAllForm
@@ -100,7 +100,7 @@ items:
         - id: formData
           description: >-
             A string that contains text and HTML and that represents the body of the reply form. The string is limited
-            to 32 KB OR An[Office.ReplyFormData](xref:Outlook_1_5.Office.ReplyFormData) object that contains body or
+            to 32 KB OR An [Office.ReplyFormData](xref:Outlook_1_5.Office.ReplyFormData) object that contains body or
             attachment data and a callback function
           type:
             - string | ReplyFormData
@@ -127,11 +127,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: displayReplyForm(formData)
     fullName: Outlook_1_5.Office.ItemRead.displayReplyForm
@@ -148,23 +148,23 @@ items:
         - id: formData
           description: >-
             A string that contains text and HTML and that represents the body of the reply form. The string is limited
-            to 32 KB. OR An[Office.ReplyFormData](xref:Outlook_1_5.Office.ReplyFormData) object that contains body or
+            to 32 KB. OR An [Office.ReplyFormData](xref:Outlook_1_5.Office.ReplyFormData) object that contains body or
             attachment data and a callback function.
           type:
             - string | ReplyFormData
   - uid: Outlook_1_5.Office.ItemRead.getEntities
     summary: |-
-      Gets the entities found in the selected item.
+      Gets the entities found in the selected item's body.
 
       Note: This method is not supported in Outlook for iOS or Outlook for Android.
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: getEntities()
     fullName: Outlook_1_5.Office.ItemRead.getEntities
@@ -179,17 +179,17 @@ items:
         description: ''
   - uid: Outlook_1_5.Office.ItemRead.getEntitiesByType
     summary: |-
-      Gets an array of all the entities of the specified entity type found in the selected item.
+      Gets an array of all the entities of the specified entity type found in the selected item's body.
 
       Note: This method is not supported in Outlook for iOS or Outlook for Android.
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
 
 
@@ -217,7 +217,7 @@ items:
           - '(string | Contact | MeetingSuggestion | PhoneNumber | TaskSuggestion)[]'
         description: >-
           If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns
-          null. If no entities of the specified type are present on the item, the method returns an empty array.
+          null. If no entities of the specified type are present in the item's body, the method returns an empty array.
           Otherwise, the type of the objects in the returned array depends on the type of entity requested in the
           entityType parameter.
       parameters:
@@ -239,11 +239,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: getFilteredEntitiesByName(name)
     fullName: Outlook_1_5.Office.ItemRead.getFilteredEntitiesByName
@@ -288,11 +288,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: getRegExMatches()
     fullName: Outlook_1_5.Office.ItemRead.getRegExMatches
@@ -328,11 +328,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: getRegExMatchesByName(name)
     fullName: Outlook_1_5.Office.ItemRead.getRegExMatchesByName
@@ -361,11 +361,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
 
 
@@ -403,16 +403,17 @@ items:
       Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The
       itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making
       REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more
-      details, see Use the Outlook REST APIs from an Outlook add-in.
+      details, see [ Use the Outlook REST APIs from an Outlook
+      add-in](https://docs.microsoft.com/outlook/add-ins/use-rest-api#get-the-item-id)<!-- -->.
 
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: itemId
     fullName: Outlook_1_5.Office.ItemRead.itemId
@@ -435,11 +436,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: normalizedSubject
     fullName: Outlook_1_5.Office.ItemRead.normalizedSubject
@@ -465,12 +466,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: subject
     fullName: Outlook_1_5.Office.ItemRead.subject
     langs:

--- a/docs/docs-ref-autogen/outlook_1_5/office.localclienttime.yml
+++ b/docs/docs-ref-autogen/outlook_1_5/office.localclienttime.yml
@@ -6,11 +6,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: Office.LocalClientTime
     fullName: Outlook_1_5.Office.LocalClientTime

--- a/docs/docs-ref-autogen/outlook_1_5/office.location.yml
+++ b/docs/docs-ref-autogen/outlook_1_5/office.location.yml
@@ -6,11 +6,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
     name: Office.Location
     fullName: Outlook_1_5.Office.Location
@@ -29,25 +29,25 @@ items:
       The getAsync method starts an asynchronous call to the Exchange server to get the location of an appointment. The
       location of the appointment is provided as a string in the asyncResult.value property.
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
 
 
       In addition to this signature, the method also has the following signature:
 
 
-      `getAsync(callback: (result: AsyncResult) => void): void;`
+      `getAsync(callback: (result: AsyncResult<string>) => void): void;`
     name: 'getAsync(options, callback)'
     fullName: Outlook_1_5.Office.Location.getAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'getAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;'
+      content: 'getAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;'
       return:
         type:
           - void
@@ -62,9 +62,12 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. \[Api set: Mailbox 1.1\]
+            parameter of type Office.AsyncResult.
+
+
+            \[Api set: Mailbox 1.1\]
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<string>) => void'
   - uid: Outlook_1_5.Office.Location.setAsync
     summary: >-
       Sets the location of an appointment.
@@ -73,11 +76,11 @@ items:
       The setAsync method starts an asynchronous call to the Exchange server to set the location of an appointment.
       Setting the location of an appointment overwrites the current location.
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -94,7 +97,7 @@ items:
       `setAsync(location: string, options: Office.AsyncContextOptions): void;`
 
 
-      `setAsync(location: string, callback: (result: AsyncResult) => void): void;`
+      `setAsync(location: string, callback: (result: AsyncResult<void>) => void): void;`
     name: 'setAsync(location, options, callback)'
     fullName: Outlook_1_5.Office.Location.setAsync
     langs:
@@ -102,8 +105,8 @@ items:
     type: method
     syntax:
       content: >-
-        setAsync(location: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void):
-        void;
+        setAsync(location: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) =>
+        void): void;
       return:
         type:
           - void
@@ -122,7 +125,10 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. If setting the location fails, the asyncResult.error property will contain an
-            error code. \[Api set: Mailbox 1.1\]
+            parameter of type Office.AsyncResult. If setting the location fails, the asyncResult.error property will
+            contain an error code.
+
+
+            \[Api set: Mailbox 1.1\]
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'

--- a/docs/docs-ref-autogen/outlook_1_5/office.mailbox.yml
+++ b/docs/docs-ref-autogen/outlook_1_5/office.mailbox.yml
@@ -2,7 +2,7 @@
 items:
   - uid: Outlook_1_5.Office.Mailbox
     summary: |-
-      Provides access to the Outlook add-in object model for Microsoft Outlook and Microsoft Outlook on the web.
+      Provides access to the Outlook Add-in object model for Microsoft Outlook and Microsoft Outlook on the web.
 
       Namespaces:
 
@@ -14,12 +14,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.Mailbox
     fullName: Outlook_1_5.Office.Mailbox
     langs:
@@ -41,26 +41,23 @@ items:
       - Outlook_1_5.Office.Mailbox.getUserIdentityTokenAsync
       - Outlook_1_5.Office.Mailbox.item
       - Outlook_1_5.Office.Mailbox.makeEwsRequestAsync
+      - Outlook_1_5.Office.Mailbox.removeHandlerAsync
       - Outlook_1_5.Office.Mailbox.restUrl
       - Outlook_1_5.Office.Mailbox.userProfile
   - uid: Outlook_1_5.Office.Mailbox.addHandlerAsync
-    summary: >-
+    summary: |-
       Adds an event handler for a supported event.
 
-
-      Currently the only supported event type is Office.EventType.ItemChanged, which is invoked when the user selects a
-      new item. This event is used by add-ins that implement a pinnable taskpane, and allows the add-in to refresh the
-      taskpane UI based on the currently selected item.
-
+      Currently, the only supported event type is `Office.EventType.ItemChanged`<!-- -->.
 
       \[ [API set: Mailbox 1.5](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: 'addHandlerAsync(eventType, handler, options, callback)'
     fullName: Outlook_1_5.Office.Mailbox.addHandlerAsync
     langs:
@@ -69,7 +66,7 @@ items:
     syntax:
       content: >-
         addHandlerAsync(eventType: Office.EventType, handler: (type: EventType) => void, options?:
-        Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -92,9 +89,9 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult.
+            parameter of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_5.Office.Mailbox.convertToEwsId
     summary: >-
       Converts an item ID formatted for REST into EWS format.
@@ -110,12 +107,12 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: 'convertToEwsId(itemId, restVersion)'
     fullName: Outlook_1_5.Office.Mailbox.convertToEwsId
     langs:
@@ -155,12 +152,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: convertToLocalClientTime(timeValue)
     fullName: Outlook_1_5.Office.Mailbox.convertToLocalClientTime
     langs:
@@ -185,19 +182,19 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
 
 
       Item IDs retrieved via EWS or via the itemId property use a different format than the format used by REST APIs
-      (such as the [Outlook Mail
+      (such as the [ Outlook Mail
       API](https://docs.microsoft.com/previous-versions/office/office-365-api/api/version-2.0/mail-rest-operations) or
-      the [Microsoft Graph](http://graph.microsoft.io/)<!-- -->. The convertToRestId method converts an EWS-formatted ID
-      into the proper format for REST.
+      the [ Microsoft Graph](http://graph.microsoft.io/)<!-- -->. The convertToRestId method converts an EWS-formatted
+      ID into the proper format for REST.
     name: 'convertToRestId(itemId, restVersion)'
     fullName: Outlook_1_5.Office.Mailbox.convertToRestId
     langs:
@@ -229,12 +226,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: convertToUtcClientTime(input)
     fullName: Outlook_1_5.Office.Mailbox.convertToUtcClientTime
     langs:
@@ -269,11 +266,11 @@ items:
       Exchange Server. An example is the string 15.0.468.0.
 
 
-      - OWAView (string): A string that represents the current view of Outlook Web App. If the host application is not
-      Outlook Web App, then accessing this property results in undefined. Outlook Web App has three views (OneColumn -
-      displayed when the screen is narrow, TwoColumns - displayed when the screen is wider, and ThreeColumns - displayed
-      when the screen is wide.) that correspond to the width of the screen and the window, and the number of columns
-      that can be displayed.
+      - OWAView (MailboxEnums.OWAView or string): An enum (or string literal) that represents the current view of
+      Outlook Web App. If the host application is not Outlook Web App, then accessing this property results in
+      undefined. Outlook Web App has three views (OneColumn - displayed when the screen is narrow, TwoColumns -
+      displayed when the screen is wider, and ThreeColumns - displayed when the screen is wide) that correspond to the
+      width of the screen and the window, and the number of columns that can be displayed.
 
 
       More information is under [Office.Diagnostics](xref:Outlook_1_5.Office.Diagnostics)<!-- -->.
@@ -281,12 +278,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: diagnostics
     fullName: Outlook_1_5.Office.Mailbox.diagnostics
     langs:
@@ -325,12 +322,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: displayAppointmentForm(itemId)
     fullName: Outlook_1_5.Office.Mailbox.displayAppointmentForm
     langs:
@@ -374,12 +371,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: displayMessageForm(itemId)
     fullName: Outlook_1_5.Office.Mailbox.displayMessageForm
     langs:
@@ -425,11 +422,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: displayNewAppointmentForm(parameters)
     fullName: Outlook_1_5.Office.Mailbox.displayNewAppointmentForm
@@ -461,16 +458,16 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
 
 
       The ewsUrl value can be used by a remote service to make EWS calls to the user's mailbox. For example, you can
-      create a remote service to [get attachments from the selected
+      create a remote service to [ get attachments from the selected
       item](https://docs.microsoft.com/outlook/add-ins/get-attachments-of-an-outlook-item)<!-- -->.
 
 
@@ -522,28 +519,30 @@ items:
 
       \[ [API set: Mailbox 1.5](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
       and read</td></tr></table>
 
 
       In addition to this signature, the method has the following signatures:
 
 
-      `getCallbackTokenAsync(callback: (result: AsyncResult) => void): void;`
+      `getCallbackTokenAsync(callback: (result: AsyncResult<string>) => void): void;`
 
 
-      `getCallbackTokenAsync(callback: (result: AsyncResult) => void, userContext?: any): void;`
+      `getCallbackTokenAsync(callback: (result: AsyncResult<string>) => void, userContext?: any): void;`
     name: 'getCallbackTokenAsync(options, callback)'
     fullName: Outlook_1_5.Office.Mailbox.getCallbackTokenAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'getCallbackTokenAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;'
+      content: >-
+        getCallbackTokenAsync(options: Office.AsyncContextOptions & { isRest?: boolean }, callback: (result:
+        AsyncResult<string>) => void): void;
       return:
         type:
           - void
@@ -555,13 +554,13 @@ items:
             provided will be used for the Outlook REST APIs or Exchange Web Services. Default value is false.
             asyncContext: Any state data that is passed to the asynchronous method.
           type:
-            - office.Office.AsyncContextOptions
+            - 'Office.AsyncContextOptions & { isRest?: boolean }'
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult. The token is provided as a string in the asyncResult.value property.
+            of type Office.AsyncResult. The token is provided as a string in the asyncResult.value property.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<string>) => void'
   - uid: Outlook_1_5.Office.Mailbox.getUserIdentityTokenAsync
     summary: |-
       Gets a token identifying the user and the Office Add-in.
@@ -570,23 +569,23 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
       and read</td></tr></table>
 
 
-      The getUserIdentityTokenAsync method returns a token that you can use to identify and [authenticate the add-in and
-      user with a third-party system](https://docs.microsoft.com/outlook/add-ins/authentication)<!-- -->.
+      The getUserIdentityTokenAsync method returns a token that you can use to identify and [ authenticate the add-in
+      and user with a third-party system](https://docs.microsoft.com/outlook/add-ins/authentication)<!-- -->.
     name: 'getUserIdentityTokenAsync(callback, userContext)'
     fullName: Outlook_1_5.Office.Mailbox.getUserIdentityTokenAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'getUserIdentityTokenAsync(callback: (result: AsyncResult) => void, userContext?: any): void;'
+      content: 'getUserIdentityTokenAsync(callback: (result: AsyncResult<string>) => void, userContext?: any): void;'
       return:
         type:
           - void
@@ -595,9 +594,9 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult.
+            of type Office.AsyncResult. The token is provided as a string in the asyncResult.value property.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<string>) => void'
         - id: userContext
           description: Optional. Any state data that is passed to the asynchronous method.\|
           type:
@@ -606,7 +605,8 @@ items:
     summary: >-
       The mailbox item. Depending on the context in which the add-in opened, the item may be of any number of types. If
       you want to see IntelliSense for only a specific type, you should cast this item to one of the following:
-      `ItemCompose`, `ItemRead`, `MessageCompose`, `MessageRead`, `AppointmentCompose`, `AppointmentRead`
+      `ItemCompose`<!-- -->, `ItemRead`<!-- -->, `MessageCompose`<!-- -->, `MessageRead`<!-- -->,
+      `AppointmentCompose`<!-- -->, `AppointmentRead`
     name: item
     fullName: Outlook_1_5.Office.Mailbox.item
     langs:
@@ -637,15 +637,21 @@ items:
 
       Your add-in must have the ReadWriteMailbox permission to use the makeEwsRequestAsync method. For information about
       using the ReadWriteMailbox permission and the EWS operations that you can call with the makeEwsRequestAsync
-      method, see Specify permissions for mail add-in access to the user's mailbox.
+      method, see [ Specify permissions for mail add-in access to the user's
+      mailbox](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)<!-- -->.
 
 
       The XML result of the EWS call is provided as a string in the asyncResult.value property. If the result exceeds 1
       MB in size, an error message is returned instead.
 
 
-      Note: This method is not supported in the following scenarios. - In Outlook for iOS or Outlook for Android - When
-      the add-in is loaded in a Gmail mailbox
+      Note: This method is not supported in the following scenarios:
+
+
+      - In Outlook for iOS or Outlook for Android.
+
+
+      - When the add-in is loaded in a Gmail mailbox.
 
 
       Note: The server administrator must set OAuthAuthentication to true on the Client Access Server EWS directory to
@@ -659,7 +665,7 @@ items:
       15.0.4535.1004, you should set the encoding value to ISO-8859-1.
 
 
-      `&lt;?xml version="1.0" encoding="iso-8859-1"?&gt;`
+      `<?xml version="1.0" encoding="iso-8859-1"?>`
 
 
       You do not need to set the encoding value when your mail app is running in Outlook on the web. You can determine
@@ -670,11 +676,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteMailbox</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
       and read</td></tr></table>
     name: 'makeEwsRequestAsync(data, callback, userContext)'
     fullName: Outlook_1_5.Office.Mailbox.makeEwsRequestAsync
@@ -682,7 +688,7 @@ items:
       - typeScript
     type: method
     syntax:
-      content: 'makeEwsRequestAsync(data: any, callback: (result: AsyncResult) => void, userContext?: any): void;'
+      content: 'makeEwsRequestAsync(data: any, callback: (result: AsyncResult<string>) => void, userContext?: any): void;'
       return:
         type:
           - void
@@ -695,13 +701,62 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult.
+            of type Office.AsyncResult. The `value` property of the result is the XML of the EWS request provided as a
+            string. If the result exceeds 1 MB in size, an error message is returned instead.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<string>) => void'
         - id: userContext
           description: Optional. Any state data that is passed to the asynchronous method.
           type:
             - any
+  - uid: Outlook_1_5.Office.Mailbox.removeHandlerAsync
+    summary: |-
+      Removes an event handler for a supported event.
+
+      Currently, the only supported event type is `Office.EventType.ItemChanged`<!-- -->.
+
+      \[ [API set: Mailbox 1.5](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
+    remarks: >-
+      <table><tr><td>[ Minimum permission
+      level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
+
+
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
+    name: 'removeHandlerAsync(eventType, handler, options, callback)'
+    fullName: Outlook_1_5.Office.Mailbox.removeHandlerAsync
+    langs:
+      - typeScript
+    type: method
+    syntax:
+      content: >-
+        removeHandlerAsync(eventType: Office.EventType, handler: (type: EventType) => void, options?:
+        Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
+      return:
+        type:
+          - void
+        description: ''
+      parameters:
+        - id: eventType
+          description: The event that should revoke the handler.
+          type:
+            - Office.EventType
+        - id: handler
+          description: >-
+            The function to handle the event. The function must accept a single parameter, which is an object literal.
+            The type property on the parameter will match the eventType parameter passed to addHandlerAsync.
+          type:
+            - '(type: EventType) => void'
+        - id: options
+          description: 'Optional. Provides an option for preserving context data of any type, unchanged, for use in a callback.'
+          type:
+            - office.Office.AsyncContextOptions
+        - id: callback
+          description: >-
+            Optional. When the method completes, the function passed in the callback parameter is called with a single
+            parameter of type Office.AsyncResult.
+          type:
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_5.Office.Mailbox.restUrl
     summary: >-
       Gets the URL of the REST endpoint for this email account.
@@ -716,15 +771,15 @@ items:
 
       \[ [API set: Mailbox 1.5](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
 
 
-      The restUrl value can be used to make [REST API](https://docs.microsoft.com/outlook/rest/) calls to the user's
+      The restUrl value can be used to make [ REST API](https://docs.microsoft.com/outlook/rest/) calls to the user's
       mailbox.
     name: restUrl
     fullName: Outlook_1_5.Office.Mailbox.restUrl
@@ -739,7 +794,7 @@ items:
   - uid: Outlook_1_5.Office.Mailbox.userProfile
     summary: >-
       Information about the user associated with the mailbox. This includes their account type, display name, email
-      adddress, and time zone.
+      address, and time zone.
 
 
       More information is under [Office.UserProfile](xref:Outlook_1_5.Office.UserProfile)

--- a/docs/docs-ref-autogen/outlook_1_5/office.mailboxenums.attachmenttype.yml
+++ b/docs/docs-ref-autogen/outlook_1_5/office.mailboxenums.attachmenttype.yml
@@ -6,7 +6,7 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td> [Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
+      <table><tr><td> [ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
       </td><td>Compose or read</td></tr></table>
     name: Office.MailboxEnums.AttachmentType
     fullName: Outlook_1_5.Office.MailboxEnums.AttachmentType

--- a/docs/docs-ref-autogen/outlook_1_5/office.mailboxenums.entitytype.yml
+++ b/docs/docs-ref-autogen/outlook_1_5/office.mailboxenums.entitytype.yml
@@ -6,7 +6,7 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td> [Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
+      <table><tr><td> [ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
       </td><td>Compose or read</td></tr></table>
     name: Office.MailboxEnums.EntityType
     fullName: Outlook_1_5.Office.MailboxEnums.EntityType

--- a/docs/docs-ref-autogen/outlook_1_5/office.mailboxenums.itemnotificationmessagetype.yml
+++ b/docs/docs-ref-autogen/outlook_1_5/office.mailboxenums.itemnotificationmessagetype.yml
@@ -6,7 +6,7 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td> [Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
+      <table><tr><td> [ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
       </td><td>Compose or read</td></tr></table>
     name: Office.MailboxEnums.ItemNotificationMessageType
     fullName: Outlook_1_5.Office.MailboxEnums.ItemNotificationMessageType

--- a/docs/docs-ref-autogen/outlook_1_5/office.mailboxenums.itemtype.yml
+++ b/docs/docs-ref-autogen/outlook_1_5/office.mailboxenums.itemtype.yml
@@ -6,7 +6,7 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td> [Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
+      <table><tr><td> [ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
       </td><td>Compose or read</td></tr></table>
     name: Office.MailboxEnums.ItemType
     fullName: Outlook_1_5.Office.MailboxEnums.ItemType

--- a/docs/docs-ref-autogen/outlook_1_5/office.mailboxenums.owaview.yml
+++ b/docs/docs-ref-autogen/outlook_1_5/office.mailboxenums.owaview.yml
@@ -1,0 +1,42 @@
+### YamlMime:UniversalReference
+items:
+  - uid: Outlook_1_5.Office.MailboxEnums.OWAView
+    summary: Represents the current view of Outlook Web App.
+    name: Office.MailboxEnums.OWAView
+    fullName: Outlook_1_5.Office.MailboxEnums.OWAView
+    langs:
+      - typeScript
+    type: enum
+    package: Outlook_1_5
+    children:
+      - Outlook_1_5.Office.MailboxEnums.OWAView.OneColumn
+      - Outlook_1_5.Office.MailboxEnums.OWAView.ThreeColumns
+      - Outlook_1_5.Office.MailboxEnums.OWAView.TwoColumns
+  - uid: Outlook_1_5.Office.MailboxEnums.OWAView.OneColumn
+    summary: >-
+      One column view. Displayed when the screen is narrow. Outlook Web App uses this single-column layout on the entire
+      screen of a smartphone.
+    name: OneColumn
+    fullName: Outlook_1_5.Office.MailboxEnums.OWAView.OneColumn
+    langs:
+      - typeScript
+    type: field
+    numericValue: '"OneColumn"'
+  - uid: Outlook_1_5.Office.MailboxEnums.OWAView.ThreeColumns
+    summary: >-
+      Three column view. Displayed when the screen is wide. For example, Outlook Web App uses this view in a full screen
+      window on a desktop computer.
+    name: ThreeColumns
+    fullName: Outlook_1_5.Office.MailboxEnums.OWAView.ThreeColumns
+    langs:
+      - typeScript
+    type: field
+    numericValue: '"ThreeColumns"'
+  - uid: Outlook_1_5.Office.MailboxEnums.OWAView.TwoColumns
+    summary: Two column view. Displayed when the screen is wider. Outlook Web App uses this view on most tablets.
+    name: TwoColumns
+    fullName: Outlook_1_5.Office.MailboxEnums.OWAView.TwoColumns
+    langs:
+      - typeScript
+    type: field
+    numericValue: '"TwoColumns"'

--- a/docs/docs-ref-autogen/outlook_1_5/office.mailboxenums.recipienttype.yml
+++ b/docs/docs-ref-autogen/outlook_1_5/office.mailboxenums.recipienttype.yml
@@ -6,7 +6,7 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td> [Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
+      <table><tr><td> [ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
       </td><td>Compose or read</td></tr></table>
     name: Office.MailboxEnums.RecipientType
     fullName: Outlook_1_5.Office.MailboxEnums.RecipientType

--- a/docs/docs-ref-autogen/outlook_1_5/office.mailboxenums.responsetype.yml
+++ b/docs/docs-ref-autogen/outlook_1_5/office.mailboxenums.responsetype.yml
@@ -6,7 +6,7 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td> [Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
+      <table><tr><td> [ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
       </td><td>Compose or read</td></tr></table>
     name: Office.MailboxEnums.ResponseType
     fullName: Outlook_1_5.Office.MailboxEnums.ResponseType

--- a/docs/docs-ref-autogen/outlook_1_5/office.mailboxenums.restversion.yml
+++ b/docs/docs-ref-autogen/outlook_1_5/office.mailboxenums.restversion.yml
@@ -6,7 +6,7 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td> [Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
+      <table><tr><td> [ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
       </td><td>Compose or read</td></tr></table>
     name: Office.MailboxEnums.RestVersion
     fullName: Outlook_1_5.Office.MailboxEnums.RestVersion

--- a/docs/docs-ref-autogen/outlook_1_5/office.meetingsuggestion.yml
+++ b/docs/docs-ref-autogen/outlook_1_5/office.meetingsuggestion.yml
@@ -15,11 +15,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: Office.MeetingSuggestion
     fullName: Outlook_1_5.Office.MeetingSuggestion

--- a/docs/docs-ref-autogen/outlook_1_5/office.message.yml
+++ b/docs/docs-ref-autogen/outlook_1_5/office.message.yml
@@ -6,7 +6,7 @@ items:
 
 
       Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat
-      this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
+      this as a mode of `Office.context.mailbox.item`<!-- -->. Refer to the Object Model pages for more information.
     name: Office.Message
     fullName: Outlook_1_5.Office.Message
     langs:
@@ -33,12 +33,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: conversationId
     fullName: Outlook_1_5.Office.Message.conversationId
     langs:

--- a/docs/docs-ref-autogen/outlook_1_5/office.messagecompose.yml
+++ b/docs/docs-ref-autogen/outlook_1_5/office.messagecompose.yml
@@ -2,11 +2,11 @@
 items:
   - uid: Outlook_1_5.Office.MessageCompose
     summary: >-
-      The message compose mode of [Office.context.mailbox.item](xref:Outlook_1_5.Office.Item)<!-- -->.
+      The message compose mode of [ Office.context.mailbox.item](xref:Outlook_1_5.Office.Item)<!-- -->.
 
 
       Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat
-      this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
+      this as a mode of `Office.context.mailbox.item`<!-- -->. Refer to the Object Model pages for more information.
     name: Office.MessageCompose
     fullName: Outlook_1_5.Office.MessageCompose
     langs:
@@ -49,11 +49,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr>
 
 
@@ -72,7 +72,8 @@ items:
       `addFileAttachmentAsync(uri: string, attachmentName: string, options: AsyncContextOptions): void;`
 
 
-      `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+      `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void):
+      void;`
     name: 'addFileAttachmentAsync(uri, attachmentName, options, callback)'
     fullName: Outlook_1_5.Office.MessageCompose.addFileAttachmentAsync
     langs:
@@ -81,7 +82,7 @@ items:
     syntax:
       content: >-
         addFileAttachmentAsync(uri: string, attachmentName: string, options?: AsyncContextOptions, callback?: (result:
-        AsyncResult) => void): void;
+        AsyncResult<string>) => void): void;
       return:
         type:
           - void
@@ -109,11 +110,11 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type asyncResult. On success, the attachment identifier will be provided in the asyncResult.value
+            of type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value
             property. If uploading the attachment fails, the asyncResult object will contain an Error object that
             provides a description of the error.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<string>) => void'
   - uid: Outlook_1_5.Office.MessageCompose.addItemAttachmentAsync
     summary: >-
       Adds an Exchange item, such as a message, as an attachment to the message or appointment.
@@ -129,17 +130,17 @@ items:
       session.
 
 
-      If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items
+      If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items
       other than the item that you are editing; however, this is not supported and is not recommended.
 
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr>
 
 
@@ -147,7 +148,7 @@ items:
       attachments.</td></tr></table>
 
 
-      In addition to the main signature, this method also has these signatures:
+      In addition to this signature, this method also has the following signatures:
 
 
       `addItemAttachmentAsync(itemId: any, attachmentName: string): void;`
@@ -156,7 +157,8 @@ items:
       `addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;`
 
 
-      `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+      `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void):
+      void;`
     name: 'addItemAttachmentAsync(itemId, attachmentName, options, callback)'
     fullName: Outlook_1_5.Office.MessageCompose.addItemAttachmentAsync
     langs:
@@ -165,7 +167,7 @@ items:
     syntax:
       content: >-
         addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?:
-        (result: AsyncResult) => void): void;
+        (result: AsyncResult<string>) => void): void;
       return:
         type:
           - void
@@ -194,7 +196,7 @@ items:
             property. If adding the attachment fails, the asyncResult object will contain an Error object that provides
             a description of the error.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<string>) => void'
   - uid: Outlook_1_5.Office.MessageCompose.bcc
     summary: >-
       Gets an object that provides methods to get or update the recipients on the Bcc (blind carbon copy) line of a
@@ -203,11 +205,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: bcc
     fullName: Outlook_1_5.Office.MessageCompose.bcc
@@ -225,11 +227,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: body
     fullName: Outlook_1_5.Office.MessageCompose.body
@@ -253,11 +255,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: cc
     fullName: Outlook_1_5.Office.MessageCompose.cc
@@ -287,11 +289,11 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: close()
     fullName: Outlook_1_5.Office.MessageCompose.close
@@ -320,11 +322,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: conversationId
     fullName: Outlook_1_5.Office.MessageCompose.conversationId
@@ -342,11 +344,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: dateTimeCreated
     fullName: Outlook_1_5.Office.MessageCompose.dateTimeCreated
@@ -364,11 +366,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
 
 
@@ -398,11 +400,11 @@ items:
 
       \[ [API set: Mailbox 1.2](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: 'getSelectedDataAsync(coerciontype, callback)'
     fullName: Outlook_1_5.Office.MessageCompose.getSelectedDataAsync
@@ -410,7 +412,7 @@ items:
       - typeScript
     type: method
     syntax:
-      content: 'getSelectedDataAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult) => void): void;'
+      content: 'getSelectedDataAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult<any>) => void): void;'
       return:
         type:
           - void
@@ -423,9 +425,9 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult.
+            of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<any>) => void'
   - uid: Outlook_1_5.Office.MessageCompose.itemType
     summary: >-
       Gets the type of item that an instance represents.
@@ -437,11 +439,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: itemType
     fullName: Outlook_1_5.Office.MessageCompose.itemType
@@ -471,11 +473,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: 'loadCustomPropertiesAsync(callback, userContext)'
     fullName: Outlook_1_5.Office.MessageCompose.loadCustomPropertiesAsync
@@ -483,7 +485,9 @@ items:
       - typeScript
     type: method
     syntax:
-      content: 'loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;'
+      content: >-
+        loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any):
+        void;
       return:
         type:
           - void
@@ -492,9 +496,9 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult.
+            of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<Office.CustomProperties>) => void'
         - id: userContext
           description: >-
             Optional. Developers can provide any object they wish to access in the callback function. This object can be
@@ -507,11 +511,11 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: notificationMessages
     fullName: Outlook_1_5.Office.MessageCompose.notificationMessages
@@ -531,17 +535,17 @@ items:
       The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best
       practice, you should use the attachment identifier to remove an attachment only if the same mail app has added
       that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid
-      only within the same session. A session is over when the user closes the app, or if the user starts composing in
-      an inline form and subsequently pops out the inline form to continue in a separate window.
+      only within the same session. A session is over when the user closes the app, or if the user starts composing an
+      inline form then subsequently pops out the form to continue in a separate window.
 
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr>
 
 
@@ -557,7 +561,7 @@ items:
       `removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;`
 
 
-      `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;`
+      `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;`
     name: 'removeAttachmentAsync(attachmentIndex, options, callback)'
     fullName: Outlook_1_5.Office.MessageCompose.removeAttachmentAsync
     langs:
@@ -566,7 +570,7 @@ items:
     syntax:
       content: >-
         removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result:
-        AsyncResult) => void): void;
+        AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -585,10 +589,10 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain
-            an error code with the reason for the failure.
+            parameter of type Office.AsyncResult. If removing the attachment fails, the asyncResult.error property will
+            contain an error code with the reason for the failure.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_5.Office.MessageCompose.saveAsync
     summary: >-
       Asynchronously saves an item.
@@ -622,11 +626,11 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr>
 
 
@@ -642,14 +646,14 @@ items:
       `saveAsync(options: Office.AsyncContextOptions): void;`
 
 
-      `saveAsync(callback: (result: AsyncResult) => void): void;`
+      `saveAsync(callback: (result: AsyncResult<void>) => void): void;`
     name: 'saveAsync(options, callback)'
     fullName: Outlook_1_5.Office.MessageCompose.saveAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;'
+      content: 'saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;'
       return:
         type:
           - void
@@ -664,10 +668,9 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain
-            an error code with the reason for the failure.
+            parameter of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_5.Office.MessageCompose.setSelectedDataAsync
     summary: >-
       Asynchronously inserts data into the body or subject of a message.
@@ -680,11 +683,11 @@ items:
 
       \[ [API set: Mailbox 1.2](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr>
 
 
@@ -697,10 +700,10 @@ items:
       `setSelectedDataAsync(data: string): void;`
 
 
-      `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions &amp; CoercionTypeOptions): void;`
+      `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`
 
 
-      `setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;`
+      `setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;`
     name: 'setSelectedDataAsync(data, options, callback)'
     fullName: Outlook_1_5.Office.MessageCompose.setSelectedDataAsync
     langs:
@@ -709,7 +712,7 @@ items:
     syntax:
       content: >-
         setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?:
-        (result: AsyncResult) => void): void;
+        (result: AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -735,10 +738,9 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain
-            an error code with the reason for the failure.
+            parameter of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_5.Office.MessageCompose.subject
     summary: |-
       Gets or sets the description that appears in the subject field of an item.
@@ -749,11 +751,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: subject
     fullName: Outlook_1_5.Office.MessageCompose.subject
@@ -777,11 +779,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: to
     fullName: Outlook_1_5.Office.MessageCompose.to

--- a/docs/docs-ref-autogen/outlook_1_5/office.messageread.yml
+++ b/docs/docs-ref-autogen/outlook_1_5/office.messageread.yml
@@ -2,7 +2,7 @@
 items:
   - uid: Outlook_1_5.Office.MessageRead
     summary: >-
-      The message read mode of [Office.context.mailbox.item](xref:Outlook_1_5.Office.Item)<!-- -->.
+      The message read mode of [ Office.context.mailbox.item](xref:Outlook_1_5.Office.Item)<!-- -->.
 
 
       Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat
@@ -42,20 +42,20 @@ items:
       - Outlook_1_5.Office.MessageRead.to
   - uid: Outlook_1_5.Office.MessageRead.attachments
     summary: |-
-      Gets an array of attachments for the item.
+      Gets the item's attachments as an array.
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
 
 
       Note: Certain types of files are blocked by Outlook due to potential security issues and are therefore not
-      returned. For more information, see [Blocked attachments in
+      returned. For more information, see [ Blocked attachments in
       Outlook](https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519)<!--
       -->.
     name: attachments
@@ -74,11 +74,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: body
     fullName: Outlook_1_5.Office.MessageRead.body
@@ -102,11 +102,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: cc
     fullName: Outlook_1_5.Office.MessageRead.cc
@@ -134,11 +134,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: conversationId
     fullName: Outlook_1_5.Office.MessageRead.conversationId
@@ -156,11 +156,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: dateTimeCreated
     fullName: Outlook_1_5.Office.MessageRead.dateTimeCreated
@@ -178,11 +178,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
 
 
@@ -220,11 +220,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: displayReplyAllForm(formData)
     fullName: Outlook_1_5.Office.MessageRead.displayReplyAllForm
@@ -241,7 +241,7 @@ items:
         - id: formData
           description: >-
             A string that contains text and HTML and that represents the body of the reply form. The string is limited
-            to 32 KB OR An[Office.ReplyFormData](xref:Outlook_1_5.Office.ReplyFormData) object that contains body or
+            to 32 KB OR An [Office.ReplyFormData](xref:Outlook_1_5.Office.ReplyFormData) object that contains body or
             attachment data and a callback function
           type:
             - string | ReplyFormData
@@ -268,11 +268,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: displayReplyForm(formData)
     fullName: Outlook_1_5.Office.MessageRead.displayReplyForm
@@ -289,7 +289,7 @@ items:
         - id: formData
           description: >-
             A string that contains text and HTML and that represents the body of the reply form. The string is limited
-            to 32 KB. OR An[Office.ReplyFormData](xref:Outlook_1_5.Office.ReplyFormData) object that contains body or
+            to 32 KB. OR An [Office.ReplyFormData](xref:Outlook_1_5.Office.ReplyFormData) object that contains body or
             attachment data and a callback function.
           type:
             - string | ReplyFormData
@@ -310,11 +310,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: from
     fullName: Outlook_1_5.Office.MessageRead.from
@@ -328,17 +328,17 @@ items:
           - EmailAddressDetails
   - uid: Outlook_1_5.Office.MessageRead.getEntities
     summary: |-
-      Gets the entities found in the selected item.
+      Gets the entities found in the selected item's body.
 
       Note: This method is not supported in Outlook for iOS or Outlook for Android.
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: getEntities()
     fullName: Outlook_1_5.Office.MessageRead.getEntities
@@ -353,17 +353,17 @@ items:
         description: ''
   - uid: Outlook_1_5.Office.MessageRead.getEntitiesByType
     summary: |-
-      Gets an array of all the entities of the specified entity type found in the selected item.
+      Gets an array of all the entities of the specified entity type found in the selected item's body.
 
       Note: This method is not supported in Outlook for iOS or Outlook for Android.
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
 
 
@@ -391,7 +391,7 @@ items:
           - '(string | Contact | MeetingSuggestion | PhoneNumber | TaskSuggestion)[]'
         description: >-
           If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns
-          null. If no entities of the specified type are present on the item, the method returns an empty array.
+          null. If no entities of the specified type are present in the item's body, the method returns an empty array.
           Otherwise, the type of the objects in the returned array depends on the type of entity requested in the
           entityType parameter.
       parameters:
@@ -413,11 +413,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: getFilteredEntitiesByName(name)
     fullName: Outlook_1_5.Office.MessageRead.getFilteredEntitiesByName
@@ -462,11 +462,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: getRegExMatches()
     fullName: Outlook_1_5.Office.MessageRead.getRegExMatches
@@ -502,11 +502,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: getRegExMatchesByName(name)
     fullName: Outlook_1_5.Office.MessageRead.getRegExMatchesByName
@@ -530,11 +530,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: internetMessageId
     fullName: Outlook_1_5.Office.MessageRead.internetMessageId
@@ -557,11 +557,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
 
 
@@ -599,16 +599,17 @@ items:
       Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The
       itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making
       REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more
-      details, see Use the Outlook REST APIs from an Outlook add-in.
+      details, see [ Use the Outlook REST APIs from an Outlook
+      add-in](https://docs.microsoft.com/outlook/add-ins/use-rest-api#get-the-item-id)<!-- -->.
 
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: itemId
     fullName: Outlook_1_5.Office.MessageRead.itemId
@@ -631,11 +632,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: itemType
     fullName: Outlook_1_5.Office.MessageRead.itemType
@@ -665,11 +666,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: 'loadCustomPropertiesAsync(callback, userContext)'
     fullName: Outlook_1_5.Office.MessageRead.loadCustomPropertiesAsync
@@ -677,7 +678,9 @@ items:
       - typeScript
     type: method
     syntax:
-      content: 'loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;'
+      content: >-
+        loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any):
+        void;
       return:
         type:
           - void
@@ -686,9 +689,9 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult.
+            of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<Office.CustomProperties>) => void'
         - id: userContext
           description: >-
             Optional. Developers can provide any object they wish to access in the callback function. This object can be
@@ -706,11 +709,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: normalizedSubject
     fullName: Outlook_1_5.Office.MessageRead.normalizedSubject
@@ -728,12 +731,12 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: notificationMessages
     fullName: Outlook_1_5.Office.MessageRead.notificationMessages
     langs:
@@ -758,11 +761,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: sender
     fullName: Outlook_1_5.Office.MessageRead.sender
@@ -788,11 +791,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: subject
     fullName: Outlook_1_5.Office.MessageRead.subject
@@ -816,11 +819,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: to
     fullName: Outlook_1_5.Office.MessageRead.to

--- a/docs/docs-ref-autogen/outlook_1_5/office.notificationmessagedetails.yml
+++ b/docs/docs-ref-autogen/outlook_1_5/office.notificationmessagedetails.yml
@@ -6,12 +6,12 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.NotificationMessageDetails
     fullName: Outlook_1_5.Office.NotificationMessageDetails
     langs:

--- a/docs/docs-ref-autogen/outlook_1_5/office.notificationmessages.yml
+++ b/docs/docs-ref-autogen/outlook_1_5/office.notificationmessages.yml
@@ -6,12 +6,12 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.NotificationMessages
     fullName: Outlook_1_5.Office.NotificationMessages
     langs:
@@ -31,12 +31,12 @@ items:
       There are a maximum of 5 notifications per message. Setting more will return a
       NumberOfNotificationMessagesExceeded error.
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
 
 
       In addition to this signature, the method also has the following signatures:
@@ -48,7 +48,8 @@ items:
       `addAsync(key: string, JSONmessage: NotificationMessageDetails, options: Office.AsyncContextOptions): void;`
 
 
-      `addAsync(key: string, JSONmessage: NotificationMessageDetails, callback: (result: AsyncResult) => void): void;`
+      `addAsync(key: string, JSONmessage: NotificationMessageDetails, callback: (result: AsyncResult<void>) => void):
+      void;`
     name: 'addAsync(key, JSONmessage, options, callback)'
     fullName: Outlook_1_5.Office.NotificationMessages.addAsync
     langs:
@@ -57,7 +58,7 @@ items:
     syntax:
       content: >-
         addAsync(key: string, JSONmessage: NotificationMessageDetails, options?: Office.AsyncContextOptions, callback?:
-        (result: AsyncResult) => void): void;
+        (result: AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -84,34 +85,39 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. \[Api set: Mailbox 1.3\]
+            parameter of type Office.AsyncResult.
+
+
+            \[Api set: Mailbox 1.3\]
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_5.Office.NotificationMessages.getAllAsync
     summary: |-
       Returns all keys and messages for an item.
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
 
 
-      In addition to the main signature, this method also has this signature:
+      In addition to this signature, this method also has the following signature:
 
 
-      `getAllAsync(callback: (result: AsyncResult) => void): void;`
+      `getAllAsync(callback: (result: AsyncResult<Office.NotificationMessageDetails[]>) => void): void;`
     name: 'getAllAsync(options, callback)'
     fullName: Outlook_1_5.Office.NotificationMessages.getAllAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'getAllAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;'
+      content: >-
+        getAllAsync(options?: Office.AsyncContextOptions, callback?: (result:
+        AsyncResult<Office.NotificationMessageDetails[]>) => void): void;
       return:
         type:
           - void
@@ -126,24 +132,25 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult.
+            parameter of type Office.AsyncResult. The `value` property of the result is an array of
+            NotificationMessageDetails objects.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<Office.NotificationMessageDetails[]>) => void'
   - uid: Outlook_1_5.Office.NotificationMessages.removeAsync
     summary: |-
       Removes a notification message for an item.
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
 
 
-      In addition to the main signature, this method also has these signatures:
+      In addition to this signature, this method also has the following signatures:
 
 
       `removeAsync(key: string): void;`
@@ -152,14 +159,16 @@ items:
       `removeAsync(key: string, options: Office.AsyncContextOptions): void;`
 
 
-      `removeAsync(key: string, callback: (result: AsyncResult) => void): void;`
+      `removeAsync(key: string, callback: (result: AsyncResult<void>) => void): void;`
     name: 'removeAsync(key, options, callback)'
     fullName: Outlook_1_5.Office.NotificationMessages.removeAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'removeAsync(key: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;'
+      content: >-
+        removeAsync(key: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void):
+        void;
       return:
         type:
           - void
@@ -178,9 +187,9 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult.
+            parameter of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_5.Office.NotificationMessages.replaceAsync
     summary: |-
       Replaces a notification message that has a given key with another message.
@@ -189,15 +198,15 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
 
 
-      In addition to the main signature, this method also has these signatures:
+      In addition to this signature, this method also has the following signatures:
 
 
       `replaceAsync(key: string, JSONmessage: NotificationMessageDetails): void;`
@@ -206,8 +215,8 @@ items:
       `replaceAsync(key: string, JSONmessage: NotificationMessageDetails, options: Office.AsyncContextOptions): void;`
 
 
-      `replaceAsync(key: string, JSONmessage: NotificationMessageDetails, callback: (result: AsyncResult) => void):
-      void;`
+      `replaceAsync(key: string, JSONmessage: NotificationMessageDetails, callback: (result: AsyncResult<void>) =>
+      void): void;`
     name: 'replaceAsync(key, JSONmessage, options, callback)'
     fullName: Outlook_1_5.Office.NotificationMessages.replaceAsync
     langs:
@@ -216,7 +225,7 @@ items:
     syntax:
       content: >-
         replaceAsync(key: string, JSONmessage: NotificationMessageDetails, options?: Office.AsyncContextOptions,
-        callback?: (result: AsyncResult) => void): void;
+        callback?: (result: AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -241,6 +250,6 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult.
+            parameter of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'

--- a/docs/docs-ref-autogen/outlook_1_5/office.phonenumber.yml
+++ b/docs/docs-ref-autogen/outlook_1_5/office.phonenumber.yml
@@ -12,11 +12,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: Office.PhoneNumber
     fullName: Outlook_1_5.Office.PhoneNumber

--- a/docs/docs-ref-autogen/outlook_1_5/office.recipients.yml
+++ b/docs/docs-ref-autogen/outlook_1_5/office.recipients.yml
@@ -3,11 +3,11 @@ items:
   - uid: Outlook_1_5.Office.Recipients
     summary: '\[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]'
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
     name: Office.Recipients
     fullName: Outlook_1_5.Office.Recipients
@@ -33,11 +33,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -45,7 +45,7 @@ items:
       entries.</td></tr></table>
 
 
-      In addition to the main signature, this method also has these signatures:
+      In addition to this signature, this method also has the following signatures:
 
 
       `addAsync(recipients: (string | EmailUser | EmailAddressDetails)[]): void;`
@@ -54,8 +54,8 @@ items:
       `addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options: Office.AsyncContextOptions): void;`
 
 
-      `addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult) => void):
-      void;`
+      `addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult<void>) =>
+      void): void;`
     name: 'addAsync(recipients, options, callback)'
     fullName: Outlook_1_5.Office.Recipients.addAsync
     langs:
@@ -64,7 +64,7 @@ items:
     syntax:
       content: >-
         addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options?: Office.AsyncContextOptions,
-        callback?: (result: AsyncResult) => void): void;
+        callback?: (result: AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -83,40 +83,42 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. If adding the recipients fails, the asyncResult.error property will contain
-            an error code.
+            parameter of type Office.AsyncResult. If adding the recipients fails, the asyncResult.error property will
+            contain an error code.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_5.Office.Recipients.getAsync
     summary: >-
       Gets a recipient list for an appointment or message.
 
 
-      When the call completes, the asyncResult.value property will contain an array
-      of[Office.EmailAddressDetails](xref:Outlook_1_5.Office.EmailAddressDetails) objects.
+      When the call completes, the asyncResult.value property will contain an array of
+      [Office.EmailAddressDetails](xref:Outlook_1_5.Office.EmailAddressDetails) objects.
 
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
 
 
-      In addition to the main signature, this method also has this signature:
+      In addition to this signature, this method also has the following signature:
 
 
-      `getAsync(callback: (result: AsyncResult) => void): void;`
+      `getAsync(callback: (result: AsyncResult<Office.EmailAddressDetails[]>) => void): void;`
     name: 'getAsync(options, callback)'
     fullName: Outlook_1_5.Office.Recipients.getAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;'
+      content: >-
+        getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult<Office.EmailAddressDetails[]>) =>
+        void): void;
       return:
         type:
           - void
@@ -131,9 +133,9 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult.
+            of type Office.AsyncResult. The `value` property of the result is an array of EmailAddressDetails objects.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<Office.EmailAddressDetails[]>) => void'
   - uid: Outlook_1_5.Office.Recipients.setAsync
     summary: |-
       Sets a recipient list for an appointment or message.
@@ -150,11 +152,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -162,7 +164,7 @@ items:
       entries.</td></tr></table>
 
 
-      In addition to the main signature, this method also has these signatures:
+      In addition to this signature, this method also has the following signatures:
 
 
       `setAsync(recipients: (string | EmailUser | EmailAddressDetails)[]): void;`
@@ -171,8 +173,8 @@ items:
       `setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options: Office.AsyncContextOptions): void;`
 
 
-      `setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult) => void):
-      void;`
+      `setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult<void>) =>
+      void): void;`
     name: 'setAsync(recipients, options, callback)'
     fullName: Outlook_1_5.Office.Recipients.setAsync
     langs:
@@ -181,7 +183,7 @@ items:
     syntax:
       content: >-
         setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options?: Office.AsyncContextOptions,
-        callback?: (result: AsyncResult) => void): void;
+        callback?: (result: AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -200,7 +202,7 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. If setting the recipients fails the asyncResult.error property will contain a
-            code that indicates any error that occurred while adding the data.
+            parameter of type Office.AsyncResult. If setting the recipients fails the asyncResult.error property will
+            contain a code that indicates any error that occurred while adding the data.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'

--- a/docs/docs-ref-autogen/outlook_1_5/office.replyformdata.yml
+++ b/docs/docs-ref-autogen/outlook_1_5/office.replyformdata.yml
@@ -31,17 +31,17 @@ items:
   - uid: Outlook_1_5.Office.ReplyFormData.callback
     summary: >-
       When the reply display call completes, the function passed in the callback parameter is called with a single
-      parameter, asyncResult, which is an AsyncResult object.
+      parameter, asyncResult, which is an Office.AsyncResult object.
     name: callback
     fullName: Outlook_1_5.Office.ReplyFormData.callback
     langs:
       - typeScript
     type: property
     syntax:
-      content: 'callback?: (result: AsyncResult) => void;'
+      content: 'callback?: (result: AsyncResult<any>) => void;'
       return:
         type:
-          - '(result: AsyncResult) => void'
+          - '(result: AsyncResult<any>) => void'
   - uid: Outlook_1_5.Office.ReplyFormData.htmlBody
     summary: >-
       A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32

--- a/docs/docs-ref-autogen/outlook_1_5/office.roamingsettings.yml
+++ b/docs/docs-ref-autogen/outlook_1_5/office.roamingsettings.yml
@@ -7,7 +7,7 @@ items:
       saved.
 
 
-      While the Outlook add-in API limits access to these settings to only the add-in that created them, these settings
+      While the Outlook Add-in API limits access to these settings to only the add-in that created them, these settings
       should not be considered secure storage. They can be accessed by Exchange Web Services or Extended MAPI. They
       should not be used to store sensitive information such as user credentials or security tokens.
 
@@ -27,12 +27,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.RoamingSettings
     fullName: Outlook_1_5.Office.RoamingSettings
     langs:
@@ -50,12 +50,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: get(name)
     fullName: Outlook_1_5.Office.RoamingSettings.get
     langs:
@@ -78,12 +78,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: remove(name)
     fullName: Outlook_1_5.Office.RoamingSettings.remove
     langs:
@@ -113,19 +113,19 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: saveAsync(callback)
     fullName: Outlook_1_5.Office.RoamingSettings.saveAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'saveAsync(callback?: (result: AsyncResult) => void): void;'
+      content: 'saveAsync(callback?: (result: AsyncResult<void>) => void): void;'
       return:
         type:
           - void
@@ -133,10 +133,10 @@ items:
       parameters:
         - id: callback
           description: >-
-            Optional? When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult.
+            Optional. When the method completes, the function passed in the callback parameter is called with a single
+            parameter of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_5.Office.RoamingSettings.set
     summary: >-
       Sets or creates the specified setting.
@@ -156,12 +156,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: 'set(name, value)'
     fullName: Outlook_1_5.Office.RoamingSettings.set
     langs:

--- a/docs/docs-ref-autogen/outlook_1_5/office.subject.yml
+++ b/docs/docs-ref-autogen/outlook_1_5/office.subject.yml
@@ -6,11 +6,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
     name: Office.Subject
     fullName: Outlook_1_5.Office.Subject
@@ -32,25 +32,25 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
 
 
-      In addition to the main signature, this method also has this signature:
+      In addition to this signature, this method also has the following signature:
 
 
-      `getAsync(callback: (result: AsyncResult) => void): void;`
+      `getAsync(callback: (result: AsyncResult<string>) => void): void;`
     name: 'getAsync(options, callback)'
     fullName: Outlook_1_5.Office.Subject.getAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;'
+      content: 'getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult<string>) => void): void;'
       return:
         type:
           - void
@@ -65,9 +65,9 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult.
+            of type Office.AsyncResult. The `value` property of the result is the subject of the item.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<string>) => void'
   - uid: Outlook_1_5.Office.Subject.setAsync
     summary: >-
       Sets the subject of an appointment or message.
@@ -80,11 +80,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -92,7 +92,7 @@ items:
       characters.</td></tr></table>
 
 
-      In addition to the main signature, this method also has these signatures:
+      In addition to this signature, this method also has the following signatures:
 
 
       `setAsync(subject: string): void;`
@@ -101,14 +101,16 @@ items:
       `setAsync(subject: string, options: Office.AsyncContextOptions): void;`
 
 
-      `setAsync(subject: string, callback: (result: AsyncResult) => void): void;`
+      `setAsync(subject: string, callback: (result: AsyncResult<void>) => void): void;`
     name: 'setAsync(subject, options, callback)'
     fullName: Outlook_1_5.Office.Subject.setAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'setAsync(subject: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;'
+      content: >-
+        setAsync(subject: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void):
+        void;
       return:
         type:
           - void
@@ -127,7 +129,7 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult. If setting the subject fails, the asyncResult.error property will contain an error
-            code.
+            of type Office.AsyncResult. If setting the subject fails, the asyncResult.error property will contain an
+            error code.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'

--- a/docs/docs-ref-autogen/outlook_1_5/office.tasksuggestion.yml
+++ b/docs/docs-ref-autogen/outlook_1_5/office.tasksuggestion.yml
@@ -5,18 +5,18 @@ items:
       Represents a suggested task identified in an item. Read mode only.
 
 
-      The list of tasks suggested in an email message is returned in the taskSuggestions property of the
-      \[Entities\]Entities object that is returned when the getEntities or getEntitiesByType method is called on the
-      active item.
+      The list of tasks suggested in an email message is returned in the taskSuggestions property of the [
+      Entities](xref:Outlook_1_5.Office.Entities) object that is returned when the getEntities or getEntitiesByType
+      method is called on the active item.
 
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: Office.TaskSuggestion
     fullName: Outlook_1_5.Office.TaskSuggestion

--- a/docs/docs-ref-autogen/outlook_1_5/office.time.yml
+++ b/docs/docs-ref-autogen/outlook_1_5/office.time.yml
@@ -6,11 +6,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
     name: Office.Time
     fullName: Outlook_1_5.Office.Time
@@ -33,25 +33,25 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
 
 
-      In addition to the main signature, this method also has this signature:
+      In addition to this signature, this method also has the following signature:
 
 
-      `getAsync(callback: (result: AsyncResult) => void): void;`
+      `getAsync(callback: (result: AsyncResult<Date>) => void): void;`
     name: 'getAsync(options, callback)'
     fullName: Outlook_1_5.Office.Time.getAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;'
+      content: 'getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult<Date>) => void): void;'
       return:
         type:
           - void
@@ -66,9 +66,9 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult.
+            of type AsyncResult. The `value` property of the result is a Date object.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<Date>) => void'
   - uid: Outlook_1_5.Office.Time.setAsync
     summary: >-
       Sets the start or end time of an appointment.
@@ -84,11 +84,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -96,7 +96,7 @@ items:
       time.</td></tr></table>
 
 
-      In addition to the main signature, this method also has these signatures:
+      In addition to this signature, this method also has the following signatures:
 
 
       `setAsync(dateTime: Date): void;`
@@ -105,14 +105,16 @@ items:
       `setAsync(dateTime: Date, options: Office.AsyncContextOptions): void;`
 
 
-      `setAsync(dateTime: Date, callback: (result: AsyncResult) => void): void;`
+      `setAsync(dateTime: Date, callback: (result: AsyncResult<void>) => void): void;`
     name: 'setAsync(dateTime, options, callback)'
     fullName: Outlook_1_5.Office.Time.setAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'setAsync(dateTime: Date, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;'
+      content: >-
+        setAsync(dateTime: Date, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void):
+        void;
       return:
         type:
           - void
@@ -131,7 +133,7 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult. If setting the date and time fails, the asyncResult.error property will contain an
-            error code.
+            of type Office.AsyncResult. If setting the date and time fails, the asyncResult.error property will contain
+            an error code.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'

--- a/docs/docs-ref-autogen/outlook_1_5/office.userprofile.yml
+++ b/docs/docs-ref-autogen/outlook_1_5/office.userprofile.yml
@@ -8,12 +8,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.UserProfile
     fullName: Outlook_1_5.Office.UserProfile
     langs:
@@ -30,12 +30,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: displayName
     fullName: Outlook_1_5.Office.UserProfile.displayName
     langs:
@@ -52,12 +52,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: emailAddress
     fullName: Outlook_1_5.Office.UserProfile.emailAddress
     langs:
@@ -74,12 +74,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: timeZone
     fullName: Outlook_1_5.Office.UserProfile.timeZone
     langs:

--- a/docs/docs-ref-autogen/outlook_1_6.yml
+++ b/docs/docs-ref-autogen/outlook_1_6.yml
@@ -30,6 +30,7 @@ items:
       - Outlook_1_6.Office.MailboxEnums.EntityType
       - Outlook_1_6.Office.MailboxEnums.ItemNotificationMessageType
       - Outlook_1_6.Office.MailboxEnums.ItemType
+      - Outlook_1_6.Office.MailboxEnums.OWAView
       - Outlook_1_6.Office.MailboxEnums.RecipientType
       - Outlook_1_6.Office.MailboxEnums.ResponseType
       - Outlook_1_6.Office.MailboxEnums.RestVersion
@@ -96,6 +97,8 @@ references:
     name: Office.MailboxEnums.ItemNotificationMessageType
   - uid: Outlook_1_6.Office.MailboxEnums.ItemType
     name: Office.MailboxEnums.ItemType
+  - uid: Outlook_1_6.Office.MailboxEnums.OWAView
+    name: Office.MailboxEnums.OWAView
   - uid: Outlook_1_6.Office.MailboxEnums.RecipientType
     name: Office.MailboxEnums.RecipientType
   - uid: Outlook_1_6.Office.MailboxEnums.ResponseType

--- a/docs/docs-ref-autogen/outlook_1_6/office.appointmentcompose.yml
+++ b/docs/docs-ref-autogen/outlook_1_6/office.appointmentcompose.yml
@@ -2,11 +2,11 @@
 items:
   - uid: Outlook_1_6.Office.AppointmentCompose
     summary: >-
-      The appointment organizer mode of [Office.context.mailbox.item](xref:Outlook_1_6.Office.Item)<!-- -->.
+      The appointment organizer mode of [ Office.context.mailbox.item](xref:Outlook_1_6.Office.Item)<!-- -->.
 
 
       Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat
-      this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
+      this as a mode of `Office.context.mailbox.item`<!-- -->. Refer to the Object Model pages for more information.
     name: Office.AppointmentCompose
     fullName: Outlook_1_6.Office.AppointmentCompose
     langs:
@@ -50,11 +50,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Organizer</td></tr>
 
 
@@ -73,7 +73,8 @@ items:
       `addFileAttachmentAsync(uri: string, attachmentName: string, options: Office.AsyncContextOptions): void;`
 
 
-      `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+      `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void):
+      void;`
     name: 'addFileAttachmentAsync(uri, attachmentName, options, callback)'
     fullName: Outlook_1_6.Office.AppointmentCompose.addFileAttachmentAsync
     langs:
@@ -82,7 +83,7 @@ items:
     syntax:
       content: >-
         addFileAttachmentAsync(uri: string, attachmentName: string, options?: Office.AsyncContextOptions, callback?:
-        (result: AsyncResult) => void): void;
+        (result: AsyncResult<string>) => void): void;
       return:
         type:
           - void
@@ -114,7 +115,7 @@ items:
             property. If uploading the attachment fails, the asyncResult object will contain an Error object that
             provides a description of the error.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<string>) => void'
   - uid: Outlook_1_6.Office.AppointmentCompose.addItemAttachmentAsync
     summary: >-
       Adds an Exchange item, such as a message, as an attachment to the message or appointment.
@@ -130,17 +131,17 @@ items:
       session.
 
 
-      If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items
+      If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items
       other than the item that you are editing; however, this is not supported and is not recommended.
 
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Organizer</td></tr>
 
 
@@ -148,7 +149,7 @@ items:
       attachments.</td></tr></table>
 
 
-      In addition to the main signature, this method also has these signatures:
+      In addition to this signature, this method also has the following signatures:
 
 
       `addItemAttachmentAsync(itemId: any, attachmentName: string): void;`
@@ -157,7 +158,8 @@ items:
       `addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;`
 
 
-      `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+      `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void):
+      void;`
     name: 'addItemAttachmentAsync(itemId, attachmentName, options, callback)'
     fullName: Outlook_1_6.Office.AppointmentCompose.addItemAttachmentAsync
     langs:
@@ -166,7 +168,7 @@ items:
     syntax:
       content: >-
         addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?:
-        (result: AsyncResult) => void): void;
+        (result: AsyncResult<string>) => void): void;
       return:
         type:
           - void
@@ -191,22 +193,22 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value
+            of type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value
             property. If adding the attachment fails, the asyncResult object will contain an Error object that provides
             a description of the error.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<string>) => void'
   - uid: Outlook_1_6.Office.AppointmentCompose.body
     summary: |-
       Gets an object that provides methods for manipulating the body of an item.
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: body
@@ -237,11 +239,11 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: close()
@@ -261,11 +263,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: dateTimeCreated
@@ -284,11 +286,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
 
@@ -320,11 +322,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: end
@@ -352,11 +354,11 @@ items:
 
       \[ [API set: Mailbox 1.2](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: 'getSelectedDataAsync(coerciontype, options, callback)'
@@ -367,7 +369,7 @@ items:
     syntax:
       content: >-
         getSelectedDataAsync(coerciontype: Office.CoercionType, options: Office.AsyncContextOptions, callback: (result:
-        AsyncResult) => void): void;
+        AsyncResult<any>) => void): void;
       return:
         type:
           - void
@@ -388,7 +390,7 @@ items:
             When the method completes, the function passed in the callback parameter is called with a single parameter
             of type AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<any>) => void'
   - uid: Outlook_1_6.Office.AppointmentCompose.itemType
     summary: >-
       Gets the type of item that an instance represents.
@@ -400,11 +402,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: itemType
@@ -435,11 +437,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: 'loadCustomPropertiesAsync(callback, userContext)'
@@ -448,7 +450,9 @@ items:
       - typeScript
     type: method
     syntax:
-      content: 'loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;'
+      content: >-
+        loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any):
+        void;
       return:
         type:
           - void
@@ -457,9 +461,9 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult.
+            of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<Office.CustomProperties>) => void'
         - id: userContext
           description: >-
             Optional. Developers can provide any object they wish to access in the callback function. This object can be
@@ -474,11 +478,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: location
@@ -497,11 +501,11 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: notificationMessages
@@ -524,11 +528,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: optionalAttendees
@@ -549,17 +553,17 @@ items:
       The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best
       practice, you should use the attachment identifier to remove an attachment only if the same mail app has added
       that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid
-      only within the same session. A session is over when the user closes the app, or if the user starts composing in
-      an inline form and subsequently pops out the inline form to continue in a separate window.
+      only within the same session. A session is over when the user closes the app, or if the user starts composing an
+      inline form then subsequently pops out the form to continue in a separate window.
 
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Organizer</td></tr>
 
 
@@ -575,7 +579,7 @@ items:
       `removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;`
 
 
-      `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;`
+      `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;`
     name: 'removeAttachmentAsync(attachmentIndex, options, callback)'
     fullName: Outlook_1_6.Office.AppointmentCompose.removeAttachmentAsync
     langs:
@@ -584,7 +588,7 @@ items:
     syntax:
       content: >-
         removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result:
-        AsyncResult) => void): void;
+        AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -603,10 +607,10 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain
-            an error code with the reason for the failure.
+            parameter of type Office.AsyncResult. If removing the attachment fails, the asyncResult.error property will
+            contain an error code with the reason for the failure.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_6.Office.AppointmentCompose.requiredAttendees
     summary: >-
       Provides access to the required attendees of an event. The type of object and level of access depends on the mode
@@ -617,11 +621,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: requiredAttendees
@@ -667,11 +671,11 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Organizer</td></tr>
 
 
@@ -687,14 +691,14 @@ items:
       `saveAsync(options: Office.AsyncContextOptions): void;`
 
 
-      `saveAsync(callback: (result: AsyncResult) => void): void;`
+      `saveAsync(callback: (result: AsyncResult<void>) => void): void;`
     name: 'saveAsync(options, callback)'
     fullName: Outlook_1_6.Office.AppointmentCompose.saveAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;'
+      content: 'saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;'
       return:
         type:
           - void
@@ -709,10 +713,9 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain
-            an error code with the reason for the failure.
+            parameter of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_6.Office.AppointmentCompose.setSelectedDataAsync
     summary: >-
       Asynchronously inserts data into the body or subject of a message.
@@ -725,11 +728,11 @@ items:
 
       \[ [API set: Mailbox 1.2](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Organizer</td></tr>
 
 
@@ -742,10 +745,10 @@ items:
       `setSelectedDataAsync(data: string): void;`
 
 
-      `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions &amp; CoercionTypeOptions): void;`
+      `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`
 
 
-      `setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;`
+      `setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;`
     name: 'setSelectedDataAsync(data, options, callback)'
     fullName: Outlook_1_6.Office.AppointmentCompose.setSelectedDataAsync
     langs:
@@ -754,7 +757,7 @@ items:
     syntax:
       content: >-
         setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?:
-        (result: AsyncResult) => void): void;
+        (result: AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -780,10 +783,9 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain
-            an error code with the reason for the failure.
+            parameter of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_6.Office.AppointmentCompose.start
     summary: >-
       Gets or sets the date and time that the appointment is to begin.
@@ -800,11 +802,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: start
@@ -827,11 +829,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: subject

--- a/docs/docs-ref-autogen/outlook_1_6/office.appointmentform.yml
+++ b/docs/docs-ref-autogen/outlook_1_6/office.appointmentform.yml
@@ -6,12 +6,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.AppointmentForm
     fullName: Outlook_1_6.Office.AppointmentForm
     langs:
@@ -33,12 +33,12 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: body
     fullName: Outlook_1_6.Office.AppointmentForm.body
     langs:
@@ -76,12 +76,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: end
     fullName: Outlook_1_6.Office.AppointmentForm.end
     langs:
@@ -112,10 +112,10 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: location
     fullName: Outlook_1_6.Office.AppointmentForm.location
     langs:
@@ -148,12 +148,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: optionalAttendees
     fullName: Outlook_1_6.Office.AppointmentForm.optionalAttendees
     langs:
@@ -186,12 +186,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: requiredAttendees
     fullName: Outlook_1_6.Office.AppointmentForm.requiredAttendees
     langs:
@@ -240,12 +240,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: start
     fullName: Outlook_1_6.Office.AppointmentForm.start
     langs:
@@ -279,12 +279,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: subject
     fullName: Outlook_1_6.Office.AppointmentForm.subject
     langs:

--- a/docs/docs-ref-autogen/outlook_1_6/office.appointmentread.yml
+++ b/docs/docs-ref-autogen/outlook_1_6/office.appointmentread.yml
@@ -2,7 +2,7 @@
 items:
   - uid: Outlook_1_6.Office.AppointmentRead
     summary: >-
-      The appointment attendee mode of [Office.context.mailbox.item](xref:Outlook_1_6.Office.Item)<!-- -->.
+      The appointment attendee mode of [ Office.context.mailbox.item](xref:Outlook_1_6.Office.Item)<!-- -->.
 
 
       Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat
@@ -44,20 +44,20 @@ items:
       - Outlook_1_6.Office.AppointmentRead.subject
   - uid: Outlook_1_6.Office.AppointmentRead.attachments
     summary: |-
-      Gets an array of attachments for the item.
+      Gets the item's attachments as an array.
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
 
 
       Note: Certain types of files are blocked by Outlook due to potential security issues and are therefore not
-      returned. For more information, see [Blocked attachments in
+      returned. For more information, see [ Blocked attachments in
       Outlook](https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519)<!--
       -->.
     name: attachments
@@ -76,11 +76,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: body
     fullName: Outlook_1_6.Office.AppointmentRead.body
@@ -98,11 +98,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: dateTimeCreated
     fullName: Outlook_1_6.Office.AppointmentRead.dateTimeCreated
@@ -120,11 +120,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
 
 
@@ -162,11 +162,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: displayReplyAllForm(formData)
     fullName: Outlook_1_6.Office.AppointmentRead.displayReplyAllForm
@@ -183,7 +183,7 @@ items:
         - id: formData
           description: >-
             A string that contains text and HTML and that represents the body of the reply form. The string is limited
-            to 32 KB OR An[Office.ReplyFormData](xref:Outlook_1_6.Office.ReplyFormData) object that contains body or
+            to 32 KB OR An [Office.ReplyFormData](xref:Outlook_1_6.Office.ReplyFormData) object that contains body or
             attachment data and a callback function
           type:
             - string | ReplyFormData
@@ -210,11 +210,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: displayReplyForm(formData)
     fullName: Outlook_1_6.Office.AppointmentRead.displayReplyForm
@@ -231,7 +231,7 @@ items:
         - id: formData
           description: >-
             A string that contains text and HTML and that represents the body of the reply form. The string is limited
-            to 32 KB. OR An[Office.ReplyFormData](xref:Outlook_1_6.Office.ReplyFormData) object that contains body or
+            to 32 KB. OR An [Office.ReplyFormData](xref:Outlook_1_6.Office.ReplyFormData) object that contains body or
             attachment data and a callback function.
           type:
             - string | ReplyFormData
@@ -250,11 +250,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: end
     fullName: Outlook_1_6.Office.AppointmentRead.end
@@ -268,17 +268,17 @@ items:
           - Date
   - uid: Outlook_1_6.Office.AppointmentRead.getEntities
     summary: |-
-      Gets the entities found in the selected item.
+      Gets the entities found in the selected item's body.
 
       Note: This method is not supported in Outlook for iOS or Outlook for Android.
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: getEntities()
     fullName: Outlook_1_6.Office.AppointmentRead.getEntities
@@ -293,17 +293,17 @@ items:
         description: ''
   - uid: Outlook_1_6.Office.AppointmentRead.getEntitiesByType
     summary: |-
-      Gets an array of all the entities of the specified entity type found in the selected item.
+      Gets an array of all the entities of the specified entity type found in the selected item's body.
 
       Note: This method is not supported in Outlook for iOS or Outlook for Android.
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
 
 
@@ -331,7 +331,7 @@ items:
           - '(string | Contact | MeetingSuggestion | PhoneNumber | TaskSuggestion)[]'
         description: >-
           If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns
-          null. If no entities of the specified type are present on the item, the method returns an empty array.
+          null. If no entities of the specified type are present in the item's body, the method returns an empty array.
           Otherwise, the type of the objects in the returned array depends on the type of entity requested in the
           entityType parameter.
       parameters:
@@ -353,11 +353,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: getFilteredEntitiesByName(name)
     fullName: Outlook_1_6.Office.AppointmentRead.getFilteredEntitiesByName
@@ -402,11 +402,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: getRegExMatches()
     fullName: Outlook_1_6.Office.AppointmentRead.getRegExMatches
@@ -442,11 +442,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: getRegExMatchesByName(name)
     fullName: Outlook_1_6.Office.AppointmentRead.getRegExMatchesByName
@@ -475,11 +475,11 @@ items:
 
       \[ [API set: Mailbox 1.6](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: getSelectedEntities()
     fullName: Outlook_1_6.Office.AppointmentRead.getSelectedEntities
@@ -515,11 +515,11 @@ items:
 
       \[ [API set: Mailbox 1.6](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: getSelectedRegExMatches()
     fullName: Outlook_1_6.Office.AppointmentRead.getSelectedRegExMatches
@@ -546,11 +546,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
 
 
@@ -588,16 +588,17 @@ items:
       Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The
       itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making
       REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more
-      details, see Use the Outlook REST APIs from an Outlook add-in.
+      details, see [ Use the Outlook REST APIs from an Outlook
+      add-in](https://docs.microsoft.com/outlook/add-ins/use-rest-api#get-the-item-id)<!-- -->.
 
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: itemId
     fullName: Outlook_1_6.Office.AppointmentRead.itemId
@@ -620,11 +621,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: itemType
     fullName: Outlook_1_6.Office.AppointmentRead.itemType
@@ -654,11 +655,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: 'loadCustomPropertiesAsync(callback, userContext)'
     fullName: Outlook_1_6.Office.AppointmentRead.loadCustomPropertiesAsync
@@ -666,7 +667,9 @@ items:
       - typeScript
     type: method
     syntax:
-      content: 'loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;'
+      content: >-
+        loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any):
+        void;
       return:
         type:
           - void
@@ -675,9 +678,9 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult.
+            of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<Office.CustomProperties>) => void'
         - id: userContext
           description: >-
             Optional. Developers can provide any object they wish to access in the callback function. This object can be
@@ -692,11 +695,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: location
     fullName: Outlook_1_6.Office.AppointmentRead.location
@@ -719,11 +722,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: normalizedSubject
     fullName: Outlook_1_6.Office.AppointmentRead.normalizedSubject
@@ -741,11 +744,11 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: notificationMessages
     fullName: Outlook_1_6.Office.AppointmentRead.notificationMessages
@@ -770,11 +773,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: optionalAttendees
     fullName: Outlook_1_6.Office.AppointmentRead.optionalAttendees
@@ -788,15 +791,15 @@ items:
           - 'EmailAddressDetails[]'
   - uid: Outlook_1_6.Office.AppointmentRead.organizer
     summary: |-
-      Gets the email address of the meeting organizer for a specified meeting. Read mode only.
+      Gets the email address of the meeting organizer for a specified meeting.
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: organizer
     fullName: Outlook_1_6.Office.AppointmentRead.organizer
@@ -821,11 +824,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: requiredAttendees
     fullName: Outlook_1_6.Office.AppointmentRead.requiredAttendees
@@ -848,11 +851,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: start
     fullName: Outlook_1_6.Office.AppointmentRead.start
@@ -878,11 +881,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: subject
     fullName: Outlook_1_6.Office.AppointmentRead.subject

--- a/docs/docs-ref-autogen/outlook_1_6/office.attachmentdetails.yml
+++ b/docs/docs-ref-autogen/outlook_1_6/office.attachmentdetails.yml
@@ -8,11 +8,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: Office.AttachmentDetails
     fullName: Outlook_1_6.Office.AttachmentDetails

--- a/docs/docs-ref-autogen/outlook_1_6/office.body.yml
+++ b/docs/docs-ref-autogen/outlook_1_6/office.body.yml
@@ -8,12 +8,12 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.Body
     fullName: Outlook_1_6.Office.Body
     langs:
@@ -42,18 +42,18 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
 
 
-      In addition to the main signature, this method also has this signature:
+      In addition to this signature, this method also has the following signature:
 
 
-      `getAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult) => void): void;`
+      `getAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult<Office.Body>) => void): void;`
     name: 'getAsync(coerciontype, options, callback)'
     fullName: Outlook_1_6.Office.Body.getAsync
     langs:
@@ -62,7 +62,7 @@ items:
     syntax:
       content: >-
         getAsync(coerciontype: Office.CoercionType, options?: Office.AsyncContextOptions, callback?: (result:
-        AsyncResult) => void): void;
+        AsyncResult<Office.Body>) => void): void;
       return:
         type:
           - void
@@ -84,18 +84,18 @@ items:
             parameter of type AsyncResult. The body is provided in the requested format in the asyncResult.value
             property.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<Office.Body>) => void'
   - uid: Outlook_1_6.Office.Body.getTypeAsync
     summary: |-
       Gets a value that indicates whether the content is in HTML or text format.
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
     name: 'getTypeAsync(options, callback)'
     fullName: Outlook_1_6.Office.Body.getTypeAsync
@@ -103,7 +103,9 @@ items:
       - typeScript
     type: method
     syntax:
-      content: 'getTypeAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;'
+      content: >-
+        getTypeAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<Office.CoercionType>) =>
+        void): void;
       return:
         type:
           - void
@@ -118,10 +120,10 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. The content type is returned as one of the CoercionType values in the
+            parameter of type Office.AsyncResult. The content type is returned as one of the CoercionType values in the
             asyncResult.value property.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<Office.CoercionType>) => void'
   - uid: Outlook_1_6.Office.Body.prependAsync
     summary: >-
       Adds the specified content to the beginning of the item body.
@@ -137,11 +139,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -149,13 +151,13 @@ items:
       characters.</td></tr></table>
 
 
-      In addition to the main signature, this method also has these signatures:
+      In addition to this signature, this method also has the following signatures:
 
 
-      `prependAsync(data: string, options: Office.AsyncContextOptions &amp; CoercionTypeOptions): void;`
+      `prependAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`
 
 
-      `prependAsync(data: string, callback: (result: AsyncResult) => void): void;`
+      `prependAsync(data: string, callback: (result: AsyncResult<void>) => void): void;`
 
 
       `prependAsync(data: string): void;`
@@ -167,7 +169,7 @@ items:
     syntax:
       content: >-
         prependAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result:
-        AsyncResult) => void): void;
+        AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -187,9 +189,10 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. Any errors encountered will be provided in the asyncResult.error property.
+            parameter of type Office.AsyncResult. Any errors encountered will be provided in the asyncResult.error
+            property.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_6.Office.Body.setAsync
     summary: >-
       Replaces the entire body with the specified text.
@@ -207,11 +210,11 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -220,13 +223,13 @@ items:
       Office.CoercionType.Html and the message body is in plain text.</td></tr></table>
 
 
-      In addition to the main signature, this method also has these signatures:
+      In addition to this signature, this method also has the following signatures:
 
 
-      `setAsync(data: string, options: Office.AsyncContextOptions &amp; CoercionTypeOptions): void;`
+      `setAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`
 
 
-      `setAsync(data: string, callback: (result: AsyncResult) => void): void;`
+      `setAsync(data: string, callback: (result: AsyncResult<void>) => void): void;`
 
 
       `setAsync(data: string): void;`
@@ -238,7 +241,7 @@ items:
     syntax:
       content: >-
         setAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result:
-        AsyncResult) => void): void;
+        AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -258,9 +261,10 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. Any errors encountered will be provided in the asyncResult.error property.
+            parameter of type Office.AsyncResult. Any errors encountered will be provided in the asyncResult.error
+            property.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_6.Office.Body.setSelectedDataAsync
     summary: >-
       Replaces the selection in the body with the specified text.
@@ -278,11 +282,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -291,13 +295,13 @@ items:
       Office.CoercionType.Html and the message body is in plain text.</td></tr></table>
 
 
-      In addition to the main signature, this method also has these signatures:
+      In addition to this signature, this method also has the following signatures:
 
 
-      `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions &amp; CoercionTypeOptions): void;`
+      `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`
 
 
-      `setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;`
+      `setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;`
 
 
       `setSelectedDataAsync(data: string): void;`
@@ -309,7 +313,7 @@ items:
     syntax:
       content: >-
         setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?:
-        (result: AsyncResult) => void): void;
+        (result: AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -329,6 +333,7 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. Any errors encountered will be provided in the asyncResult.error property.
+            parameter of type Office.AsyncResult. Any errors encountered will be provided in the asyncResult.error
+            property.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'

--- a/docs/docs-ref-autogen/outlook_1_6/office.contact.yml
+++ b/docs/docs-ref-autogen/outlook_1_6/office.contact.yml
@@ -12,11 +12,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: Office.Contact
     fullName: Outlook_1_6.Office.Contact

--- a/docs/docs-ref-autogen/outlook_1_6/office.customproperties.yml
+++ b/docs/docs-ref-autogen/outlook_1_6/office.customproperties.yml
@@ -15,12 +15,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.CustomProperties
     fullName: Outlook_1_6.Office.CustomProperties
     langs:
@@ -35,12 +35,12 @@ items:
   - uid: Outlook_1_6.Office.CustomProperties.get
     summary: Returns the value of the specified custom property.
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: get(name)
     fullName: Outlook_1_6.Office.CustomProperties.get
     langs:
@@ -66,12 +66,12 @@ items:
 
       To make the removal of the property permanent, you must call the saveAsync method of the CustomProperties object.
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: remove(name)
     fullName: Outlook_1_6.Office.CustomProperties.remove
     langs:
@@ -85,7 +85,10 @@ items:
         description: ''
       parameters:
         - id: name
-          description: 'The name of the property to be removed. \[Api set: Mailbox 1.0\]'
+          description: |-
+            The name of the property to be removed.
+
+            \[Api set: Mailbox 1.0\]
           type:
             - string
   - uid: Outlook_1_6.Office.CustomProperties.saveAsync
@@ -102,19 +105,19 @@ items:
       becomes disconnected. If the add-in calls saveAsync while in the disconnected state, saveAsync would return an
       error. Your callback method should handle this error accordingly.
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: 'saveAsync(callback, asyncContext)'
     fullName: Outlook_1_6.Office.CustomProperties.saveAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'saveAsync(callback?: (result: AsyncResult) => void, asyncContext?: any): void;'
+      content: 'saveAsync(callback?: (result: AsyncResult<void>) => void, asyncContext?: any): void;'
       return:
         type:
           - void
@@ -123,11 +126,14 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult.
+            parameter of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
         - id: asyncContext
-          description: 'Optional. Any state data that is passed to the callback method. \[Api set: Mailbox 1.0\]'
+          description: |-
+            Optional. Any state data that is passed to the callback method.
+
+            \[Api set: Mailbox 1.0\]
           type:
             - any
   - uid: Outlook_1_6.Office.CustomProperties.set
@@ -146,12 +152,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: 'set(name, value)'
     fullName: Outlook_1_6.Office.CustomProperties.set
     langs:

--- a/docs/docs-ref-autogen/outlook_1_6/office.diagnostics.yml
+++ b/docs/docs-ref-autogen/outlook_1_6/office.diagnostics.yml
@@ -6,12 +6,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.Diagnostics
     fullName: Outlook_1_6.Office.Diagnostics
     langs:
@@ -30,12 +30,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: hostName
     fullName: Outlook_1_6.Office.Diagnostics.hostName
     langs:
@@ -58,12 +58,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: hostVersion
     fullName: Outlook_1_6.Office.Diagnostics.hostVersion
     langs:
@@ -102,19 +102,19 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: OWAView
     fullName: Outlook_1_6.Office.Diagnostics.OWAView
     langs:
       - typeScript
     type: property
     syntax:
-      content: 'OWAView: "string";'
+      content: 'OWAView: MailboxEnums.OWAView | "OneColumn" | "TwoColumns" | "ThreeColumns";'
       return:
         type:
-          - '"string"'
+          - MailboxEnums.OWAView | "OneColumn" | "TwoColumns" | "ThreeColumns"

--- a/docs/docs-ref-autogen/outlook_1_6/office.emailaddressdetails.yml
+++ b/docs/docs-ref-autogen/outlook_1_6/office.emailaddressdetails.yml
@@ -6,12 +6,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.EmailAddressDetails
     fullName: Outlook_1_6.Office.EmailAddressDetails
     langs:

--- a/docs/docs-ref-autogen/outlook_1_6/office.emailuser.yml
+++ b/docs/docs-ref-autogen/outlook_1_6/office.emailuser.yml
@@ -6,11 +6,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: Office.EmailUser
     fullName: Outlook_1_6.Office.EmailUser

--- a/docs/docs-ref-autogen/outlook_1_6/office.entities.yml
+++ b/docs/docs-ref-autogen/outlook_1_6/office.entities.yml
@@ -34,11 +34,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: Office.Entities
     fullName: Outlook_1_6.Office.Entities

--- a/docs/docs-ref-autogen/outlook_1_6/office.item.yml
+++ b/docs/docs-ref-autogen/outlook_1_6/office.item.yml
@@ -8,12 +8,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.Item
     fullName: Outlook_1_6.Office.Item
     langs:
@@ -33,12 +33,12 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: body
     fullName: Outlook_1_6.Office.Item.body
     langs:
@@ -55,11 +55,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: dateTimeCreated
     fullName: Outlook_1_6.Office.Item.dateTimeCreated
@@ -77,11 +77,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
 
 
@@ -107,12 +107,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: itemType
     fullName: Outlook_1_6.Office.Item.itemType
     langs:
@@ -141,19 +141,21 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: 'loadCustomPropertiesAsync(callback, userContext)'
     fullName: Outlook_1_6.Office.Item.loadCustomPropertiesAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;'
+      content: >-
+        loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any):
+        void;
       return:
         type:
           - void
@@ -162,9 +164,9 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult.
+            of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<Office.CustomProperties>) => void'
         - id: userContext
           description: >-
             Optional. Developers can provide any object they wish to access in the callback function. This object can be
@@ -177,12 +179,12 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: notificationMessages
     fullName: Outlook_1_6.Office.Item.notificationMessages
     langs:

--- a/docs/docs-ref-autogen/outlook_1_6/office.itemcompose.yml
+++ b/docs/docs-ref-autogen/outlook_1_6/office.itemcompose.yml
@@ -2,11 +2,11 @@
 items:
   - uid: Outlook_1_6.Office.ItemCompose
     summary: >-
-      The compose mode of [Office.context.mailbox.item](xref:Outlook_1_6.Office.Item)<!-- -->.
+      The compose mode of [ Office.context.mailbox.item](xref:Outlook_1_6.Office.Item)<!-- -->.
 
 
       Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat
-      this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
+      this as a mode of `Office.context.mailbox.item`<!-- -->. Refer to the Object Model pages for more information.
     name: Office.ItemCompose
     fullName: Outlook_1_6.Office.ItemCompose
     langs:
@@ -39,11 +39,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -62,7 +62,8 @@ items:
       `addFileAttachmentAsync(uri: string, attachmentName: string, options: Office.AsyncContextOptions): void;`
 
 
-      `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+      `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void):
+      void;`
     name: 'addFileAttachmentAsync(uri, attachmentName, options, callback)'
     fullName: Outlook_1_6.Office.ItemCompose.addFileAttachmentAsync
     langs:
@@ -71,7 +72,7 @@ items:
     syntax:
       content: >-
         addFileAttachmentAsync(uri: string, attachmentName: string, options?: Office.AsyncContextOptions, callback?:
-        (result: AsyncResult) => void): void;
+        (result: AsyncResult<string>) => void): void;
       return:
         type:
           - void
@@ -103,7 +104,7 @@ items:
             property. If uploading the attachment fails, the asyncResult object will contain an Error object that
             provides a description of the error.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<string>) => void'
   - uid: Outlook_1_6.Office.ItemCompose.addItemAttachmentAsync
     summary: >-
       Adds an Exchange item, such as a message, as an attachment to the message or appointment.
@@ -119,17 +120,17 @@ items:
       session.
 
 
-      If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items
+      If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items
       other than the item that you are editing; however, this is not supported and is not recommended.
 
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -137,7 +138,7 @@ items:
       attachments.</td></tr></table>
 
 
-      In addition to the main signature, this method also has these signatures:
+      In addition to this signature, this method also has the following signatures:
 
 
       `addItemAttachmentAsync(itemId: any, attachmentName: string): void;`
@@ -146,7 +147,8 @@ items:
       `addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;`
 
 
-      `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+      `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void):
+      void;`
     name: 'addItemAttachmentAsync(itemId, attachmentName, options, callback)'
     fullName: Outlook_1_6.Office.ItemCompose.addItemAttachmentAsync
     langs:
@@ -155,7 +157,7 @@ items:
     syntax:
       content: >-
         addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?:
-        (result: AsyncResult) => void): void;
+        (result: AsyncResult<string>) => void): void;
       return:
         type:
           - void
@@ -180,11 +182,11 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value
+            of type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value
             property. If adding the attachment fails, the asyncResult object will contain an Error object that provides
             a description of the error.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<string>) => void'
   - uid: Outlook_1_6.Office.ItemCompose.close
     summary: >-
       Closes the current item that is being composed
@@ -203,11 +205,11 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
     name: close()
     fullName: Outlook_1_6.Office.ItemCompose.close
@@ -235,11 +237,11 @@ items:
 
       \[ [API set: Mailbox 1.2](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
     name: 'getSelectedDataAsync(coerciontype, callback)'
     fullName: Outlook_1_6.Office.ItemCompose.getSelectedDataAsync
@@ -247,7 +249,7 @@ items:
       - typeScript
     type: method
     syntax:
-      content: 'getSelectedDataAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult) => void): void;'
+      content: 'getSelectedDataAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult<any>) => void): void;'
       return:
         type:
           - void
@@ -260,9 +262,9 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult.
+            of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<any>) => void'
   - uid: Outlook_1_6.Office.ItemCompose.removeAttachmentAsync
     summary: >-
       Removes an attachment from a message or appointment.
@@ -271,17 +273,17 @@ items:
       The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best
       practice, you should use the attachment identifier to remove an attachment only if the same mail app has added
       that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid
-      only within the same session. A session is over when the user closes the app, or if the user starts composing in
-      an inline form and subsequently pops out the inline form to continue in a separate window.
+      only within the same session. A session is over when the user closes the app, or if the user starts composing an
+      inline form then subsequently pops out the form to continue in a separate window.
 
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -297,7 +299,7 @@ items:
       `removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;`
 
 
-      `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;`
+      `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;`
     name: 'removeAttachmentAsync(attachmentIndex, options, callback)'
     fullName: Outlook_1_6.Office.ItemCompose.removeAttachmentAsync
     langs:
@@ -306,7 +308,7 @@ items:
     syntax:
       content: >-
         removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result:
-        AsyncResult) => void): void;
+        AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -325,10 +327,10 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain
-            an error code with the reason for the failure.
+            parameter of type Office.AsyncResult. If removing the attachment fails, the asyncResult.error property will
+            contain an error code with the reason for the failure.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_6.Office.ItemCompose.saveAsync
     summary: >-
       Asynchronously saves an item.
@@ -362,11 +364,11 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -382,14 +384,14 @@ items:
       `saveAsync(options: Office.AsyncContextOptions): void;`
 
 
-      `saveAsync(callback: (result: AsyncResult) => void): void;`
+      `saveAsync(callback: (result: AsyncResult<void>) => void): void;`
     name: 'saveAsync(options, callback)'
     fullName: Outlook_1_6.Office.ItemCompose.saveAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;'
+      content: 'saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;'
       return:
         type:
           - void
@@ -404,10 +406,10 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain
-            an error code with the reason for the failure.
+            parameter of type Office.AsyncResult. If removing the attachment fails, the asyncResult.error property will
+            contain an error code with the reason for the failure.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_6.Office.ItemCompose.setSelectedDataAsync
     summary: >-
       Asynchronously inserts data into the body or subject of a message.
@@ -420,11 +422,11 @@ items:
 
       \[ [API set: Mailbox 1.2](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -437,10 +439,10 @@ items:
       `setSelectedDataAsync(data: string): void;`
 
 
-      `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions &amp; CoercionTypeOptions): void;`
+      `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`
 
 
-      `setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;`
+      `setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;`
     name: 'setSelectedDataAsync(data, options, callback)'
     fullName: Outlook_1_6.Office.ItemCompose.setSelectedDataAsync
     langs:
@@ -449,7 +451,7 @@ items:
     syntax:
       content: >-
         setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?:
-        (result: AsyncResult) => void): void;
+        (result: AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -475,10 +477,9 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain
-            an error code with the reason for the failure.
+            parameter of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_6.Office.ItemCompose.subject
     summary: |-
       Gets or sets the description that appears in the subject field of an item.
@@ -489,12 +490,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: subject
     fullName: Outlook_1_6.Office.ItemCompose.subject
     langs:

--- a/docs/docs-ref-autogen/outlook_1_6/office.itemread.yml
+++ b/docs/docs-ref-autogen/outlook_1_6/office.itemread.yml
@@ -2,11 +2,11 @@
 items:
   - uid: Outlook_1_6.Office.ItemRead
     summary: >-
-      The read mode of [Office.context.mailbox.item](xref:Outlook_1_6.Office.Item)<!-- -->.
+      The read mode of [ Office.context.mailbox.item](xref:Outlook_1_6.Office.Item)<!-- -->.
 
 
       Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat
-      this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
+      this as a mode of `Office.context.mailbox.item`<!-- -->. Refer to the Object Model pages for more information.
     name: Office.ItemRead
     fullName: Outlook_1_6.Office.ItemRead
     langs:
@@ -32,20 +32,20 @@ items:
       - Outlook_1_6.Office.ItemRead.subject
   - uid: Outlook_1_6.Office.ItemRead.attachments
     summary: |-
-      Gets an array of attachments for the item.
+      Gets the item's attachments as an array.
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
 
 
       Note: Certain types of files are blocked by Outlook due to potential security issues and are therefore not
-      returned. For more information, see [Blocked attachments in
+      returned. For more information, see [ Blocked attachments in
       Outlook](https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519)<!--
       -->.
     name: attachments
@@ -81,11 +81,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: displayReplyAllForm(formData)
     fullName: Outlook_1_6.Office.ItemRead.displayReplyAllForm
@@ -102,7 +102,7 @@ items:
         - id: formData
           description: >-
             A string that contains text and HTML and that represents the body of the reply form. The string is limited
-            to 32 KB OR An[Office.ReplyFormData](xref:Outlook_1_6.Office.ReplyFormData) object that contains body or
+            to 32 KB OR An [Office.ReplyFormData](xref:Outlook_1_6.Office.ReplyFormData) object that contains body or
             attachment data and a callback function
           type:
             - string | ReplyFormData
@@ -129,11 +129,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: displayReplyForm(formData)
     fullName: Outlook_1_6.Office.ItemRead.displayReplyForm
@@ -150,23 +150,23 @@ items:
         - id: formData
           description: >-
             A string that contains text and HTML and that represents the body of the reply form. The string is limited
-            to 32 KB. OR An[Office.ReplyFormData](xref:Outlook_1_6.Office.ReplyFormData) object that contains body or
+            to 32 KB. OR An [Office.ReplyFormData](xref:Outlook_1_6.Office.ReplyFormData) object that contains body or
             attachment data and a callback function.
           type:
             - string | ReplyFormData
   - uid: Outlook_1_6.Office.ItemRead.getEntities
     summary: |-
-      Gets the entities found in the selected item.
+      Gets the entities found in the selected item's body.
 
       Note: This method is not supported in Outlook for iOS or Outlook for Android.
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: getEntities()
     fullName: Outlook_1_6.Office.ItemRead.getEntities
@@ -181,17 +181,17 @@ items:
         description: ''
   - uid: Outlook_1_6.Office.ItemRead.getEntitiesByType
     summary: |-
-      Gets an array of all the entities of the specified entity type found in the selected item.
+      Gets an array of all the entities of the specified entity type found in the selected item's body.
 
       Note: This method is not supported in Outlook for iOS or Outlook for Android.
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
 
 
@@ -219,7 +219,7 @@ items:
           - '(string | Contact | MeetingSuggestion | PhoneNumber | TaskSuggestion)[]'
         description: >-
           If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns
-          null. If no entities of the specified type are present on the item, the method returns an empty array.
+          null. If no entities of the specified type are present in the item's body, the method returns an empty array.
           Otherwise, the type of the objects in the returned array depends on the type of entity requested in the
           entityType parameter.
       parameters:
@@ -241,11 +241,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: getFilteredEntitiesByName(name)
     fullName: Outlook_1_6.Office.ItemRead.getFilteredEntitiesByName
@@ -290,11 +290,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: getRegExMatches()
     fullName: Outlook_1_6.Office.ItemRead.getRegExMatches
@@ -330,11 +330,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: getRegExMatchesByName(name)
     fullName: Outlook_1_6.Office.ItemRead.getRegExMatchesByName
@@ -363,11 +363,11 @@ items:
 
       \[ [API set: Mailbox 1.6](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: getSelectedEntities()
     fullName: Outlook_1_6.Office.ItemRead.getSelectedEntities
@@ -403,11 +403,11 @@ items:
 
       \[ [API set: Mailbox 1.6](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: getSelectedRegExMatches()
     fullName: Outlook_1_6.Office.ItemRead.getSelectedRegExMatches
@@ -434,11 +434,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
 
 
@@ -476,16 +476,17 @@ items:
       Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The
       itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making
       REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more
-      details, see Use the Outlook REST APIs from an Outlook add-in.
+      details, see [ Use the Outlook REST APIs from an Outlook
+      add-in](https://docs.microsoft.com/outlook/add-ins/use-rest-api#get-the-item-id)<!-- -->.
 
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: itemId
     fullName: Outlook_1_6.Office.ItemRead.itemId
@@ -508,11 +509,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: normalizedSubject
     fullName: Outlook_1_6.Office.ItemRead.normalizedSubject
@@ -538,12 +539,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: subject
     fullName: Outlook_1_6.Office.ItemRead.subject
     langs:

--- a/docs/docs-ref-autogen/outlook_1_6/office.localclienttime.yml
+++ b/docs/docs-ref-autogen/outlook_1_6/office.localclienttime.yml
@@ -6,11 +6,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: Office.LocalClientTime
     fullName: Outlook_1_6.Office.LocalClientTime

--- a/docs/docs-ref-autogen/outlook_1_6/office.location.yml
+++ b/docs/docs-ref-autogen/outlook_1_6/office.location.yml
@@ -6,11 +6,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
     name: Office.Location
     fullName: Outlook_1_6.Office.Location
@@ -29,25 +29,25 @@ items:
       The getAsync method starts an asynchronous call to the Exchange server to get the location of an appointment. The
       location of the appointment is provided as a string in the asyncResult.value property.
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
 
 
       In addition to this signature, the method also has the following signature:
 
 
-      `getAsync(callback: (result: AsyncResult) => void): void;`
+      `getAsync(callback: (result: AsyncResult<string>) => void): void;`
     name: 'getAsync(options, callback)'
     fullName: Outlook_1_6.Office.Location.getAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'getAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;'
+      content: 'getAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;'
       return:
         type:
           - void
@@ -62,9 +62,12 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. \[Api set: Mailbox 1.1\]
+            parameter of type Office.AsyncResult.
+
+
+            \[Api set: Mailbox 1.1\]
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<string>) => void'
   - uid: Outlook_1_6.Office.Location.setAsync
     summary: >-
       Sets the location of an appointment.
@@ -73,11 +76,11 @@ items:
       The setAsync method starts an asynchronous call to the Exchange server to set the location of an appointment.
       Setting the location of an appointment overwrites the current location.
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -94,7 +97,7 @@ items:
       `setAsync(location: string, options: Office.AsyncContextOptions): void;`
 
 
-      `setAsync(location: string, callback: (result: AsyncResult) => void): void;`
+      `setAsync(location: string, callback: (result: AsyncResult<void>) => void): void;`
     name: 'setAsync(location, options, callback)'
     fullName: Outlook_1_6.Office.Location.setAsync
     langs:
@@ -102,8 +105,8 @@ items:
     type: method
     syntax:
       content: >-
-        setAsync(location: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void):
-        void;
+        setAsync(location: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) =>
+        void): void;
       return:
         type:
           - void
@@ -122,7 +125,10 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. If setting the location fails, the asyncResult.error property will contain an
-            error code. \[Api set: Mailbox 1.1\]
+            parameter of type Office.AsyncResult. If setting the location fails, the asyncResult.error property will
+            contain an error code.
+
+
+            \[Api set: Mailbox 1.1\]
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'

--- a/docs/docs-ref-autogen/outlook_1_6/office.mailbox.yml
+++ b/docs/docs-ref-autogen/outlook_1_6/office.mailbox.yml
@@ -2,7 +2,7 @@
 items:
   - uid: Outlook_1_6.Office.Mailbox
     summary: |-
-      Provides access to the Outlook add-in object model for Microsoft Outlook and Microsoft Outlook on the web.
+      Provides access to the Outlook Add-in object model for Microsoft Outlook and Microsoft Outlook on the web.
 
       Namespaces:
 
@@ -14,12 +14,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.Mailbox
     fullName: Outlook_1_6.Office.Mailbox
     langs:
@@ -42,26 +42,23 @@ items:
       - Outlook_1_6.Office.Mailbox.getUserIdentityTokenAsync
       - Outlook_1_6.Office.Mailbox.item
       - Outlook_1_6.Office.Mailbox.makeEwsRequestAsync
+      - Outlook_1_6.Office.Mailbox.removeHandlerAsync
       - Outlook_1_6.Office.Mailbox.restUrl
       - Outlook_1_6.Office.Mailbox.userProfile
   - uid: Outlook_1_6.Office.Mailbox.addHandlerAsync
-    summary: >-
+    summary: |-
       Adds an event handler for a supported event.
 
-
-      Currently the only supported event type is Office.EventType.ItemChanged, which is invoked when the user selects a
-      new item. This event is used by add-ins that implement a pinnable taskpane, and allows the add-in to refresh the
-      taskpane UI based on the currently selected item.
-
+      Currently, the only supported event type is `Office.EventType.ItemChanged`<!-- -->.
 
       \[ [API set: Mailbox 1.5](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: 'addHandlerAsync(eventType, handler, options, callback)'
     fullName: Outlook_1_6.Office.Mailbox.addHandlerAsync
     langs:
@@ -70,7 +67,7 @@ items:
     syntax:
       content: >-
         addHandlerAsync(eventType: Office.EventType, handler: (type: EventType) => void, options?:
-        Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -93,9 +90,9 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult.
+            parameter of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_6.Office.Mailbox.convertToEwsId
     summary: >-
       Converts an item ID formatted for REST into EWS format.
@@ -111,12 +108,12 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: 'convertToEwsId(itemId, restVersion)'
     fullName: Outlook_1_6.Office.Mailbox.convertToEwsId
     langs:
@@ -156,12 +153,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: convertToLocalClientTime(timeValue)
     fullName: Outlook_1_6.Office.Mailbox.convertToLocalClientTime
     langs:
@@ -186,19 +183,19 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
 
 
       Item IDs retrieved via EWS or via the itemId property use a different format than the format used by REST APIs
-      (such as the [Outlook Mail
+      (such as the [ Outlook Mail
       API](https://docs.microsoft.com/previous-versions/office/office-365-api/api/version-2.0/mail-rest-operations) or
-      the [Microsoft Graph](http://graph.microsoft.io/)<!-- -->. The convertToRestId method converts an EWS-formatted ID
-      into the proper format for REST.
+      the [ Microsoft Graph](http://graph.microsoft.io/)<!-- -->. The convertToRestId method converts an EWS-formatted
+      ID into the proper format for REST.
     name: 'convertToRestId(itemId, restVersion)'
     fullName: Outlook_1_6.Office.Mailbox.convertToRestId
     langs:
@@ -230,12 +227,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: convertToUtcClientTime(input)
     fullName: Outlook_1_6.Office.Mailbox.convertToUtcClientTime
     langs:
@@ -270,11 +267,11 @@ items:
       Exchange Server. An example is the string 15.0.468.0.
 
 
-      - OWAView (string): A string that represents the current view of Outlook Web App. If the host application is not
-      Outlook Web App, then accessing this property results in undefined. Outlook Web App has three views (OneColumn -
-      displayed when the screen is narrow, TwoColumns - displayed when the screen is wider, and ThreeColumns - displayed
-      when the screen is wide.) that correspond to the width of the screen and the window, and the number of columns
-      that can be displayed.
+      - OWAView (MailboxEnums.OWAView or string): An enum (or string literal) that represents the current view of
+      Outlook Web App. If the host application is not Outlook Web App, then accessing this property results in
+      undefined. Outlook Web App has three views (OneColumn - displayed when the screen is narrow, TwoColumns -
+      displayed when the screen is wider, and ThreeColumns - displayed when the screen is wide) that correspond to the
+      width of the screen and the window, and the number of columns that can be displayed.
 
 
       More information is under [Office.Diagnostics](xref:Outlook_1_6.Office.Diagnostics)<!-- -->.
@@ -282,12 +279,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: diagnostics
     fullName: Outlook_1_6.Office.Mailbox.diagnostics
     langs:
@@ -326,12 +323,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: displayAppointmentForm(itemId)
     fullName: Outlook_1_6.Office.Mailbox.displayAppointmentForm
     langs:
@@ -375,12 +372,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: displayMessageForm(itemId)
     fullName: Outlook_1_6.Office.Mailbox.displayMessageForm
     langs:
@@ -426,11 +423,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: displayNewAppointmentForm(parameters)
     fullName: Outlook_1_6.Office.Mailbox.displayNewAppointmentForm
@@ -463,11 +460,11 @@ items:
 
       \[ [API set: Mailbox 1.6](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: displayNewMessageForm(parameters)
     fullName: Outlook_1_6.Office.Mailbox.displayNewMessageForm
@@ -484,24 +481,50 @@ items:
         - id: parameters
           description: >-
             A dictionary containing all values to be filled in for the user in the new form. All parameters are
-            optional. toRecipients: An array of strings containing the email addresses or an array containing
-            an[Office.EmailAddressDetails](xref:Outlook_1_6.Office.EmailAddressDetails) object for each of the
-            recipients on the To line. The array is limited to a maximum of 100 entries. ccRecipients: An array of
-            strings containing the email addresses or an array containing an
+            optional.
+
+
+            toRecipients: An array of strings containing the email addresses or an array containing an
             [Office.EmailAddressDetails](xref:Outlook_1_6.Office.EmailAddressDetails) object for each of the recipients
-            on the Cc line. The array is limited to a maximum of 100 entries. bccRecipients: An array of strings
-            containing the email addresses or an array containing an
+            on the To line. The array is limited to a maximum of 100 entries.
+
+
+            ccRecipients: An array of strings containing the email addresses or an array containing an
             [Office.EmailAddressDetails](xref:Outlook_1_6.Office.EmailAddressDetails) object for each of the recipients
-            on the Bcc line. The array is limited to a maximum of 100 entries. subject: A string containing the subject
-            of the message. The string is limited to a maximum of 255 characters. htmlBody: The HTML body of the
-            message. The body content is limited to a maximum size of 32 KB. attachments: An array of JSON objects that
-            are either file or item attachments. attachments.type: Indicates the type of attachment. Must be file for a
-            file attachment or item for an item attachment. attachments.name: A string that contains the name of the
-            attachment, up to 255 characters in length. attachments.url: Only used if type is set to file. The URI of
-            the location for the file. attachments.isInline: Only used if type is set to file. If true, indicates that
-            the attachment will be shown inline in the message body, and should not be displayed in the attachment list.
-            attachments.itemId: Only used if type is set to item. The EWS item id of the attachment. This is a string up
-            to 100 characters.
+            on the Cc line. The array is limited to a maximum of 100 entries.
+
+
+            bccRecipients: An array of strings containing the email addresses or an array containing an
+            [Office.EmailAddressDetails](xref:Outlook_1_6.Office.EmailAddressDetails) object for each of the recipients
+            on the Bcc line. The array is limited to a maximum of 100 entries.
+
+
+            subject: A string containing the subject of the message. The string is limited to a maximum of 255
+            characters.
+
+
+            htmlBody: The HTML body of the message. The body content is limited to a maximum size of 32 KB.
+
+
+            attachments: An array of JSON objects that are either file or item attachments.
+
+
+            attachments.type: Indicates the type of attachment. Must be file for a file attachment or item for an item
+            attachment.
+
+
+            attachments.name: A string that contains the name of the attachment, up to 255 characters in length.
+
+
+            attachments.url: Only used if type is set to file. The URI of the location for the file.
+
+
+            attachments.isInline: Only used if type is set to file. If true, indicates that the attachment will be shown
+            inline in the message body, and should not be displayed in the attachment list.
+
+
+            attachments.itemId: Only used if type is set to item. The EWS item id of the existing e-mail you want to
+            attach to the new message. This is a string up to 100 characters.
           type:
             - any
   - uid: Outlook_1_6.Office.Mailbox.ewsUrl
@@ -518,16 +541,16 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
 
 
       The ewsUrl value can be used by a remote service to make EWS calls to the user's mailbox. For example, you can
-      create a remote service to [get attachments from the selected
+      create a remote service to [ get attachments from the selected
       item](https://docs.microsoft.com/outlook/add-ins/get-attachments-of-an-outlook-item)<!-- -->.
 
 
@@ -579,28 +602,30 @@ items:
 
       \[ [API set: Mailbox 1.5](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
       and read</td></tr></table>
 
 
       In addition to this signature, the method has the following signatures:
 
 
-      `getCallbackTokenAsync(callback: (result: AsyncResult) => void): void;`
+      `getCallbackTokenAsync(callback: (result: AsyncResult<string>) => void): void;`
 
 
-      `getCallbackTokenAsync(callback: (result: AsyncResult) => void, userContext?: any): void;`
+      `getCallbackTokenAsync(callback: (result: AsyncResult<string>) => void, userContext?: any): void;`
     name: 'getCallbackTokenAsync(options, callback)'
     fullName: Outlook_1_6.Office.Mailbox.getCallbackTokenAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'getCallbackTokenAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;'
+      content: >-
+        getCallbackTokenAsync(options: Office.AsyncContextOptions & { isRest?: boolean }, callback: (result:
+        AsyncResult<string>) => void): void;
       return:
         type:
           - void
@@ -612,13 +637,13 @@ items:
             provided will be used for the Outlook REST APIs or Exchange Web Services. Default value is false.
             asyncContext: Any state data that is passed to the asynchronous method.
           type:
-            - office.Office.AsyncContextOptions
+            - 'Office.AsyncContextOptions & { isRest?: boolean }'
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult. The token is provided as a string in the asyncResult.value property.
+            of type Office.AsyncResult. The token is provided as a string in the asyncResult.value property.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<string>) => void'
   - uid: Outlook_1_6.Office.Mailbox.getUserIdentityTokenAsync
     summary: |-
       Gets a token identifying the user and the Office Add-in.
@@ -627,23 +652,23 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
       and read</td></tr></table>
 
 
-      The getUserIdentityTokenAsync method returns a token that you can use to identify and [authenticate the add-in and
-      user with a third-party system](https://docs.microsoft.com/outlook/add-ins/authentication)<!-- -->.
+      The getUserIdentityTokenAsync method returns a token that you can use to identify and [ authenticate the add-in
+      and user with a third-party system](https://docs.microsoft.com/outlook/add-ins/authentication)<!-- -->.
     name: 'getUserIdentityTokenAsync(callback, userContext)'
     fullName: Outlook_1_6.Office.Mailbox.getUserIdentityTokenAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'getUserIdentityTokenAsync(callback: (result: AsyncResult) => void, userContext?: any): void;'
+      content: 'getUserIdentityTokenAsync(callback: (result: AsyncResult<string>) => void, userContext?: any): void;'
       return:
         type:
           - void
@@ -652,9 +677,9 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult.
+            of type Office.AsyncResult. The token is provided as a string in the asyncResult.value property.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<string>) => void'
         - id: userContext
           description: Optional. Any state data that is passed to the asynchronous method.\|
           type:
@@ -663,7 +688,8 @@ items:
     summary: >-
       The mailbox item. Depending on the context in which the add-in opened, the item may be of any number of types. If
       you want to see IntelliSense for only a specific type, you should cast this item to one of the following:
-      `ItemCompose`, `ItemRead`, `MessageCompose`, `MessageRead`, `AppointmentCompose`, `AppointmentRead`
+      `ItemCompose`<!-- -->, `ItemRead`<!-- -->, `MessageCompose`<!-- -->, `MessageRead`<!-- -->,
+      `AppointmentCompose`<!-- -->, `AppointmentRead`
     name: item
     fullName: Outlook_1_6.Office.Mailbox.item
     langs:
@@ -694,15 +720,21 @@ items:
 
       Your add-in must have the ReadWriteMailbox permission to use the makeEwsRequestAsync method. For information about
       using the ReadWriteMailbox permission and the EWS operations that you can call with the makeEwsRequestAsync
-      method, see Specify permissions for mail add-in access to the user's mailbox.
+      method, see [ Specify permissions for mail add-in access to the user's
+      mailbox](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)<!-- -->.
 
 
       The XML result of the EWS call is provided as a string in the asyncResult.value property. If the result exceeds 1
       MB in size, an error message is returned instead.
 
 
-      Note: This method is not supported in the following scenarios. - In Outlook for iOS or Outlook for Android - When
-      the add-in is loaded in a Gmail mailbox
+      Note: This method is not supported in the following scenarios:
+
+
+      - In Outlook for iOS or Outlook for Android.
+
+
+      - When the add-in is loaded in a Gmail mailbox.
 
 
       Note: The server administrator must set OAuthAuthentication to true on the Client Access Server EWS directory to
@@ -716,7 +748,7 @@ items:
       15.0.4535.1004, you should set the encoding value to ISO-8859-1.
 
 
-      `&lt;?xml version="1.0" encoding="iso-8859-1"?&gt;`
+      `<?xml version="1.0" encoding="iso-8859-1"?>`
 
 
       You do not need to set the encoding value when your mail app is running in Outlook on the web. You can determine
@@ -727,11 +759,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteMailbox</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
       and read</td></tr></table>
     name: 'makeEwsRequestAsync(data, callback, userContext)'
     fullName: Outlook_1_6.Office.Mailbox.makeEwsRequestAsync
@@ -739,7 +771,7 @@ items:
       - typeScript
     type: method
     syntax:
-      content: 'makeEwsRequestAsync(data: any, callback: (result: AsyncResult) => void, userContext?: any): void;'
+      content: 'makeEwsRequestAsync(data: any, callback: (result: AsyncResult<string>) => void, userContext?: any): void;'
       return:
         type:
           - void
@@ -752,13 +784,62 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult.
+            of type Office.AsyncResult. The `value` property of the result is the XML of the EWS request provided as a
+            string. If the result exceeds 1 MB in size, an error message is returned instead.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<string>) => void'
         - id: userContext
           description: Optional. Any state data that is passed to the asynchronous method.
           type:
             - any
+  - uid: Outlook_1_6.Office.Mailbox.removeHandlerAsync
+    summary: |-
+      Removes an event handler for a supported event.
+
+      Currently, the only supported event type is `Office.EventType.ItemChanged`<!-- -->.
+
+      \[ [API set: Mailbox 1.5](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
+    remarks: >-
+      <table><tr><td>[ Minimum permission
+      level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
+
+
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
+    name: 'removeHandlerAsync(eventType, handler, options, callback)'
+    fullName: Outlook_1_6.Office.Mailbox.removeHandlerAsync
+    langs:
+      - typeScript
+    type: method
+    syntax:
+      content: >-
+        removeHandlerAsync(eventType: Office.EventType, handler: (type: EventType) => void, options?:
+        Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
+      return:
+        type:
+          - void
+        description: ''
+      parameters:
+        - id: eventType
+          description: The event that should revoke the handler.
+          type:
+            - Office.EventType
+        - id: handler
+          description: >-
+            The function to handle the event. The function must accept a single parameter, which is an object literal.
+            The type property on the parameter will match the eventType parameter passed to addHandlerAsync.
+          type:
+            - '(type: EventType) => void'
+        - id: options
+          description: 'Optional. Provides an option for preserving context data of any type, unchanged, for use in a callback.'
+          type:
+            - office.Office.AsyncContextOptions
+        - id: callback
+          description: >-
+            Optional. When the method completes, the function passed in the callback parameter is called with a single
+            parameter of type Office.AsyncResult.
+          type:
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_6.Office.Mailbox.restUrl
     summary: >-
       Gets the URL of the REST endpoint for this email account.
@@ -773,15 +854,15 @@ items:
 
       \[ [API set: Mailbox 1.5](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
 
 
-      The restUrl value can be used to make [REST API](https://docs.microsoft.com/outlook/rest/) calls to the user's
+      The restUrl value can be used to make [ REST API](https://docs.microsoft.com/outlook/rest/) calls to the user's
       mailbox.
     name: restUrl
     fullName: Outlook_1_6.Office.Mailbox.restUrl
@@ -796,7 +877,7 @@ items:
   - uid: Outlook_1_6.Office.Mailbox.userProfile
     summary: >-
       Information about the user associated with the mailbox. This includes their account type, display name, email
-      adddress, and time zone.
+      address, and time zone.
 
 
       More information is under [Office.UserProfile](xref:Outlook_1_6.Office.UserProfile)

--- a/docs/docs-ref-autogen/outlook_1_6/office.mailboxenums.attachmenttype.yml
+++ b/docs/docs-ref-autogen/outlook_1_6/office.mailboxenums.attachmenttype.yml
@@ -6,7 +6,7 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td> [Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
+      <table><tr><td> [ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
       </td><td>Compose or read</td></tr></table>
     name: Office.MailboxEnums.AttachmentType
     fullName: Outlook_1_6.Office.MailboxEnums.AttachmentType

--- a/docs/docs-ref-autogen/outlook_1_6/office.mailboxenums.entitytype.yml
+++ b/docs/docs-ref-autogen/outlook_1_6/office.mailboxenums.entitytype.yml
@@ -6,7 +6,7 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td> [Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
+      <table><tr><td> [ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
       </td><td>Compose or read</td></tr></table>
     name: Office.MailboxEnums.EntityType
     fullName: Outlook_1_6.Office.MailboxEnums.EntityType

--- a/docs/docs-ref-autogen/outlook_1_6/office.mailboxenums.itemnotificationmessagetype.yml
+++ b/docs/docs-ref-autogen/outlook_1_6/office.mailboxenums.itemnotificationmessagetype.yml
@@ -6,7 +6,7 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td> [Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
+      <table><tr><td> [ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
       </td><td>Compose or read</td></tr></table>
     name: Office.MailboxEnums.ItemNotificationMessageType
     fullName: Outlook_1_6.Office.MailboxEnums.ItemNotificationMessageType

--- a/docs/docs-ref-autogen/outlook_1_6/office.mailboxenums.itemtype.yml
+++ b/docs/docs-ref-autogen/outlook_1_6/office.mailboxenums.itemtype.yml
@@ -6,7 +6,7 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td> [Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
+      <table><tr><td> [ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
       </td><td>Compose or read</td></tr></table>
     name: Office.MailboxEnums.ItemType
     fullName: Outlook_1_6.Office.MailboxEnums.ItemType

--- a/docs/docs-ref-autogen/outlook_1_6/office.mailboxenums.owaview.yml
+++ b/docs/docs-ref-autogen/outlook_1_6/office.mailboxenums.owaview.yml
@@ -1,0 +1,42 @@
+### YamlMime:UniversalReference
+items:
+  - uid: Outlook_1_6.Office.MailboxEnums.OWAView
+    summary: Represents the current view of Outlook Web App.
+    name: Office.MailboxEnums.OWAView
+    fullName: Outlook_1_6.Office.MailboxEnums.OWAView
+    langs:
+      - typeScript
+    type: enum
+    package: Outlook_1_6
+    children:
+      - Outlook_1_6.Office.MailboxEnums.OWAView.OneColumn
+      - Outlook_1_6.Office.MailboxEnums.OWAView.ThreeColumns
+      - Outlook_1_6.Office.MailboxEnums.OWAView.TwoColumns
+  - uid: Outlook_1_6.Office.MailboxEnums.OWAView.OneColumn
+    summary: >-
+      One column view. Displayed when the screen is narrow. Outlook Web App uses this single-column layout on the entire
+      screen of a smartphone.
+    name: OneColumn
+    fullName: Outlook_1_6.Office.MailboxEnums.OWAView.OneColumn
+    langs:
+      - typeScript
+    type: field
+    numericValue: '"OneColumn"'
+  - uid: Outlook_1_6.Office.MailboxEnums.OWAView.ThreeColumns
+    summary: >-
+      Three column view. Displayed when the screen is wide. For example, Outlook Web App uses this view in a full screen
+      window on a desktop computer.
+    name: ThreeColumns
+    fullName: Outlook_1_6.Office.MailboxEnums.OWAView.ThreeColumns
+    langs:
+      - typeScript
+    type: field
+    numericValue: '"ThreeColumns"'
+  - uid: Outlook_1_6.Office.MailboxEnums.OWAView.TwoColumns
+    summary: Two column view. Displayed when the screen is wider. Outlook Web App uses this view on most tablets.
+    name: TwoColumns
+    fullName: Outlook_1_6.Office.MailboxEnums.OWAView.TwoColumns
+    langs:
+      - typeScript
+    type: field
+    numericValue: '"TwoColumns"'

--- a/docs/docs-ref-autogen/outlook_1_6/office.mailboxenums.recipienttype.yml
+++ b/docs/docs-ref-autogen/outlook_1_6/office.mailboxenums.recipienttype.yml
@@ -6,7 +6,7 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td> [Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
+      <table><tr><td> [ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
       </td><td>Compose or read</td></tr></table>
     name: Office.MailboxEnums.RecipientType
     fullName: Outlook_1_6.Office.MailboxEnums.RecipientType

--- a/docs/docs-ref-autogen/outlook_1_6/office.mailboxenums.responsetype.yml
+++ b/docs/docs-ref-autogen/outlook_1_6/office.mailboxenums.responsetype.yml
@@ -6,7 +6,7 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td> [Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
+      <table><tr><td> [ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
       </td><td>Compose or read</td></tr></table>
     name: Office.MailboxEnums.ResponseType
     fullName: Outlook_1_6.Office.MailboxEnums.ResponseType

--- a/docs/docs-ref-autogen/outlook_1_6/office.mailboxenums.restversion.yml
+++ b/docs/docs-ref-autogen/outlook_1_6/office.mailboxenums.restversion.yml
@@ -6,7 +6,7 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td> [Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
+      <table><tr><td> [ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
       </td><td>Compose or read</td></tr></table>
     name: Office.MailboxEnums.RestVersion
     fullName: Outlook_1_6.Office.MailboxEnums.RestVersion

--- a/docs/docs-ref-autogen/outlook_1_6/office.meetingsuggestion.yml
+++ b/docs/docs-ref-autogen/outlook_1_6/office.meetingsuggestion.yml
@@ -15,11 +15,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: Office.MeetingSuggestion
     fullName: Outlook_1_6.Office.MeetingSuggestion

--- a/docs/docs-ref-autogen/outlook_1_6/office.message.yml
+++ b/docs/docs-ref-autogen/outlook_1_6/office.message.yml
@@ -6,7 +6,7 @@ items:
 
 
       Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat
-      this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
+      this as a mode of `Office.context.mailbox.item`<!-- -->. Refer to the Object Model pages for more information.
     name: Office.Message
     fullName: Outlook_1_6.Office.Message
     langs:
@@ -33,12 +33,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: conversationId
     fullName: Outlook_1_6.Office.Message.conversationId
     langs:

--- a/docs/docs-ref-autogen/outlook_1_6/office.messagecompose.yml
+++ b/docs/docs-ref-autogen/outlook_1_6/office.messagecompose.yml
@@ -2,11 +2,11 @@
 items:
   - uid: Outlook_1_6.Office.MessageCompose
     summary: >-
-      The message compose mode of [Office.context.mailbox.item](xref:Outlook_1_6.Office.Item)<!-- -->.
+      The message compose mode of [ Office.context.mailbox.item](xref:Outlook_1_6.Office.Item)<!-- -->.
 
 
       Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat
-      this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
+      this as a mode of `Office.context.mailbox.item`<!-- -->. Refer to the Object Model pages for more information.
     name: Office.MessageCompose
     fullName: Outlook_1_6.Office.MessageCompose
     langs:
@@ -49,11 +49,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr>
 
 
@@ -72,7 +72,8 @@ items:
       `addFileAttachmentAsync(uri: string, attachmentName: string, options: AsyncContextOptions): void;`
 
 
-      `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+      `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void):
+      void;`
     name: 'addFileAttachmentAsync(uri, attachmentName, options, callback)'
     fullName: Outlook_1_6.Office.MessageCompose.addFileAttachmentAsync
     langs:
@@ -81,7 +82,7 @@ items:
     syntax:
       content: >-
         addFileAttachmentAsync(uri: string, attachmentName: string, options?: AsyncContextOptions, callback?: (result:
-        AsyncResult) => void): void;
+        AsyncResult<string>) => void): void;
       return:
         type:
           - void
@@ -109,11 +110,11 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type asyncResult. On success, the attachment identifier will be provided in the asyncResult.value
+            of type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value
             property. If uploading the attachment fails, the asyncResult object will contain an Error object that
             provides a description of the error.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<string>) => void'
   - uid: Outlook_1_6.Office.MessageCompose.addItemAttachmentAsync
     summary: >-
       Adds an Exchange item, such as a message, as an attachment to the message or appointment.
@@ -129,17 +130,17 @@ items:
       session.
 
 
-      If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items
+      If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items
       other than the item that you are editing; however, this is not supported and is not recommended.
 
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr>
 
 
@@ -147,7 +148,7 @@ items:
       attachments.</td></tr></table>
 
 
-      In addition to the main signature, this method also has these signatures:
+      In addition to this signature, this method also has the following signatures:
 
 
       `addItemAttachmentAsync(itemId: any, attachmentName: string): void;`
@@ -156,7 +157,8 @@ items:
       `addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;`
 
 
-      `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+      `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void):
+      void;`
     name: 'addItemAttachmentAsync(itemId, attachmentName, options, callback)'
     fullName: Outlook_1_6.Office.MessageCompose.addItemAttachmentAsync
     langs:
@@ -165,7 +167,7 @@ items:
     syntax:
       content: >-
         addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?:
-        (result: AsyncResult) => void): void;
+        (result: AsyncResult<string>) => void): void;
       return:
         type:
           - void
@@ -194,7 +196,7 @@ items:
             property. If adding the attachment fails, the asyncResult object will contain an Error object that provides
             a description of the error.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<string>) => void'
   - uid: Outlook_1_6.Office.MessageCompose.bcc
     summary: >-
       Gets an object that provides methods to get or update the recipients on the Bcc (blind carbon copy) line of a
@@ -203,11 +205,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: bcc
     fullName: Outlook_1_6.Office.MessageCompose.bcc
@@ -225,11 +227,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: body
     fullName: Outlook_1_6.Office.MessageCompose.body
@@ -253,11 +255,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: cc
     fullName: Outlook_1_6.Office.MessageCompose.cc
@@ -287,11 +289,11 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: close()
     fullName: Outlook_1_6.Office.MessageCompose.close
@@ -320,11 +322,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: conversationId
     fullName: Outlook_1_6.Office.MessageCompose.conversationId
@@ -342,11 +344,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: dateTimeCreated
     fullName: Outlook_1_6.Office.MessageCompose.dateTimeCreated
@@ -364,11 +366,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
 
 
@@ -398,11 +400,11 @@ items:
 
       \[ [API set: Mailbox 1.2](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: 'getSelectedDataAsync(coerciontype, callback)'
     fullName: Outlook_1_6.Office.MessageCompose.getSelectedDataAsync
@@ -410,7 +412,7 @@ items:
       - typeScript
     type: method
     syntax:
-      content: 'getSelectedDataAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult) => void): void;'
+      content: 'getSelectedDataAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult<any>) => void): void;'
       return:
         type:
           - void
@@ -423,9 +425,9 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult.
+            of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<any>) => void'
   - uid: Outlook_1_6.Office.MessageCompose.itemType
     summary: >-
       Gets the type of item that an instance represents.
@@ -437,11 +439,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: itemType
     fullName: Outlook_1_6.Office.MessageCompose.itemType
@@ -471,11 +473,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: 'loadCustomPropertiesAsync(callback, userContext)'
     fullName: Outlook_1_6.Office.MessageCompose.loadCustomPropertiesAsync
@@ -483,7 +485,9 @@ items:
       - typeScript
     type: method
     syntax:
-      content: 'loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;'
+      content: >-
+        loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any):
+        void;
       return:
         type:
           - void
@@ -492,9 +496,9 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult.
+            of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<Office.CustomProperties>) => void'
         - id: userContext
           description: >-
             Optional. Developers can provide any object they wish to access in the callback function. This object can be
@@ -507,11 +511,11 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: notificationMessages
     fullName: Outlook_1_6.Office.MessageCompose.notificationMessages
@@ -531,17 +535,17 @@ items:
       The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best
       practice, you should use the attachment identifier to remove an attachment only if the same mail app has added
       that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid
-      only within the same session. A session is over when the user closes the app, or if the user starts composing in
-      an inline form and subsequently pops out the inline form to continue in a separate window.
+      only within the same session. A session is over when the user closes the app, or if the user starts composing an
+      inline form then subsequently pops out the form to continue in a separate window.
 
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr>
 
 
@@ -557,7 +561,7 @@ items:
       `removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;`
 
 
-      `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;`
+      `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;`
     name: 'removeAttachmentAsync(attachmentIndex, options, callback)'
     fullName: Outlook_1_6.Office.MessageCompose.removeAttachmentAsync
     langs:
@@ -566,7 +570,7 @@ items:
     syntax:
       content: >-
         removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result:
-        AsyncResult) => void): void;
+        AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -585,10 +589,10 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain
-            an error code with the reason for the failure.
+            parameter of type Office.AsyncResult. If removing the attachment fails, the asyncResult.error property will
+            contain an error code with the reason for the failure.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_6.Office.MessageCompose.saveAsync
     summary: >-
       Asynchronously saves an item.
@@ -622,11 +626,11 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr>
 
 
@@ -642,14 +646,14 @@ items:
       `saveAsync(options: Office.AsyncContextOptions): void;`
 
 
-      `saveAsync(callback: (result: AsyncResult) => void): void;`
+      `saveAsync(callback: (result: AsyncResult<void>) => void): void;`
     name: 'saveAsync(options, callback)'
     fullName: Outlook_1_6.Office.MessageCompose.saveAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;'
+      content: 'saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;'
       return:
         type:
           - void
@@ -664,10 +668,9 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain
-            an error code with the reason for the failure.
+            parameter of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_6.Office.MessageCompose.setSelectedDataAsync
     summary: >-
       Asynchronously inserts data into the body or subject of a message.
@@ -680,11 +683,11 @@ items:
 
       \[ [API set: Mailbox 1.2](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr>
 
 
@@ -697,10 +700,10 @@ items:
       `setSelectedDataAsync(data: string): void;`
 
 
-      `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions &amp; CoercionTypeOptions): void;`
+      `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`
 
 
-      `setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;`
+      `setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;`
     name: 'setSelectedDataAsync(data, options, callback)'
     fullName: Outlook_1_6.Office.MessageCompose.setSelectedDataAsync
     langs:
@@ -709,7 +712,7 @@ items:
     syntax:
       content: >-
         setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?:
-        (result: AsyncResult) => void): void;
+        (result: AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -735,10 +738,9 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain
-            an error code with the reason for the failure.
+            parameter of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_6.Office.MessageCompose.subject
     summary: |-
       Gets or sets the description that appears in the subject field of an item.
@@ -749,11 +751,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: subject
     fullName: Outlook_1_6.Office.MessageCompose.subject
@@ -777,11 +779,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: to
     fullName: Outlook_1_6.Office.MessageCompose.to

--- a/docs/docs-ref-autogen/outlook_1_6/office.messageread.yml
+++ b/docs/docs-ref-autogen/outlook_1_6/office.messageread.yml
@@ -2,7 +2,7 @@
 items:
   - uid: Outlook_1_6.Office.MessageRead
     summary: >-
-      The message read mode of [Office.context.mailbox.item](xref:Outlook_1_6.Office.Item)<!-- -->.
+      The message read mode of [ Office.context.mailbox.item](xref:Outlook_1_6.Office.Item)<!-- -->.
 
 
       Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat
@@ -44,20 +44,20 @@ items:
       - Outlook_1_6.Office.MessageRead.to
   - uid: Outlook_1_6.Office.MessageRead.attachments
     summary: |-
-      Gets an array of attachments for the item.
+      Gets the item's attachments as an array.
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
 
 
       Note: Certain types of files are blocked by Outlook due to potential security issues and are therefore not
-      returned. For more information, see [Blocked attachments in
+      returned. For more information, see [ Blocked attachments in
       Outlook](https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519)<!--
       -->.
     name: attachments
@@ -76,11 +76,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: body
     fullName: Outlook_1_6.Office.MessageRead.body
@@ -104,11 +104,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: cc
     fullName: Outlook_1_6.Office.MessageRead.cc
@@ -136,11 +136,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: conversationId
     fullName: Outlook_1_6.Office.MessageRead.conversationId
@@ -158,11 +158,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: dateTimeCreated
     fullName: Outlook_1_6.Office.MessageRead.dateTimeCreated
@@ -180,11 +180,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
 
 
@@ -222,11 +222,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: displayReplyAllForm(formData)
     fullName: Outlook_1_6.Office.MessageRead.displayReplyAllForm
@@ -243,7 +243,7 @@ items:
         - id: formData
           description: >-
             A string that contains text and HTML and that represents the body of the reply form. The string is limited
-            to 32 KB OR An[Office.ReplyFormData](xref:Outlook_1_6.Office.ReplyFormData) object that contains body or
+            to 32 KB OR An [Office.ReplyFormData](xref:Outlook_1_6.Office.ReplyFormData) object that contains body or
             attachment data and a callback function
           type:
             - string | ReplyFormData
@@ -270,11 +270,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: displayReplyForm(formData)
     fullName: Outlook_1_6.Office.MessageRead.displayReplyForm
@@ -291,7 +291,7 @@ items:
         - id: formData
           description: >-
             A string that contains text and HTML and that represents the body of the reply form. The string is limited
-            to 32 KB. OR An[Office.ReplyFormData](xref:Outlook_1_6.Office.ReplyFormData) object that contains body or
+            to 32 KB. OR An [Office.ReplyFormData](xref:Outlook_1_6.Office.ReplyFormData) object that contains body or
             attachment data and a callback function.
           type:
             - string | ReplyFormData
@@ -312,11 +312,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: from
     fullName: Outlook_1_6.Office.MessageRead.from
@@ -330,17 +330,17 @@ items:
           - EmailAddressDetails
   - uid: Outlook_1_6.Office.MessageRead.getEntities
     summary: |-
-      Gets the entities found in the selected item.
+      Gets the entities found in the selected item's body.
 
       Note: This method is not supported in Outlook for iOS or Outlook for Android.
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: getEntities()
     fullName: Outlook_1_6.Office.MessageRead.getEntities
@@ -355,17 +355,17 @@ items:
         description: ''
   - uid: Outlook_1_6.Office.MessageRead.getEntitiesByType
     summary: |-
-      Gets an array of all the entities of the specified entity type found in the selected item.
+      Gets an array of all the entities of the specified entity type found in the selected item's body.
 
       Note: This method is not supported in Outlook for iOS or Outlook for Android.
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
 
 
@@ -393,7 +393,7 @@ items:
           - '(string | Contact | MeetingSuggestion | PhoneNumber | TaskSuggestion)[]'
         description: >-
           If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns
-          null. If no entities of the specified type are present on the item, the method returns an empty array.
+          null. If no entities of the specified type are present in the item's body, the method returns an empty array.
           Otherwise, the type of the objects in the returned array depends on the type of entity requested in the
           entityType parameter.
       parameters:
@@ -415,11 +415,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: getFilteredEntitiesByName(name)
     fullName: Outlook_1_6.Office.MessageRead.getFilteredEntitiesByName
@@ -464,11 +464,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: getRegExMatches()
     fullName: Outlook_1_6.Office.MessageRead.getRegExMatches
@@ -504,11 +504,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: getRegExMatchesByName(name)
     fullName: Outlook_1_6.Office.MessageRead.getRegExMatchesByName
@@ -537,11 +537,11 @@ items:
 
       \[ [API set: Mailbox 1.6](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: getSelectedEntities()
     fullName: Outlook_1_6.Office.MessageRead.getSelectedEntities
@@ -577,11 +577,11 @@ items:
 
       \[ [API set: Mailbox 1.6](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: getSelectedRegExMatches()
     fullName: Outlook_1_6.Office.MessageRead.getSelectedRegExMatches
@@ -603,11 +603,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: internetMessageId
     fullName: Outlook_1_6.Office.MessageRead.internetMessageId
@@ -630,11 +630,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
 
 
@@ -672,16 +672,17 @@ items:
       Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The
       itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making
       REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more
-      details, see Use the Outlook REST APIs from an Outlook add-in.
+      details, see [ Use the Outlook REST APIs from an Outlook
+      add-in](https://docs.microsoft.com/outlook/add-ins/use-rest-api#get-the-item-id)<!-- -->.
 
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: itemId
     fullName: Outlook_1_6.Office.MessageRead.itemId
@@ -704,11 +705,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: itemType
     fullName: Outlook_1_6.Office.MessageRead.itemType
@@ -738,11 +739,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: 'loadCustomPropertiesAsync(callback, userContext)'
     fullName: Outlook_1_6.Office.MessageRead.loadCustomPropertiesAsync
@@ -750,7 +751,9 @@ items:
       - typeScript
     type: method
     syntax:
-      content: 'loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;'
+      content: >-
+        loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any):
+        void;
       return:
         type:
           - void
@@ -759,9 +762,9 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult.
+            of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<Office.CustomProperties>) => void'
         - id: userContext
           description: >-
             Optional. Developers can provide any object they wish to access in the callback function. This object can be
@@ -779,11 +782,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: normalizedSubject
     fullName: Outlook_1_6.Office.MessageRead.normalizedSubject
@@ -801,12 +804,12 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: notificationMessages
     fullName: Outlook_1_6.Office.MessageRead.notificationMessages
     langs:
@@ -831,11 +834,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: sender
     fullName: Outlook_1_6.Office.MessageRead.sender
@@ -861,11 +864,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: subject
     fullName: Outlook_1_6.Office.MessageRead.subject
@@ -889,11 +892,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: to
     fullName: Outlook_1_6.Office.MessageRead.to

--- a/docs/docs-ref-autogen/outlook_1_6/office.notificationmessagedetails.yml
+++ b/docs/docs-ref-autogen/outlook_1_6/office.notificationmessagedetails.yml
@@ -6,12 +6,12 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.NotificationMessageDetails
     fullName: Outlook_1_6.Office.NotificationMessageDetails
     langs:

--- a/docs/docs-ref-autogen/outlook_1_6/office.notificationmessages.yml
+++ b/docs/docs-ref-autogen/outlook_1_6/office.notificationmessages.yml
@@ -6,12 +6,12 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.NotificationMessages
     fullName: Outlook_1_6.Office.NotificationMessages
     langs:
@@ -31,12 +31,12 @@ items:
       There are a maximum of 5 notifications per message. Setting more will return a
       NumberOfNotificationMessagesExceeded error.
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
 
 
       In addition to this signature, the method also has the following signatures:
@@ -48,7 +48,8 @@ items:
       `addAsync(key: string, JSONmessage: NotificationMessageDetails, options: Office.AsyncContextOptions): void;`
 
 
-      `addAsync(key: string, JSONmessage: NotificationMessageDetails, callback: (result: AsyncResult) => void): void;`
+      `addAsync(key: string, JSONmessage: NotificationMessageDetails, callback: (result: AsyncResult<void>) => void):
+      void;`
     name: 'addAsync(key, JSONmessage, options, callback)'
     fullName: Outlook_1_6.Office.NotificationMessages.addAsync
     langs:
@@ -57,7 +58,7 @@ items:
     syntax:
       content: >-
         addAsync(key: string, JSONmessage: NotificationMessageDetails, options?: Office.AsyncContextOptions, callback?:
-        (result: AsyncResult) => void): void;
+        (result: AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -84,34 +85,39 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. \[Api set: Mailbox 1.3\]
+            parameter of type Office.AsyncResult.
+
+
+            \[Api set: Mailbox 1.3\]
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_6.Office.NotificationMessages.getAllAsync
     summary: |-
       Returns all keys and messages for an item.
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
 
 
-      In addition to the main signature, this method also has this signature:
+      In addition to this signature, this method also has the following signature:
 
 
-      `getAllAsync(callback: (result: AsyncResult) => void): void;`
+      `getAllAsync(callback: (result: AsyncResult<Office.NotificationMessageDetails[]>) => void): void;`
     name: 'getAllAsync(options, callback)'
     fullName: Outlook_1_6.Office.NotificationMessages.getAllAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'getAllAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;'
+      content: >-
+        getAllAsync(options?: Office.AsyncContextOptions, callback?: (result:
+        AsyncResult<Office.NotificationMessageDetails[]>) => void): void;
       return:
         type:
           - void
@@ -126,24 +132,25 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult.
+            parameter of type Office.AsyncResult. The `value` property of the result is an array of
+            NotificationMessageDetails objects.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<Office.NotificationMessageDetails[]>) => void'
   - uid: Outlook_1_6.Office.NotificationMessages.removeAsync
     summary: |-
       Removes a notification message for an item.
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
 
 
-      In addition to the main signature, this method also has these signatures:
+      In addition to this signature, this method also has the following signatures:
 
 
       `removeAsync(key: string): void;`
@@ -152,14 +159,16 @@ items:
       `removeAsync(key: string, options: Office.AsyncContextOptions): void;`
 
 
-      `removeAsync(key: string, callback: (result: AsyncResult) => void): void;`
+      `removeAsync(key: string, callback: (result: AsyncResult<void>) => void): void;`
     name: 'removeAsync(key, options, callback)'
     fullName: Outlook_1_6.Office.NotificationMessages.removeAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'removeAsync(key: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;'
+      content: >-
+        removeAsync(key: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void):
+        void;
       return:
         type:
           - void
@@ -178,9 +187,9 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult.
+            parameter of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_6.Office.NotificationMessages.replaceAsync
     summary: |-
       Replaces a notification message that has a given key with another message.
@@ -189,15 +198,15 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
 
 
-      In addition to the main signature, this method also has these signatures:
+      In addition to this signature, this method also has the following signatures:
 
 
       `replaceAsync(key: string, JSONmessage: NotificationMessageDetails): void;`
@@ -206,8 +215,8 @@ items:
       `replaceAsync(key: string, JSONmessage: NotificationMessageDetails, options: Office.AsyncContextOptions): void;`
 
 
-      `replaceAsync(key: string, JSONmessage: NotificationMessageDetails, callback: (result: AsyncResult) => void):
-      void;`
+      `replaceAsync(key: string, JSONmessage: NotificationMessageDetails, callback: (result: AsyncResult<void>) =>
+      void): void;`
     name: 'replaceAsync(key, JSONmessage, options, callback)'
     fullName: Outlook_1_6.Office.NotificationMessages.replaceAsync
     langs:
@@ -216,7 +225,7 @@ items:
     syntax:
       content: >-
         replaceAsync(key: string, JSONmessage: NotificationMessageDetails, options?: Office.AsyncContextOptions,
-        callback?: (result: AsyncResult) => void): void;
+        callback?: (result: AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -241,6 +250,6 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult.
+            parameter of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'

--- a/docs/docs-ref-autogen/outlook_1_6/office.phonenumber.yml
+++ b/docs/docs-ref-autogen/outlook_1_6/office.phonenumber.yml
@@ -12,11 +12,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: Office.PhoneNumber
     fullName: Outlook_1_6.Office.PhoneNumber

--- a/docs/docs-ref-autogen/outlook_1_6/office.recipients.yml
+++ b/docs/docs-ref-autogen/outlook_1_6/office.recipients.yml
@@ -3,11 +3,11 @@ items:
   - uid: Outlook_1_6.Office.Recipients
     summary: '\[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]'
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
     name: Office.Recipients
     fullName: Outlook_1_6.Office.Recipients
@@ -33,11 +33,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -45,7 +45,7 @@ items:
       entries.</td></tr></table>
 
 
-      In addition to the main signature, this method also has these signatures:
+      In addition to this signature, this method also has the following signatures:
 
 
       `addAsync(recipients: (string | EmailUser | EmailAddressDetails)[]): void;`
@@ -54,8 +54,8 @@ items:
       `addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options: Office.AsyncContextOptions): void;`
 
 
-      `addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult) => void):
-      void;`
+      `addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult<void>) =>
+      void): void;`
     name: 'addAsync(recipients, options, callback)'
     fullName: Outlook_1_6.Office.Recipients.addAsync
     langs:
@@ -64,7 +64,7 @@ items:
     syntax:
       content: >-
         addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options?: Office.AsyncContextOptions,
-        callback?: (result: AsyncResult) => void): void;
+        callback?: (result: AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -83,40 +83,42 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. If adding the recipients fails, the asyncResult.error property will contain
-            an error code.
+            parameter of type Office.AsyncResult. If adding the recipients fails, the asyncResult.error property will
+            contain an error code.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_6.Office.Recipients.getAsync
     summary: >-
       Gets a recipient list for an appointment or message.
 
 
-      When the call completes, the asyncResult.value property will contain an array
-      of[Office.EmailAddressDetails](xref:Outlook_1_6.Office.EmailAddressDetails) objects.
+      When the call completes, the asyncResult.value property will contain an array of
+      [Office.EmailAddressDetails](xref:Outlook_1_6.Office.EmailAddressDetails) objects.
 
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
 
 
-      In addition to the main signature, this method also has this signature:
+      In addition to this signature, this method also has the following signature:
 
 
-      `getAsync(callback: (result: AsyncResult) => void): void;`
+      `getAsync(callback: (result: AsyncResult<Office.EmailAddressDetails[]>) => void): void;`
     name: 'getAsync(options, callback)'
     fullName: Outlook_1_6.Office.Recipients.getAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;'
+      content: >-
+        getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult<Office.EmailAddressDetails[]>) =>
+        void): void;
       return:
         type:
           - void
@@ -131,9 +133,9 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult.
+            of type Office.AsyncResult. The `value` property of the result is an array of EmailAddressDetails objects.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<Office.EmailAddressDetails[]>) => void'
   - uid: Outlook_1_6.Office.Recipients.setAsync
     summary: |-
       Sets a recipient list for an appointment or message.
@@ -150,11 +152,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -162,7 +164,7 @@ items:
       entries.</td></tr></table>
 
 
-      In addition to the main signature, this method also has these signatures:
+      In addition to this signature, this method also has the following signatures:
 
 
       `setAsync(recipients: (string | EmailUser | EmailAddressDetails)[]): void;`
@@ -171,8 +173,8 @@ items:
       `setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options: Office.AsyncContextOptions): void;`
 
 
-      `setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult) => void):
-      void;`
+      `setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult<void>) =>
+      void): void;`
     name: 'setAsync(recipients, options, callback)'
     fullName: Outlook_1_6.Office.Recipients.setAsync
     langs:
@@ -181,7 +183,7 @@ items:
     syntax:
       content: >-
         setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options?: Office.AsyncContextOptions,
-        callback?: (result: AsyncResult) => void): void;
+        callback?: (result: AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -200,7 +202,7 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult. If setting the recipients fails the asyncResult.error property will contain a
-            code that indicates any error that occurred while adding the data.
+            parameter of type Office.AsyncResult. If setting the recipients fails the asyncResult.error property will
+            contain a code that indicates any error that occurred while adding the data.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'

--- a/docs/docs-ref-autogen/outlook_1_6/office.replyformdata.yml
+++ b/docs/docs-ref-autogen/outlook_1_6/office.replyformdata.yml
@@ -31,17 +31,17 @@ items:
   - uid: Outlook_1_6.Office.ReplyFormData.callback
     summary: >-
       When the reply display call completes, the function passed in the callback parameter is called with a single
-      parameter, asyncResult, which is an AsyncResult object.
+      parameter, asyncResult, which is an Office.AsyncResult object.
     name: callback
     fullName: Outlook_1_6.Office.ReplyFormData.callback
     langs:
       - typeScript
     type: property
     syntax:
-      content: 'callback?: (result: AsyncResult) => void;'
+      content: 'callback?: (result: AsyncResult<any>) => void;'
       return:
         type:
-          - '(result: AsyncResult) => void'
+          - '(result: AsyncResult<any>) => void'
   - uid: Outlook_1_6.Office.ReplyFormData.htmlBody
     summary: >-
       A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32

--- a/docs/docs-ref-autogen/outlook_1_6/office.roamingsettings.yml
+++ b/docs/docs-ref-autogen/outlook_1_6/office.roamingsettings.yml
@@ -7,7 +7,7 @@ items:
       saved.
 
 
-      While the Outlook add-in API limits access to these settings to only the add-in that created them, these settings
+      While the Outlook Add-in API limits access to these settings to only the add-in that created them, these settings
       should not be considered secure storage. They can be accessed by Exchange Web Services or Extended MAPI. They
       should not be used to store sensitive information such as user credentials or security tokens.
 
@@ -27,12 +27,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.RoamingSettings
     fullName: Outlook_1_6.Office.RoamingSettings
     langs:
@@ -50,12 +50,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: get(name)
     fullName: Outlook_1_6.Office.RoamingSettings.get
     langs:
@@ -78,12 +78,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: remove(name)
     fullName: Outlook_1_6.Office.RoamingSettings.remove
     langs:
@@ -113,19 +113,19 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: saveAsync(callback)
     fullName: Outlook_1_6.Office.RoamingSettings.saveAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'saveAsync(callback?: (result: AsyncResult) => void): void;'
+      content: 'saveAsync(callback?: (result: AsyncResult<void>) => void): void;'
       return:
         type:
           - void
@@ -133,10 +133,10 @@ items:
       parameters:
         - id: callback
           description: >-
-            Optional? When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type AsyncResult.
+            Optional. When the method completes, the function passed in the callback parameter is called with a single
+            parameter of type Office.AsyncResult.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_6.Office.RoamingSettings.set
     summary: >-
       Sets or creates the specified setting.
@@ -156,12 +156,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: 'set(name, value)'
     fullName: Outlook_1_6.Office.RoamingSettings.set
     langs:

--- a/docs/docs-ref-autogen/outlook_1_6/office.subject.yml
+++ b/docs/docs-ref-autogen/outlook_1_6/office.subject.yml
@@ -6,11 +6,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
     name: Office.Subject
     fullName: Outlook_1_6.Office.Subject
@@ -32,25 +32,25 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
 
 
-      In addition to the main signature, this method also has this signature:
+      In addition to this signature, this method also has the following signature:
 
 
-      `getAsync(callback: (result: AsyncResult) => void): void;`
+      `getAsync(callback: (result: AsyncResult<string>) => void): void;`
     name: 'getAsync(options, callback)'
     fullName: Outlook_1_6.Office.Subject.getAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;'
+      content: 'getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult<string>) => void): void;'
       return:
         type:
           - void
@@ -65,9 +65,9 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult.
+            of type Office.AsyncResult. The `value` property of the result is the subject of the item.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<string>) => void'
   - uid: Outlook_1_6.Office.Subject.setAsync
     summary: >-
       Sets the subject of an appointment or message.
@@ -80,11 +80,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -92,7 +92,7 @@ items:
       characters.</td></tr></table>
 
 
-      In addition to the main signature, this method also has these signatures:
+      In addition to this signature, this method also has the following signatures:
 
 
       `setAsync(subject: string): void;`
@@ -101,14 +101,16 @@ items:
       `setAsync(subject: string, options: Office.AsyncContextOptions): void;`
 
 
-      `setAsync(subject: string, callback: (result: AsyncResult) => void): void;`
+      `setAsync(subject: string, callback: (result: AsyncResult<void>) => void): void;`
     name: 'setAsync(subject, options, callback)'
     fullName: Outlook_1_6.Office.Subject.setAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'setAsync(subject: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;'
+      content: >-
+        setAsync(subject: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void):
+        void;
       return:
         type:
           - void
@@ -127,7 +129,7 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult. If setting the subject fails, the asyncResult.error property will contain an error
-            code.
+            of type Office.AsyncResult. If setting the subject fails, the asyncResult.error property will contain an
+            error code.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'

--- a/docs/docs-ref-autogen/outlook_1_6/office.tasksuggestion.yml
+++ b/docs/docs-ref-autogen/outlook_1_6/office.tasksuggestion.yml
@@ -5,18 +5,18 @@ items:
       Represents a suggested task identified in an item. Read mode only.
 
 
-      The list of tasks suggested in an email message is returned in the taskSuggestions property of the
-      \[Entities\]Entities object that is returned when the getEntities or getEntitiesByType method is called on the
-      active item.
+      The list of tasks suggested in an email message is returned in the taskSuggestions property of the [
+      Entities](xref:Outlook_1_6.Office.Entities) object that is returned when the getEntities or getEntitiesByType
+      method is called on the active item.
 
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: Office.TaskSuggestion
     fullName: Outlook_1_6.Office.TaskSuggestion

--- a/docs/docs-ref-autogen/outlook_1_6/office.time.yml
+++ b/docs/docs-ref-autogen/outlook_1_6/office.time.yml
@@ -6,11 +6,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
     name: Office.Time
     fullName: Outlook_1_6.Office.Time
@@ -33,25 +33,25 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
 
 
-      In addition to the main signature, this method also has this signature:
+      In addition to this signature, this method also has the following signature:
 
 
-      `getAsync(callback: (result: AsyncResult) => void): void;`
+      `getAsync(callback: (result: AsyncResult<Date>) => void): void;`
     name: 'getAsync(options, callback)'
     fullName: Outlook_1_6.Office.Time.getAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;'
+      content: 'getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult<Date>) => void): void;'
       return:
         type:
           - void
@@ -66,9 +66,9 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult.
+            of type AsyncResult. The `value` property of the result is a Date object.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<Date>) => void'
   - uid: Outlook_1_6.Office.Time.setAsync
     summary: >-
       Sets the start or end time of an appointment.
@@ -84,11 +84,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -96,7 +96,7 @@ items:
       time.</td></tr></table>
 
 
-      In addition to the main signature, this method also has these signatures:
+      In addition to this signature, this method also has the following signatures:
 
 
       `setAsync(dateTime: Date): void;`
@@ -105,14 +105,16 @@ items:
       `setAsync(dateTime: Date, options: Office.AsyncContextOptions): void;`
 
 
-      `setAsync(dateTime: Date, callback: (result: AsyncResult) => void): void;`
+      `setAsync(dateTime: Date, callback: (result: AsyncResult<void>) => void): void;`
     name: 'setAsync(dateTime, options, callback)'
     fullName: Outlook_1_6.Office.Time.setAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'setAsync(dateTime: Date, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;'
+      content: >-
+        setAsync(dateTime: Date, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void):
+        void;
       return:
         type:
           - void
@@ -131,7 +133,7 @@ items:
         - id: callback
           description: >-
             When the method completes, the function passed in the callback parameter is called with a single parameter
-            of type AsyncResult. If setting the date and time fails, the asyncResult.error property will contain an
-            error code.
+            of type Office.AsyncResult. If setting the date and time fails, the asyncResult.error property will contain
+            an error code.
           type:
-            - '(result: AsyncResult) => void'
+            - '(result: AsyncResult<void>) => void'

--- a/docs/docs-ref-autogen/outlook_1_6/office.userprofile.yml
+++ b/docs/docs-ref-autogen/outlook_1_6/office.userprofile.yml
@@ -8,12 +8,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.UserProfile
     fullName: Outlook_1_6.Office.UserProfile
     langs:
@@ -33,12 +33,12 @@ items:
 
       \[ [API set: Mailbox 1.6](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
 
 
       The possible account types are listed in the following table.
@@ -65,12 +65,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: displayName
     fullName: Outlook_1_6.Office.UserProfile.displayName
     langs:
@@ -87,12 +87,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: emailAddress
     fullName: Outlook_1_6.Office.UserProfile.emailAddress
     langs:
@@ -109,12 +109,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: timeZone
     fullName: Outlook_1_6.Office.UserProfile.timeZone
     langs:

--- a/docs/docs-ref-autogen/outlook_1_7/office.appointmentcompose.yml
+++ b/docs/docs-ref-autogen/outlook_1_7/office.appointmentcompose.yml
@@ -2,11 +2,11 @@
 items:
   - uid: Outlook_1_7.Office.AppointmentCompose
     summary: >-
-      The appointment organizer mode of [Office.context.mailbox.item](xref:Outlook_1_7.Office.Item)<!-- -->.
+      The appointment organizer mode of [ Office.context.mailbox.item](xref:Outlook_1_7.Office.Item)<!-- -->.
 
 
       Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat
-      this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
+      this as a mode of `Office.context.mailbox.item`<!-- -->. Refer to the Object Model pages for more information.
     name: Office.AppointmentCompose
     fullName: Outlook_1_7.Office.AppointmentCompose
     langs:
@@ -55,11 +55,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Organizer</td></tr>
 
 
@@ -126,17 +126,17 @@ items:
       Adds an event handler for a supported event.
 
 
-      Currently the supported event types are `Office.EventType.AppointmentTimeChanged`,
-      `Office.EventType.RecipientsChanged`, and `Office.EventType.RecurrenceChanged`.
+      Currently the supported event types are `Office.EventType.AppointmentTimeChanged`<!-- -->,
+      `Office.EventType.RecipientsChanged`<!-- -->, and `Office.EventType.RecurrenceChanged`<!-- -->.
 
 
       \[ [API set: Mailbox 1.7](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
 
@@ -202,11 +202,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Organizer</td></tr>
 
 
@@ -269,11 +269,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: body
@@ -304,11 +304,11 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: close()
@@ -328,11 +328,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: dateTimeCreated
@@ -351,11 +351,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
 
@@ -387,11 +387,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: end
@@ -419,11 +419,11 @@ items:
 
       \[ [API set: Mailbox 1.2](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: 'getSelectedDataAsync(coerciontype, options, callback)'
@@ -467,11 +467,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: itemType
@@ -502,11 +502,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: 'loadCustomPropertiesAsync(callback, userContext)'
@@ -543,11 +543,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: location
@@ -566,11 +566,11 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: notificationMessages
@@ -593,11 +593,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: optionalAttendees
@@ -615,17 +615,17 @@ items:
       Gets the organizer for the specified meeting.
 
 
-      The organizer property returns an [Organizer](xref:Outlook_1_7.Office.Organizer) object that provides a method to
+      The organizer property returns an [ Organizer](xref:Outlook_1_7.Office.Organizer) object that provides a method to
       get the organizer value.
 
 
       \[ [API set: Mailbox 1.7](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: organizer
@@ -657,11 +657,11 @@ items:
 
       \[ [API set: Mailbox 1.7](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: recurrence
@@ -682,17 +682,17 @@ items:
       The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best
       practice, you should use the attachment identifier to remove an attachment only if the same mail app has added
       that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid
-      only within the same session. A session is over when the user closes the app, or if the user starts composing in
-      an inline form and subsequently pops out the inline form to continue in a separate window.
+      only within the same session. A session is over when the user closes the app, or if the user starts composing an
+      inline form then subsequently pops out the form to continue in a separate window.
 
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Organizer</td></tr>
 
 
@@ -745,17 +745,17 @@ items:
       Removes an event handler for a supported event.
 
 
-      Currently the supported event types are `Office.EventType.AppointmentTimeChanged`,
-      `Office.EventType.RecipientsChanged`, and `Office.EventType.RecurrenceChanged`.
+      Currently the supported event types are `Office.EventType.AppointmentTimeChanged`<!-- -->,
+      `Office.EventType.RecipientsChanged`<!-- -->, and `Office.EventType.RecurrenceChanged`<!-- -->.
 
 
       \[ [API set: Mailbox 1.7](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
 
@@ -779,7 +779,7 @@ items:
         description: ''
       parameters:
         - id: eventType
-          description: The event that should invoke the handler.
+          description: The event that should revoke the handler.
           type:
             - EventType
         - id: handler
@@ -810,11 +810,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: requiredAttendees
@@ -860,11 +860,11 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Organizer</td></tr>
 
 
@@ -917,7 +917,7 @@ items:
       Note: The identifier returned by the seriesId property is the same as the Exchange Web Services item identifier.
       The seriesId property is not identical to the Outlook IDs used by the Outlook REST API. Before making REST API
       calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more details, see
-      [Use the Outlook REST APIs from an Outlook add-in](https://docs.microsoft.com/outlook/add-ins/use-rest-api)<!--
+      [ Use the Outlook REST APIs from an Outlook add-in](https://docs.microsoft.com/outlook/add-ins/use-rest-api)<!--
       -->.
 
 
@@ -927,11 +927,11 @@ items:
 
       \[ [API set: Mailbox 1.7](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: seriesId
@@ -956,11 +956,11 @@ items:
 
       \[ [API set: Mailbox 1.2](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Organizer</td></tr>
 
 
@@ -973,7 +973,7 @@ items:
       `setSelectedDataAsync(data: string): void;`
 
 
-      `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions &amp; CoercionTypeOptions): void;`
+      `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`
 
 
       `setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;`
@@ -1030,11 +1030,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: start
@@ -1057,11 +1057,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment
       Organizer</td></tr></table>
     name: subject

--- a/docs/docs-ref-autogen/outlook_1_7/office.appointmentform.yml
+++ b/docs/docs-ref-autogen/outlook_1_7/office.appointmentform.yml
@@ -6,12 +6,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.AppointmentForm
     fullName: Outlook_1_7.Office.AppointmentForm
     langs:
@@ -33,12 +33,12 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: body
     fullName: Outlook_1_7.Office.AppointmentForm.body
     langs:
@@ -76,12 +76,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: end
     fullName: Outlook_1_7.Office.AppointmentForm.end
     langs:
@@ -112,10 +112,10 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: location
     fullName: Outlook_1_7.Office.AppointmentForm.location
     langs:
@@ -148,12 +148,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: optionalAttendees
     fullName: Outlook_1_7.Office.AppointmentForm.optionalAttendees
     langs:
@@ -186,12 +186,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: requiredAttendees
     fullName: Outlook_1_7.Office.AppointmentForm.requiredAttendees
     langs:
@@ -240,12 +240,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: start
     fullName: Outlook_1_7.Office.AppointmentForm.start
     langs:
@@ -279,12 +279,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: subject
     fullName: Outlook_1_7.Office.AppointmentForm.subject
     langs:

--- a/docs/docs-ref-autogen/outlook_1_7/office.appointmentread.yml
+++ b/docs/docs-ref-autogen/outlook_1_7/office.appointmentread.yml
@@ -2,7 +2,7 @@
 items:
   - uid: Outlook_1_7.Office.AppointmentRead
     summary: >-
-      The appointment attendee mode of [Office.context.mailbox.item](xref:Outlook_1_7.Office.Item)<!-- -->.
+      The appointment attendee mode of [ Office.context.mailbox.item](xref:Outlook_1_7.Office.Item)<!-- -->.
 
 
       Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat
@@ -51,17 +51,17 @@ items:
       Adds an event handler for a supported event.
 
 
-      Currently the supported event types are `Office.EventType.AppointmentTimeChanged`,
-      `Office.EventType.RecipientsChanged`, and `Office.EventType.RecurrenceChanged`.
+      Currently the supported event types are `Office.EventType.AppointmentTimeChanged`<!-- -->,
+      `Office.EventType.RecipientsChanged`<!-- -->, and `Office.EventType.RecurrenceChanged`<!-- -->.
 
 
       \[ [API set: Mailbox 1.7](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
 
 
@@ -108,20 +108,20 @@ items:
             - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_7.Office.AppointmentRead.attachments
     summary: |-
-      Gets an array of attachments for the item.
+      Gets the item's attachments as an array.
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
 
 
       Note: Certain types of files are blocked by Outlook due to potential security issues and are therefore not
-      returned. For more information, see [Blocked attachments in
+      returned. For more information, see [ Blocked attachments in
       Outlook](https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519)<!--
       -->.
     name: attachments
@@ -140,11 +140,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: body
     fullName: Outlook_1_7.Office.AppointmentRead.body
@@ -162,11 +162,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: dateTimeCreated
     fullName: Outlook_1_7.Office.AppointmentRead.dateTimeCreated
@@ -184,11 +184,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
 
 
@@ -226,11 +226,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: displayReplyAllForm(formData)
     fullName: Outlook_1_7.Office.AppointmentRead.displayReplyAllForm
@@ -247,7 +247,7 @@ items:
         - id: formData
           description: >-
             A string that contains text and HTML and that represents the body of the reply form. The string is limited
-            to 32 KB OR An[Office.ReplyFormData](xref:Outlook_1_7.Office.ReplyFormData) object that contains body or
+            to 32 KB OR An [Office.ReplyFormData](xref:Outlook_1_7.Office.ReplyFormData) object that contains body or
             attachment data and a callback function
           type:
             - string | ReplyFormData
@@ -274,11 +274,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: displayReplyForm(formData)
     fullName: Outlook_1_7.Office.AppointmentRead.displayReplyForm
@@ -295,7 +295,7 @@ items:
         - id: formData
           description: >-
             A string that contains text and HTML and that represents the body of the reply form. The string is limited
-            to 32 KB. OR An[Office.ReplyFormData](xref:Outlook_1_7.Office.ReplyFormData) object that contains body or
+            to 32 KB. OR An [Office.ReplyFormData](xref:Outlook_1_7.Office.ReplyFormData) object that contains body or
             attachment data and a callback function.
           type:
             - string | ReplyFormData
@@ -314,11 +314,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: end
     fullName: Outlook_1_7.Office.AppointmentRead.end
@@ -338,11 +338,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: getEntities()
     fullName: Outlook_1_7.Office.AppointmentRead.getEntities
@@ -363,11 +363,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
 
 
@@ -417,11 +417,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: getFilteredEntitiesByName(name)
     fullName: Outlook_1_7.Office.AppointmentRead.getFilteredEntitiesByName
@@ -466,11 +466,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: getRegExMatches()
     fullName: Outlook_1_7.Office.AppointmentRead.getRegExMatches
@@ -506,11 +506,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: getRegExMatchesByName(name)
     fullName: Outlook_1_7.Office.AppointmentRead.getRegExMatchesByName
@@ -539,11 +539,11 @@ items:
 
       \[ [API set: Mailbox 1.6](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: getSelectedEntities()
     fullName: Outlook_1_7.Office.AppointmentRead.getSelectedEntities
@@ -579,11 +579,11 @@ items:
 
       \[ [API set: Mailbox 1.6](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: getSelectedRegExMatches()
     fullName: Outlook_1_7.Office.AppointmentRead.getSelectedRegExMatches
@@ -610,11 +610,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
 
 
@@ -652,17 +652,17 @@ items:
       Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The
       itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making
       REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more
-      details, see [Use the Outlook REST APIs from an Outlook
+      details, see [ Use the Outlook REST APIs from an Outlook
       add-in](https://docs.microsoft.com/outlook/add-ins/use-rest-api#get-the-item-id)<!-- -->.
 
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: itemId
     fullName: Outlook_1_7.Office.AppointmentRead.itemId
@@ -685,11 +685,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: itemType
     fullName: Outlook_1_7.Office.AppointmentRead.itemType
@@ -719,11 +719,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: 'loadCustomPropertiesAsync(callback, userContext)'
     fullName: Outlook_1_7.Office.AppointmentRead.loadCustomPropertiesAsync
@@ -759,11 +759,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: location
     fullName: Outlook_1_7.Office.AppointmentRead.location
@@ -786,11 +786,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: normalizedSubject
     fullName: Outlook_1_7.Office.AppointmentRead.normalizedSubject
@@ -808,11 +808,11 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: notificationMessages
     fullName: Outlook_1_7.Office.AppointmentRead.notificationMessages
@@ -837,11 +837,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: optionalAttendees
     fullName: Outlook_1_7.Office.AppointmentRead.optionalAttendees
@@ -859,11 +859,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: organizer
     fullName: Outlook_1_7.Office.AppointmentRead.organizer
@@ -894,11 +894,11 @@ items:
 
       \[ [API set: Mailbox 1.7](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: recurrence
     fullName: Outlook_1_7.Office.AppointmentRead.recurrence
@@ -915,17 +915,17 @@ items:
       Removes an event handler for a supported event.
 
 
-      Currently the supported event types are `Office.EventType.AppointmentTimeChanged`,
-      `Office.EventType.RecipientsChanged`, and `Office.EventType.RecurrenceChanged`.
+      Currently the supported event types are `Office.EventType.AppointmentTimeChanged`<!-- -->,
+      `Office.EventType.RecipientsChanged`<!-- -->, and `Office.EventType.RecurrenceChanged`<!-- -->.
 
 
       \[ [API set: Mailbox 1.7](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
 
 
@@ -948,7 +948,7 @@ items:
         description: ''
       parameters:
         - id: eventType
-          description: The event that should invoke the handler.
+          description: The event that should revoke the handler.
           type:
             - EventType
         - id: handler
@@ -982,11 +982,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: requiredAttendees
     fullName: Outlook_1_7.Office.AppointmentRead.requiredAttendees
@@ -1010,7 +1010,7 @@ items:
       Note: The identifier returned by the seriesId property is the same as the Exchange Web Services item identifier.
       The seriesId property is not identical to the Outlook IDs used by the Outlook REST API. Before making REST API
       calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more details, see
-      [Use the Outlook REST APIs from an Outlook add-in](https://docs.microsoft.com/outlook/add-ins/use-rest-api)<!--
+      [ Use the Outlook REST APIs from an Outlook add-in](https://docs.microsoft.com/outlook/add-ins/use-rest-api)<!--
       -->.
 
 
@@ -1020,11 +1020,11 @@ items:
 
       \[ [API set: Mailbox 1.7](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: seriesId
     fullName: Outlook_1_7.Office.AppointmentRead.seriesId
@@ -1047,11 +1047,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: start
     fullName: Outlook_1_7.Office.AppointmentRead.start
@@ -1077,11 +1077,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Appointment Attendee</td></tr></table>
     name: subject
     fullName: Outlook_1_7.Office.AppointmentRead.subject

--- a/docs/docs-ref-autogen/outlook_1_7/office.attachmentdetails.yml
+++ b/docs/docs-ref-autogen/outlook_1_7/office.attachmentdetails.yml
@@ -8,11 +8,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: Office.AttachmentDetails
     fullName: Outlook_1_7.Office.AttachmentDetails

--- a/docs/docs-ref-autogen/outlook_1_7/office.body.yml
+++ b/docs/docs-ref-autogen/outlook_1_7/office.body.yml
@@ -8,12 +8,12 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.Body
     fullName: Outlook_1_7.Office.Body
     langs:
@@ -42,18 +42,18 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
 
 
       In addition to this signature, this method also has the following signature:
 
 
-      `getAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult&lt;Office.Body&gt;) => void): void;`
+      `getAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult<Office.Body>) => void): void;`
     name: 'getAsync(coerciontype, options, callback)'
     fullName: Outlook_1_7.Office.Body.getAsync
     langs:
@@ -91,11 +91,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
     name: 'getTypeAsync(options, callback)'
     fullName: Outlook_1_7.Office.Body.getTypeAsync
@@ -139,11 +139,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -154,7 +154,7 @@ items:
       In addition to this signature, this method also has the following signatures:
 
 
-      `prependAsync(data: string, options: Office.AsyncContextOptions &amp; CoercionTypeOptions): void;`
+      `prependAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`
 
 
       `prependAsync(data: string, callback: (result: AsyncResult<void>) => void): void;`
@@ -210,11 +210,11 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -226,7 +226,7 @@ items:
       In addition to this signature, this method also has the following signatures:
 
 
-      `setAsync(data: string, options: Office.AsyncContextOptions &amp; CoercionTypeOptions): void;`
+      `setAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`
 
 
       `setAsync(data: string, callback: (result: AsyncResult<void>) => void): void;`
@@ -282,11 +282,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -298,7 +298,7 @@ items:
       In addition to this signature, this method also has the following signatures:
 
 
-      `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions &amp; CoercionTypeOptions): void;`
+      `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`
 
 
       `setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;`

--- a/docs/docs-ref-autogen/outlook_1_7/office.contact.yml
+++ b/docs/docs-ref-autogen/outlook_1_7/office.contact.yml
@@ -12,11 +12,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: Office.Contact
     fullName: Outlook_1_7.Office.Contact

--- a/docs/docs-ref-autogen/outlook_1_7/office.customproperties.yml
+++ b/docs/docs-ref-autogen/outlook_1_7/office.customproperties.yml
@@ -15,12 +15,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.CustomProperties
     fullName: Outlook_1_7.Office.CustomProperties
     langs:
@@ -35,12 +35,12 @@ items:
   - uid: Outlook_1_7.Office.CustomProperties.get
     summary: Returns the value of the specified custom property.
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: get(name)
     fullName: Outlook_1_7.Office.CustomProperties.get
     langs:
@@ -66,12 +66,12 @@ items:
 
       To make the removal of the property permanent, you must call the saveAsync method of the CustomProperties object.
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: remove(name)
     fullName: Outlook_1_7.Office.CustomProperties.remove
     langs:
@@ -85,7 +85,10 @@ items:
         description: ''
       parameters:
         - id: name
-          description: 'The name of the property to be removed. \[Api set: Mailbox 1.0\]'
+          description: |-
+            The name of the property to be removed.
+
+            \[Api set: Mailbox 1.0\]
           type:
             - string
   - uid: Outlook_1_7.Office.CustomProperties.saveAsync
@@ -102,12 +105,12 @@ items:
       becomes disconnected. If the add-in calls saveAsync while in the disconnected state, saveAsync would return an
       error. Your callback method should handle this error accordingly.
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: 'saveAsync(callback, asyncContext)'
     fullName: Outlook_1_7.Office.CustomProperties.saveAsync
     langs:
@@ -127,7 +130,10 @@ items:
           type:
             - '(result: AsyncResult<void>) => void'
         - id: asyncContext
-          description: 'Optional. Any state data that is passed to the callback method. \[Api set: Mailbox 1.0\]'
+          description: |-
+            Optional. Any state data that is passed to the callback method.
+
+            \[Api set: Mailbox 1.0\]
           type:
             - any
   - uid: Outlook_1_7.Office.CustomProperties.set
@@ -146,12 +152,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: 'set(name, value)'
     fullName: Outlook_1_7.Office.CustomProperties.set
     langs:

--- a/docs/docs-ref-autogen/outlook_1_7/office.diagnostics.yml
+++ b/docs/docs-ref-autogen/outlook_1_7/office.diagnostics.yml
@@ -6,12 +6,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.Diagnostics
     fullName: Outlook_1_7.Office.Diagnostics
     langs:
@@ -30,12 +30,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: hostName
     fullName: Outlook_1_7.Office.Diagnostics.hostName
     langs:
@@ -58,12 +58,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: hostVersion
     fullName: Outlook_1_7.Office.Diagnostics.hostVersion
     langs:
@@ -102,12 +102,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: OWAView
     fullName: Outlook_1_7.Office.Diagnostics.OWAView
     langs:

--- a/docs/docs-ref-autogen/outlook_1_7/office.emailaddressdetails.yml
+++ b/docs/docs-ref-autogen/outlook_1_7/office.emailaddressdetails.yml
@@ -6,12 +6,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.EmailAddressDetails
     fullName: Outlook_1_7.Office.EmailAddressDetails
     langs:

--- a/docs/docs-ref-autogen/outlook_1_7/office.emailuser.yml
+++ b/docs/docs-ref-autogen/outlook_1_7/office.emailuser.yml
@@ -6,11 +6,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: Office.EmailUser
     fullName: Outlook_1_7.Office.EmailUser

--- a/docs/docs-ref-autogen/outlook_1_7/office.entities.yml
+++ b/docs/docs-ref-autogen/outlook_1_7/office.entities.yml
@@ -34,11 +34,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: Office.Entities
     fullName: Outlook_1_7.Office.Entities

--- a/docs/docs-ref-autogen/outlook_1_7/office.from.yml
+++ b/docs/docs-ref-autogen/outlook_1_7/office.from.yml
@@ -6,11 +6,11 @@ items:
 
       \[ [API set: Mailbox 1.7](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
     name: Office.From
     fullName: Outlook_1_7.Office.From
@@ -34,18 +34,18 @@ items:
 
       \[ [API set: Mailbox 1.7](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
 
 
       In addition to this signature, the method also has the following signature:
 
 
-      `getAsync(callback?: (result: AsyncResult&lt;Office.EmailAddressDetails&gt;) => void): void;`
+      `getAsync(callback?: (result: AsyncResult<Office.EmailAddressDetails>) => void): void;`
     name: 'getAsync(options, callback)'
     fullName: Outlook_1_7.Office.From.getAsync
     langs:

--- a/docs/docs-ref-autogen/outlook_1_7/office.item.yml
+++ b/docs/docs-ref-autogen/outlook_1_7/office.item.yml
@@ -8,12 +8,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.Item
     fullName: Outlook_1_7.Office.Item
     langs:
@@ -36,18 +36,18 @@ items:
       Adds an event handler for a supported event.
 
 
-      Currently the supported event types are `Office.EventType.AppointmentTimeChanged`,
-      `Office.EventType.RecipientsChanged`, and `Office.EventType.RecurrenceChanged`.
+      Currently the supported event types are `Office.EventType.AppointmentTimeChanged`<!-- -->,
+      `Office.EventType.RecipientsChanged`<!-- -->, and `Office.EventType.RecurrenceChanged`<!-- -->.
 
 
       \[ [API set: Mailbox 1.7](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
 
 
       In addition to this signature, the method also has the following signature:
@@ -97,12 +97,12 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: body
     fullName: Outlook_1_7.Office.Item.body
     langs:
@@ -119,11 +119,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: dateTimeCreated
     fullName: Outlook_1_7.Office.Item.dateTimeCreated
@@ -141,11 +141,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
 
 
@@ -171,12 +171,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: itemType
     fullName: Outlook_1_7.Office.Item.itemType
     langs:
@@ -205,12 +205,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: 'loadCustomPropertiesAsync(callback, userContext)'
     fullName: Outlook_1_7.Office.Item.loadCustomPropertiesAsync
     langs:
@@ -243,12 +243,12 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: notificationMessages
     fullName: Outlook_1_7.Office.Item.notificationMessages
     langs:
@@ -279,12 +279,12 @@ items:
 
       \[ [API set: Mailbox 1.7](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: recurrence
     fullName: Outlook_1_7.Office.Item.recurrence
     langs:
@@ -300,18 +300,18 @@ items:
       Removes an event handler for a supported event.
 
 
-      Currently the supported event types are `Office.EventType.AppointmentTimeChanged`,
-      `Office.EventType.RecipientsChanged`, and `Office.EventType.RecurrenceChanged`.
+      Currently the supported event types are `Office.EventType.AppointmentTimeChanged`<!-- -->,
+      `Office.EventType.RecipientsChanged`<!-- -->, and `Office.EventType.RecurrenceChanged`<!-- -->.
 
 
       \[ [API set: Mailbox 1.7](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
 
 
       In addition to this signature, the method also has the following signature:
@@ -334,7 +334,7 @@ items:
         description: ''
       parameters:
         - id: eventType
-          description: The event that should invoke the handler.
+          description: The event that should revoke the handler.
           type:
             - Office.EventType
         - id: handler
@@ -367,7 +367,7 @@ items:
       Note: The identifier returned by the seriesId property is the same as the Exchange Web Services item identifier.
       The seriesId property is not identical to the Outlook IDs used by the Outlook REST API. Before making REST API
       calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more details, see
-      [Use the Outlook REST APIs from an Outlook add-in](https://docs.microsoft.com/outlook/add-ins/use-rest-api)<!--
+      [ Use the Outlook REST APIs from an Outlook add-in](https://docs.microsoft.com/outlook/add-ins/use-rest-api)<!--
       -->.
 
 
@@ -377,12 +377,12 @@ items:
 
       \[ [API set: Mailbox 1.7](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: seriesId
     fullName: Outlook_1_7.Office.Item.seriesId
     langs:

--- a/docs/docs-ref-autogen/outlook_1_7/office.itemcompose.yml
+++ b/docs/docs-ref-autogen/outlook_1_7/office.itemcompose.yml
@@ -2,11 +2,11 @@
 items:
   - uid: Outlook_1_7.Office.ItemCompose
     summary: >-
-      The compose mode of [Office.context.mailbox.item](xref:Outlook_1_7.Office.Item)<!-- -->.
+      The compose mode of [ Office.context.mailbox.item](xref:Outlook_1_7.Office.Item)<!-- -->.
 
 
       Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat
-      this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
+      this as a mode of `Office.context.mailbox.item`<!-- -->. Refer to the Object Model pages for more information.
     name: Office.ItemCompose
     fullName: Outlook_1_7.Office.ItemCompose
     langs:
@@ -39,11 +39,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -126,11 +126,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -205,11 +205,11 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
     name: close()
     fullName: Outlook_1_7.Office.ItemCompose.close
@@ -237,11 +237,11 @@ items:
 
       \[ [API set: Mailbox 1.2](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
     name: 'getSelectedDataAsync(coerciontype, callback)'
     fullName: Outlook_1_7.Office.ItemCompose.getSelectedDataAsync
@@ -273,17 +273,17 @@ items:
       The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best
       practice, you should use the attachment identifier to remove an attachment only if the same mail app has added
       that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid
-      only within the same session. A session is over when the user closes the app, or if the user starts composing in
-      an inline form and subsequently pops out the inline form to continue in a separate window.
+      only within the same session. A session is over when the user closes the app, or if the user starts composing an
+      inline form then subsequently pops out the form to continue in a separate window.
 
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -364,11 +364,11 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -422,11 +422,11 @@ items:
 
       \[ [API set: Mailbox 1.2](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -439,7 +439,7 @@ items:
       `setSelectedDataAsync(data: string): void;`
 
 
-      `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions &amp; CoercionTypeOptions): void;`
+      `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`
 
 
       `setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;`
@@ -490,12 +490,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: subject
     fullName: Outlook_1_7.Office.ItemCompose.subject
     langs:

--- a/docs/docs-ref-autogen/outlook_1_7/office.itemread.yml
+++ b/docs/docs-ref-autogen/outlook_1_7/office.itemread.yml
@@ -2,11 +2,11 @@
 items:
   - uid: Outlook_1_7.Office.ItemRead
     summary: >-
-      The read mode of [Office.context.mailbox.item](xref:Outlook_1_7.Office.Item)<!-- -->.
+      The read mode of [ Office.context.mailbox.item](xref:Outlook_1_7.Office.Item)<!-- -->.
 
 
       Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat
-      this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
+      this as a mode of `Office.context.mailbox.item`<!-- -->. Refer to the Object Model pages for more information.
     name: Office.ItemRead
     fullName: Outlook_1_7.Office.ItemRead
     langs:
@@ -32,20 +32,20 @@ items:
       - Outlook_1_7.Office.ItemRead.subject
   - uid: Outlook_1_7.Office.ItemRead.attachments
     summary: |-
-      Gets an array of attachments for the item.
+      Gets the item's attachments as an array.
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
 
 
       Note: Certain types of files are blocked by Outlook due to potential security issues and are therefore not
-      returned. For more information, see [Blocked attachments in
+      returned. For more information, see [ Blocked attachments in
       Outlook](https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519)<!--
       -->.
     name: attachments
@@ -81,11 +81,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: displayReplyAllForm(formData)
     fullName: Outlook_1_7.Office.ItemRead.displayReplyAllForm
@@ -102,7 +102,7 @@ items:
         - id: formData
           description: >-
             A string that contains text and HTML and that represents the body of the reply form. The string is limited
-            to 32 KB OR An[Office.ReplyFormData](xref:Outlook_1_7.Office.ReplyFormData) object that contains body or
+            to 32 KB OR An [Office.ReplyFormData](xref:Outlook_1_7.Office.ReplyFormData) object that contains body or
             attachment data and a callback function
           type:
             - string | ReplyFormData
@@ -129,11 +129,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: displayReplyForm(formData)
     fullName: Outlook_1_7.Office.ItemRead.displayReplyForm
@@ -150,7 +150,7 @@ items:
         - id: formData
           description: >-
             A string that contains text and HTML and that represents the body of the reply form. The string is limited
-            to 32 KB. OR An[Office.ReplyFormData](xref:Outlook_1_7.Office.ReplyFormData) object that contains body or
+            to 32 KB. OR An [Office.ReplyFormData](xref:Outlook_1_7.Office.ReplyFormData) object that contains body or
             attachment data and a callback function.
           type:
             - string | ReplyFormData
@@ -162,11 +162,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: getEntities()
     fullName: Outlook_1_7.Office.ItemRead.getEntities
@@ -187,11 +187,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
 
 
@@ -241,11 +241,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: getFilteredEntitiesByName(name)
     fullName: Outlook_1_7.Office.ItemRead.getFilteredEntitiesByName
@@ -290,11 +290,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: getRegExMatches()
     fullName: Outlook_1_7.Office.ItemRead.getRegExMatches
@@ -330,11 +330,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: getRegExMatchesByName(name)
     fullName: Outlook_1_7.Office.ItemRead.getRegExMatchesByName
@@ -363,11 +363,11 @@ items:
 
       \[ [API set: Mailbox 1.6](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: getSelectedEntities()
     fullName: Outlook_1_7.Office.ItemRead.getSelectedEntities
@@ -403,11 +403,11 @@ items:
 
       \[ [API set: Mailbox 1.6](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: getSelectedRegExMatches()
     fullName: Outlook_1_7.Office.ItemRead.getSelectedRegExMatches
@@ -434,11 +434,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
 
 
@@ -476,17 +476,17 @@ items:
       Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The
       itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making
       REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more
-      details, see [Use the Outlook REST APIs from an Outlook
+      details, see [ Use the Outlook REST APIs from an Outlook
       add-in](https://docs.microsoft.com/outlook/add-ins/use-rest-api#get-the-item-id)<!-- -->.
 
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: itemId
     fullName: Outlook_1_7.Office.ItemRead.itemId
@@ -509,11 +509,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: normalizedSubject
     fullName: Outlook_1_7.Office.ItemRead.normalizedSubject
@@ -539,12 +539,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: subject
     fullName: Outlook_1_7.Office.ItemRead.subject
     langs:

--- a/docs/docs-ref-autogen/outlook_1_7/office.localclienttime.yml
+++ b/docs/docs-ref-autogen/outlook_1_7/office.localclienttime.yml
@@ -6,11 +6,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: Office.LocalClientTime
     fullName: Outlook_1_7.Office.LocalClientTime

--- a/docs/docs-ref-autogen/outlook_1_7/office.location.yml
+++ b/docs/docs-ref-autogen/outlook_1_7/office.location.yml
@@ -6,11 +6,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
     name: Office.Location
     fullName: Outlook_1_7.Office.Location
@@ -29,11 +29,11 @@ items:
       The getAsync method starts an asynchronous call to the Exchange server to get the location of an appointment. The
       location of the appointment is provided as a string in the asyncResult.value property.
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
 
 
@@ -62,7 +62,10 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type Office.AsyncResult. \[Api set: Mailbox 1.1\]
+            parameter of type Office.AsyncResult.
+
+
+            \[Api set: Mailbox 1.1\]
           type:
             - '(result: AsyncResult<string>) => void'
   - uid: Outlook_1_7.Office.Location.setAsync
@@ -73,11 +76,11 @@ items:
       The setAsync method starts an asynchronous call to the Exchange server to set the location of an appointment.
       Setting the location of an appointment overwrites the current location.
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -123,6 +126,9 @@ items:
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
             parameter of type Office.AsyncResult. If setting the location fails, the asyncResult.error property will
-            contain an error code. \[Api set: Mailbox 1.1\]
+            contain an error code.
+
+
+            \[Api set: Mailbox 1.1\]
           type:
             - '(result: AsyncResult<void>) => void'

--- a/docs/docs-ref-autogen/outlook_1_7/office.mailbox.yml
+++ b/docs/docs-ref-autogen/outlook_1_7/office.mailbox.yml
@@ -14,12 +14,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.Mailbox
     fullName: Outlook_1_7.Office.Mailbox
     langs:
@@ -42,22 +42,23 @@ items:
       - Outlook_1_7.Office.Mailbox.getUserIdentityTokenAsync
       - Outlook_1_7.Office.Mailbox.item
       - Outlook_1_7.Office.Mailbox.makeEwsRequestAsync
+      - Outlook_1_7.Office.Mailbox.removeHandlerAsync
       - Outlook_1_7.Office.Mailbox.restUrl
       - Outlook_1_7.Office.Mailbox.userProfile
   - uid: Outlook_1_7.Office.Mailbox.addHandlerAsync
     summary: |-
       Adds an event handler for a supported event.
 
-      Currently, the supported event types are `Office.EventType.ItemChanged` and `Office.EventType.OfficeThemeChanged`.
+      Currently, the only supported event type is `Office.EventType.ItemChanged`<!-- -->.
 
       \[ [API set: Mailbox 1.5](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: 'addHandlerAsync(eventType, handler, options, callback)'
     fullName: Outlook_1_7.Office.Mailbox.addHandlerAsync
     langs:
@@ -107,12 +108,12 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: 'convertToEwsId(itemId, restVersion)'
     fullName: Outlook_1_7.Office.Mailbox.convertToEwsId
     langs:
@@ -152,12 +153,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: convertToLocalClientTime(timeValue)
     fullName: Outlook_1_7.Office.Mailbox.convertToLocalClientTime
     langs:
@@ -182,19 +183,19 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
 
 
       Item IDs retrieved via EWS or via the itemId property use a different format than the format used by REST APIs
-      (such as the [Outlook Mail
+      (such as the [ Outlook Mail
       API](https://docs.microsoft.com/previous-versions/office/office-365-api/api/version-2.0/mail-rest-operations) or
-      the [Microsoft Graph](http://graph.microsoft.io/)<!-- -->. The convertToRestId method converts an EWS-formatted ID
-      into the proper format for REST.
+      the [ Microsoft Graph](http://graph.microsoft.io/)<!-- -->. The convertToRestId method converts an EWS-formatted
+      ID into the proper format for REST.
     name: 'convertToRestId(itemId, restVersion)'
     fullName: Outlook_1_7.Office.Mailbox.convertToRestId
     langs:
@@ -226,12 +227,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: convertToUtcClientTime(input)
     fullName: Outlook_1_7.Office.Mailbox.convertToUtcClientTime
     langs:
@@ -278,12 +279,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: diagnostics
     fullName: Outlook_1_7.Office.Mailbox.diagnostics
     langs:
@@ -322,12 +323,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: displayAppointmentForm(itemId)
     fullName: Outlook_1_7.Office.Mailbox.displayAppointmentForm
     langs:
@@ -371,12 +372,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: displayMessageForm(itemId)
     fullName: Outlook_1_7.Office.Mailbox.displayMessageForm
     langs:
@@ -422,11 +423,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: displayNewAppointmentForm(parameters)
     fullName: Outlook_1_7.Office.Mailbox.displayNewAppointmentForm
@@ -459,11 +460,11 @@ items:
 
       \[ [API set: Mailbox 1.6](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: displayNewMessageForm(parameters)
     fullName: Outlook_1_7.Office.Mailbox.displayNewMessageForm
@@ -480,9 +481,12 @@ items:
         - id: parameters
           description: >-
             A dictionary containing all values to be filled in for the user in the new form. All parameters are
-            optional. toRecipients: An array of strings containing the email addresses or an array containing
-            an[Office.EmailAddressDetails](xref:Outlook_1_7.Office.EmailAddressDetails) object for each of the
-            recipients on the To line. The array is limited to a maximum of 100 entries.
+            optional.
+
+
+            toRecipients: An array of strings containing the email addresses or an array containing an
+            [Office.EmailAddressDetails](xref:Outlook_1_7.Office.EmailAddressDetails) object for each of the recipients
+            on the To line. The array is limited to a maximum of 100 entries.
 
 
             ccRecipients: An array of strings containing the email addresses or an array containing an
@@ -537,16 +541,16 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
 
 
       The ewsUrl value can be used by a remote service to make EWS calls to the user's mailbox. For example, you can
-      create a remote service to [get attachments from the selected
+      create a remote service to [ get attachments from the selected
       item](https://docs.microsoft.com/outlook/add-ins/get-attachments-of-an-outlook-item)<!-- -->.
 
 
@@ -598,11 +602,11 @@ items:
 
       \[ [API set: Mailbox 1.5](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
       and read</td></tr></table>
 
 
@@ -648,16 +652,16 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
       and read</td></tr></table>
 
 
-      The getUserIdentityTokenAsync method returns a token that you can use to identify and [authenticate the add-in and
-      user with a third-party system](https://docs.microsoft.com/outlook/add-ins/authentication)<!-- -->.
+      The getUserIdentityTokenAsync method returns a token that you can use to identify and [ authenticate the add-in
+      and user with a third-party system](https://docs.microsoft.com/outlook/add-ins/authentication)<!-- -->.
     name: 'getUserIdentityTokenAsync(callback, userContext)'
     fullName: Outlook_1_7.Office.Mailbox.getUserIdentityTokenAsync
     langs:
@@ -684,7 +688,8 @@ items:
     summary: >-
       The mailbox item. Depending on the context in which the add-in opened, the item may be of any number of types. If
       you want to see IntelliSense for only a specific type, you should cast this item to one of the following:
-      `ItemCompose`, `ItemRead`, `MessageCompose`, `MessageRead`, `AppointmentCompose`, `AppointmentRead`
+      `ItemCompose`<!-- -->, `ItemRead`<!-- -->, `MessageCompose`<!-- -->, `MessageRead`<!-- -->,
+      `AppointmentCompose`<!-- -->, `AppointmentRead`
     name: item
     fullName: Outlook_1_7.Office.Mailbox.item
     langs:
@@ -715,7 +720,7 @@ items:
 
       Your add-in must have the ReadWriteMailbox permission to use the makeEwsRequestAsync method. For information about
       using the ReadWriteMailbox permission and the EWS operations that you can call with the makeEwsRequestAsync
-      method, see [Specify permissions for mail add-in access to the user's
+      method, see [ Specify permissions for mail add-in access to the user's
       mailbox](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)<!-- -->.
 
 
@@ -743,7 +748,7 @@ items:
       15.0.4535.1004, you should set the encoding value to ISO-8859-1.
 
 
-      `&lt;?xml version="1.0" encoding="iso-8859-1"?&gt;`
+      `<?xml version="1.0" encoding="iso-8859-1"?>`
 
 
       You do not need to set the encoding value when your mail app is running in Outlook on the web. You can determine
@@ -754,11 +759,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteMailbox</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
       and read</td></tr></table>
     name: 'makeEwsRequestAsync(data, callback, userContext)'
     fullName: Outlook_1_7.Office.Mailbox.makeEwsRequestAsync
@@ -787,6 +792,54 @@ items:
           description: Optional. Any state data that is passed to the asynchronous method.
           type:
             - any
+  - uid: Outlook_1_7.Office.Mailbox.removeHandlerAsync
+    summary: |-
+      Removes an event handler for a supported event.
+
+      Currently, the only supported event type is `Office.EventType.ItemChanged`<!-- -->.
+
+      \[ [API set: Mailbox 1.5](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
+    remarks: >-
+      <table><tr><td>[ Minimum permission
+      level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
+
+
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
+    name: 'removeHandlerAsync(eventType, handler, options, callback)'
+    fullName: Outlook_1_7.Office.Mailbox.removeHandlerAsync
+    langs:
+      - typeScript
+    type: method
+    syntax:
+      content: >-
+        removeHandlerAsync(eventType: Office.EventType, handler: (type: EventType) => void, options?:
+        Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
+      return:
+        type:
+          - void
+        description: ''
+      parameters:
+        - id: eventType
+          description: The event that should revoke the handler.
+          type:
+            - Office.EventType
+        - id: handler
+          description: >-
+            The function to handle the event. The function must accept a single parameter, which is an object literal.
+            The type property on the parameter will match the eventType parameter passed to addHandlerAsync.
+          type:
+            - '(type: EventType) => void'
+        - id: options
+          description: 'Optional. Provides an option for preserving context data of any type, unchanged, for use in a callback.'
+          type:
+            - office.Office.AsyncContextOptions
+        - id: callback
+          description: >-
+            Optional. When the method completes, the function passed in the callback parameter is called with a single
+            parameter of type Office.AsyncResult.
+          type:
+            - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_7.Office.Mailbox.restUrl
     summary: >-
       Gets the URL of the REST endpoint for this email account.
@@ -801,15 +854,15 @@ items:
 
       \[ [API set: Mailbox 1.5](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
 
 
-      The restUrl value can be used to make [REST API](https://docs.microsoft.com/outlook/rest/) calls to the user's
+      The restUrl value can be used to make [ REST API](https://docs.microsoft.com/outlook/rest/) calls to the user's
       mailbox.
     name: restUrl
     fullName: Outlook_1_7.Office.Mailbox.restUrl
@@ -824,7 +877,7 @@ items:
   - uid: Outlook_1_7.Office.Mailbox.userProfile
     summary: >-
       Information about the user associated with the mailbox. This includes their account type, display name, email
-      adddress, and time zone.
+      address, and time zone.
 
 
       More information is under [Office.UserProfile](xref:Outlook_1_7.Office.UserProfile)

--- a/docs/docs-ref-autogen/outlook_1_7/office.mailboxenums.attachmenttype.yml
+++ b/docs/docs-ref-autogen/outlook_1_7/office.mailboxenums.attachmenttype.yml
@@ -6,7 +6,7 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td> [Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
+      <table><tr><td> [ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
       </td><td>Compose or read</td></tr></table>
     name: Office.MailboxEnums.AttachmentType
     fullName: Outlook_1_7.Office.MailboxEnums.AttachmentType

--- a/docs/docs-ref-autogen/outlook_1_7/office.mailboxenums.days.yml
+++ b/docs/docs-ref-autogen/outlook_1_7/office.mailboxenums.days.yml
@@ -6,7 +6,7 @@ items:
 
       \[ [API set: Mailbox 1.7](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td> [Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
+      <table><tr><td> [ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
       </td><td>Compose or read</td></tr></table>
     name: Office.MailboxEnums.Days
     fullName: Outlook_1_7.Office.MailboxEnums.Days

--- a/docs/docs-ref-autogen/outlook_1_7/office.mailboxenums.entitytype.yml
+++ b/docs/docs-ref-autogen/outlook_1_7/office.mailboxenums.entitytype.yml
@@ -6,7 +6,7 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td> [Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
+      <table><tr><td> [ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
       </td><td>Compose or read</td></tr></table>
     name: Office.MailboxEnums.EntityType
     fullName: Outlook_1_7.Office.MailboxEnums.EntityType

--- a/docs/docs-ref-autogen/outlook_1_7/office.mailboxenums.itemnotificationmessagetype.yml
+++ b/docs/docs-ref-autogen/outlook_1_7/office.mailboxenums.itemnotificationmessagetype.yml
@@ -6,7 +6,7 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td> [Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
+      <table><tr><td> [ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
       </td><td>Compose or read</td></tr></table>
     name: Office.MailboxEnums.ItemNotificationMessageType
     fullName: Outlook_1_7.Office.MailboxEnums.ItemNotificationMessageType

--- a/docs/docs-ref-autogen/outlook_1_7/office.mailboxenums.itemtype.yml
+++ b/docs/docs-ref-autogen/outlook_1_7/office.mailboxenums.itemtype.yml
@@ -6,7 +6,7 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td> [Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
+      <table><tr><td> [ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
       </td><td>Compose or read</td></tr></table>
     name: Office.MailboxEnums.ItemType
     fullName: Outlook_1_7.Office.MailboxEnums.ItemType

--- a/docs/docs-ref-autogen/outlook_1_7/office.mailboxenums.month.yml
+++ b/docs/docs-ref-autogen/outlook_1_7/office.mailboxenums.month.yml
@@ -6,7 +6,7 @@ items:
 
       \[ [API set: Mailbox 1.7](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td> [Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
+      <table><tr><td> [ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
       </td><td>Compose or read</td></tr></table>
     name: Office.MailboxEnums.Month
     fullName: Outlook_1_7.Office.MailboxEnums.Month

--- a/docs/docs-ref-autogen/outlook_1_7/office.mailboxenums.recipienttype.yml
+++ b/docs/docs-ref-autogen/outlook_1_7/office.mailboxenums.recipienttype.yml
@@ -6,7 +6,7 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td> [Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
+      <table><tr><td> [ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
       </td><td>Compose or read</td></tr></table>
     name: Office.MailboxEnums.RecipientType
     fullName: Outlook_1_7.Office.MailboxEnums.RecipientType

--- a/docs/docs-ref-autogen/outlook_1_7/office.mailboxenums.recurrencetimezone.yml
+++ b/docs/docs-ref-autogen/outlook_1_7/office.mailboxenums.recurrencetimezone.yml
@@ -6,7 +6,7 @@ items:
 
       \[ [API set: Mailbox 1.7](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td> [Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
+      <table><tr><td> [ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
       </td><td>Compose or read</td></tr></table>
     name: Office.MailboxEnums.RecurrenceTimeZone
     fullName: Outlook_1_7.Office.MailboxEnums.RecurrenceTimeZone

--- a/docs/docs-ref-autogen/outlook_1_7/office.mailboxenums.recurrencetype.yml
+++ b/docs/docs-ref-autogen/outlook_1_7/office.mailboxenums.recurrencetype.yml
@@ -6,7 +6,7 @@ items:
 
       \[ [API set: Mailbox 1.7](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td> [Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
+      <table><tr><td> [ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
       </td><td>Compose or read</td></tr></table>
     name: Office.MailboxEnums.RecurrenceType
     fullName: Outlook_1_7.Office.MailboxEnums.RecurrenceType

--- a/docs/docs-ref-autogen/outlook_1_7/office.mailboxenums.responsetype.yml
+++ b/docs/docs-ref-autogen/outlook_1_7/office.mailboxenums.responsetype.yml
@@ -6,7 +6,7 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td> [Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
+      <table><tr><td> [ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
       </td><td>Compose or read</td></tr></table>
     name: Office.MailboxEnums.ResponseType
     fullName: Outlook_1_7.Office.MailboxEnums.ResponseType

--- a/docs/docs-ref-autogen/outlook_1_7/office.mailboxenums.restversion.yml
+++ b/docs/docs-ref-autogen/outlook_1_7/office.mailboxenums.restversion.yml
@@ -6,7 +6,7 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td> [Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
+      <table><tr><td> [ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
       </td><td>Compose or read</td></tr></table>
     name: Office.MailboxEnums.RestVersion
     fullName: Outlook_1_7.Office.MailboxEnums.RestVersion

--- a/docs/docs-ref-autogen/outlook_1_7/office.mailboxenums.weeknumber.yml
+++ b/docs/docs-ref-autogen/outlook_1_7/office.mailboxenums.weeknumber.yml
@@ -6,7 +6,7 @@ items:
 
       \[ [API set: Mailbox 1.7](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td> [Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
+      <table><tr><td> [ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)
       </td><td>Compose or read</td></tr></table>
     name: Office.MailboxEnums.WeekNumber
     fullName: Outlook_1_7.Office.MailboxEnums.WeekNumber

--- a/docs/docs-ref-autogen/outlook_1_7/office.meetingsuggestion.yml
+++ b/docs/docs-ref-autogen/outlook_1_7/office.meetingsuggestion.yml
@@ -15,11 +15,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: Office.MeetingSuggestion
     fullName: Outlook_1_7.Office.MeetingSuggestion

--- a/docs/docs-ref-autogen/outlook_1_7/office.message.yml
+++ b/docs/docs-ref-autogen/outlook_1_7/office.message.yml
@@ -6,7 +6,7 @@ items:
 
 
       Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat
-      this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
+      this as a mode of `Office.context.mailbox.item`<!-- -->. Refer to the Object Model pages for more information.
     name: Office.Message
     fullName: Outlook_1_7.Office.Message
     langs:
@@ -33,12 +33,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: conversationId
     fullName: Outlook_1_7.Office.Message.conversationId
     langs:

--- a/docs/docs-ref-autogen/outlook_1_7/office.messagecompose.yml
+++ b/docs/docs-ref-autogen/outlook_1_7/office.messagecompose.yml
@@ -2,11 +2,11 @@
 items:
   - uid: Outlook_1_7.Office.MessageCompose
     summary: >-
-      The message compose mode of [Office.context.mailbox.item](xref:Outlook_1_7.Office.Item)<!-- -->.
+      The message compose mode of [ Office.context.mailbox.item](xref:Outlook_1_7.Office.Item)<!-- -->.
 
 
       Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat
-      this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
+      this as a mode of `Office.context.mailbox.item`<!-- -->. Refer to the Object Model pages for more information.
     name: Office.MessageCompose
     fullName: Outlook_1_7.Office.MessageCompose
     langs:
@@ -54,11 +54,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr>
 
 
@@ -125,17 +125,17 @@ items:
       Adds an event handler for a supported event.
 
 
-      Currently the supported event types are `Office.EventType.AppointmentTimeChanged`,
-      `Office.EventType.RecipientsChanged`, and `Office.EventType.RecurrenceChanged`.
+      Currently the supported event types are `Office.EventType.AppointmentTimeChanged`<!-- -->,
+      `Office.EventType.RecipientsChanged`<!-- -->, and `Office.EventType.RecurrenceChanged`<!-- -->.
 
 
       \[ [API set: Mailbox 1.7](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
 
 
@@ -200,11 +200,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr>
 
 
@@ -269,11 +269,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: bcc
     fullName: Outlook_1_7.Office.MessageCompose.bcc
@@ -291,11 +291,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: body
     fullName: Outlook_1_7.Office.MessageCompose.body
@@ -319,11 +319,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: cc
     fullName: Outlook_1_7.Office.MessageCompose.cc
@@ -353,11 +353,11 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: close()
     fullName: Outlook_1_7.Office.MessageCompose.close
@@ -386,11 +386,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: conversationId
     fullName: Outlook_1_7.Office.MessageCompose.conversationId
@@ -408,11 +408,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: dateTimeCreated
     fullName: Outlook_1_7.Office.MessageCompose.dateTimeCreated
@@ -430,11 +430,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
 
 
@@ -463,11 +463,11 @@ items:
 
       \[ [API set: Mailbox 1.7](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: from
     fullName: Outlook_1_7.Office.MessageCompose.from
@@ -494,11 +494,11 @@ items:
 
       \[ [API set: Mailbox 1.2](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: 'getSelectedDataAsync(coerciontype, callback)'
     fullName: Outlook_1_7.Office.MessageCompose.getSelectedDataAsync
@@ -533,11 +533,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: itemType
     fullName: Outlook_1_7.Office.MessageCompose.itemType
@@ -567,11 +567,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: 'loadCustomPropertiesAsync(callback, userContext)'
     fullName: Outlook_1_7.Office.MessageCompose.loadCustomPropertiesAsync
@@ -605,11 +605,11 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: notificationMessages
     fullName: Outlook_1_7.Office.MessageCompose.notificationMessages
@@ -641,11 +641,11 @@ items:
 
       \[ [API set: Mailbox 1.7](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: recurrence
     fullName: Outlook_1_7.Office.MessageCompose.recurrence
@@ -665,17 +665,17 @@ items:
       The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best
       practice, you should use the attachment identifier to remove an attachment only if the same mail app has added
       that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid
-      only within the same session. A session is over when the user closes the app, or if the user starts composing in
-      an inline form and subsequently pops out the inline form to continue in a separate window.
+      only within the same session. A session is over when the user closes the app, or if the user starts composing an
+      inline form then subsequently pops out the form to continue in a separate window.
 
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr>
 
 
@@ -728,17 +728,17 @@ items:
       Removes an event handler for a supported event.
 
 
-      Currently the supported event types are `Office.EventType.AppointmentTimeChanged`,
-      `Office.EventType.RecipientsChanged`, and `Office.EventType.RecurrenceChanged`.
+      Currently the supported event types are `Office.EventType.AppointmentTimeChanged`<!-- -->,
+      `Office.EventType.RecipientsChanged`<!-- -->, and `Office.EventType.RecurrenceChanged`<!-- -->.
 
 
       \[ [API set: Mailbox 1.7](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
 
 
@@ -761,7 +761,7 @@ items:
         description: ''
       parameters:
         - id: eventType
-          description: The event that should invoke the handler.
+          description: The event that should revoke the handler.
           type:
             - EventType
         - id: handler
@@ -815,11 +815,11 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr>
 
 
@@ -872,7 +872,7 @@ items:
       Note: The identifier returned by the seriesId property is the same as the Exchange Web Services item identifier.
       The seriesId property is not identical to the Outlook IDs used by the Outlook REST API. Before making REST API
       calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more details, see
-      [Use the Outlook REST APIs from an Outlook add-in](https://docs.microsoft.com/outlook/add-ins/use-rest-api)<!--
+      [ Use the Outlook REST APIs from an Outlook add-in](https://docs.microsoft.com/outlook/add-ins/use-rest-api)<!--
       -->.
 
 
@@ -882,11 +882,11 @@ items:
 
       \[ [API set: Mailbox 1.7](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: seriesId
     fullName: Outlook_1_7.Office.MessageCompose.seriesId
@@ -910,11 +910,11 @@ items:
 
       \[ [API set: Mailbox 1.2](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr>
 
 
@@ -927,7 +927,7 @@ items:
       `setSelectedDataAsync(data: string): void;`
 
 
-      `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions &amp; CoercionTypeOptions): void;`
+      `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`
 
 
       `setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;`
@@ -978,11 +978,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: subject
     fullName: Outlook_1_7.Office.MessageCompose.subject
@@ -1006,11 +1006,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Compose</td></tr></table>
     name: to
     fullName: Outlook_1_7.Office.MessageCompose.to

--- a/docs/docs-ref-autogen/outlook_1_7/office.messageread.yml
+++ b/docs/docs-ref-autogen/outlook_1_7/office.messageread.yml
@@ -2,7 +2,7 @@
 items:
   - uid: Outlook_1_7.Office.MessageRead
     summary: >-
-      The message read mode of [Office.context.mailbox.item](xref:Outlook_1_7.Office.Item)<!-- -->.
+      The message read mode of [ Office.context.mailbox.item](xref:Outlook_1_7.Office.Item)<!-- -->.
 
 
       Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat
@@ -51,17 +51,17 @@ items:
       Adds an event handler for a supported event.
 
 
-      Currently the supported event types are `Office.EventType.AppointmentTimeChanged`,
-      `Office.EventType.RecipientsChanged`, and `Office.EventType.RecurrenceChanged`.
+      Currently the supported event types are `Office.EventType.AppointmentTimeChanged`<!-- -->,
+      `Office.EventType.RecipientsChanged`<!-- -->, and `Office.EventType.RecurrenceChanged`<!-- -->.
 
 
       \[ [API set: Mailbox 1.7](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
 
 
@@ -107,20 +107,20 @@ items:
             - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_7.Office.MessageRead.attachments
     summary: |-
-      Gets an array of attachments for the item.
+      Gets the item's attachments as an array.
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
 
 
       Note: Certain types of files are blocked by Outlook due to potential security issues and are therefore not
-      returned. For more information, see [Blocked attachments in
+      returned. For more information, see [ Blocked attachments in
       Outlook](https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519)<!--
       -->.
     name: attachments
@@ -139,11 +139,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: body
     fullName: Outlook_1_7.Office.MessageRead.body
@@ -167,11 +167,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: cc
     fullName: Outlook_1_7.Office.MessageRead.cc
@@ -199,11 +199,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: conversationId
     fullName: Outlook_1_7.Office.MessageRead.conversationId
@@ -221,11 +221,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: dateTimeCreated
     fullName: Outlook_1_7.Office.MessageRead.dateTimeCreated
@@ -243,11 +243,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
 
 
@@ -285,11 +285,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: displayReplyAllForm(formData)
     fullName: Outlook_1_7.Office.MessageRead.displayReplyAllForm
@@ -306,7 +306,7 @@ items:
         - id: formData
           description: >-
             A string that contains text and HTML and that represents the body of the reply form. The string is limited
-            to 32 KB OR An[Office.ReplyFormData](xref:Outlook_1_7.Office.ReplyFormData) object that contains body or
+            to 32 KB OR An [Office.ReplyFormData](xref:Outlook_1_7.Office.ReplyFormData) object that contains body or
             attachment data and a callback function
           type:
             - string | ReplyFormData
@@ -333,11 +333,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: displayReplyForm(formData)
     fullName: Outlook_1_7.Office.MessageRead.displayReplyForm
@@ -354,7 +354,7 @@ items:
         - id: formData
           description: >-
             A string that contains text and HTML and that represents the body of the reply form. The string is limited
-            to 32 KB. OR An[Office.ReplyFormData](xref:Outlook_1_7.Office.ReplyFormData) object that contains body or
+            to 32 KB. OR An [Office.ReplyFormData](xref:Outlook_1_7.Office.ReplyFormData) object that contains body or
             attachment data and a callback function.
           type:
             - string | ReplyFormData
@@ -375,11 +375,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: from
     fullName: Outlook_1_7.Office.MessageRead.from
@@ -399,11 +399,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: getEntities()
     fullName: Outlook_1_7.Office.MessageRead.getEntities
@@ -424,11 +424,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
 
 
@@ -478,11 +478,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: getFilteredEntitiesByName(name)
     fullName: Outlook_1_7.Office.MessageRead.getFilteredEntitiesByName
@@ -527,11 +527,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: getRegExMatches()
     fullName: Outlook_1_7.Office.MessageRead.getRegExMatches
@@ -567,11 +567,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: getRegExMatchesByName(name)
     fullName: Outlook_1_7.Office.MessageRead.getRegExMatchesByName
@@ -600,11 +600,11 @@ items:
 
       \[ [API set: Mailbox 1.6](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: getSelectedEntities()
     fullName: Outlook_1_7.Office.MessageRead.getSelectedEntities
@@ -640,11 +640,11 @@ items:
 
       \[ [API set: Mailbox 1.6](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: getSelectedRegExMatches()
     fullName: Outlook_1_7.Office.MessageRead.getSelectedRegExMatches
@@ -666,11 +666,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: internetMessageId
     fullName: Outlook_1_7.Office.MessageRead.internetMessageId
@@ -693,11 +693,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
 
 
@@ -735,17 +735,17 @@ items:
       Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The
       itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making
       REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more
-      details, see [Use the Outlook REST APIs from an Outlook
+      details, see [ Use the Outlook REST APIs from an Outlook
       add-in](https://docs.microsoft.com/outlook/add-ins/use-rest-api#get-the-item-id)<!-- -->.
 
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: itemId
     fullName: Outlook_1_7.Office.MessageRead.itemId
@@ -768,11 +768,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: itemType
     fullName: Outlook_1_7.Office.MessageRead.itemType
@@ -802,11 +802,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: 'loadCustomPropertiesAsync(callback, userContext)'
     fullName: Outlook_1_7.Office.MessageRead.loadCustomPropertiesAsync
@@ -845,11 +845,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: normalizedSubject
     fullName: Outlook_1_7.Office.MessageRead.normalizedSubject
@@ -867,12 +867,12 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: notificationMessages
     fullName: Outlook_1_7.Office.MessageRead.notificationMessages
     langs:
@@ -903,11 +903,11 @@ items:
 
       \[ [API set: Mailbox 1.7](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: recurrence
     fullName: Outlook_1_7.Office.MessageRead.recurrence
@@ -924,17 +924,17 @@ items:
       Removes an event handler for a supported event.
 
 
-      Currently the supported event types are `Office.EventType.AppointmentTimeChanged`,
-      `Office.EventType.RecipientsChanged`, and `Office.EventType.RecurrenceChanged`.
+      Currently the supported event types are `Office.EventType.AppointmentTimeChanged`<!-- -->,
+      `Office.EventType.RecipientsChanged`<!-- -->, and `Office.EventType.RecurrenceChanged`<!-- -->.
 
 
       \[ [API set: Mailbox 1.7](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
 
 
@@ -957,7 +957,7 @@ items:
         description: ''
       parameters:
         - id: eventType
-          description: The event that should invoke the handler.
+          description: The event that should revoke the handler.
           type:
             - EventType
         - id: handler
@@ -992,11 +992,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: sender
     fullName: Outlook_1_7.Office.MessageRead.sender
@@ -1020,7 +1020,7 @@ items:
       Note: The identifier returned by the seriesId property is the same as the Exchange Web Services item identifier.
       The seriesId property is not identical to the Outlook IDs used by the Outlook REST API. Before making REST API
       calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more details, see
-      [Use the Outlook REST APIs from an Outlook add-in](https://docs.microsoft.com/outlook/add-ins/use-rest-api)<!--
+      [ Use the Outlook REST APIs from an Outlook add-in](https://docs.microsoft.com/outlook/add-ins/use-rest-api)<!--
       -->.
 
 
@@ -1030,11 +1030,11 @@ items:
 
       \[ [API set: Mailbox 1.7](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: seriesId
     fullName: Outlook_1_7.Office.MessageRead.seriesId
@@ -1060,11 +1060,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: subject
     fullName: Outlook_1_7.Office.MessageRead.subject
@@ -1088,11 +1088,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Message
       Read</td></tr></table>
     name: to
     fullName: Outlook_1_7.Office.MessageRead.to

--- a/docs/docs-ref-autogen/outlook_1_7/office.notificationmessagedetails.yml
+++ b/docs/docs-ref-autogen/outlook_1_7/office.notificationmessagedetails.yml
@@ -6,12 +6,12 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.NotificationMessageDetails
     fullName: Outlook_1_7.Office.NotificationMessageDetails
     langs:

--- a/docs/docs-ref-autogen/outlook_1_7/office.notificationmessages.yml
+++ b/docs/docs-ref-autogen/outlook_1_7/office.notificationmessages.yml
@@ -6,12 +6,12 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.NotificationMessages
     fullName: Outlook_1_7.Office.NotificationMessages
     langs:
@@ -31,12 +31,12 @@ items:
       There are a maximum of 5 notifications per message. Setting more will return a
       NumberOfNotificationMessagesExceeded error.
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
 
 
       In addition to this signature, the method also has the following signatures:
@@ -85,7 +85,10 @@ items:
         - id: callback
           description: >-
             Optional. When the method completes, the function passed in the callback parameter is called with a single
-            parameter of type Office.AsyncResult. \[Api set: Mailbox 1.3\]
+            parameter of type Office.AsyncResult.
+
+
+            \[Api set: Mailbox 1.3\]
           type:
             - '(result: AsyncResult<void>) => void'
   - uid: Outlook_1_7.Office.NotificationMessages.getAllAsync
@@ -94,18 +97,18 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
 
 
       In addition to this signature, this method also has the following signature:
 
 
-      `getAllAsync(callback: (result: AsyncResult&lt;Office.NotificationMessageDetails[]&gt;) => void): void;`
+      `getAllAsync(callback: (result: AsyncResult<Office.NotificationMessageDetails[]>) => void): void;`
     name: 'getAllAsync(options, callback)'
     fullName: Outlook_1_7.Office.NotificationMessages.getAllAsync
     langs:
@@ -139,12 +142,12 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
 
 
       In addition to this signature, this method also has the following signatures:
@@ -195,12 +198,12 @@ items:
 
       \[ [API set: Mailbox 1.3](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
 
 
       In addition to this signature, this method also has the following signatures:

--- a/docs/docs-ref-autogen/outlook_1_7/office.organizer.yml
+++ b/docs/docs-ref-autogen/outlook_1_7/office.organizer.yml
@@ -8,11 +8,11 @@ items:
 
       \[ [API set: Mailbox 1.7](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
     name: Office.Organizer
     fullName: Outlook_1_7.Office.Organizer
@@ -30,11 +30,11 @@ items:
 
       \[ [API set: Mailbox 1.7](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
     name: 'getAsync(options, callback)'
     fullName: Outlook_1_7.Office.Organizer.getAsync

--- a/docs/docs-ref-autogen/outlook_1_7/office.phonenumber.yml
+++ b/docs/docs-ref-autogen/outlook_1_7/office.phonenumber.yml
@@ -12,11 +12,11 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: Office.PhoneNumber
     fullName: Outlook_1_7.Office.PhoneNumber

--- a/docs/docs-ref-autogen/outlook_1_7/office.recipients.yml
+++ b/docs/docs-ref-autogen/outlook_1_7/office.recipients.yml
@@ -3,11 +3,11 @@ items:
   - uid: Outlook_1_7.Office.Recipients
     summary: '\[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]'
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
     name: Office.Recipients
     fullName: Outlook_1_7.Office.Recipients
@@ -33,11 +33,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -98,18 +98,18 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
 
 
       In addition to this signature, this method also has the following signature:
 
 
-      `getAsync(callback: (result: AsyncResult&lt;Office.EmailAddressDetails[]&gt;) => void): void;`
+      `getAsync(callback: (result: AsyncResult<Office.EmailAddressDetails[]>) => void): void;`
     name: 'getAsync(options, callback)'
     fullName: Outlook_1_7.Office.Recipients.getAsync
     langs:
@@ -152,11 +152,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 

--- a/docs/docs-ref-autogen/outlook_1_7/office.recurrence.yml
+++ b/docs/docs-ref-autogen/outlook_1_7/office.recurrence.yml
@@ -9,12 +9,12 @@ items:
 
       \[ [API set: Mailbox 1.7](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
 
 
       **States**
@@ -49,18 +49,18 @@ items:
 
       \[ [API set: Mailbox 1.7](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
 
 
       In addition to this signature, this method also has the following signature:
 
 
-      `getAsync(callback?: (result: AsyncResult&lt;Office.Recurrence&gt;) => void): void;`
+      `getAsync(callback?: (result: AsyncResult<Office.Recurrence>) => void): void;`
     name: 'getAsync(options, callback)'
     fullName: Outlook_1_7.Office.Recurrence.getAsync
     langs:
@@ -94,12 +94,12 @@ items:
 
       \[ [API set: Mailbox 1.7](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: recurrenceProperties
     fullName: Outlook_1_7.Office.Recurrence.recurrenceProperties
     langs:
@@ -116,12 +116,12 @@ items:
 
       \[ [API set: Mailbox 1.7](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: recurrenceTimeZone
     fullName: Outlook_1_7.Office.Recurrence.recurrenceTimeZone
     langs:
@@ -138,12 +138,12 @@ items:
 
       \[ [API set: Mailbox 1.7](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: recurrenceType
     fullName: Outlook_1_7.Office.Recurrence.recurrenceType
     langs:
@@ -164,12 +164,12 @@ items:
 
       \[ [API set: Mailbox 1.7](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: seriesTime
     fullName: Outlook_1_7.Office.Recurrence.seriesTime
     langs:
@@ -188,11 +188,11 @@ items:
 
       \[ [API set: Mailbox 1.7](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 

--- a/docs/docs-ref-autogen/outlook_1_7/office.recurrenceproperties.yml
+++ b/docs/docs-ref-autogen/outlook_1_7/office.recurrenceproperties.yml
@@ -6,12 +6,12 @@ items:
 
       \[ [API set: Mailbox 1.7](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.RecurrenceProperties
     fullName: Outlook_1_7.Office.RecurrenceProperties
     langs:

--- a/docs/docs-ref-autogen/outlook_1_7/office.recurrencetimezone.yml
+++ b/docs/docs-ref-autogen/outlook_1_7/office.recurrencetimezone.yml
@@ -6,12 +6,12 @@ items:
 
       \[ [API set: Mailbox 1.7](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.RecurrenceTimeZone
     fullName: Outlook_1_7.Office.RecurrenceTimeZone
     langs:

--- a/docs/docs-ref-autogen/outlook_1_7/office.roamingsettings.yml
+++ b/docs/docs-ref-autogen/outlook_1_7/office.roamingsettings.yml
@@ -27,12 +27,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.RoamingSettings
     fullName: Outlook_1_7.Office.RoamingSettings
     langs:
@@ -50,12 +50,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: get(name)
     fullName: Outlook_1_7.Office.RoamingSettings.get
     langs:
@@ -78,12 +78,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: remove(name)
     fullName: Outlook_1_7.Office.RoamingSettings.remove
     langs:
@@ -113,12 +113,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: saveAsync(callback)
     fullName: Outlook_1_7.Office.RoamingSettings.saveAsync
     langs:
@@ -156,12 +156,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>Restricted</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: 'set(name, value)'
     fullName: Outlook_1_7.Office.RoamingSettings.set
     langs:

--- a/docs/docs-ref-autogen/outlook_1_7/office.seriestime.yml
+++ b/docs/docs-ref-autogen/outlook_1_7/office.seriestime.yml
@@ -8,12 +8,12 @@ items:
 
       \[ [API set: Mailbox 1.7](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.SeriesTime
     fullName: Outlook_1_7.Office.SeriesTime
     langs:
@@ -36,12 +36,12 @@ items:
 
       \[ [API set: Mailbox 1.7](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: getDuration()
     fullName: Outlook_1_7.Office.SeriesTime.getDuration
     langs:
@@ -55,18 +55,18 @@ items:
         description: ''
   - uid: Outlook_1_7.Office.SeriesTime.getEndDate
     summary: >-
-      Gets the end date of a recurrence pattern in the following [ISO
+      Gets the end date of a recurrence pattern in the following [ ISO
       8601](https://www.iso.org/iso-8601-date-and-time-format.html) date format: "YYYY-MM-DD"
 
 
       \[ [API set: Mailbox 1.7](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: getEndDate()
     fullName: Outlook_1_7.Office.SeriesTime.getEndDate
     langs:
@@ -81,18 +81,18 @@ items:
   - uid: Outlook_1_7.Office.SeriesTime.getEndTime
     summary: >-
       Gets the end time of a usual appointment or meeting request instance of a recurrence pattern in whichever time
-      zone that the user or add-in set the recurrence pattern using the following [ISO
+      zone that the user or add-in set the recurrence pattern using the following [ ISO
       8601](https://www.iso.org/iso-8601-date-and-time-format.html) format: "THH:mm:ss:mmm"
 
 
       \[ [API set: Mailbox 1.7](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: getEndTime()
     fullName: Outlook_1_7.Office.SeriesTime.getEndTime
     langs:
@@ -106,18 +106,18 @@ items:
         description: ''
   - uid: Outlook_1_7.Office.SeriesTime.getStartDate
     summary: >-
-      Gets the start date of a recurrence pattern in the following [ISO
+      Gets the start date of a recurrence pattern in the following [ ISO
       8601](https://www.iso.org/iso-8601-date-and-time-format.html) date format: "YYYY-MM-DD"
 
 
       \[ [API set: Mailbox 1.7](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: getStartDate()
     fullName: Outlook_1_7.Office.SeriesTime.getStartDate
     langs:
@@ -132,18 +132,18 @@ items:
   - uid: Outlook_1_7.Office.SeriesTime.getStartTime
     summary: >-
       Gets the start time of a usual appointment instance of a recurrence pattern in whichever time zone that the
-      user/add-in set the recurrence pattern using the following [ISO
+      user/add-in set the recurrence pattern using the following [ ISO
       8601](https://www.iso.org/iso-8601-date-and-time-format.html) format: "THH:mm:ss:mmm"
 
 
       \[ [API set: Mailbox 1.7](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: getStartTime()
     fullName: Outlook_1_7.Office.SeriesTime.getStartTime
     langs:
@@ -163,11 +163,11 @@ items:
 
       \[ [API set: Mailbox 1.7](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
     name: setDuration(minutes)
     fullName: Outlook_1_7.Office.SeriesTime.setDuration
@@ -191,11 +191,11 @@ items:
 
       \[ [API set: Mailbox 1.7](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -206,7 +206,7 @@ items:
 
 
       `setEndDate(date: string): void;` (Where date is the end date of the recurring appointment series represented in
-      the [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) date format: "YYYY-MM-DD").
+      the [ ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) date format: "YYYY-MM-DD").
     name: 'setEndDate(year, month, day)'
     fullName: Outlook_1_7.Office.SeriesTime.setEndDate
     langs:
@@ -239,11 +239,11 @@ items:
 
       \[ [API set: Mailbox 1.7](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 
@@ -254,7 +254,7 @@ items:
 
 
       `setStartDate(date: string): void;` (Where date is the start date of the recurring appointment series represented
-      in the [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) date format: "YYYY-MM-DD").
+      in the [ ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) date format: "YYYY-MM-DD").
     name: 'setStartDate(year, month, day)'
     fullName: Outlook_1_7.Office.SeriesTime.setStartDate
     langs:
@@ -289,11 +289,11 @@ items:
 
       \[ [API set: Mailbox 1.7](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 

--- a/docs/docs-ref-autogen/outlook_1_7/office.subject.yml
+++ b/docs/docs-ref-autogen/outlook_1_7/office.subject.yml
@@ -6,11 +6,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
     name: Office.Subject
     fullName: Outlook_1_7.Office.Subject
@@ -32,11 +32,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
 
 
@@ -80,11 +80,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 

--- a/docs/docs-ref-autogen/outlook_1_7/office.tasksuggestion.yml
+++ b/docs/docs-ref-autogen/outlook_1_7/office.tasksuggestion.yml
@@ -5,18 +5,18 @@ items:
       Represents a suggested task identified in an item. Read mode only.
 
 
-      The list of tasks suggested in an email message is returned in the taskSuggestions property of the
-      [Entities](xref:Outlook_1_7.Office.Entities) object that is returned when the getEntities or getEntitiesByType
+      The list of tasks suggested in an email message is returned in the taskSuggestions property of the [
+      Entities](xref:Outlook_1_7.Office.Entities) object that is returned when the getEntities or getEntitiesByType
       method is called on the active item.
 
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Read</td></tr></table>
     name: Office.TaskSuggestion
     fullName: Outlook_1_7.Office.TaskSuggestion

--- a/docs/docs-ref-autogen/outlook_1_7/office.time.yml
+++ b/docs/docs-ref-autogen/outlook_1_7/office.time.yml
@@ -6,11 +6,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
     name: Office.Time
     fullName: Outlook_1_7.Office.Time
@@ -33,11 +33,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr></table>
 
 
@@ -84,11 +84,11 @@ items:
 
       \[ [API set: Mailbox 1.1](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadWriteItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook
+      <tr><td>[ Applicable Outlook
       mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose</td></tr>
 
 

--- a/docs/docs-ref-autogen/outlook_1_7/office.userprofile.yml
+++ b/docs/docs-ref-autogen/outlook_1_7/office.userprofile.yml
@@ -8,12 +8,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: Office.UserProfile
     fullName: Outlook_1_7.Office.UserProfile
     langs:
@@ -33,12 +33,12 @@ items:
 
       \[ [API set: Mailbox 1.6](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
 
 
       The possible account types are listed in the following table.
@@ -65,12 +65,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: displayName
     fullName: Outlook_1_7.Office.UserProfile.displayName
     langs:
@@ -87,12 +87,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: emailAddress
     fullName: Outlook_1_7.Office.UserProfile.emailAddress
     langs:
@@ -109,12 +109,12 @@ items:
 
       \[ [API set: Mailbox 1.0](/office/dev/add-ins/reference/requirement-sets/outlook-api-requirement-sets) \]
     remarks: >-
-      <table><tr><td>[Minimum permission
+      <table><tr><td>[ Minimum permission
       level](https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions)</td><td>ReadItem</td></tr>
 
 
-      <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
-      read</td></tr></table>
+      <tr><td>[ Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose
+      or read</td></tr></table>
     name: timeZone
     fullName: Outlook_1_7.Office.UserProfile.timeZone
     langs:

--- a/docs/docs-ref-autogen/toc.yml
+++ b/docs/docs-ref-autogen/toc.yml
@@ -762,6 +762,8 @@ items:
                       Outlook_1_6.Office.MailboxEnums.ItemNotificationMessageType
                   - name: ItemType
                     uid: Outlook_1_6.Office.MailboxEnums.ItemType
+                  - name: OWAView
+                    uid: Outlook_1_6.Office.MailboxEnums.OWAView
                   - name: RecipientType
                     uid: Outlook_1_6.Office.MailboxEnums.RecipientType
                   - name: ResponseType
@@ -834,6 +836,8 @@ items:
                       Outlook_1_5.Office.MailboxEnums.ItemNotificationMessageType
                   - name: ItemType
                     uid: Outlook_1_5.Office.MailboxEnums.ItemType
+                  - name: OWAView
+                    uid: Outlook_1_5.Office.MailboxEnums.OWAView
                   - name: RecipientType
                     uid: Outlook_1_5.Office.MailboxEnums.RecipientType
                   - name: ResponseType
@@ -906,6 +910,8 @@ items:
                       Outlook_1_4.Office.MailboxEnums.ItemNotificationMessageType
                   - name: ItemType
                     uid: Outlook_1_4.Office.MailboxEnums.ItemType
+                  - name: OWAView
+                    uid: Outlook_1_4.Office.MailboxEnums.OWAView
                   - name: RecipientType
                     uid: Outlook_1_4.Office.MailboxEnums.RecipientType
                   - name: ResponseType
@@ -978,6 +984,8 @@ items:
                       Outlook_1_3.Office.MailboxEnums.ItemNotificationMessageType
                   - name: ItemType
                     uid: Outlook_1_3.Office.MailboxEnums.ItemType
+                  - name: OWAView
+                    uid: Outlook_1_3.Office.MailboxEnums.OWAView
                   - name: RecipientType
                     uid: Outlook_1_3.Office.MailboxEnums.RecipientType
                   - name: ResponseType
@@ -1047,6 +1055,8 @@ items:
                     uid: Outlook_1_2.Office.MailboxEnums.EntityType
                   - name: ItemType
                     uid: Outlook_1_2.Office.MailboxEnums.ItemType
+                  - name: OWAView
+                    uid: Outlook_1_2.Office.MailboxEnums.OWAView
                   - name: RecipientType
                     uid: Outlook_1_2.Office.MailboxEnums.RecipientType
                   - name: ResponseType
@@ -1110,6 +1120,8 @@ items:
                     uid: Outlook_1_1.Office.MailboxEnums.EntityType
                   - name: ItemType
                     uid: Outlook_1_1.Office.MailboxEnums.ItemType
+                  - name: OWAView
+                    uid: Outlook_1_1.Office.MailboxEnums.OWAView
                   - name: RecipientType
                     uid: Outlook_1_1.Office.MailboxEnums.RecipientType
                   - name: ResponseType

--- a/generate-docs/api-extractor-inputs-outlook-legacy/Outlook_1_1/Outlook_1_1.d.ts
+++ b/generate-docs/api-extractor-inputs-outlook-legacy/Outlook_1_1/Outlook_1_1.d.ts
@@ -89,6 +89,24 @@ export declare namespace Office {
             Appointment = "appointment"
         }
         /**
+         * Represents the current view of Outlook Web App.
+         */
+        enum OWAView {
+            /**
+             * One column view. Displayed when the screen is narrow. Outlook Web App uses this single-column layout on the entire screen of a smartphone.
+             */
+            OneColumn = "OneColumn",
+            /**
+             * Two column view. Displayed when the screen is wider. Outlook Web App uses this view on most tablets.
+             */
+            TwoColumns = "TwoColumns",
+            /**
+             Three column view. Displayed when the screen is wide. For example, Outlook Web App uses this view in a full screen window on a desktop 
+             computer.
+             */
+            ThreeColumns = "ThreeColumns"
+        }
+        /**
          * Specifies the type of recipient for an appointment.
          *
          * [Api set: Mailbox 1.1]
@@ -116,7 +134,7 @@ export declare namespace Office {
              */
             Other = "other"
         }
-        /**  
+        /**
          * Specifies the type of response to a meeting invitation.
          *
          * [Api set: Mailbox 1.0]
@@ -188,7 +206,8 @@ export declare namespace Office {
         /**
          * Gets or sets the date and time that the appointment is to end.
          *
-         * The end property is expressed as a Coordinated Universal Time (UTC) date and time value. You can use the convertToLocalClientTime method to convert the end property value to the client's local date and time.
+         * The end property is expressed as a Coordinated Universal Time (UTC) date and time value. You can use the convertToLocalClientTime method to 
+         * convert the end property value to the client's local date and time.
          *
          * *Read mode*
          *
@@ -198,7 +217,8 @@ export declare namespace Office {
          *
          * The end property returns a Time object.
          *
-         * When you use the Time.setAsync method to set the end time, you should use the convertToUtcClientTime method to convert the local time on the client to UTC for the server.
+         * When you use the Time.setAsync method to set the end time, you should use the convertToUtcClientTime method to convert the local time on 
+         * the client to UTC for the server.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -272,7 +292,8 @@ export declare namespace Office {
         /**
          * Gets or sets the date and time that the appointment is to begin.
          *
-         * The start property is expressed as a Coordinated Universal Time (UTC) date and time value. You can use the convertToLocalClientTime method to convert the value to the client's local date and time.
+         * The start property is expressed as a Coordinated Universal Time (UTC) date and time value. You can use the convertToLocalClientTime method 
+         * to convert the value to the client's local date and time.
          *
          * *Read mode*
          *
@@ -282,7 +303,8 @@ export declare namespace Office {
          *
          * The start property returns a Time object.
          *
-         * When you use the Time.setAsync method to set the start time, you should use the convertToUtcClientTime method to convert the local time on the client to UTC for the server.
+         * When you use the Time.setAsync method to set the start time, you should use the convertToUtcClientTime method to convert the local time on 
+         * the client to UTC for the server.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -355,7 +377,8 @@ export declare namespace Office {
         size: number;
     }
     /**
-     * The body object provides methods for adding and updating the content of the message or appointment. It is returned in the body property of the selected item.
+     * The body object provides methods for adding and updating the content of the message or appointment. 
+     * It is returned in the body property of the selected item.
      *
      * [Api set: Mailbox 1.1]
      *
@@ -377,15 +400,18 @@ export declare namespace Office {
          *
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. The content type is returned as one of the CoercionType values in the asyncResult.value property.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult.
+         *                  The content type is returned as one of the CoercionType values in the asyncResult.value property.
          */
-        getTypeAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        getTypeAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<Office.CoercionType>) => void): void;
         /**
          * Adds the specified content to the beginning of the item body.
          *
-         * The prependAsync method inserts the specified string at the beginning of the item body. After insertion, the cursor is returned to its original place, relative to the inserted content.
+         * The prependAsync method inserts the specified string at the beginning of the item body. 
+         * After insertion, the cursor is returned to its original place, relative to the inserted content.
          *
-         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" (please see the Examples section for a sample).
+         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" 
+         * (please see the Examples section for a sample).
          *
          * [Api set: Mailbox 1.1]
          *
@@ -396,11 +422,11 @@ export declare namespace Office {
          * 
          * <tr><td>Errors</td><td>DataExceedsMaximumSize - The data parameter is longer than 1,000,000 characters.</td></tr></table>
          * 
-         * In addition to the main signature, this method also has these signatures:
+         * In addition to this signature, this method also has the following signatures:
          * 
          * `prependAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`
          * 
-         * `prependAsync(data: string, callback: (result: AsyncResult) => void): void;`
+         * `prependAsync(data: string, callback: (result: AsyncResult<void>) => void): void;`
          * 
          * `prependAsync(data: string): void;`
          *
@@ -408,15 +434,18 @@ export declare namespace Office {
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
          *        coercionType: The desired format for the body. The string in the data parameter will be converted to this format.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. Any errors encountered will be provided in the asyncResult.error property.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult.
+         *                  Any errors encountered will be provided in the asyncResult.error property.
          */
-        prependAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult) => void): void;
+        prependAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Adds the specified content to the beginning of the item body.
          *
-         * The prependAsync method inserts the specified string at the beginning of the item body. After insertion, the cursor is returned to its original place, relative to the inserted content.
+         * The prependAsync method inserts the specified string at the beginning of the item body. 
+         * After insertion, the cursor is returned to its original place, relative to the inserted content.
          *
-         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" (please see the Examples section for a sample).
+         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" 
+         * (please see the Examples section for a sample).
          *
          * [Api set: Mailbox 1.1]
          *
@@ -436,9 +465,11 @@ export declare namespace Office {
         /**
          * Adds the specified content to the beginning of the item body.
          *
-         * The prependAsync method inserts the specified string at the beginning of the item body. After insertion, the cursor is returned to its original place, relative to the inserted content.
+         * The prependAsync method inserts the specified string at the beginning of the item body. 
+         * After insertion, the cursor is returned to its original place, relative to the inserted content.
          *
-         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" (please see the Examples section for a sample).
+         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" 
+         * (please see the Examples section for a sample).
          *
          * [Api set: Mailbox 1.1]
          *
@@ -448,15 +479,18 @@ export declare namespace Office {
          * <tr><td>Errors</td><td>DataExceedsMaximumSize - The data parameter is longer than 1,000,000 characters.</td></tr></table>
          *
          * @param data - The string to be inserted at the beginning of the body. The string is limited to 1,000,000 characters.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. Any errors encountered will be provided in the asyncResult.error property.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult.
+         *                  Any errors encountered will be provided in the asyncResult.error property.
          */
-        prependAsync(data: string, callback: (result: AsyncResult) => void): void;
+        prependAsync(data: string, callback: (result: AsyncResult<void>) => void): void;
         /**
          * Adds the specified content to the beginning of the item body.
          *
-         * The prependAsync method inserts the specified string at the beginning of the item body. After insertion, the cursor is returned to its original place, relative to the inserted content.
+         * The prependAsync method inserts the specified string at the beginning of the item body. 
+         * After insertion, the cursor is returned to its original place, relative to the inserted content.
          *
-         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" (please see the Examples section for a sample).
+         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" 
+         * (please see the Examples section for a sample).
          *
          * [Api set: Mailbox 1.1]
          *
@@ -471,9 +505,12 @@ export declare namespace Office {
         /**
          * Replaces the selection in the body with the specified text.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor was never in the body of the item, or if the body of the item lost focus in the UI, the string will be inserted at the top of the body content. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the body of the item, or, if text is selected in 
+         * the editor, it replaces the selected text. If the cursor was never in the body of the item, or if the body of the item lost focus in the 
+         * UI, the string will be inserted at the top of the body content. After insertion, the cursor is placed at the end of the inserted content.
          *
-         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" (please see the Examples section for a sample).
+         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" 
+         * (please see the Examples section for a sample).
          *
          * [Api set: Mailbox 1.1]
          *
@@ -484,11 +521,11 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>DataExceedsMaximumSize - The data parameter is longer than 1,000,000 characters.</td></tr><tr><td></td><td>InvalidFormatError - The options.coercionType parameter is set to Office.CoercionType.Html and the message body is in plain text.</td></tr></table>
          * 
-         * In addition to the main signature, this method also has these signatures:
+         * In addition to this signature, this method also has the following signatures:
          * 
          * `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`
          * 
-         * `setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;`
+         * `setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;`
          * 
          * `setSelectedDataAsync(data: string): void;`
          *         
@@ -496,15 +533,19 @@ export declare namespace Office {
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
          *        coercionType: The desired format for the body. The string in the data parameter will be converted to this format.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.  Any errors encountered will be provided in the asyncResult.error property.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult.
+         *                  Any errors encountered will be provided in the asyncResult.error property.
          */
-        setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult) => void): void;
+        setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Replaces the selection in the body with the specified text.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor was never in the body of the item, or if the body of the item lost focus in the UI, the string will be inserted at the top of the body content. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the body of the item, or, if text is selected in 
+         * the editor, it replaces the selected text. If the cursor was never in the body of the item, or if the body of the item lost focus in the 
+         * UI, the string will be inserted at the top of the body content. After insertion, the cursor is placed at the end of the inserted content.
          *
-         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" (please see the Examples section for a sample).
+         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" 
+         * (please see the Examples section for a sample).
          *
          * [Api set: Mailbox 1.1]
          *
@@ -524,9 +565,12 @@ export declare namespace Office {
         /**
          * Replaces the selection in the body with the specified text.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor was never in the body of the item, or if the body of the item lost focus in the UI, the string will be inserted at the top of the body content. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the body of the item, or, if text is selected in 
+         * the editor, it replaces the selected text. If the cursor was never in the body of the item, or if the body of the item lost focus in the 
+         * UI, the string will be inserted at the top of the body content. After insertion, the cursor is placed at the end of the inserted content.
          *
-         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" (please see the Examples section for a sample).
+         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" 
+         * (please see the Examples section for a sample).
          *
          * [Api set: Mailbox 1.1]
          *
@@ -538,15 +582,19 @@ export declare namespace Office {
          * <tr><td>Errors</td><td>DataExceedsMaximumSize - The data parameter is longer than 1,000,000 characters.</td></tr><tr><td></td><td>InvalidFormatError - The options.coercionType parameter is set to Office.CoercionType.Html and the message body is in plain text.</td></tr></table>
          *
          * @param data - The string that will replace the existing body. The string is limited to 1,000,000 characters.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.  Any errors encountered will be provided in the asyncResult.error property.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult.
+         *                  Any errors encountered will be provided in the asyncResult.error property.
          */
-        setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;
+        setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;
         /**
          * Replaces the selection in the body with the specified text.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor was never in the body of the item, or if the body of the item lost focus in the UI, the string will be inserted at the top of the body content. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the body of the item, or, if text is selected in 
+         * the editor, it replaces the selected text. If the cursor was never in the body of the item, or if the body of the item lost focus in the 
+         * UI, the string will be inserted at the top of the body content. After insertion, the cursor is placed at the end of the inserted content.
          *
-         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" (please see the Examples section for a sample).
+         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" 
+         * (please see the Examples section for a sample).
          *
          * [Api set: Mailbox 1.1]
          *
@@ -564,7 +612,8 @@ export declare namespace Office {
     /**
      * Represents a contact stored on the server. Read mode only.
      *
-     * The list of contacts associated with an email message or appointment is returned in the contacts property of the {@link Office.Entities} object that is returned by the getEntities or getEntitiesByType method of the active item.
+     * The list of contacts associated with an email message or appointment is returned in the contacts property of the {@link Office.Entities} object 
+     * that is returned by the getEntities or getEntitiesByType method of the active item.
      *
      * [Api set: Mailbox 1.0]
      *
@@ -600,7 +649,10 @@ export declare namespace Office {
         urls: Array<string>;
     }
     /**
-     * The CustomProperties object represents custom properties that are specific to a particular item and specific to a mail add-in for Outlook. For example, there might be a need for a mail add-in to save some data that is specific to the current email message that activated the add-in. If the user revisits the same message in the future and activates the mail add-in again, the add-in will be able to retrieve the data that had been saved as custom properties.
+     * The CustomProperties object represents custom properties that are specific to a particular item and specific to a mail add-in for Outlook. 
+     * For example, there might be a need for a mail add-in to save some data that is specific to the current email message that activated the add-in. 
+     * If the user revisits the same message in the future and activates the mail add-in again, the add-in will be able to retrieve the data that had 
+     * been saved as custom properties.
      *
      * Because Outlook for Mac doesn't cache custom properties, if the user's network goes down, mail add-ins cannot access their custom properties.
      *
@@ -630,7 +682,9 @@ export declare namespace Office {
          *
          * The set method sets the specified property to the specified value. You must use the saveAsync method to save the property to the server.
          *
-         * The set method creates a new property if the specified property does not already exist; otherwise, the existing value is replaced with the new value. The value parameter can be of any type; however, it is always passed to the server as a string.
+         * The set method creates a new property if the specified property does not already exist; 
+         * otherwise, the existing value is replaced with the new value. 
+         * The value parameter can be of any type; however, it is always passed to the server as a string.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -660,11 +714,17 @@ export declare namespace Office {
         /**
          * Saves item-specific custom properties to the server.
          *
-         * You must call the saveAsync method to persist any changes made with the set method or the remove method of the CustomProperties object. The saving action is asynchronous.
+         * You must call the saveAsync method to persist any changes made with the set method or the remove method of the CustomProperties object. 
+         * The saving action is asynchronous.
          *
-         * It's a good practice to have your callback function check for and handle errors from saveAsync. In particular, a read add-in can be activated while the user is in a connected state in a read form, and subsequently the user becomes disconnected. If the add-in calls saveAsync while in the disconnected state, saveAsync would return an error. Your callback method should handle this error accordingly.
+         * It's a good practice to have your callback function check for and handle errors from saveAsync. 
+         * In particular, a read add-in can be activated while the user is in a connected state in a read form, and subsequently the user becomes 
+         * disconnected. 
+         * If the add-in calls saveAsync while in the disconnected state, saveAsync would return an error. 
+         * Your callback method should handle this error accordingly.
          *
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          * @param asyncContext - Optional. Any state data that is passed to the callback method.
          *
          * [Api set: Mailbox 1.0]
@@ -674,7 +734,7 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          */
-        saveAsync(callback?: (result: AsyncResult) => void, asyncContext?: any): void;
+        saveAsync(callback?: (result: AsyncResult<void>) => void, asyncContext?: any): void;
     }
     /**
      * Provides diagnostic information to an Outlook add-in.
@@ -703,7 +763,8 @@ export declare namespace Office {
         /**
          * Gets a string that represents the version of either the host application or the Exchange Server.
          *
-         * If the mail add-in is running on the Outlook desktop client or Outlook for iOS, the hostVersion property returns the version of the host application, Outlook. In Outlook Web App, the property returns the version of the Exchange Server. An example is the string 15.0.468.0.
+         * If the mail add-in is running on the Outlook desktop client or Outlook for iOS, the hostVersion property returns the version of the host 
+         * application, Outlook. In Outlook Web App, the property returns the version of the Exchange Server. An example is the string 15.0.468.0.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -722,11 +783,13 @@ export declare namespace Office {
          *
          * Outlook Web App has three views that correspond to the width of the screen and the window, and the number of columns that can be displayed:
          *
-         * - OneColumn, which is displayed when the screen is narrow. Outlook Web App uses this single-column layout on the entire screen of a smartphone.
+         * - OneColumn, which is displayed when the screen is narrow. Outlook Web App uses this single-column layout on the entire screen of a 
+         * smartphone.
          *
          * - TwoColumns, which is displayed when the screen is wider. Outlook Web App uses this view on most tablets.
          *
-         * - ThreeColumns, which is displayed when the screen is wide. For example, Outlook Web App uses this view in a full screen window on a desktop computer.
+         * - ThreeColumns, which is displayed when the screen is wide. For example, Outlook Web App uses this view in a full screen window on a 
+         * desktop computer.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -735,7 +798,7 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          */
-        OWAView: "string";
+        OWAView: MailboxEnums.OWAView | "OneColumn" | "TwoColumns" | "ThreeColumns";
     }
     /**
      * Provides the email properties of the sender or specified recipients of an email message or appointment.
@@ -757,7 +820,9 @@ export declare namespace Office {
          */
         displayName: string;
         /**
-         * Gets the response that an attendee returned for an appointment. This property applies to only an attendee of an appointment, as represented by the optionalAttendees or requiredAttendees property. This property returns undefined in other scenarios.
+         * Gets the response that an attendee returned for an appointment. 
+         * This property applies to only an attendee of an appointment, as represented by the optionalAttendees or requiredAttendees property. 
+         * This property returns undefined in other scenarios.
          */
         appointmentResponse: Office.MailboxEnums.ResponseType;
         /**
@@ -788,17 +853,25 @@ export declare namespace Office {
     /**
      * Represents a collection of entities found in an email message or appointment. Read mode only.
      *
-     * The Entities object is a container for the entity arrays returned by the getEntities and getEntitiesByType methods when the item (either an email message or an appointment) contains one or more entities that have been found by the server. You can use these entities in your code to provide additional context information to the viewer, such as a map to an address found in the item, or to open a dialer for a phone number found in the item.
+     * The Entities object is a container for the entity arrays returned by the getEntities and getEntitiesByType methods when the item 
+     * (either an email message or an appointment) contains one or more entities that have been found by the server. 
+     * You can use these entities in your code to provide additional context information to the viewer, such as a map to an address found in the item, 
+     * or to open a dialer for a phone number found in the item.
      *
-     * If no entities of the type specified in the property are present in the item, the property associated with that entity is null. For example, if a message contains a street address and a phone number, the addresses property and phoneNumbers property would contain information, and the other properties would be null.
+     * If no entities of the type specified in the property are present in the item, the property associated with that entity is null. 
+     * For example, if a message contains a street address and a phone number, the addresses property and phoneNumbers property would contain 
+     * information, and the other properties would be null.
      *
-     * To be recognized as an address, the string must contain a United States postal address that has at least a subset of the elements of a street number, street name, city, state, and zip code.
+     * To be recognized as an address, the string must contain a United States postal address that has at least a subset of the elements of a street 
+     * number, street name, city, state, and zip code.
      *
      * To be recognized as a phone number, the string must contain a North American phone number format.
      *
-     * Entity recognition relies on natural language recognition that is based on machine learning of large amounts of data. The recognition of an entity is non-deterministic and success sometimes relies on the particular context in the item.
+     * Entity recognition relies on natural language recognition that is based on machine learning of large amounts of data. 
+     * The recognition of an entity is non-deterministic and success sometimes relies on the particular context in the item.
      *
-     * When the property arrays are returned by the getEntitiesByType method, only the property for the specified entity contains data; all other properties are null.
+     * When the property arrays are returned by the getEntitiesByType method, only the property for the specified entity contains data; 
+     * all other properties are null.
      *
      * [Api set: Mailbox 1.0]
      *
@@ -840,14 +913,16 @@ export declare namespace Office {
     /**
      * The subclass of {@link Office.Item} dealing with appointments.
      * 
-     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of Office.context.mailbox.item. Refer to the Object Model pages for more information.
+     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. 
+     * You should treat this as a mode of Office.context.mailbox.item. Refer to the Object Model pages for more information.
      */
     export interface Appointment extends Item {
     }
     /**
      * The appointment organizer mode of {@link Office.Item | Office.context.mailbox.item}.
      * 
-     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
+     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. 
+     * You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
      */
     export interface AppointmentCompose extends Appointment, ItemCompose {
          /**
@@ -891,9 +966,11 @@ export declare namespace Office {
         /**
          * Gets or sets the date and time that the appointment is to end.
          *
-         * The end property is an {@link Office.Time} object expressed as a Coordinated Universal Time (UTC) date and time value. You can use the convertToLocalClientTime method to convert the end property value to the client's local date and time.
+         * The end property is an {@link Office.Time} object expressed as a Coordinated Universal Time (UTC) date and time value. 
+         * You can use the convertToLocalClientTime method to convert the end property value to the client's local date and time.
          *
-         * When you use the Time.setAsync method to set the end time, you should use the convertToUtcClientTime method to convert the local time on the client to UTC for the server.
+         * When you use the Time.setAsync method to set the end time, you should use the convertToUtcClientTime method to convert the local time on 
+         * the client to UTC for the server.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -919,7 +996,8 @@ export declare namespace Office {
          */
         itemType: Office.MailboxEnums.ItemType;
         /**
-         * Gets or sets the {@link Office.Location} of an appointment. The location property returns a Location object that provides methods that are used to get and set the location of the appointment.
+         * Gets or sets the {@link Office.Location} of an appointment. The location property returns a Location object that provides methods that are 
+         * used to get and set the location of the appointment.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -931,7 +1009,9 @@ export declare namespace Office {
          */
         location: Location;
         /**
-         * Provides access to the optional attendees of an event. The type of object and level of access depends on the mode of the current item. The optionalAttendees property returns an {@link Office.Recipients} object that provides methods to get or update the optional attendees for a meeting.
+         * Provides access to the optional attendees of an event. The type of object and level of access depends on the mode of the current item. 
+         * The optionalAttendees property returns an {@link Office.Recipients} object that provides methods to get or update the optional attendees 
+         * for a meeting.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -943,7 +1023,9 @@ export declare namespace Office {
          */
         optionalAttendees: Recipients;
         /**
-         * Provides access to the required attendees of an event. The type of object and level of access depends on the mode of the current item. The requiredAttendees property returns an {@link Office.Recipients} object that provides methods to get or update the required attendees for a meeting.
+         * Provides access to the required attendees of an event. The type of object and level of access depends on the mode of the current item. 
+         * The requiredAttendees property returns an {@link Office.Recipients} object that provides methods to get or update the required attendees 
+         * for a meeting.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -957,9 +1039,11 @@ export declare namespace Office {
         /**
          * Gets or sets the date and time that the appointment is to begin.
          *
-         * The start property is an {@link Office.Time} object expressed as a Coordinated Universal Time (UTC) date and time value. You can use the convertToLocalClientTime method to convert the value to the client's local date and time.
+         * The start property is an {@link Office.Time} object expressed as a Coordinated Universal Time (UTC) date and time value. 
+         * You can use the convertToLocalClientTime method to convert the value to the client's local date and time.
          *
-         * When you use the Time.setAsync method to set the start time, you should use the convertToUtcClientTime method to convert the local time on the client to UTC for the server.
+         * When you use the Time.setAsync method to set the start time, you should use the convertToUtcClientTime method to convert the local time on 
+         * the client to UTC for the server.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1008,16 +1092,18 @@ export declare namespace Office {
          * 
          * `addFileAttachmentAsync(uri: string, attachmentName: string, options: Office.AsyncContextOptions): void;`
          * 
-         * `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+         * `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;`
          *
          * @param uri - The URI that provides the location of the file to attach to the message or appointment. The maximum length is 2048 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
          *        isInline: If true, indicates that the attachment will be shown inline in the message body, and should not be displayed in the attachment list.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type asyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type asyncResult. 
+         *                 On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
          */
-        addFileAttachmentAsync(uri: string, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        addFileAttachmentAsync(uri: string, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;
         /**
          * Adds a file to a message or appointment as an attachment.
          *
@@ -1058,7 +1144,7 @@ export declare namespace Office {
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         *        isInline: If true, indicates that the attachment will be shown inline in the message body, and should not be displayed in the attachment list.
+         *        isInline: If true, indicates that the attachment will be shown inline in the message body and should not be displayed in the attachment list.
          */
         addFileAttachmentAsync(uri: string, attachmentName: string, options: Office.AsyncContextOptions): void;
         /**
@@ -1079,17 +1165,23 @@ export declare namespace Office {
          *
          * @param uri - The URI that provides the location of the file to attach to the message or appointment. The maximum length is 2048 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type asyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type asyncResult. 
+         *                 On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
          */
-        addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;
+        addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. 
+         * You can use the options parameter to pass state information to the callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -1100,29 +1192,35 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>NumberOfAttachmentsExceeded - The message or appointment has too many attachments.</td></tr></table>
          * 
-         * In addition to the main signature, this method also has these signatures:
+         * In addition to this signature, this method also has the following signatures:
          * 
          * `addItemAttachmentAsync(itemId: any, attachmentName: string): void;`
          * 
          * `addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;`
          * 
-         * `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+         * `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;`
          *
          * @param itemId - The Exchange identifier of the item to attach. The maximum length is 100 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
          * @param options - An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. 
+         *                 On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
          */
-        addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. 
+         * You can use the options parameter to pass state information to the callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -1140,11 +1238,15 @@ export declare namespace Office {
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. 
+         * You can use the options parameter to pass state information to the callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -1164,11 +1266,15 @@ export declare namespace Office {
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. 
+         * You can use the options parameter to pass state information to the callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -1181,15 +1287,21 @@ export declare namespace Office {
          *
          * @param itemId - The Exchange identifier of the item to attach. The maximum length is 100 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. 
+         *                 On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
          */
-        addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;
+        addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;
         /**
          * Asynchronously loads custom properties for this add-in on the selected item.
          *
-         * Custom properties are stored as key/value pairs on a per-app, per-item basis. This method returns a CustomProperties object in the callback, which provides methods to access the custom properties specific to the current item and the current add-in. Custom properties are not encrypted on the item, so this should not be used as secure storage.
+         * Custom properties are stored as key/value pairs on a per-app, per-item basis. 
+         * This method returns a CustomProperties object in the callback, which provides methods to access the custom properties specific to the 
+         * current item and the current add-in. Custom properties are not encrypted on the item, so this should not be used as secure storage.
          *
-         * The custom properties are provided as a CustomProperties object in the asyncResult.value property. This object can be used to get, set, and remove custom properties from the item and save changes to the custom property set back to the server.
+         * The custom properties are provided as a CustomProperties object in the asyncResult.value property. 
+         * This object can be used to get, set, and remove custom properties from the item and save changes to the custom property set back to 
+         * the server.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1199,14 +1311,20 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Appointment Organizer</td></tr></table>
          *
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
-         * @param userContext - Optional. Developers can provide any object they wish to access in the callback function. This object can be accessed by the asyncResult.asyncContext property in the callback function.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
+         * @param userContext - Optional. Developers can provide any object they wish to access in the callback function. 
+         *                    This object can be accessed by the asyncResult.asyncContext property in the callback function.
          */
-        loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;
+        loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any): void;
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -1224,18 +1342,23 @@ export declare namespace Office {
          * 
          * `removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;`
          * 
-         * `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;`
+         * `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;`
          *
          * @param attachmentIndex - The identifier of the attachment to remove. The maximum length of the string is 100 characters.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. 
+         *                 If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
          */
-        removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -1253,7 +1376,11 @@ export declare namespace Office {
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -1273,7 +1400,12 @@ export declare namespace Office {
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. 
+         * In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -1286,19 +1418,22 @@ export declare namespace Office {
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
          * @param attachmentIndex - The identifier of the attachment to remove. The maximum length of the string is 100 characters.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. 
+         *                 If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
          */
-        removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;
+        removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;
     }
 
     /**
      * The appointment attendee mode of {@link Office.Item | Office.context.mailbox.item}.
      * 
-     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of 'Office.context.mailbox.item'. Refer to the Object Model pages for more information.
+     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. 
+     * You should treat this as a mode of 'Office.context.mailbox.item'. Refer to the Object Model pages for more information.
      */
     export interface AppointmentRead extends Appointment, ItemRead {
         /**
-         * Gets an array of attachments for the item.
+         * Gets the item's attachments as an array.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1308,7 +1443,8 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Appointment Attendee</td></tr></table>
          *
-         * Note: Certain types of files are blocked by Outlook due to potential security issues and are therefore not returned. For more information, see {@link https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519 | Blocked attachments in Outlook}.
+         * Note: Certain types of files are blocked by Outlook due to potential security issues and are therefore not returned. For more information, see 
+         * {@link https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519 | Blocked attachments in Outlook}.
          *
          */
         attachments: Office.AttachmentDetails[];
@@ -1353,9 +1489,11 @@ export declare namespace Office {
         /**
          * Gets the date and time that the appointment is to end.
          *
-         * The end property is a Date object expressed as a Coordinated Universal Time (UTC) date and time value. You can use the convertToLocalClientTime method to convert the end property value to the client's local date and time.
+         * The end property is a Date object expressed as a Coordinated Universal Time (UTC) date and time value. 
+         * You can use the convertToLocalClientTime method to convert the end property value to the client's local date and time.
          *
-         * When you use the Time.setAsync method to set the end time, you should use the convertToUtcClientTime method to convert the local time on the client to UTC for the server.
+         * When you use the Time.setAsync method to set the end time, you should use the convertToUtcClientTime method to convert the local time on 
+         * the client to UTC for the server.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1405,9 +1543,14 @@ export declare namespace Office {
         /**
          * Gets the Exchange Web Services item identifier for the current item.
          *
-         * The itemId property is not available in compose mode. If an item identifier is required, the saveAsync method can be used to save the item to the store, which will return the item identifier in the AsyncResult.value parameter in the callback function.
+         * The itemId property is not available in compose mode. 
+         * If an item identifier is required, the saveAsync method can be used to save the item to the store, which will return the item identifier 
+         * in the AsyncResult.value parameter in the callback function.
          *
-         * Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more details, see Use the Outlook REST APIs from an Outlook add-in.
+         * Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. 
+         * The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. 
+         * Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. 
+         * For more details, see {@link https://docs.microsoft.com/outlook/add-ins/use-rest-api#get-the-item-id | Use the Outlook REST APIs from an Outlook add-in}.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1449,7 +1592,8 @@ export declare namespace Office {
         /**
          * Gets the subject of an item, with all prefixes removed (including RE: and FWD:).
          *
-         * The normalizedSubject property gets the subject of the item, with any standard prefixes (such as RE: and FW:) that are added by email programs. To get the subject of the item with the prefixes intact, use the subject property.
+         * The normalizedSubject property gets the subject of the item, with any standard prefixes (such as RE: and FW:) that are added by email programs. 
+         * To get the subject of the item with the prefixes intact, use the subject property.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1463,7 +1607,8 @@ export declare namespace Office {
         /**
          * Provides access to the optional attendees of an event. The type of object and level of access depends on the mode of the current item.
          *
-         * The optionalAttendees property returns an array that contains an {@link Office.EmailAddressDetails} object for each optional attendee to the meeting.
+         * The optionalAttendees property returns an array that contains an {@link Office.EmailAddressDetails} object for each optional attendee to 
+         * the meeting.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1475,7 +1620,7 @@ export declare namespace Office {
          */
         optionalAttendees: EmailAddressDetails[];
         /**
-         * Gets the email address of the meeting organizer for a specified meeting. Read mode only.
+         * Gets the email address of the meeting organizer for a specified meeting.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1489,7 +1634,8 @@ export declare namespace Office {
         /**
          * Provides access to the required attendees of an event. The type of object and level of access depends on the mode of the current item.
          *
-         * The requiredAttendees property returns an array that contains an {@link Office.EmailAddressDetails} object for each required attendee to the meeting.
+         * The requiredAttendees property returns an array that contains an {@link Office.EmailAddressDetails} object for each required attendee to 
+         * the meeting.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1503,7 +1649,8 @@ export declare namespace Office {
         /**
          * Gets the date and time that the appointment is to begin.
          *
-         * The start property is a Date object expressed as a Coordinated Universal Time (UTC) date and time value. You can use the convertToLocalClientTime method to convert the value to the client's local date and time.
+         * The start property is a Date object expressed as a Coordinated Universal Time (UTC) date and time value. 
+         * You can use the convertToLocalClientTime method to convert the value to the client's local date and time.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1530,14 +1677,18 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Appointment Attendee</td></tr></table>
          */
         subject: string;
+
         /**
-         * Displays a reply form that includes the sender and all recipients of the selected message or the organizer and all attendees of the selected appointment.
+         * Displays a reply form that includes the sender and all recipients of the selected message or the organizer and all attendees of the 
+         * selected appointment.
          *
          * In Outlook Web App, the reply form is displayed as a pop-out form in the 3-column view and a pop-up form in the 2- or 1-column view.
          *
          * If any of the string parameters exceed their limits, displayReplyAllForm throws an exception.
          *
-         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. If this isn't possible, then no error message is thrown.
+         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and 
+         * attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. 
+         * If this isn't possible, then no error message is thrown.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -1560,7 +1711,9 @@ export declare namespace Office {
          *
          * If any of the string parameters exceed their limits, displayReplyForm throws an exception.
          *
-         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. If this isn't possible, then no error message is thrown.
+         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and 
+         * attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. 
+         * If this isn't possible, then no error message is thrown.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -1578,7 +1731,7 @@ export declare namespace Office {
          */
         displayReplyForm(formData: string | ReplyFormData): void;
         /**
-         * Gets the entities found in the selected item.
+         * Gets the entities found in the selected item's body.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -1592,7 +1745,7 @@ export declare namespace Office {
          */
         getEntities(): Entities;
         /**
-         * Gets an array of all the entities of the specified entity type found in the selected item.
+         * Gets an array of all the entities of the specified entity type found in the selected item's body.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -1601,7 +1754,9 @@ export declare namespace Office {
          * @param entityType - One of the EntityType enumeration values.
          *
          * @returns
-         * If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. If no entities of the specified type are present on the item, the method returns an empty array. Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter.
+         * If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. 
+         * If no entities of the specified type are present in the item's body, the method returns an empty array. 
+         * Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter.
          *
          * @remarks
          * <table><tr><td>{@link https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions | Minimum permission level}</td><td>Restricted</td></tr>
@@ -1657,7 +1812,8 @@ export declare namespace Office {
         /**
          * Returns well-known entities in the selected item that pass the named filter defined in the manifest XML file.
          *
-         * The getFilteredEntitiesByName method returns the entities that match the regular expression defined in the ItemHasKnownEntity rule element in the manifest XML file with the specified FilterName element value.
+         * The getFilteredEntitiesByName method returns the entities that match the regular expression defined in the ItemHasKnownEntity rule element 
+         * in the manifest XML file with the specified FilterName element value.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -1670,22 +1826,33 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Appointment Attendee</td></tr></table>
          *
          * @param name - The name of the ItemHasKnownEntity rule element that defines the filter to match.
-         * @returns If there is no ItemHasKnownEntity element in the manifest with a FilterName element value that matches the name parameter, the method returns null. If the name parameter does match an ItemHasKnownEntity element in the manifest, but there are no entities in the current item that match, the method return an empty array.
+         * @returns If there is no ItemHasKnownEntity element in the manifest with a FilterName element value that matches the name parameter, 
+         * the method returns null. 
+         * If the name parameter does match an ItemHasKnownEntity element in the manifest, but there are no entities in the current item that match, 
+         * the method return an empty array.
          */
         getFilteredEntitiesByName(name: string): (string | Contact | MeetingSuggestion | PhoneNumber | TaskSuggestion)[];
         /**
          * Returns string values in the selected item that match the regular expressions defined in the manifest XML file.
          *
-         * The getRegExMatches method returns the strings that match the regular expression defined in each ItemHasRegularExpressionMatch or ItemHasKnownEntity rule element in the manifest XML file. For an ItemHasRegularExpressionMatch rule, a matching string has to occur in the property of the item that is specified by that rule. The PropertyName simple type defines the supported properties.
+         * The getRegExMatches method returns the strings that match the regular expression defined in each ItemHasRegularExpressionMatch or 
+         * ItemHasKnownEntity rule element in the manifest XML file. 
+         * For an ItemHasRegularExpressionMatch rule, a matching string has to occur in the property of the item that is specified by that rule. 
+         * The PropertyName simple type defines the supported properties.
          *
-         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body and should not attempt to return the entire body of the item. Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results. Instead, use the Body.getAsync method to retrieve the entire body.
+         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body 
+         * and should not attempt to return the entire body of the item. 
+         * Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results. 
+         * Instead, use the Body.getAsync method to retrieve the entire body.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
          * [Api set: Mailbox 1.0]
          *
          * @returns
-         * An object that contains arrays of strings that match the regular expressions defined in the manifest XML file. The name of each array is equal to the corresponding value of the RegExName attribute of the matching ItemHasRegularExpressionMatch rule or the FilterName attribute of the matching ItemHasKnownEntity rule.
+         * An object that contains arrays of strings that match the regular expressions defined in the manifest XML file. 
+         * The name of each array is equal to the corresponding value of the RegExName attribute of the matching ItemHasRegularExpressionMatch rule 
+         * or the FilterName attribute of the matching ItemHasKnownEntity rule.
          *
          * @remarks
          *
@@ -1697,9 +1864,12 @@ export declare namespace Office {
         /**
          * Returns string values in the selected item that match the named regular expression defined in the manifest XML file.
          *
-         * The getRegExMatchesByName method returns the strings that match the regular expression defined in the ItemHasRegularExpressionMatch rule element in the manifest XML file with the specified RegExName element value.
+         * The getRegExMatchesByName method returns the strings that match the regular expression defined in the ItemHasRegularExpressionMatch rule 
+         * element in the manifest XML file with the specified RegExName element value.
          *
-         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body and should not attempt to return the entire body of the item. Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results.
+         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body 
+         * and should not attempt to return the entire body of the item. 
+         * Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -1717,12 +1887,16 @@ export declare namespace Office {
          * @param name - The name of the ItemHasRegularExpressionMatch rule element that defines the filter to match.
          */
         getRegExMatchesByName(name: string): string[];
-       /**
+        /**
         * Asynchronously loads custom properties for this add-in on the selected item.
         *
-        * Custom properties are stored as key/value pairs on a per-app, per-item basis. This method returns a CustomProperties object in the callback, which provides methods to access the custom properties specific to the current item and the current add-in. Custom properties are not encrypted on the item, so this should not be used as secure storage.
+        * Custom properties are stored as key/value pairs on a per-app, per-item basis. 
+        * This method returns a CustomProperties object in the callback, which provides methods to access the custom properties specific to the 
+        * current item and the current add-in. Custom properties are not encrypted on the item, so this should not be used as secure storage.
         *
-        * The custom properties are provided as a CustomProperties object in the asyncResult.value property. This object can be used to get, set, and remove custom properties from the item and save changes to the custom property set back to the server.
+        * The custom properties are provided as a CustomProperties object in the asyncResult.value property. 
+        * This object can be used to get, set, and remove custom properties from the item and save changes to the custom property set back to 
+        * the server.
         *
         * [Api set: Mailbox 1.0]
         *
@@ -1732,14 +1906,17 @@ export declare namespace Office {
         *
         * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Appointment Attendee</td></tr></table>
         *
-        * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
-        * @param userContext - Optional. Developers can provide any object they wish to access in the callback function. This object can be accessed by the asyncResult.asyncContext property in the callback function.
+        * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+        *                 type Office.AsyncResult.
+        * @param userContext - Optional. Developers can provide any object they wish to access in the callback function. 
+        *                    This object can be accessed by the asyncResult.asyncContext property in the callback function.
         */
-       loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;
+       loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any): void;
     }
 
     /**
-     * The item namespace is used to access the currently selected message, meeting request, or appointment. You can determine the type of the item by using the `itemType` property.
+     * The item namespace is used to access the currently selected message, meeting request, or appointment. 
+     * You can determine the type of the item by using the `itemType` property.
      *
      * [Api set: Mailbox 1.0]
      *
@@ -1790,7 +1967,8 @@ export declare namespace Office {
         /**
          * Gets the type of item that an instance represents.
          *
-         * The itemType property returns one of the ItemType enumeration values, indicating whether the item object instance is a message or an appointment.
+         * The itemType property returns one of the ItemType enumeration values, indicating whether the item object instance is a message or 
+         * an appointment.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1801,12 +1979,17 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          */
         itemType: Office.MailboxEnums.ItemType;
+
        /**
         * Asynchronously loads custom properties for this add-in on the selected item.
         *
-        * Custom properties are stored as key/value pairs on a per-app, per-item basis. This method returns a CustomProperties object in the callback, which provides methods to access the custom properties specific to the current item and the current add-in. Custom properties are not encrypted on the item, so this should not be used as secure storage.
+        * Custom properties are stored as key/value pairs on a per-app, per-item basis. 
+        * This method returns a CustomProperties object in the callback, which provides methods to access the custom properties specific to the 
+        * current item and the current add-in. Custom properties are not encrypted on the item, so this should not be used as secure storage.
         *
-        * The custom properties are provided as a CustomProperties object in the asyncResult.value property. This object can be used to get, set, and remove custom properties from the item and save changes to the custom property set back to the server.
+        * The custom properties are provided as a CustomProperties object in the asyncResult.value property. 
+        * This object can be used to get, set, and remove custom properties from the item and save changes to the custom property set back to 
+        * the server.
         *
         * [Api set: Mailbox 1.0]
         *
@@ -1816,15 +1999,18 @@ export declare namespace Office {
         *
         * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
         *
-        * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
-        * @param userContext - Optional. Developers can provide any object they wish to access in the callback function. This object can be accessed by the asyncResult.asyncContext property in the callback function.
+        * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+        *                 type Office.AsyncResult.
+        * @param userContext - Optional. Developers can provide any object they wish to access in the callback function. 
+        *                    This object can be accessed by the asyncResult.asyncContext property in the callback function.
         */
-       loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;
+       loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any): void;
     }
     /**
      * The compose mode of {@link Office.Item | Office.context.mailbox.item}.
      * 
-     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
+     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. 
+     * You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
      */
     export interface ItemCompose extends Item {
         /**
@@ -1865,16 +2051,20 @@ export declare namespace Office {
          * 
          * `addFileAttachmentAsync(uri: string, attachmentName: string, options: Office.AsyncContextOptions): void;`
          * 
-         * `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+         * `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;`
          *
          * @param uri - The URI that provides the location of the file to attach to the message or appointment. The maximum length is 2048 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         *        isInline: If true, indicates that the attachment will be shown inline in the message body, and should not be displayed in the attachment list.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type asyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         *        isInline: If true, indicates that the attachment will be shown inline in the message body, and should not be displayed in the 
+         *        attachment list.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type asyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of 
+         *                 the error.
          */
-        addFileAttachmentAsync(uri: string, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        addFileAttachmentAsync(uri: string, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;
         /**
          * Adds a file to a message or appointment as an attachment.
          *
@@ -1915,7 +2105,8 @@ export declare namespace Office {
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         *        isInline: If true, indicates that the attachment will be shown inline in the message body, and should not be displayed in the attachment list.
+         *        isInline: If true, indicates that the attachment will be shown inline in the message body, and should not be displayed in the 
+         *        attachment list.
          */
         addFileAttachmentAsync(uri: string, attachmentName: string, options: Office.AsyncContextOptions): void;
         /**
@@ -1936,18 +2127,25 @@ export declare namespace Office {
          *
          * @param uri - The URI that provides the location of the file to attach to the message or appointment. The maximum length is 2048 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type asyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of 
+         *                 the error.
          */
-        addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;
+        addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;
 
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the 
+         * callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -1958,29 +2156,36 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>NumberOfAttachmentsExceeded - The message or appointment has too many attachments.</td></tr></table>
          * 
-         * In addition to the main signature, this method also has these signatures:
+         * In addition to this signature, this method also has the following signatures:
          * 
          * `addItemAttachmentAsync(itemId: any, attachmentName: string): void;`
          * 
          * `addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;`
          * 
-         * `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+         * `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;`
          *
          * @param itemId - The Exchange identifier of the item to attach. The maximum length is 100 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
          * @param options - An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of 
+         *                 the error.
          */
-        addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the 
+         * callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -1998,11 +2203,15 @@ export declare namespace Office {
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the 
+         * callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -2022,11 +2231,15 @@ export declare namespace Office {
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the 
+         * callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -2039,13 +2252,20 @@ export declare namespace Office {
          *
          * @param itemId - The Exchange identifier of the item to attach. The maximum length is 100 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of 
+         *                 the error.
          */
-        addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;
+        addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -2063,18 +2283,24 @@ export declare namespace Office {
          * 
          * `removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;`
          * 
-         * `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;`
+         * `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;`
          *
          * @param attachmentIndex - The identifier of the attachment to remove. The maximum length of the string is 100 characters.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. 
+         *                 If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
          */
-        removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -2092,7 +2318,11 @@ export declare namespace Office {
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -2112,7 +2342,11 @@ export declare namespace Office {
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -2125,18 +2359,21 @@ export declare namespace Office {
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
          * @param attachmentIndex - The identifier of the attachment to remove. The maximum length of the string is 100 characters.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type {@link Offfice.AsyncResult}. 
+         *                 If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
          */
-        removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;
+        removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;
     }
     /**
      * The read mode of {@link Office.Item | Office.context.mailbox.item}.
      * 
-     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
+     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. 
+     * You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
      */
     export interface ItemRead extends Item {
         /**
-         * Gets an array of attachments for the item.
+         * Gets the item's attachments as an array.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -2145,7 +2382,9 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Read</td></tr></table>
          *
-         * Note: Certain types of files are blocked by Outlook due to potential security issues and are therefore not returned. For more information, see {@link https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519 | Blocked attachments in Outlook}.
+         * Note: Certain types of files are blocked by Outlook due to potential security issues and are therefore not returned. 
+         * For more information, see 
+         * {@link https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519 | Blocked attachments in Outlook}.
          *
          */
         attachments: Office.AttachmentDetails[];
@@ -2153,7 +2392,8 @@ export declare namespace Office {
          * Gets the Exchange Web Services item class of the selected item.
          *
          *
-         * You can create custom message classes that extends a default message class, for example, a custom appointment message class IPM.Appointment.Contoso.
+         * You can create custom message classes that extends a default message class, for example, a custom appointment message class 
+         * IPM.Appointment.Contoso.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -2163,7 +2403,8 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Read</td></tr></table>
          * 
-         * The itemClass property specifies the message class of the selected item. The following are the default message classes for the message or appointment item.
+         * The itemClass property specifies the message class of the selected item. The following are the default message classes for the message or 
+         * appointment item.
          * 
          * <table>
          *   <tr>
@@ -2187,9 +2428,14 @@ export declare namespace Office {
         /**
          * Gets the Exchange Web Services item identifier for the current item.
          *
-         * The itemId property is not available in compose mode. If an item identifier is required, the saveAsync method can be used to save the item to the store, which will return the item identifier in the AsyncResult.value parameter in the callback function.
+         * The itemId property is not available in compose mode. 
+         * If an item identifier is required, the saveAsync method can be used to save the item to the store, which will return the item identifier 
+         * in the AsyncResult.value parameter in the callback function.
          *
-         * Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more details, see Use the Outlook REST APIs from an Outlook add-in.
+         * Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. 
+         * The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. 
+         * Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. 
+         * For more details, see {@link https://docs.microsoft.com/outlook/add-ins/use-rest-api#get-the-item-id | Use the Outlook REST APIs from an Outlook add-in}.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -2203,7 +2449,8 @@ export declare namespace Office {
         /**
          * Gets the subject of an item, with all prefixes removed (including RE: and FWD:).
          *
-         * The normalizedSubject property gets the subject of the item, with any standard prefixes (such as RE: and FW:) that are added by email programs. To get the subject of the item with the prefixes intact, use the subject property.
+         * The normalizedSubject property gets the subject of the item, with any standard prefixes (such as RE: and FW:) that are added by 
+         * email programs. To get the subject of the item with the prefixes intact, use the subject property.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -2231,13 +2478,16 @@ export declare namespace Office {
          */
         subject: string;
         /**
-         * Displays a reply form that includes the sender and all recipients of the selected message or the organizer and all attendees of the selected appointment.
+         * Displays a reply form that includes the sender and all recipients of the selected message or the organizer and all attendees of the 
+         * selected appointment.
          *
          * In Outlook Web App, the reply form is displayed as a pop-out form in the 3-column view and a pop-up form in the 2- or 1-column view.
          *
          * If any of the string parameters exceed their limits, displayReplyAllForm throws an exception.
          *
-         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. If this isn't possible, then no error message is thrown.
+         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and 
+         * attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. 
+         * If this isn't possible, then no error message is thrown.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -2260,7 +2510,9 @@ export declare namespace Office {
          *
          * If any of the string parameters exceed their limits, displayReplyForm throws an exception.
          *
-         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. If this isn't possible, then no error message is thrown.
+         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and 
+         * attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. 
+         * If this isn't possible, then no error message is thrown.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -2278,7 +2530,7 @@ export declare namespace Office {
          */
         displayReplyForm(formData: string | ReplyFormData): void;
         /**
-         * Gets the entities found in the selected item.
+         * Gets the entities found in the selected item's body.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -2292,7 +2544,7 @@ export declare namespace Office {
          */
         getEntities(): Entities;
         /**
-         * Gets an array of all the entities of the specified entity type found in the selected item.
+         * Gets an array of all the entities of the specified entity type found in the selected item's body.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -2301,14 +2553,17 @@ export declare namespace Office {
          * @param entityType - One of the EntityType enumeration values.
          *
          * @returns
-         * If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. If no entities of the specified type are present on the item, the method returns an empty array. Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter.
+         * If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. 
+         * If no entities of the specified type are present in the item's body, the method returns an empty array. 
+         * Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter.
          *
          * @remarks
          * <table><tr><td>{@link https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions | Minimum permission level}</td><td>Restricted</td></tr>
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Read</td></tr></table>
          * 
-         * While the minimum permission level to use this method is Restricted, some entity types require ReadItem to access, as specified in the following table.
+         * While the minimum permission level to use this method is Restricted, some entity types require ReadItem to access, as specified in the 
+         * following table.
          * 
          * <table>
          *   <tr>
@@ -2357,7 +2612,8 @@ export declare namespace Office {
         /**
          * Returns well-known entities in the selected item that pass the named filter defined in the manifest XML file.
          *
-         * The getFilteredEntitiesByName method returns the entities that match the regular expression defined in the ItemHasKnownEntity rule element in the manifest XML file with the specified FilterName element value.
+         * The getFilteredEntitiesByName method returns the entities that match the regular expression defined in the ItemHasKnownEntity rule element 
+         * in the manifest XML file with the specified FilterName element value.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -2370,22 +2626,33 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Read</td></tr></table>
          *
          * @param name - The name of the ItemHasKnownEntity rule element that defines the filter to match.
-         * @returns If there is no ItemHasKnownEntity element in the manifest with a FilterName element value that matches the name parameter, the method returns null. If the name parameter does match an ItemHasKnownEntity element in the manifest, but there are no entities in the current item that match, the method return an empty array.
+         * @returns If there is no ItemHasKnownEntity element in the manifest with a FilterName element value that matches the name parameter, 
+         * the method returns null. 
+         * If the name parameter does match an ItemHasKnownEntity element in the manifest, but there are no entities in the current item that match, 
+         * the method return an empty array.
          */
         getFilteredEntitiesByName(name: string): (string | Contact | MeetingSuggestion | PhoneNumber | TaskSuggestion)[];
         /**
          * Returns string values in the selected item that match the regular expressions defined in the manifest XML file.
          *
-         * The getRegExMatches method returns the strings that match the regular expression defined in each ItemHasRegularExpressionMatch or ItemHasKnownEntity rule element in the manifest XML file. For an ItemHasRegularExpressionMatch rule, a matching string has to occur in the property of the item that is specified by that rule. The PropertyName simple type defines the supported properties.
+         * The getRegExMatches method returns the strings that match the regular expression defined in each ItemHasRegularExpressionMatch or 
+         * ItemHasKnownEntity rule element in the manifest XML file. 
+         * For an ItemHasRegularExpressionMatch rule, a matching string has to occur in the property of the item that is specified by that rule. 
+         * The PropertyName simple type defines the supported properties.
          *
-         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body and should not attempt to return the entire body of the item. Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results. Instead, use the Body.getAsync method to retrieve the entire body.
+         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body 
+         * and should not attempt to return the entire body of the item. 
+         * Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results. 
+         * Instead, use the Body.getAsync method to retrieve the entire body.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
          * [Api set: Mailbox 1.0]
          *
          * @returns
-         * An object that contains arrays of strings that match the regular expressions defined in the manifest XML file. The name of each array is equal to the corresponding value of the RegExName attribute of the matching ItemHasRegularExpressionMatch rule or the FilterName attribute of the matching ItemHasKnownEntity rule.
+         * An object that contains arrays of strings that match the regular expressions defined in the manifest XML file. 
+         * The name of each array is equal to the corresponding value of the RegExName attribute of the matching ItemHasRegularExpressionMatch rule 
+         * or the FilterName attribute of the matching ItemHasKnownEntity rule.
          *
          * @remarks
          *
@@ -2397,9 +2664,12 @@ export declare namespace Office {
         /**
          * Returns string values in the selected item that match the named regular expression defined in the manifest XML file.
          *
-         * The getRegExMatchesByName method returns the strings that match the regular expression defined in the ItemHasRegularExpressionMatch rule element in the manifest XML file with the specified RegExName element value.
+         * The getRegExMatchesByName method returns the strings that match the regular expression defined in the ItemHasRegularExpressionMatch rule 
+         * element in the manifest XML file with the specified RegExName element value.
          *
-         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body and should not attempt to return the entire body of the item. Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results.
+         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body 
+         * and should not attempt to return the entire body of the item. 
+         * Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -2421,15 +2691,19 @@ export declare namespace Office {
     /**
      * A subclass of {@link Office.Item} for messages.
      * 
-     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
+     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. 
+     * You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
      */
     export interface Message extends Item {
         /**
          * Gets an identifier for the email conversation that contains a particular message.
          *
-         * You can get an integer for this property if your mail app is activated in read forms or responses in compose forms. If subsequently the user changes the subject of the reply message, upon sending the reply, the conversation ID for that message will change and that value you obtained earlier will no longer apply.
+         * You can get an integer for this property if your mail app is activated in read forms or responses in compose forms. 
+         * If subsequently the user changes the subject of the reply message, upon sending the reply, the conversation ID for that message will 
+         * change and that value you obtained earlier will no longer apply.
          *
-         * You get null for this property for a new item in a compose form. If the user sets a subject and saves the item, the conversationId property will return a value.
+         * You get null for this property for a new item in a compose form. 
+         * If the user sets a subject and saves the item, the conversationId property will return a value.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -2445,7 +2719,8 @@ export declare namespace Office {
      /**
      * The message compose mode of {@link Office.Item | Office.context.mailbox.item}.
      * 
-     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
+     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. 
+     * You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
      */
     export interface MessageCompose extends Message, ItemCompose {
         /**
@@ -2473,9 +2748,11 @@ export declare namespace Office {
          */
         body: Office.Body;
         /**
-         * Provides access to the Cc (carbon copy) recipients of a message. The type of object and level of access depends on the mode of the current item.
+         * Provides access to the Cc (carbon copy) recipients of a message. The type of object and level of access depends on the mode of the 
+         * current item.
          *
-         * The cc property returns a {@link Office.Recipients} object that provides methods to get or update the recipients on the Cc line of the message.
+         * The cc property returns a {@link Office.Recipients} object that provides methods to get or update the recipients on the Cc line of 
+         * the message.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -2489,9 +2766,12 @@ export declare namespace Office {
         /**
          * Gets an identifier for the email conversation that contains a particular message.
          *
-         * You can get an integer for this property if your mail app is activated in read forms or responses in compose forms. If subsequently the user changes the subject of the reply message, upon sending the reply, the conversation ID for that message will change and that value you obtained earlier will no longer apply.
+         * You can get an integer for this property if your mail app is activated in read forms or responses in compose forms. 
+         * If subsequently the user changes the subject of the reply message, upon sending the reply, the conversation ID for that message will change 
+         * and that value you obtained earlier will no longer apply.
          *
-         * You get null for this property for a new item in a compose form. If the user sets a subject and saves the item, the conversationId property will return a value.
+         * You get null for this property for a new item in a compose form. 
+         * If the user sets a subject and saves the item, the conversationId property will return a value.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -2531,7 +2811,8 @@ export declare namespace Office {
         /**
          * Gets the type of item that an instance represents.
          *
-         * The itemType property returns one of the ItemType enumeration values, indicating whether the item object instance is a message or an appointment.
+         * The itemType property returns one of the ItemType enumeration values, indicating whether the item object instance is a message or 
+         * an appointment.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -2559,7 +2840,8 @@ export declare namespace Office {
          */
         subject: Subject;
         /**
-         * Provides access to the recipients on the To line of a message. The type of object and level of access depends on the mode of the current item.
+         * Provides access to the recipients on the To line of a message. The type of object and level of access depends on the mode of the 
+         * current item.
          *
          * The to property returns a Recipients object that provides methods to get or update the recipients on the To line of the message.
          *
@@ -2595,16 +2877,20 @@ export declare namespace Office {
          * 
          * `addFileAttachmentAsync(uri: string, attachmentName: string, options: AsyncContextOptions): void;`
          * 
-         * `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+         * `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;`
          *
          * @param uri - The URI that provides the location of the file to attach to the message or appointment. The maximum length is 2048 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         *        isInline: If true, indicates that the attachment will be shown inline in the message body, and should not be displayed in the attachment list.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type asyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         *        isInline: If true, indicates that the attachment will be shown inline in the message body, and should not be displayed in the 
+         *        attachment list.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of 
+         *                 the error.
          */
-        addFileAttachmentAsync(uri: string, attachmentName: string, options?: AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        addFileAttachmentAsync(uri: string, attachmentName: string, options?: AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;
         /**
          * Adds a file to a message or appointment as an attachment.
          *
@@ -2645,7 +2931,7 @@ export declare namespace Office {
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         *        isInline: If true, indicates that the attachment will be shown inline in the message body, and should not be displayed in the attachment list.
+         *        isInline: If true, indicates that the attachment will be shown inline in the message body and should not be displayed in the attachment list.
          */
         addFileAttachmentAsync(uri: string, attachmentName: string, options: AsyncContextOptions): void;
         /**
@@ -2666,17 +2952,24 @@ export declare namespace Office {
          *
          * @param uri - The URI that provides the location of the file to attach to the message or appointment. The maximum length is 2048 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type asyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of 
+         *                 the error.
          */
-        addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;
+        addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the 
+         * callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -2687,29 +2980,36 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>NumberOfAttachmentsExceeded - The message or appointment has too many attachments.</td></tr></table>
          * 
-         * In addition to the main signature, this method also has these signatures:
+         * In addition to this signature, this method also has the following signatures:
          * 
          * `addItemAttachmentAsync(itemId: any, attachmentName: string): void;`
          * 
          * `addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;`
          * 
-         * `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+         * `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;`
          *
          * @param itemId - The Exchange identifier of the item to attach. The maximum length is 100 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
          * @param options - An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of 
+         *                 the error.
          */
-        addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. 
+         * You can use the options parameter to pass state information to the callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -2727,11 +3027,15 @@ export declare namespace Office {
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. 
+         * You can use the options parameter to pass state information to the callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -2751,11 +3055,15 @@ export declare namespace Office {
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. 
+         * You can use the options parameter to pass state information to the callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -2768,15 +3076,22 @@ export declare namespace Office {
          *
          * @param itemId - The Exchange identifier of the item to attach. The maximum length is 100 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of 
+         *                 the error.
          */
-        addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;
+        addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;
         /**
          * Asynchronously loads custom properties for this add-in on the selected item.
          *
-         * Custom properties are stored as key/value pairs on a per-app, per-item basis. This method returns a CustomProperties object in the callback, which provides methods to access the custom properties specific to the current item and the current add-in. Custom properties are not encrypted on the item, so this should not be used as secure storage.
+         * Custom properties are stored as key/value pairs on a per-app, per-item basis. 
+         * This method returns a CustomProperties object in the callback, which provides methods to access the custom properties specific to the 
+         * current item and the current add-in. Custom properties are not encrypted on the item, so this should not be used as secure storage.
          *
-         * The custom properties are provided as a CustomProperties object in the asyncResult.value property. This object can be used to get, set, and remove custom properties from the item and save changes to the custom property set back to the server.
+         * The custom properties are provided as a CustomProperties object in the asyncResult.value property. 
+         * This object can be used to get, set, and remove custom properties from the item and save changes to the custom property set back to 
+         * the server.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -2786,14 +3101,20 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Message Compose</td></tr></table>
          *
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
-         * @param userContext - Optional. Developers can provide any object they wish to access in the callback function. This object can be accessed by the asyncResult.asyncContext property in the callback function.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
+         * @param userContext - Optional. Developers can provide any object they wish to access in the callback function. 
+         *                    This object can be accessed by the asyncResult.asyncContext property in the callback function.
          */
-        loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;
+        loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any): void;
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -2811,18 +3132,24 @@ export declare namespace Office {
          * 
          * `removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;`
          * 
-         * `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;`
+         * `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;`
          *
          * @param attachmentIndex - The identifier of the attachment to remove. The maximum length of the string is 100 characters.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. 
+         *                 If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
          */
-        removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -2840,7 +3167,11 @@ export declare namespace Office {
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -2860,7 +3191,11 @@ export declare namespace Office {
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -2873,18 +3208,21 @@ export declare namespace Office {
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
          * @param attachmentIndex - The identifier of the attachment to remove. The maximum length of the string is 100 characters.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. 
+         *                 If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
          */
-        removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;
+        removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;
     }
     /**
      * The message read mode of {@link Office.Item | Office.context.mailbox.item}.
      * 
-     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of Office.context.mailbox.item. Refer to the Object Model pages for more information.
+     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. 
+     * You should treat this as a mode of Office.context.mailbox.item. Refer to the Object Model pages for more information.
      */
     export interface MessageRead extends Message, ItemRead {
         /**
-         * Gets an array of attachments for the item.
+         * Gets the item's attachments as an array.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -2894,7 +3232,9 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Message Read</td></tr></table>
          * 
-         * Note: Certain types of files are blocked by Outlook due to potential security issues and are therefore not returned. For more information, see {@link https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519 | Blocked attachments in Outlook}.
+         * Note: Certain types of files are blocked by Outlook due to potential security issues and are therefore not returned. 
+         * For more information, see 
+         * {@link https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519 | Blocked attachments in Outlook}.
          *
          */
         attachments: Office.AttachmentDetails[];
@@ -2911,9 +3251,11 @@ export declare namespace Office {
          */
         body: Office.Body;
         /**
-         * Provides access to the Cc (carbon copy) recipients of a message. The type of object and level of access depends on the mode of the current item.
+         * Provides access to the Cc (carbon copy) recipients of a message. The type of object and level of access depends on the mode of the 
+         * current item.
          *
-         * The cc property returns an array that contains an EmailAddressDetails object for each recipient listed on the Cc line of the message. The collection is limited to a maximum of 100 members.
+         * The cc property returns an array that contains an EmailAddressDetails object for each recipient listed on the Cc line of the message. 
+         * The collection is limited to a maximum of 100 members.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -2927,9 +3269,12 @@ export declare namespace Office {
         /**
          * Gets an identifier for the email conversation that contains a particular message.
          *
-         * You can get an integer for this property if your mail app is activated in read forms or responses in compose forms. If subsequently the user changes the subject of the reply message, upon sending the reply, the conversation ID for that message will change and that value you obtained earlier will no longer apply.
+         * You can get an integer for this property if your mail app is activated in read forms or responses in compose forms. 
+         * If subsequently the user changes the subject of the reply message, upon sending the reply, the conversation ID for that message will change 
+         * and that value you obtained earlier will no longer apply.
          *
-         * You get null for this property for a new item in a compose form. If the user sets a subject and saves the item, the conversationId property will return a value.
+         * You get null for this property for a new item in a compose form. 
+         * If the user sets a subject and saves the item, the conversationId property will return a value.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -2969,7 +3314,8 @@ export declare namespace Office {
         /**
          * Gets the email address of the sender of a message.
          *
-         * The from and sender properties represent the same person unless the message is sent by a delegate. In that case, the from property represents the delegator, and the sender property represents the delegate.
+         * The from and sender properties represent the same person unless the message is sent by a delegate. 
+         * In that case, the from property represents the delegator, and the sender property represents the delegate.
          *
          * Note: The recipientType property of the EmailAddressDetails object in the from property is undefined.
          * 
@@ -2999,7 +3345,8 @@ export declare namespace Office {
         /**
          * Gets the Exchange Web Services item class of the selected item.
          * 
-         * You can create custom message classes that extends a default message class, for example, a custom appointment message class IPM.Appointment.Contoso.
+         * You can create custom message classes that extends a default message class, for example, a custom appointment message class 
+         * IPM.Appointment.Contoso.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -3009,7 +3356,8 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Message Read</td></tr></table>
 		 
-         * The itemClass property specifies the message class of the selected item. The following are the default message classes for the message or appointment item.
+         * The itemClass property specifies the message class of the selected item. 
+         * The following are the default message classes for the message or appointment item.
          * 
          * <table>
          *   <tr>
@@ -3034,9 +3382,14 @@ export declare namespace Office {
         /**
          * Gets the Exchange Web Services item identifier for the current item.
          *
-         * The itemId property is not available in compose mode. If an item identifier is required, the saveAsync method can be used to save the item to the store, which will return the item identifier in the AsyncResult.value parameter in the callback function.
+         * The itemId property is not available in compose mode. 
+         * If an item identifier is required, the saveAsync method can be used to save the item to the store, which will return the item identifier 
+         * in the AsyncResult.value parameter in the callback function.
          *
-         * Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more details, see Use the Outlook REST APIs from an Outlook add-in.
+         * Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. 
+         * The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. 
+         * Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. 
+         * For more details, see {@link https://docs.microsoft.com/outlook/add-ins/use-rest-api#get-the-item-id | Use the Outlook REST APIs from an Outlook add-in}.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -3050,7 +3403,8 @@ export declare namespace Office {
         /**
          * Gets the type of item that an instance represents.
          *
-         * The itemType property returns one of the ItemType enumeration values, indicating whether the item object instance is a message or an appointment.
+         * The itemType property returns one of the ItemType enumeration values, indicating whether the item object instance is a message or 
+         * an appointment.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -3064,7 +3418,9 @@ export declare namespace Office {
         /**
          * Gets the subject of an item, with all prefixes removed (including RE: and FWD:).
          *
-         * The normalizedSubject property gets the subject of the item, with any standard prefixes (such as RE: and FW:) that are added by email programs. To get the subject of the item with the prefixes intact, use the subject property.
+         * The normalizedSubject property gets the subject of the item, with any standard prefixes (such as RE: and FW:) that are added by 
+         * email programs. 
+         * To get the subject of the item with the prefixes intact, use the subject property.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -3078,7 +3434,8 @@ export declare namespace Office {
         /**
          * Gets the email address of the sender of an email message.
          *
-         * The from and sender properties represent the same person unless the message is sent by a delegate. In that case, the from property represents the delegator, and the sender property represents the delegate.
+         * The from and sender properties represent the same person unless the message is sent by a delegate. 
+         * In that case, the from property represents the delegator, and the sender property represents the delegate.
          *
          * Note: The recipientType property of the EmailAddressDetails object in the sender property is undefined.
          *
@@ -3108,9 +3465,11 @@ export declare namespace Office {
          */
         subject: string;
         /**
-         * Provides access to the recipients on the To line of a message. The type of object and level of access depends on the mode of the current item.
+         * Provides access to the recipients on the To line of a message. The type of object and level of access depends on the mode of the 
+         * current item.
          *
-         * The to property returns an array that contains an EmailAddressDetails object for each recipient listed on the To line of the message. The collection is limited to a maximum of 100 members.
+         * The to property returns an array that contains an EmailAddressDetails object for each recipient listed on the To line of the message. 
+         * The collection is limited to a maximum of 100 members.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -3121,14 +3480,18 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Message Read</td></tr></table>
          */
         to: EmailAddressDetails[];
+
         /**
-         * Displays a reply form that includes the sender and all recipients of the selected message or the organizer and all attendees of the selected appointment.
+         * Displays a reply form that includes the sender and all recipients of the selected message or the organizer and all attendees of the 
+         * selected appointment.
          *
          * In Outlook Web App, the reply form is displayed as a pop-out form in the 3-column view and a pop-up form in the 2- or 1-column view.
          *
          * If any of the string parameters exceed their limits, displayReplyAllForm throws an exception.
          *
-         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. If this isn't possible, then no error message is thrown.
+         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and 
+         * attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. 
+         * If this isn't possible, then no error message is thrown.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -3151,7 +3514,9 @@ export declare namespace Office {
          *
          * If any of the string parameters exceed their limits, displayReplyForm throws an exception.
          *
-         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. If this isn't possible, then no error message is thrown.
+         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and 
+         * attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. 
+         * If this isn't possible, then no error message is thrown.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -3169,7 +3534,7 @@ export declare namespace Office {
          */
         displayReplyForm(formData: string | ReplyFormData): void;
         /**
-         * Gets the entities found in the selected item.
+         * Gets the entities found in the selected item's body.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -3183,7 +3548,7 @@ export declare namespace Office {
          */
         getEntities(): Entities;
         /**
-         * Gets an array of all the entities of the specified entity type found in the selected item.
+         * Gets an array of all the entities of the specified entity type found in the selected item's body.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -3192,7 +3557,9 @@ export declare namespace Office {
          * @param entityType - One of the EntityType enumeration values.
          * 
          * @returns
-         * If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. If no entities of the specified type are present on the item, the method returns an empty array. Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter.
+         * If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. 
+         * If no entities of the specified type are present in the item's body, the method returns an empty array. 
+         * Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter.
          *
          * @remarks
          * 
@@ -3200,7 +3567,8 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Read</td></tr></table>
          * 
-         * While the minimum permission level to use this method is Restricted, some entity types require ReadItem to access, as specified in the following table.
+         * While the minimum permission level to use this method is Restricted, some entity types require ReadItem to access, as specified in the 
+         * following table.
          * 
          * <table>
          *   <tr>
@@ -3249,7 +3617,8 @@ export declare namespace Office {
         /**
          * Returns well-known entities in the selected item that pass the named filter defined in the manifest XML file.
          *
-         * The getFilteredEntitiesByName method returns the entities that match the regular expression defined in the ItemHasKnownEntity rule element in the manifest XML file with the specified FilterName element value.
+         * The getFilteredEntitiesByName method returns the entities that match the regular expression defined in the ItemHasKnownEntity rule element 
+         * in the manifest XML file with the specified FilterName element value.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -3262,22 +3631,33 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Message Read</td></tr></table>
          *
          * @param name - The name of the ItemHasKnownEntity rule element that defines the filter to match.
-         * @returns If there is no ItemHasKnownEntity element in the manifest with a FilterName element value that matches the name parameter, the method returns null. If the name parameter does match an ItemHasKnownEntity element in the manifest, but there are no entities in the current item that match, the method return an empty array.
+         * @returns If there is no ItemHasKnownEntity element in the manifest with a FilterName element value that matches the name parameter, 
+         * the method returns null. 
+         * If the name parameter does match an ItemHasKnownEntity element in the manifest, but there are no entities in the current item that match, 
+         * the method return an empty array.
          */
         getFilteredEntitiesByName(name: string): (string | Contact | MeetingSuggestion | PhoneNumber | TaskSuggestion)[];
         /**
          * Returns string values in the selected item that match the regular expressions defined in the manifest XML file.
          *
-         * The getRegExMatches method returns the strings that match the regular expression defined in each ItemHasRegularExpressionMatch or ItemHasKnownEntity rule element in the manifest XML file. For an ItemHasRegularExpressionMatch rule, a matching string has to occur in the property of the item that is specified by that rule. The PropertyName simple type defines the supported properties.
+         * The getRegExMatches method returns the strings that match the regular expression defined in each ItemHasRegularExpressionMatch or 
+         * ItemHasKnownEntity rule element in the manifest XML file. 
+         * For an ItemHasRegularExpressionMatch rule, a matching string has to occur in the property of the item that is specified by that rule. 
+         * The PropertyName simple type defines the supported properties.
          *
-         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body and should not attempt to return the entire body of the item. Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results. Instead, use the Body.getAsync method to retrieve the entire body.
+         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body 
+         * and should not attempt to return the entire body of the item. 
+         * Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results. 
+         * Instead, use the Body.getAsync method to retrieve the entire body.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
          * [Api set: Mailbox 1.0]
          *
          * @returns
-         * An object that contains arrays of strings that match the regular expressions defined in the manifest XML file. The name of each array is equal to the corresponding value of the RegExName attribute of the matching ItemHasRegularExpressionMatch rule or the FilterName attribute of the matching ItemHasKnownEntity rule.
+         * An object that contains arrays of strings that match the regular expressions defined in the manifest XML file. 
+         * The name of each array is equal to the corresponding value of the RegExName attribute of the matching ItemHasRegularExpressionMatch rule 
+         * or the FilterName attribute of the matching ItemHasKnownEntity rule.
          *
          * @remarks
          *
@@ -3289,9 +3669,12 @@ export declare namespace Office {
         /**
          * Returns string values in the selected item that match the named regular expression defined in the manifest XML file.
          *
-         * The getRegExMatchesByName method returns the strings that match the regular expression defined in the ItemHasRegularExpressionMatch rule element in the manifest XML file with the specified RegExName element value.
+         * The getRegExMatchesByName method returns the strings that match the regular expression defined in the ItemHasRegularExpressionMatch rule 
+         * element in the manifest XML file with the specified RegExName element value.
          *
-         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body and should not attempt to return the entire body of the item. Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results.
+         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body 
+         * and should not attempt to return the entire body of the item. 
+         * Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -3312,9 +3695,13 @@ export declare namespace Office {
         /**
          * Asynchronously loads custom properties for this add-in on the selected item.
          *
-         * Custom properties are stored as key/value pairs on a per-app, per-item basis. This method returns a CustomProperties object in the callback, which provides methods to access the custom properties specific to the current item and the current add-in. Custom properties are not encrypted on the item, so this should not be used as secure storage.
+         * Custom properties are stored as key/value pairs on a per-app, per-item basis. 
+         * This method returns a CustomProperties object in the callback, which provides methods to access the custom properties specific to the 
+         * current item and the current add-in. Custom properties are not encrypted on the item, so this should not be used as secure storage.
          *
-         * The custom properties are provided as a CustomProperties object in the asyncResult.value property. This object can be used to get, set, and remove custom properties from the item and save changes to the custom property set back to the server.
+         * The custom properties are provided as a CustomProperties object in the asyncResult.value property. 
+         * This object can be used to get, set, and remove custom properties from the item and save changes to the custom property set back to 
+         * the server.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -3324,10 +3711,12 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Message Read</td></tr></table>
          *
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
-         * @param userContext - Optional. Developers can provide any object they wish to access in the callback function. This object can be accessed by the asyncResult.asyncContext property in the callback function.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
+         * @param userContext - Optional. Developers can provide any object they wish to access in the callback function. 
+         *                    This object can be accessed by the asyncResult.asyncContext property in the callback function.
          */
-        loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;
+        loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any): void;
     }
 
     /**
@@ -3389,11 +3778,13 @@ export declare namespace Office {
         /**
          * Gets the location of an appointment.
          *
-         * The getAsync method starts an asynchronous call to the Exchange server to get the location of an appointment. The location of the appointment is provided as a string in the asyncResult.value property.
+         * The getAsync method starts an asynchronous call to the Exchange server to get the location of an appointment. 
+         * The location of the appointment is provided as a string in the asyncResult.value property.
          *
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -3404,16 +3795,18 @@ export declare namespace Office {
          * 
          * In addition to this signature, the method also has the following signature:
          * 
-         * `getAsync(callback: (result: AsyncResult) => void): void;`
+         * `getAsync(callback: (result: AsyncResult<string>) => void): void;`
          * 
          */
-        getAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        getAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;
         /**
          * Gets the location of an appointment.
          *
-         * The getAsync method starts an asynchronous call to the Exchange server to get the location of an appointment. The location of the appointment is provided as a string in the asyncResult.value property.
+         * The getAsync method starts an asynchronous call to the Exchange server to get the location of an appointment. 
+         * The location of the appointment is provided as a string in the asyncResult.value property.
          *
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -3422,16 +3815,18 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose</td></tr></table>
          */
-        getAsync(callback: (result: AsyncResult) => void): void;
+        getAsync(callback: (result: AsyncResult<string>) => void): void;
         /**
          * Sets the location of an appointment.
          *
-         * The setAsync method starts an asynchronous call to the Exchange server to set the location of an appointment. Setting the location of an appointment overwrites the current location.
+         * The setAsync method starts an asynchronous call to the Exchange server to set the location of an appointment. 
+         * Setting the location of an appointment overwrites the current location.
          *
          * @param location - The location of the appointment. The string is limited to 255 characters.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.  If setting the location fails, the asyncResult.error property will contain an error code.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. If setting the location fails, the asyncResult.error property will contain an error code.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -3448,13 +3843,14 @@ export declare namespace Office {
          * 
          * `setAsync(location: string, options: Office.AsyncContextOptions): void;`
          * 
-         * `setAsync(location: string, callback: (result: AsyncResult) => void): void;`
+         * `setAsync(location: string, callback: (result: AsyncResult<void>) => void): void;`
          */
-        setAsync(location: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        setAsync(location: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Sets the location of an appointment.
          *
-         * The setAsync method starts an asynchronous call to the Exchange server to set the location of an appointment. Setting the location of an appointment overwrites the current location.
+         * The setAsync method starts an asynchronous call to the Exchange server to set the location of an appointment. 
+         * Setting the location of an appointment overwrites the current location.
          *
          * @param location - The location of the appointment. The string is limited to 255 characters.
          *
@@ -3471,7 +3867,8 @@ export declare namespace Office {
         /**
          * Sets the location of an appointment.
          *
-         * The setAsync method starts an asynchronous call to the Exchange server to set the location of an appointment. Setting the location of an appointment overwrites the current location.
+         * The setAsync method starts an asynchronous call to the Exchange server to set the location of an appointment. 
+         * Setting the location of an appointment overwrites the current location.
          *
          * @param location - The location of the appointment. The string is limited to 255 characters.
          * @param options - Optional. An object literal that contains one or more of the following properties.
@@ -3490,10 +3887,12 @@ export declare namespace Office {
         /**
          * Sets the location of an appointment.
          *
-         * The setAsync method starts an asynchronous call to the Exchange server to set the location of an appointment. Setting the location of an appointment overwrites the current location.
+         * The setAsync method starts an asynchronous call to the Exchange server to set the location of an appointment. 
+         * Setting the location of an appointment overwrites the current location.
          *
          * @param location - The location of the appointment. The string is limited to 255 characters.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.  If setting the location fails, the asyncResult.error property will contain an error code.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. If setting the location fails, the asyncResult.error property will contain an error code.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -3504,10 +3903,10 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>DataExceedsMaximumSize - The location parameter is longer than 255 characters.</td></tr></table>
          */
-        setAsync(location: string, callback: (result: AsyncResult) => void): void;
+        setAsync(location: string, callback: (result: AsyncResult<void>) => void): void;
     }
     /**
-     * Provides access to the Outlook add-in object model for Microsoft Outlook and Microsoft Outlook on the web.
+     * Provides access to the Outlook Add-in object model for Microsoft Outlook and Microsoft Outlook on the web.
      *
      * Namespaces:
      *
@@ -3530,11 +3929,18 @@ export declare namespace Office {
          * 
          * Contains the following members:
          * 
-         *  - hostName (string): A string that represents the name of the host application. It be one of the following values: Outlook, Mac Outlook, OutlookIOS, or OutlookWebApp.
+         *  - hostName (string): A string that represents the name of the host application. 
+         * It be one of the following values: Outlook, Mac Outlook, OutlookIOS, or OutlookWebApp.
          * 
-         *  - hostVersion (string): A string that represents the version of either the host application or the Exchange Server. If the mail add-in is running on the Outlook desktop client or Outlook for iOS, the hostVersion property returns the version of the host application, Outlook. In Outlook Web App, the property returns the version of the Exchange Server. An example is the string 15.0.468.0.
+         *  - hostVersion (string): A string that represents the version of either the host application or the Exchange Server. 
+         * If the mail add-in is running on the Outlook desktop client or Outlook for iOS, the hostVersion property returns the version of the 
+         * host application, Outlook. In Outlook Web App, the property returns the version of the Exchange Server. An example is the string 15.0.468.0.
          * 
-         *  - OWAView (string): A string that represents the current view of Outlook Web App. If the host application is not Outlook Web App, then accessing this property results in undefined. Outlook Web App has three views (OneColumn - displayed when the screen is narrow, TwoColumns - displayed when the screen is wider, and ThreeColumns - displayed when the screen is wide.) that correspond to the width of the screen and the window, and the number of columns that can be displayed.
+         *  - OWAView (MailboxEnums.OWAView or string): An enum (or string literal) that represents the current view of Outlook Web App. 
+         * If the host application is not Outlook Web App, then accessing this property results in undefined. 
+         * Outlook Web App has three views (OneColumn - displayed when the screen is narrow, TwoColumns - displayed when the screen is wider, 
+         * and ThreeColumns - displayed when the screen is wide) that correspond to the width of the screen and the window, and the number of columns 
+         * that can be displayed.
          *
          *  More information is under {@link Office.Diagnostics}. 
          *
@@ -3551,7 +3957,8 @@ export declare namespace Office {
          *
          * Your app must have the ReadItem permission specified in its manifest to call the ewsUrl member in read mode.
          *
-         * In compose mode you must call the saveAsync method before you can use the ewsUrl member. Your app must have ReadWriteItem permissions to call the saveAsync method.
+         * In compose mode you must call the saveAsync method before you can use the ewsUrl member. 
+         * Your app must have ReadWriteItem permissions to call the saveAsync method.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -3573,7 +3980,7 @@ export declare namespace Office {
          */
         item: Item & ItemCompose & ItemRead & MessageRead & MessageCompose & AppointmentRead & AppointmentCompose;
         /**
-         * Information about the user associated with the mailbox. This includes their account type, display name, email adddress, and time zone.
+         * Information about the user associated with the mailbox. This includes their account type, display name, email address, and time zone.
          * 
          * More information is under {@link Office.UserProfile}
          */
@@ -3581,9 +3988,15 @@ export declare namespace Office {
         /**
          * Gets a dictionary containing time information in local client time.
          *
-         * The dates and times used by a mail app for Outlook or Outlook Web App can use different time zones. Outlook uses the client computer time zone; Outlook Web App uses the time zone set on the Exchange Admin Center (EAC). You should handle date and time values so that the values you display on the user interface are always consistent with the time zone that the user expects.
+         * The dates and times used by a mail app for Outlook or Outlook Web App can use different time zones. 
+         * Outlook uses the client computer time zone; Outlook Web App uses the time zone set on the Exchange Admin Center (EAC). 
+         * You should handle date and time values so that the values you display on the user interface are always consistent with the time zone that 
+         * the user expects.
          *
-         * If the mail app is running in Outlook, the convertToLocalClientTime method will return a dictionary object with the values set to the client computer time zone. If the mail app is running in Outlook Web App, the convertToLocalClientTime method will return a dictionary object with the values set to the time zone specified in the EAC.
+         * If the mail app is running in Outlook, the convertToLocalClientTime method will return a dictionary object with the values set to the 
+         * client computer time zone. 
+         * If the mail app is running in Outlook Web App, the convertToLocalClientTime method will return a dictionary object with the values set to 
+         * the time zone specified in the EAC.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -3599,7 +4012,8 @@ export declare namespace Office {
         /**
          * Gets a Date object from a dictionary containing time information.
          *
-         * The convertToUtcClientTime method converts a dictionary containing a local date and time to a Date object with the correct values for the local date and time.
+         * The convertToUtcClientTime method converts a dictionary containing a local date and time to a Date object with the correct values for the 
+         * local date and time.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -3616,13 +4030,17 @@ export declare namespace Office {
         /**
          * Displays an existing calendar appointment.
          *
-         * The displayAppointmentForm method opens an existing calendar appointment in a new window on the desktop or in a dialog box on mobile devices.
+         * The displayAppointmentForm method opens an existing calendar appointment in a new window on the desktop or in a dialog box on 
+         * mobile devices.
          *
-         * In Outlook for Mac, you can use this method to display a single appointment that is not part of a recurring series, or the master appointment of a recurring series, but you cannot display an instance of the series. This is because in Outlook for Mac, you cannot access the properties (including the item ID) of instances of a recurring series.
+         * In Outlook for Mac, you can use this method to display a single appointment that is not part of a recurring series, or the 
+         * master appointment of a recurring series, but you cannot display an instance of the series. 
+         * This is because in Outlook for Mac, you cannot access the properties (including the item ID) of instances of a recurring series.
          *
          * In Outlook Web App, this method opens the specified form only if the body of the form is less than or equal to 32KB number of characters.
          *
-         * If the specified item identifier does not identify an existing appointment, a blank pane opens on the client computer or device, and no error message will be returned.
+         * If the specified item identifier does not identify an existing appointment, a blank pane opens on the client computer or device, and 
+         * no error message will be returned.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -3644,9 +4062,11 @@ export declare namespace Office {
          *
          * In Outlook Web App, this method opens the specified form only if the body of the form is less than or equal to 32 KB number of characters.
          *
-         * If the specified item identifier does not identify an existing message, no message will be displayed on the client computer, and no error message will be returned.
+         * If the specified item identifier does not identify an existing message, no message will be displayed on the client computer, and 
+         * no error message will be returned.
          *
-         * Do not use the displayMessageForm with an itemId that represents an appointment. Use the displayAppointmentForm method to display an existing appointment, and displayNewAppointmentForm to display a form to create a new appointment.
+         * Do not use the displayMessageForm with an itemId that represents an appointment. Use the displayAppointmentForm method to display 
+         * an existing appointment, and displayNewAppointmentForm to display a form to create a new appointment.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -3664,11 +4084,16 @@ export declare namespace Office {
         /**
          * Displays a form for creating a new calendar appointment.
          *
-         * The displayNewAppointmentForm method opens a form that enables the user to create a new appointment or meeting. If parameters are specified, the appointment form fields are automatically populated with the contents of the parameters.
+         * The displayNewAppointmentForm method opens a form that enables the user to create a new appointment or meeting. 
+         * If parameters are specified, the appointment form fields are automatically populated with the contents of the parameters.
          *
-         * In Outlook Web App and OWA for Devices, this method always displays a form with an attendees field. If you do not specify any attendees as input arguments, the method displays a form with a Save button. If you have specified attendees, the form would include the attendees and a Send button.
+         * In Outlook Web App and OWA for Devices, this method always displays a form with an attendees field. 
+         * If you do not specify any attendees as input arguments, the method displays a form with a Save button. 
+         * If you have specified attendees, the form would include the attendees and a Send button.
          *
-         * In the Outlook rich client and Outlook RT, if you specify any attendees or resources in the requiredAttendees, optionalAttendees, or resources parameter, this method displays a meeting form with a Send button. If you don't specify any recipients, this method displays an appointment form with a Save & Close button.
+         * In the Outlook rich client and Outlook RT, if you specify any attendees or resources in the requiredAttendees, optionalAttendees, or 
+         * resources parameter, this method displays a meeting form with a Send button. 
+         * If you don't specify any recipients, this method displays an appointment form with a Save & Close button.
          *
          * If any of the parameters exceed the specified size limits, or if an unknown parameter name is specified, an exception is thrown.
          *
@@ -3698,12 +4123,15 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose and read</td></tr></table>
          *
-         * The getUserIdentityTokenAsync method returns a token that you can use to identify and {@link https://docs.microsoft.com/outlook/add-ins/authentication | authenticate the add-in and user with a third-party system}.
+         * The getUserIdentityTokenAsync method returns a token that you can use to identify and 
+         * {@link https://docs.microsoft.com/outlook/add-ins/authentication | authenticate the add-in and user with a third-party system}.
          *
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
+         *                 The token is provided as a string in the asyncResult.value property.
          * @param userContext - Optional. Any state data that is passed to the asynchronous method.|
          */
-        getUserIdentityTokenAsync(callback: (result: AsyncResult) => void, userContext?: any): void;
+        getUserIdentityTokenAsync(callback: (result: AsyncResult<string>) => void, userContext?: any): void;
         /**
          * Makes an asynchronous request to an Exchange Web Services (EWS) service on the Exchange server that hosts the user's mailbox.
          *
@@ -3715,21 +4143,32 @@ export declare namespace Office {
          *
          * The XML request must specify UTF-8 encoding. \<?xml version="1.0" encoding="utf-8"?\>
          *
-         * Your add-in must have the ReadWriteMailbox permission to use the makeEwsRequestAsync method. For information about using the ReadWriteMailbox permission and the EWS operations that you can call with the makeEwsRequestAsync method, see Specify permissions for mail add-in access to the user's mailbox.
+         * Your add-in must have the ReadWriteMailbox permission to use the makeEwsRequestAsync method. 
+         * For information about using the ReadWriteMailbox permission and the EWS operations that you can call with the makeEwsRequestAsync method, 
+         * see {@link https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions | Specify permissions for mail add-in access to the user's mailbox}.
          *
-         * The XML result of the EWS call is provided as a string in the asyncResult.value property. If the result exceeds 1 MB in size, an error message is returned instead.
+         * The XML result of the EWS call is provided as a string in the asyncResult.value property. 
+         * If the result exceeds 1 MB in size, an error message is returned instead.
          *
-         * Note: This method is not supported in the following scenarios. - In Outlook for iOS or Outlook for Android - When the add-in is loaded in a Gmail mailbox
+         * Note: This method is not supported in the following scenarios:
+         * 
+         * - In Outlook for iOS or Outlook for Android.
+         * 
+         * - When the add-in is loaded in a Gmail mailbox.
          *
-         * Note: The server administrator must set OAuthAuthentication to true on the Client Access Server EWS directory to enable the makeEwsRequestAsync method to make EWS requests.
+         * Note: The server administrator must set OAuthAuthentication to true on the Client Access Server EWS directory to enable the 
+         * makeEwsRequestAsync method to make EWS requests.
          *
          * *Version differences*
          *
-         * When you use the makeEwsRequestAsync method in mail apps running in Outlook versions earlier than version 15.0.4535.1004, you should set the encoding value to ISO-8859-1.
+         * When you use the makeEwsRequestAsync method in mail apps running in Outlook versions earlier than version 15.0.4535.1004, you should set 
+         * the encoding value to ISO-8859-1.
          *
          * `<?xml version="1.0" encoding="iso-8859-1"?>`
          *
-         * You do not need to set the encoding value when your mail app is running in Outlook on the web. You can determine whether your mail app is running in Outlook or Outlook on the web by using the mailbox.diagnostics.hostName property. You can determine what version of Outlook is running by using the mailbox.diagnostics.hostVersion property.
+         * You do not need to set the encoding value when your mail app is running in Outlook on the web. 
+         * You can determine whether your mail app is running in Outlook or Outlook on the web by using the mailbox.diagnostics.hostName property. 
+         * You can determine what version of Outlook is running by using the mailbox.diagnostics.hostVersion property.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -3740,18 +4179,23 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose and read</td></tr></table>
          *
          * @param data - The EWS request.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult.
+         *                 The `value` property of the result is the XML of the EWS request provided as a string. 
+         *                 If the result exceeds 1 MB in size, an error message is returned instead.
          * @param userContext - Optional. Any state data that is passed to the asynchronous method.
          */
-        makeEwsRequestAsync(data: any, callback: (result: AsyncResult) => void, userContext?: any): void;
+        makeEwsRequestAsync(data: any, callback: (result: AsyncResult<string>) => void, userContext?: any): void;
     }
 
     /**
      * Represents a suggested meeting found in an item. Read mode only.
      *
-     * The list of meetings suggested in an email message is returned in the meetingSuggestions property of the Entities object that is returned when the getEntities or getEntitiesByType method is called on the active item.
+     * The list of meetings suggested in an email message is returned in the meetingSuggestions property of the Entities object that is returned when 
+     * the getEntities or getEntitiesByType method is called on the active item.
      *
-     * The start and end values are string representations of a Date object that contains the date and time at which the suggested meeting is to begin and end. The values are in the default time zone specified for the current user.
+     * The start and end values are string representations of a Date object that contains the date and time at which the suggested meeting is to 
+     * begin and end. 
+     * The values are in the default time zone specified for the current user.
      *
      * [Api set: Mailbox 1.0]
      *
@@ -3789,7 +4233,8 @@ export declare namespace Office {
     /**
      * Represents a phone number identified in an item. Read mode only.
      *
-     * An array of PhoneNumber objects containing the phone numbers found in an email message is returned in the phoneNumbers property of the Entities object that is returned when you call the getEntities method on the selected item.
+     * An array of PhoneNumber objects containing the phone numbers found in an email message is returned in the phoneNumbers property of the 
+     * Entities object that is returned when you call the getEntities method on the selected item.
      *
      * [Api set: Mailbox 1.0]
      *
@@ -3841,20 +4286,21 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>NumberOfRecipientsExceeded - The number of recipients exceeded 100 entries.</td></tr></table>
          * 
-         * In addition to the main signature, this method also has these signatures:
+         * In addition to this signature, this method also has the following signatures:
          * 
          * `addAsync(recipients: (string | EmailUser | EmailAddressDetails)[]): void;`
          * 
          * `addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options: Office.AsyncContextOptions): void;`
          * 
-         * `addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult) => void): void;`
+         * `addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult<void>) => void): void;`
          *
          * @param recipients - The recipients to add to the recipients list.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If adding the recipients fails, the asyncResult.error property will contain an error code.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. If adding the recipients fails, the asyncResult.error property will contain an error code.
          */
-        addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Adds a recipient list to the existing recipients for an appointment or message.
          *
@@ -3924,13 +4370,14 @@ export declare namespace Office {
          * <tr><td>Errors</td><td>NumberOfRecipientsExceeded - The number of recipients exceeded 100 entries.</td></tr></table>
          *
          * @param recipients - The recipients to add to the recipients list.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If adding the recipients fails, the asyncResult.error property will contain an error code.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. If adding the recipients fails, the asyncResult.error property will contain an error code.
          */
-        addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult) => void): void;
+        addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult<void>) => void): void;
         /**
          * Gets a recipient list for an appointment or message.
          *
-         * When the call completes, the asyncResult.value property will contain an array of{@link Office.EmailAddressDetails} objects.
+         * When the call completes, the asyncResult.value property will contain an array of {@link Office.EmailAddressDetails} objects.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -3939,15 +4386,17 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose</td></tr></table>
          * 
-         * In addition to the main signature, this method also has this signature:
+         * In addition to this signature, this method also has the following signature:
          * 
-         * `getAsync(callback: (result: AsyncResult) => void): void;`
+         * `getAsync(callback: (result: AsyncResult<Office.EmailAddressDetails[]>) => void): void;`
          *
          * @param options - An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
+         *                 The `value` property of the result is an array of EmailAddressDetails objects.
          */
-        getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;
+        getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult<Office.EmailAddressDetails[]>) => void): void;
         /**
          * Gets a recipient list for an appointment or message.
          *
@@ -3960,9 +4409,11 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose</td></tr></table>
          *
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
+         *                 The `value` property of the result is an array of EmailAddressDetails objects.
          */
-        getAsync(callback: (result: AsyncResult) => void): void;
+        getAsync(callback: (result: AsyncResult<Office.EmailAddressDetails[]>) => void): void;
         /**
          * Sets a recipient list for an appointment or message.
          *
@@ -3985,20 +4436,23 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>NumberOfRecipientsExceeded - The number of recipients exceeded 100 entries.</td></tr></table>
          * 
-         * In addition to the main signature, this method also has these signatures:
+         * In addition to this signature, this method also has the following signatures:
          * 
          * `setAsync(recipients: (string | EmailUser | EmailAddressDetails)[]): void;`
          * 
          * `setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options: Office.AsyncContextOptions): void;`
          * 
-         * `setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult) => void): void;`
+         * `setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult<void>) => void): void;`
          *
          * @param recipients - The recipients to add to the recipients list.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.  If setting the recipients fails the asyncResult.error property will contain a code that indicates any error that occurred while adding the data.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
+         *                 If setting the recipients fails the asyncResult.error property will contain a code that indicates any error that occurred 
+         *                 while adding the data.
          */
-        setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Sets a recipient list for an appointment or message.
          *
@@ -4074,9 +4528,12 @@ export declare namespace Office {
          * <tr><td>Errors</td><td>NumberOfRecipientsExceeded - The number of recipients exceeded 100 entries.</td></tr></table>
          *
          * @param recipients - The recipients to add to the recipients list.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.  If setting the recipients fails the asyncResult.error property will contain a code that indicates any error that occurred while adding the data.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. 
+         *                 If setting the recipients fails the asyncResult.error property will contain a code that indicates any error that occurred 
+         *                 while adding the data.
          */
-        setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult) => void): void;
+        setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult<void>) => void): void;
 
     }
 
@@ -4097,7 +4554,8 @@ export declare namespace Office {
          */
         url?: string;
         /**
-         * Only used if type is set to file. If true, indicates that the attachment will be shown inline in the message body, and should not be displayed in the attachment list.
+         * Only used if type is set to file. If true, indicates that the attachment will be shown inline in the message body, and should not be 
+         * displayed in the attachment list.
          */
         inLine?: boolean;
         /**
@@ -4119,20 +4577,27 @@ export declare namespace Office {
          */
         attachments?: ReplyFormAttachment[];
         /**
-         * When the reply display call completes, the function passed in the callback parameter is called with a single parameter, asyncResult, which is an AsyncResult object.
+         * When the reply display call completes, the function passed in the callback parameter is called with a single parameter, 
+         * asyncResult, which is an Office.AsyncResult object.
          */
-        callback?: (result: AsyncResult) => void;
+        callback?: (result: AsyncResult<any>) => void;
     }
     /**
-     * The settings created by using the methods of the RoamingSettings object are saved per add-in and per user. That is, they are available only to the add-in that created them, and only from the user's mail box in which they are saved.
+     * The settings created by using the methods of the RoamingSettings object are saved per add-in and per user. 
+     * That is, they are available only to the add-in that created them, and only from the user's mail box in which they are saved.
      *
-     * While the Outlook add-in API limits access to these settings to only the add-in that created them, these settings should not be considered secure storage. They can be accessed by Exchange Web Services or Extended MAPI. They should not be used to store sensitive information such as user credentials or security tokens.
+     * While the Outlook Add-in API limits access to these settings to only the add-in that created them, these settings should not be considered 
+     * secure storage. They can be accessed by Exchange Web Services or Extended MAPI. 
+     * They should not be used to store sensitive information such as user credentials or security tokens.
      *
      * The name of a setting is a String, while the value can be a String, Number, Boolean, null, Object, or Array.
      *
      * The RoamingSettings object is accessible via the roamingSettings property in the Office.context namespace.
      *
-     * Important: The RoamingSettings object is initialized from the persisted storage only when the add-in is first loaded. For task panes, this means that it is only initialized when the task pane first opens. If the task pane navigates to another page or reloads the current page, the in-memory object is reset to its initial values, even if your add-in has persisted changes. The persisted changes will not be available until the task pane is closed and reopened.
+     * Important: The RoamingSettings object is initialized from the persisted storage only when the add-in is first loaded. 
+     * For task panes, this means that it is only initialized when the task pane first opens. 
+     * If the task pane navigates to another page or reloads the current page, the in-memory object is reset to its initial values, even if 
+     * your add-in has persisted changes. The persisted changes will not be available until the task pane is closed and reopened.
      *
      * [Api set: Mailbox 1.0]
      *
@@ -4172,7 +4637,9 @@ export declare namespace Office {
         /**
          * Saves the settings.
          *
-         * Any settings previously saved by an add-in are loaded when it is initialized, so during the lifetime of the session you can just use the set and get methods to work with the in-memory copy of the settings property bag. When you want to persist the settings so that they are available the next time the add-in is used, use the saveAsync method.
+         * Any settings previously saved by an add-in are loaded when it is initialized, so during the lifetime of the session you can just use 
+         * the set and get methods to work with the in-memory copy of the settings property bag. 
+         * When you want to persist the settings so that they are available the next time the add-in is used, use the saveAsync method.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -4181,13 +4648,15 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          *
-         * @param callback - Optional? When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          */
-        saveAsync(callback?: (result: AsyncResult) => void): void;
+        saveAsync(callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Sets or creates the specified setting.
          *
-         * The set method creates a new setting of the specified name if it does not already exist, or sets an existing setting of the specified name. The value is stored in the document as the serialized JSON representation of its data type.
+         * The set method creates a new setting of the specified name if it does not already exist, or sets an existing setting of the specified name. 
+         * The value is stored in the document as the serialized JSON representation of its data type.
          *
          * A maximum of 32KB is available for the settings of each add-in.
          *
@@ -4205,6 +4674,7 @@ export declare namespace Office {
          */
         set(name: string, value: any): void;
     }
+    
     /**
      * Provides methods to get and set the subject of an appointment or message in an Outlook add-in.
      *
@@ -4228,17 +4698,20 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose</td></tr></table>
          * 
-         * In addition to the main signature, this method also has this signature:
+         * In addition to this signature, this method also has the following signature:
          * 
-         * `getAsync(callback: (result: AsyncResult) => void): void;`
+         * `getAsync(callback: (result: AsyncResult<string>) => void): void;`
          *
          * @param options - An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
+         *                 The `value` property of the result is the subject of the item.
          */
-        getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;
+        getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult<string>) => void): void;
         /**
          * Gets the subject of an appointment or message.
+         * 
          * The getAsync method starts an asynchronous call to the Exchange server to get the subject of an appointment or message.
          *
          * [Api set: Mailbox 1.1]
@@ -4249,12 +4722,14 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose</td></tr></table>
          *
          * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         *                  The `value` property of the result is the subject of the item.
          */
-        getAsync(callback: (result: AsyncResult) => void): void;
+        getAsync(callback: (result: AsyncResult<string>) => void): void;
         /**
          * Sets the subject of an appointment or message.
          *
-         * The setAsync method starts an asynchronous call to the Exchange server to set the subject of an appointment or message. Setting the subject overwrites the current subject, but leaves any prefixes, such as "Fwd:" or "Re:" in place.
+         * The setAsync method starts an asynchronous call to the Exchange server to set the subject of an appointment or message. 
+         * Setting the subject overwrites the current subject, but leaves any prefixes, such as "Fwd:" or "Re:" in place.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -4265,24 +4740,26 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>DataExceedsMaximumSize - The subject parameter is longer than 255 characters.</td></tr></table>
          * 
-         * In addition to the main signature, this method also has these signatures:
+         * In addition to this signature, this method also has the following signatures:
          * 
          * `setAsync(subject: string): void;`
          * 
          * `setAsync(subject: string, options: Office.AsyncContextOptions): void;`
          * 
-         * `setAsync(subject: string, callback: (result: AsyncResult) => void): void;`
+         * `setAsync(subject: string, callback: (result: AsyncResult<void>) => void): void;`
          *
          * @param subject - The subject of the appointment or message. The string is limited to 255 characters.
          * @param options - An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If setting the subject fails, the asyncResult.error property will contain an error code.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. If setting the subject fails, the asyncResult.error property will contain an error code.
          */
-        setAsync(subject: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        setAsync(subject: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Sets the subject of an appointment or message.
          *
-         * The setAsync method starts an asynchronous call to the Exchange server to set the subject of an appointment or message. Setting the subject overwrites the current subject, but leaves any prefixes, such as "Fwd:" or "Re:" in place.
+         * The setAsync method starts an asynchronous call to the Exchange server to set the subject of an appointment or message. 
+         * Setting the subject overwrites the current subject, but leaves any prefixes, such as "Fwd:" or "Re:" in place.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -4299,7 +4776,8 @@ export declare namespace Office {
         /**
          * Sets the subject of an appointment or message.
          *
-         * The setAsync method starts an asynchronous call to the Exchange server to set the subject of an appointment or message. Setting the subject overwrites the current subject, but leaves any prefixes, such as "Fwd:" or "Re:" in place.
+         * The setAsync method starts an asynchronous call to the Exchange server to set the subject of an appointment or message. 
+         * Setting the subject overwrites the current subject, but leaves any prefixes, such as "Fwd:" or "Re:" in place.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -4318,7 +4796,8 @@ export declare namespace Office {
         /**
          * Sets the subject of an appointment or message.
          *
-         * The setAsync method starts an asynchronous call to the Exchange server to set the subject of an appointment or message. Setting the subject overwrites the current subject, but leaves any prefixes, such as "Fwd:" or "Re:" in place.
+         * The setAsync method starts an asynchronous call to the Exchange server to set the subject of an appointment or message. 
+         * Setting the subject overwrites the current subject, but leaves any prefixes, such as "Fwd:" or "Re:" in place.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -4330,15 +4809,17 @@ export declare namespace Office {
          * <tr><td>Errors</td><td>DataExceedsMaximumSize - The subject parameter is longer than 255 characters.</td></tr></table>
          *
          * @param subject - The subject of the appointment or message. The string is limited to 255 characters.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If setting the subject fails, the asyncResult.error property will contain an error code.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. If setting the subject fails, the asyncResult.error property will contain an error code.
          */
-        setAsync(data: string, callback: (result: AsyncResult) => void): void;
+        setAsync(data: string, callback: (result: AsyncResult<void>) => void): void;
 
     }
     /**
      * Represents a suggested task identified in an item. Read mode only.
      *
-     * The list of tasks suggested in an email message is returned in the taskSuggestions property of the [Entities]Entities object that is returned when the getEntities or getEntitiesByType method is called on the active item.
+     * The list of tasks suggested in an email message is returned in the taskSuggestions property of the {@link Office.Entities | Entities} object 
+     * that is returned when the getEntities or getEntitiesByType method is called on the active item.
      *
      * [Api set: Mailbox 1.0]
      *
@@ -4371,7 +4852,8 @@ export declare namespace Office {
         /**
          * Gets the start or end time of an appointment.
          *
-         * The date and time is provided as a Date object in the asyncResult.value property. The value is in Coordinated Universal Time (UTC). You can convert the UTC time to the local client time by using the convertToLocalClientTime method.
+         * The date and time is provided as a Date object in the asyncResult.value property. The value is in Coordinated Universal Time (UTC). 
+         * You can convert the UTC time to the local client time by using the convertToLocalClientTime method.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -4380,19 +4862,21 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose</td></tr></table>
          * 
-         * In addition to the main signature, this method also has this signature:
+         * In addition to this signature, this method also has the following signature:
          * 
-         * `getAsync(callback: (result: AsyncResult) => void): void;`
+         * `getAsync(callback: (result: AsyncResult<Date>) => void): void;`
          *
          * @param options - An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
          * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         *                  The `value` property of the result is a Date object.
          */
-        getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;
+        getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult<Date>) => void): void;
         /**
          * Gets the start or end time of an appointment.
          *
-         * The date and time is provided as a Date object in the asyncResult.value property. The value is in Coordinated Universal Time (UTC). You can convert the UTC time to the local client time by using the convertToLocalClientTime method.
+         * The date and time is provided as a Date object in the asyncResult.value property. The value is in Coordinated Universal Time (UTC). 
+         * You can convert the UTC time to the local client time by using the convertToLocalClientTime method.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -4402,12 +4886,14 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose</td></tr></table>
          *
          * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         *                  The `value` property of the result is a Date object.
          */
-        getAsync(callback: (result: AsyncResult) => void): void;
+        getAsync(callback: (result: AsyncResult<Date>) => void): void;
         /**
          * Sets the start or end time of an appointment.
          *
-         * If the setAsync method is called on the start property, the end property will be adjusted to maintain the duration of the appointment as previously set. If the setAsync method is called on the end property, the duration of the appointment will be extended to the new end time.
+         * If the setAsync method is called on the start property, the end property will be adjusted to maintain the duration of the appointment as 
+         * previously set. If the setAsync method is called on the end property, the duration of the appointment will be extended to the new end time.
          *
          * The time must be in UTC; you can get the correct UTC time by using the convertToUtcClientTime method.
          *
@@ -4420,24 +4906,27 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>InvalidEndTime - The appointment end time is before the appointment start time.</td></tr></table>
          * 
-         * In addition to the main signature, this method also has these signatures:
+         * In addition to this signature, this method also has the following signatures:
          * 
          * `setAsync(dateTime: Date): void;`
          * 
          * `setAsync(dateTime: Date, options: Office.AsyncContextOptions): void;`
          * 
-         * `setAsync(dateTime: Date, callback: (result: AsyncResult) => void): void;`
+         * `setAsync(dateTime: Date, callback: (result: AsyncResult<void>) => void): void;`
          *
          * @param dateTime - A date-time object in Coordinated Universal Time (UTC).
          * @param options - An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If setting the date and time fails, the asyncResult.error property will contain an error code.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. 
+         *                 If setting the date and time fails, the asyncResult.error property will contain an error code.
          */
-        setAsync(dateTime: Date, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        setAsync(dateTime: Date, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Sets the start or end time of an appointment.
          *
-         * If the setAsync method is called on the start property, the end property will be adjusted to maintain the duration of the appointment as previously set. If the setAsync method is called on the end property, the duration of the appointment will be extended to the new end time.
+         * If the setAsync method is called on the start property, the end property will be adjusted to maintain the duration of the appointment as 
+         * previously set. If the setAsync method is called on the end property, the duration of the appointment will be extended to the new end time.
          *
          * The time must be in UTC; you can get the correct UTC time by using the convertToUtcClientTime method.
          *
@@ -4456,7 +4945,8 @@ export declare namespace Office {
         /**
          * Sets the start or end time of an appointment.
          *
-         * If the setAsync method is called on the start property, the end property will be adjusted to maintain the duration of the appointment as previously set. If the setAsync method is called on the end property, the duration of the appointment will be extended to the new end time.
+         * If the setAsync method is called on the start property, the end property will be adjusted to maintain the duration of the appointment as 
+         * previously set. If the setAsync method is called on the end property, the duration of the appointment will be extended to the new end time.
          *
          * The time must be in UTC; you can get the correct UTC time by using the convertToUtcClientTime method.
          *
@@ -4477,7 +4967,8 @@ export declare namespace Office {
         /**
          * Sets the start or end time of an appointment.
          *
-         * If the setAsync method is called on the start property, the end property will be adjusted to maintain the duration of the appointment as previously set. If the setAsync method is called on the end property, the duration of the appointment will be extended to the new end time.
+         * If the setAsync method is called on the start property, the end property will be adjusted to maintain the duration of the appointment as 
+         * previously set. If the setAsync method is called on the end property, the duration of the appointment will be extended to the new end time.
          *
          * The time must be in UTC; you can get the correct UTC time by using the convertToUtcClientTime method.
          *
@@ -4491,9 +4982,11 @@ export declare namespace Office {
          * <tr><td>Errors</td><td>InvalidEndTime - The appointment end time is before the appointment start time.</td></tr></table>
          *
          * @param dateTime - A date-time object in Coordinated Universal Time (UTC).
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If setting the date and time fails, the asyncResult.error property will contain an error code.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. 
+         *                 If setting the date and time fails, the asyncResult.error property will contain an error code.
          */
-        setAsync(dateTime: Date, callback: (result: AsyncResult) => void): void;
+        setAsync(dateTime: Date, callback: (result: AsyncResult<void>) => void): void;
 
     }
     /**

--- a/generate-docs/api-extractor-inputs-outlook-legacy/Outlook_1_2/Outlook_1_2.d.ts
+++ b/generate-docs/api-extractor-inputs-outlook-legacy/Outlook_1_2/Outlook_1_2.d.ts
@@ -89,6 +89,24 @@ export declare namespace Office {
             Appointment = "appointment"
         }
         /**
+         * Represents the current view of Outlook Web App.
+         */
+        enum OWAView {
+            /**
+             * One column view. Displayed when the screen is narrow. Outlook Web App uses this single-column layout on the entire screen of a smartphone.
+             */
+            OneColumn = "OneColumn",
+            /**
+             * Two column view. Displayed when the screen is wider. Outlook Web App uses this view on most tablets.
+             */
+            TwoColumns = "TwoColumns",
+            /**
+             Three column view. Displayed when the screen is wide. For example, Outlook Web App uses this view in a full screen window on a desktop 
+             computer.
+             */
+            ThreeColumns = "ThreeColumns"
+        }
+        /**
          * Specifies the type of recipient for an appointment.
          *
          * [Api set: Mailbox 1.1]
@@ -116,7 +134,7 @@ export declare namespace Office {
              */
             Other = "other"
         }
-        /**  
+        /**
          * Specifies the type of response to a meeting invitation.
          *
          * [Api set: Mailbox 1.0]
@@ -188,7 +206,8 @@ export declare namespace Office {
         /**
          * Gets or sets the date and time that the appointment is to end.
          *
-         * The end property is expressed as a Coordinated Universal Time (UTC) date and time value. You can use the convertToLocalClientTime method to convert the end property value to the client's local date and time.
+         * The end property is expressed as a Coordinated Universal Time (UTC) date and time value. You can use the convertToLocalClientTime method to 
+         * convert the end property value to the client's local date and time.
          *
          * *Read mode*
          *
@@ -198,7 +217,8 @@ export declare namespace Office {
          *
          * The end property returns a Time object.
          *
-         * When you use the Time.setAsync method to set the end time, you should use the convertToUtcClientTime method to convert the local time on the client to UTC for the server.
+         * When you use the Time.setAsync method to set the end time, you should use the convertToUtcClientTime method to convert the local time on 
+         * the client to UTC for the server.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -272,7 +292,8 @@ export declare namespace Office {
         /**
          * Gets or sets the date and time that the appointment is to begin.
          *
-         * The start property is expressed as a Coordinated Universal Time (UTC) date and time value. You can use the convertToLocalClientTime method to convert the value to the client's local date and time.
+         * The start property is expressed as a Coordinated Universal Time (UTC) date and time value. You can use the convertToLocalClientTime method 
+         * to convert the value to the client's local date and time.
          *
          * *Read mode*
          *
@@ -282,7 +303,8 @@ export declare namespace Office {
          *
          * The start property returns a Time object.
          *
-         * When you use the Time.setAsync method to set the start time, you should use the convertToUtcClientTime method to convert the local time on the client to UTC for the server.
+         * When you use the Time.setAsync method to set the start time, you should use the convertToUtcClientTime method to convert the local time on 
+         * the client to UTC for the server.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -355,7 +377,8 @@ export declare namespace Office {
         size: number;
     }
     /**
-     * The body object provides methods for adding and updating the content of the message or appointment. It is returned in the body property of the selected item.
+     * The body object provides methods for adding and updating the content of the message or appointment. 
+     * It is returned in the body property of the selected item.
      *
      * [Api set: Mailbox 1.1]
      *
@@ -377,15 +400,18 @@ export declare namespace Office {
          *
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. The content type is returned as one of the CoercionType values in the asyncResult.value property.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult.
+         *                  The content type is returned as one of the CoercionType values in the asyncResult.value property.
          */
-        getTypeAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        getTypeAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<Office.CoercionType>) => void): void;
         /**
          * Adds the specified content to the beginning of the item body.
          *
-         * The prependAsync method inserts the specified string at the beginning of the item body. After insertion, the cursor is returned to its original place, relative to the inserted content.
+         * The prependAsync method inserts the specified string at the beginning of the item body. 
+         * After insertion, the cursor is returned to its original place, relative to the inserted content.
          *
-         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" (please see the Examples section for a sample).
+         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" 
+         * (please see the Examples section for a sample).
          *
          * [Api set: Mailbox 1.1]
          *
@@ -396,11 +422,11 @@ export declare namespace Office {
          * 
          * <tr><td>Errors</td><td>DataExceedsMaximumSize - The data parameter is longer than 1,000,000 characters.</td></tr></table>
          * 
-         * In addition to the main signature, this method also has these signatures:
+         * In addition to this signature, this method also has the following signatures:
          * 
          * `prependAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`
          * 
-         * `prependAsync(data: string, callback: (result: AsyncResult) => void): void;`
+         * `prependAsync(data: string, callback: (result: AsyncResult<void>) => void): void;`
          * 
          * `prependAsync(data: string): void;`
          *
@@ -408,15 +434,18 @@ export declare namespace Office {
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
          *        coercionType: The desired format for the body. The string in the data parameter will be converted to this format.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. Any errors encountered will be provided in the asyncResult.error property.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult.
+         *                  Any errors encountered will be provided in the asyncResult.error property.
          */
-        prependAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult) => void): void;
+        prependAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Adds the specified content to the beginning of the item body.
          *
-         * The prependAsync method inserts the specified string at the beginning of the item body. After insertion, the cursor is returned to its original place, relative to the inserted content.
+         * The prependAsync method inserts the specified string at the beginning of the item body. 
+         * After insertion, the cursor is returned to its original place, relative to the inserted content.
          *
-         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" (please see the Examples section for a sample).
+         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" 
+         * (please see the Examples section for a sample).
          *
          * [Api set: Mailbox 1.1]
          *
@@ -436,9 +465,11 @@ export declare namespace Office {
         /**
          * Adds the specified content to the beginning of the item body.
          *
-         * The prependAsync method inserts the specified string at the beginning of the item body. After insertion, the cursor is returned to its original place, relative to the inserted content.
+         * The prependAsync method inserts the specified string at the beginning of the item body. 
+         * After insertion, the cursor is returned to its original place, relative to the inserted content.
          *
-         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" (please see the Examples section for a sample).
+         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" 
+         * (please see the Examples section for a sample).
          *
          * [Api set: Mailbox 1.1]
          *
@@ -448,15 +479,18 @@ export declare namespace Office {
          * <tr><td>Errors</td><td>DataExceedsMaximumSize - The data parameter is longer than 1,000,000 characters.</td></tr></table>
          *
          * @param data - The string to be inserted at the beginning of the body. The string is limited to 1,000,000 characters.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. Any errors encountered will be provided in the asyncResult.error property.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult.
+         *                  Any errors encountered will be provided in the asyncResult.error property.
          */
-        prependAsync(data: string, callback: (result: AsyncResult) => void): void;
+        prependAsync(data: string, callback: (result: AsyncResult<void>) => void): void;
         /**
          * Adds the specified content to the beginning of the item body.
          *
-         * The prependAsync method inserts the specified string at the beginning of the item body. After insertion, the cursor is returned to its original place, relative to the inserted content.
+         * The prependAsync method inserts the specified string at the beginning of the item body. 
+         * After insertion, the cursor is returned to its original place, relative to the inserted content.
          *
-         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" (please see the Examples section for a sample).
+         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" 
+         * (please see the Examples section for a sample).
          *
          * [Api set: Mailbox 1.1]
          *
@@ -471,9 +505,12 @@ export declare namespace Office {
         /**
          * Replaces the selection in the body with the specified text.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor was never in the body of the item, or if the body of the item lost focus in the UI, the string will be inserted at the top of the body content. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the body of the item, or, if text is selected in 
+         * the editor, it replaces the selected text. If the cursor was never in the body of the item, or if the body of the item lost focus in the 
+         * UI, the string will be inserted at the top of the body content. After insertion, the cursor is placed at the end of the inserted content.
          *
-         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" (please see the Examples section for a sample).
+         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" 
+         * (please see the Examples section for a sample).
          *
          * [Api set: Mailbox 1.1]
          *
@@ -484,11 +521,11 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>DataExceedsMaximumSize - The data parameter is longer than 1,000,000 characters.</td></tr><tr><td></td><td>InvalidFormatError - The options.coercionType parameter is set to Office.CoercionType.Html and the message body is in plain text.</td></tr></table>
          * 
-         * In addition to the main signature, this method also has these signatures:
+         * In addition to this signature, this method also has the following signatures:
          * 
          * `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`
          * 
-         * `setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;`
+         * `setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;`
          * 
          * `setSelectedDataAsync(data: string): void;`
          *         
@@ -496,15 +533,19 @@ export declare namespace Office {
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
          *        coercionType: The desired format for the body. The string in the data parameter will be converted to this format.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.  Any errors encountered will be provided in the asyncResult.error property.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult.
+         *                  Any errors encountered will be provided in the asyncResult.error property.
          */
-        setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult) => void): void;
+        setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Replaces the selection in the body with the specified text.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor was never in the body of the item, or if the body of the item lost focus in the UI, the string will be inserted at the top of the body content. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the body of the item, or, if text is selected in 
+         * the editor, it replaces the selected text. If the cursor was never in the body of the item, or if the body of the item lost focus in the 
+         * UI, the string will be inserted at the top of the body content. After insertion, the cursor is placed at the end of the inserted content.
          *
-         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" (please see the Examples section for a sample).
+         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" 
+         * (please see the Examples section for a sample).
          *
          * [Api set: Mailbox 1.1]
          *
@@ -524,9 +565,12 @@ export declare namespace Office {
         /**
          * Replaces the selection in the body with the specified text.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor was never in the body of the item, or if the body of the item lost focus in the UI, the string will be inserted at the top of the body content. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the body of the item, or, if text is selected in 
+         * the editor, it replaces the selected text. If the cursor was never in the body of the item, or if the body of the item lost focus in the 
+         * UI, the string will be inserted at the top of the body content. After insertion, the cursor is placed at the end of the inserted content.
          *
-         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" (please see the Examples section for a sample).
+         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" 
+         * (please see the Examples section for a sample).
          *
          * [Api set: Mailbox 1.1]
          *
@@ -538,15 +582,19 @@ export declare namespace Office {
          * <tr><td>Errors</td><td>DataExceedsMaximumSize - The data parameter is longer than 1,000,000 characters.</td></tr><tr><td></td><td>InvalidFormatError - The options.coercionType parameter is set to Office.CoercionType.Html and the message body is in plain text.</td></tr></table>
          *
          * @param data - The string that will replace the existing body. The string is limited to 1,000,000 characters.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.  Any errors encountered will be provided in the asyncResult.error property.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult.
+         *                  Any errors encountered will be provided in the asyncResult.error property.
          */
-        setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;
+        setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;
         /**
          * Replaces the selection in the body with the specified text.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor was never in the body of the item, or if the body of the item lost focus in the UI, the string will be inserted at the top of the body content. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the body of the item, or, if text is selected in 
+         * the editor, it replaces the selected text. If the cursor was never in the body of the item, or if the body of the item lost focus in the 
+         * UI, the string will be inserted at the top of the body content. After insertion, the cursor is placed at the end of the inserted content.
          *
-         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" (please see the Examples section for a sample).
+         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" 
+         * (please see the Examples section for a sample).
          *
          * [Api set: Mailbox 1.1]
          *
@@ -564,7 +612,8 @@ export declare namespace Office {
     /**
      * Represents a contact stored on the server. Read mode only.
      *
-     * The list of contacts associated with an email message or appointment is returned in the contacts property of the {@link Office.Entities} object that is returned by the getEntities or getEntitiesByType method of the active item.
+     * The list of contacts associated with an email message or appointment is returned in the contacts property of the {@link Office.Entities} object 
+     * that is returned by the getEntities or getEntitiesByType method of the active item.
      *
      * [Api set: Mailbox 1.0]
      *
@@ -600,7 +649,10 @@ export declare namespace Office {
         urls: Array<string>;
     }
     /**
-     * The CustomProperties object represents custom properties that are specific to a particular item and specific to a mail add-in for Outlook. For example, there might be a need for a mail add-in to save some data that is specific to the current email message that activated the add-in. If the user revisits the same message in the future and activates the mail add-in again, the add-in will be able to retrieve the data that had been saved as custom properties.
+     * The CustomProperties object represents custom properties that are specific to a particular item and specific to a mail add-in for Outlook. 
+     * For example, there might be a need for a mail add-in to save some data that is specific to the current email message that activated the add-in. 
+     * If the user revisits the same message in the future and activates the mail add-in again, the add-in will be able to retrieve the data that had 
+     * been saved as custom properties.
      *
      * Because Outlook for Mac doesn't cache custom properties, if the user's network goes down, mail add-ins cannot access their custom properties.
      *
@@ -630,7 +682,9 @@ export declare namespace Office {
          *
          * The set method sets the specified property to the specified value. You must use the saveAsync method to save the property to the server.
          *
-         * The set method creates a new property if the specified property does not already exist; otherwise, the existing value is replaced with the new value. The value parameter can be of any type; however, it is always passed to the server as a string.
+         * The set method creates a new property if the specified property does not already exist; 
+         * otherwise, the existing value is replaced with the new value. 
+         * The value parameter can be of any type; however, it is always passed to the server as a string.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -660,11 +714,17 @@ export declare namespace Office {
         /**
          * Saves item-specific custom properties to the server.
          *
-         * You must call the saveAsync method to persist any changes made with the set method or the remove method of the CustomProperties object. The saving action is asynchronous.
+         * You must call the saveAsync method to persist any changes made with the set method or the remove method of the CustomProperties object. 
+         * The saving action is asynchronous.
          *
-         * It's a good practice to have your callback function check for and handle errors from saveAsync. In particular, a read add-in can be activated while the user is in a connected state in a read form, and subsequently the user becomes disconnected. If the add-in calls saveAsync while in the disconnected state, saveAsync would return an error. Your callback method should handle this error accordingly.
+         * It's a good practice to have your callback function check for and handle errors from saveAsync. 
+         * In particular, a read add-in can be activated while the user is in a connected state in a read form, and subsequently the user becomes 
+         * disconnected. 
+         * If the add-in calls saveAsync while in the disconnected state, saveAsync would return an error. 
+         * Your callback method should handle this error accordingly.
          *
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          * @param asyncContext - Optional. Any state data that is passed to the callback method.
          *
          * [Api set: Mailbox 1.0]
@@ -674,7 +734,7 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          */
-        saveAsync(callback?: (result: AsyncResult) => void, asyncContext?: any): void;
+        saveAsync(callback?: (result: AsyncResult<void>) => void, asyncContext?: any): void;
     }
     /**
      * Provides diagnostic information to an Outlook add-in.
@@ -703,7 +763,8 @@ export declare namespace Office {
         /**
          * Gets a string that represents the version of either the host application or the Exchange Server.
          *
-         * If the mail add-in is running on the Outlook desktop client or Outlook for iOS, the hostVersion property returns the version of the host application, Outlook. In Outlook Web App, the property returns the version of the Exchange Server. An example is the string 15.0.468.0.
+         * If the mail add-in is running on the Outlook desktop client or Outlook for iOS, the hostVersion property returns the version of the host 
+         * application, Outlook. In Outlook Web App, the property returns the version of the Exchange Server. An example is the string 15.0.468.0.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -722,11 +783,13 @@ export declare namespace Office {
          *
          * Outlook Web App has three views that correspond to the width of the screen and the window, and the number of columns that can be displayed:
          *
-         * - OneColumn, which is displayed when the screen is narrow. Outlook Web App uses this single-column layout on the entire screen of a smartphone.
+         * - OneColumn, which is displayed when the screen is narrow. Outlook Web App uses this single-column layout on the entire screen of a 
+         * smartphone.
          *
          * - TwoColumns, which is displayed when the screen is wider. Outlook Web App uses this view on most tablets.
          *
-         * - ThreeColumns, which is displayed when the screen is wide. For example, Outlook Web App uses this view in a full screen window on a desktop computer.
+         * - ThreeColumns, which is displayed when the screen is wide. For example, Outlook Web App uses this view in a full screen window on a 
+         * desktop computer.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -735,7 +798,7 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          */
-        OWAView: "string";
+        OWAView: MailboxEnums.OWAView | "OneColumn" | "TwoColumns" | "ThreeColumns";
     }
     /**
      * Provides the email properties of the sender or specified recipients of an email message or appointment.
@@ -757,7 +820,9 @@ export declare namespace Office {
          */
         displayName: string;
         /**
-         * Gets the response that an attendee returned for an appointment. This property applies to only an attendee of an appointment, as represented by the optionalAttendees or requiredAttendees property. This property returns undefined in other scenarios.
+         * Gets the response that an attendee returned for an appointment. 
+         * This property applies to only an attendee of an appointment, as represented by the optionalAttendees or requiredAttendees property. 
+         * This property returns undefined in other scenarios.
          */
         appointmentResponse: Office.MailboxEnums.ResponseType;
         /**
@@ -788,17 +853,25 @@ export declare namespace Office {
     /**
      * Represents a collection of entities found in an email message or appointment. Read mode only.
      *
-     * The Entities object is a container for the entity arrays returned by the getEntities and getEntitiesByType methods when the item (either an email message or an appointment) contains one or more entities that have been found by the server. You can use these entities in your code to provide additional context information to the viewer, such as a map to an address found in the item, or to open a dialer for a phone number found in the item.
+     * The Entities object is a container for the entity arrays returned by the getEntities and getEntitiesByType methods when the item 
+     * (either an email message or an appointment) contains one or more entities that have been found by the server. 
+     * You can use these entities in your code to provide additional context information to the viewer, such as a map to an address found in the item, 
+     * or to open a dialer for a phone number found in the item.
      *
-     * If no entities of the type specified in the property are present in the item, the property associated with that entity is null. For example, if a message contains a street address and a phone number, the addresses property and phoneNumbers property would contain information, and the other properties would be null.
+     * If no entities of the type specified in the property are present in the item, the property associated with that entity is null. 
+     * For example, if a message contains a street address and a phone number, the addresses property and phoneNumbers property would contain 
+     * information, and the other properties would be null.
      *
-     * To be recognized as an address, the string must contain a United States postal address that has at least a subset of the elements of a street number, street name, city, state, and zip code.
+     * To be recognized as an address, the string must contain a United States postal address that has at least a subset of the elements of a street 
+     * number, street name, city, state, and zip code.
      *
      * To be recognized as a phone number, the string must contain a North American phone number format.
      *
-     * Entity recognition relies on natural language recognition that is based on machine learning of large amounts of data. The recognition of an entity is non-deterministic and success sometimes relies on the particular context in the item.
+     * Entity recognition relies on natural language recognition that is based on machine learning of large amounts of data. 
+     * The recognition of an entity is non-deterministic and success sometimes relies on the particular context in the item.
      *
-     * When the property arrays are returned by the getEntitiesByType method, only the property for the specified entity contains data; all other properties are null.
+     * When the property arrays are returned by the getEntitiesByType method, only the property for the specified entity contains data; 
+     * all other properties are null.
      *
      * [Api set: Mailbox 1.0]
      *
@@ -840,14 +913,16 @@ export declare namespace Office {
     /**
      * The subclass of {@link Office.Item} dealing with appointments.
      * 
-     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of Office.context.mailbox.item. Refer to the Object Model pages for more information.
+     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. 
+     * You should treat this as a mode of Office.context.mailbox.item. Refer to the Object Model pages for more information.
      */
     export interface Appointment extends Item {
     }
     /**
      * The appointment organizer mode of {@link Office.Item | Office.context.mailbox.item}.
      * 
-     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
+     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. 
+     * You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
      */
     export interface AppointmentCompose extends Appointment, ItemCompose {
          /**
@@ -891,9 +966,11 @@ export declare namespace Office {
         /**
          * Gets or sets the date and time that the appointment is to end.
          *
-         * The end property is an {@link Office.Time} object expressed as a Coordinated Universal Time (UTC) date and time value. You can use the convertToLocalClientTime method to convert the end property value to the client's local date and time.
+         * The end property is an {@link Office.Time} object expressed as a Coordinated Universal Time (UTC) date and time value. 
+         * You can use the convertToLocalClientTime method to convert the end property value to the client's local date and time.
          *
-         * When you use the Time.setAsync method to set the end time, you should use the convertToUtcClientTime method to convert the local time on the client to UTC for the server.
+         * When you use the Time.setAsync method to set the end time, you should use the convertToUtcClientTime method to convert the local time on 
+         * the client to UTC for the server.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -919,7 +996,8 @@ export declare namespace Office {
          */
         itemType: Office.MailboxEnums.ItemType;
         /**
-         * Gets or sets the {@link Office.Location} of an appointment. The location property returns a Location object that provides methods that are used to get and set the location of the appointment.
+         * Gets or sets the {@link Office.Location} of an appointment. The location property returns a Location object that provides methods that are 
+         * used to get and set the location of the appointment.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -931,7 +1009,9 @@ export declare namespace Office {
          */
         location: Location;
         /**
-         * Provides access to the optional attendees of an event. The type of object and level of access depends on the mode of the current item. The optionalAttendees property returns an {@link Office.Recipients} object that provides methods to get or update the optional attendees for a meeting.
+         * Provides access to the optional attendees of an event. The type of object and level of access depends on the mode of the current item. 
+         * The optionalAttendees property returns an {@link Office.Recipients} object that provides methods to get or update the optional attendees 
+         * for a meeting.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -943,7 +1023,9 @@ export declare namespace Office {
          */
         optionalAttendees: Recipients;
         /**
-         * Provides access to the required attendees of an event. The type of object and level of access depends on the mode of the current item. The requiredAttendees property returns an {@link Office.Recipients} object that provides methods to get or update the required attendees for a meeting.
+         * Provides access to the required attendees of an event. The type of object and level of access depends on the mode of the current item. 
+         * The requiredAttendees property returns an {@link Office.Recipients} object that provides methods to get or update the required attendees 
+         * for a meeting.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -957,9 +1039,11 @@ export declare namespace Office {
         /**
          * Gets or sets the date and time that the appointment is to begin.
          *
-         * The start property is an {@link Office.Time} object expressed as a Coordinated Universal Time (UTC) date and time value. You can use the convertToLocalClientTime method to convert the value to the client's local date and time.
+         * The start property is an {@link Office.Time} object expressed as a Coordinated Universal Time (UTC) date and time value. 
+         * You can use the convertToLocalClientTime method to convert the value to the client's local date and time.
          *
-         * When you use the Time.setAsync method to set the start time, you should use the convertToUtcClientTime method to convert the local time on the client to UTC for the server.
+         * When you use the Time.setAsync method to set the start time, you should use the convertToUtcClientTime method to convert the local time on 
+         * the client to UTC for the server.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1008,16 +1092,18 @@ export declare namespace Office {
          * 
          * `addFileAttachmentAsync(uri: string, attachmentName: string, options: Office.AsyncContextOptions): void;`
          * 
-         * `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+         * `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;`
          *
          * @param uri - The URI that provides the location of the file to attach to the message or appointment. The maximum length is 2048 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
          *        isInline: If true, indicates that the attachment will be shown inline in the message body, and should not be displayed in the attachment list.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type asyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type asyncResult. 
+         *                 On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
          */
-        addFileAttachmentAsync(uri: string, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        addFileAttachmentAsync(uri: string, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;
         /**
          * Adds a file to a message or appointment as an attachment.
          *
@@ -1058,7 +1144,7 @@ export declare namespace Office {
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         *        isInline: If true, indicates that the attachment will be shown inline in the message body, and should not be displayed in the attachment list.
+         *        isInline: If true, indicates that the attachment will be shown inline in the message body and should not be displayed in the attachment list.
          */
         addFileAttachmentAsync(uri: string, attachmentName: string, options: Office.AsyncContextOptions): void;
         /**
@@ -1079,17 +1165,23 @@ export declare namespace Office {
          *
          * @param uri - The URI that provides the location of the file to attach to the message or appointment. The maximum length is 2048 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type asyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type asyncResult. 
+         *                 On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
          */
-        addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;
+        addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. 
+         * You can use the options parameter to pass state information to the callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -1100,29 +1192,35 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>NumberOfAttachmentsExceeded - The message or appointment has too many attachments.</td></tr></table>
          * 
-         * In addition to the main signature, this method also has these signatures:
+         * In addition to this signature, this method also has the following signatures:
          * 
          * `addItemAttachmentAsync(itemId: any, attachmentName: string): void;`
          * 
          * `addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;`
          * 
-         * `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+         * `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;`
          *
          * @param itemId - The Exchange identifier of the item to attach. The maximum length is 100 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
          * @param options - An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. 
+         *                 On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
          */
-        addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. 
+         * You can use the options parameter to pass state information to the callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -1140,11 +1238,15 @@ export declare namespace Office {
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. 
+         * You can use the options parameter to pass state information to the callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -1164,11 +1266,15 @@ export declare namespace Office {
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. 
+         * You can use the options parameter to pass state information to the callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -1181,15 +1287,19 @@ export declare namespace Office {
          *
          * @param itemId - The Exchange identifier of the item to attach. The maximum length is 100 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. 
+         *                 On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
          */
-        addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;
+        addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;
         /**
          * Asynchronously returns selected data from the subject or body of a message.
          *
-         * If there is no selection but the cursor is in the body or subject, the method returns null for the selected data. If a field other than the body or subject is selected, the method returns the InvalidSelection error.
+         * If there is no selection but the cursor is in the body or subject, the method returns null for the selected data. 
+         * If a field other than the body or subject is selected, the method returns the InvalidSelection error.
          *
-         * To access the selected data from the callback method, call asyncResult.value.data. To access the source property that the selection comes from, call asyncResult.value.sourceProperty, which will be either body or subject.
+         * To access the selected data from the callback method, call asyncResult.value.data. 
+         * To access the source property that the selection comes from, call asyncResult.value.sourceProperty, which will be either body or subject.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -1202,18 +1312,21 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Appointment Organizer</td></tr></table>
          *
-         * @param coercionType - Requests a format for the data. If Text, the method returns the plain text as a string , removing any HTML tags present. If HTML, the method returns the selected text, whether it is plaintext or HTML.
+         * @param coercionType - Requests a format for the data. If Text, the method returns the plain text as a string , removing any HTML tags present. 
+         *                     If HTML, the method returns the selected text, whether it is plaintext or HTML.
          * @param options - An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
          * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
          */
-        getSelectedDataAsync(coerciontype: Office.CoercionType, options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;
+        getSelectedDataAsync(coerciontype: Office.CoercionType, options: Office.AsyncContextOptions, callback: (result: AsyncResult<any>) => void): void;
          /**
          * Asynchronously returns selected data from the subject or body of a message.
          *
-         * If there is no selection but the cursor is in the body or subject, the method returns null for the selected data. If a field other than the body or subject is selected, the method returns the InvalidSelection error.
+         * If there is no selection but the cursor is in the body or subject, the method returns null for the selected data. 
+         * If a field other than the body or subject is selected, the method returns the InvalidSelection error.
          *
-         * To access the selected data from the callback method, call asyncResult.value.data. To access the source property that the selection comes from, call asyncResult.value.sourceProperty, which will be either body or subject.
+         * To access the selected data from the callback method, call asyncResult.value.data. 
+         * To access the source property that the selection comes from, call asyncResult.value.sourceProperty, which will be either body or subject.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -1226,16 +1339,22 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Appointment Organizer</td></tr></table>
          *
-         * @param coercionType - Requests a format for the data. If Text, the method returns the plain text as a string , removing any HTML tags present. If HTML, the method returns the selected text, whether it is plaintext or HTML.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param coercionType - Requests a format for the data. If Text, the method returns the plain text as a string , removing any HTML tags present. 
+         *                     If HTML, the method returns the selected text, whether it is plaintext or HTML.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          */
-        getSelectedDataAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult) => void): void;
+        getSelectedDataAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult<string>) => void): void;
         /**
          * Asynchronously loads custom properties for this add-in on the selected item.
          *
-         * Custom properties are stored as key/value pairs on a per-app, per-item basis. This method returns a CustomProperties object in the callback, which provides methods to access the custom properties specific to the current item and the current add-in. Custom properties are not encrypted on the item, so this should not be used as secure storage.
+         * Custom properties are stored as key/value pairs on a per-app, per-item basis. 
+         * This method returns a CustomProperties object in the callback, which provides methods to access the custom properties specific to the 
+         * current item and the current add-in. Custom properties are not encrypted on the item, so this should not be used as secure storage.
          *
-         * The custom properties are provided as a CustomProperties object in the asyncResult.value property. This object can be used to get, set, and remove custom properties from the item and save changes to the custom property set back to the server.
+         * The custom properties are provided as a CustomProperties object in the asyncResult.value property. 
+         * This object can be used to get, set, and remove custom properties from the item and save changes to the custom property set back to 
+         * the server.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1245,14 +1364,20 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Appointment Organizer</td></tr></table>
          *
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
-         * @param userContext - Optional. Developers can provide any object they wish to access in the callback function. This object can be accessed by the asyncResult.asyncContext property in the callback function.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
+         * @param userContext - Optional. Developers can provide any object they wish to access in the callback function. 
+         *                    This object can be accessed by the asyncResult.asyncContext property in the callback function.
          */
-        loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;
+        loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any): void;
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -1270,18 +1395,23 @@ export declare namespace Office {
          * 
          * `removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;`
          * 
-         * `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;`
+         * `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;`
          *
          * @param attachmentIndex - The identifier of the attachment to remove. The maximum length of the string is 100 characters.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. 
+         *                 If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
          */
-        removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -1299,7 +1429,11 @@ export declare namespace Office {
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -1319,7 +1453,12 @@ export declare namespace Office {
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. 
+         * In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -1332,13 +1471,17 @@ export declare namespace Office {
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
          * @param attachmentIndex - The identifier of the attachment to remove. The maximum length of the string is 100 characters.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. 
+         *                 If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
          */
-        removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;
+        removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;
         /**
          * Asynchronously inserts data into the body or subject of a message.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is 
+         * selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. 
+         * After insertion, the cursor is placed at the end of the inserted content.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -1356,19 +1499,29 @@ export declare namespace Office {
          * 
          * `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`
          * 
-         * `setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;`
+         * `setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;`
          *
-         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
+         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. 
+         *             If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         *        coercionType: If text, the current style is applied in Outlook Web App and Outlook. If the field is an HTML editor, only the text data is inserted, even if the data is HTML. If html and the field supports HTML (the subject doesn't), the current style is applied in Outlook Web App and the default style is applied in Outlook. If the field is a text field, an InvalidDataFormat error is returned. If coercionType is not set, the result depends on the field: if the field is HTML then HTML is used; if the field is text, then plain text is used.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         *        coercionType: If text, the current style is applied in Outlook Web App and Outlook. 
+         *                      If the field is an HTML editor, only the text data is inserted, even if the data is HTML. 
+         *                      If html and the field supports HTML (the subject doesn't), the current style is applied in Outlook Web App and the 
+         *                      default style is applied in Outlook. 
+         *                      If the field is a text field, an InvalidDataFormat error is returned. 
+         *                      If coercionType is not set, the result depends on the field: if the field is HTML then HTML is used; 
+         *                      if the field is text, then plain text is used.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          */
-        setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult) => void): void;
+        setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Asynchronously inserts data into the body or subject of a message.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is 
+         * selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. 
+         * After insertion, the cursor is placed at the end of the inserted content.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -1380,13 +1533,16 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
-         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
+         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. 
+         *             If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
          */
         setSelectedDataAsync(data: string): void;
         /**
          * Asynchronously inserts data into the body or subject of a message.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is 
+         * selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. 
+         * After insertion, the cursor is placed at the end of the inserted content.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -1398,16 +1554,24 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
-         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
+         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. 
+         *             If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         *        coercionType: If text, the current style is applied in Outlook Web App and Outlook. If the field is an HTML editor, only the text data is inserted, even if the data is HTML. If html and the field supports HTML (the subject doesn't), the current style is applied in Outlook Web App and the default style is applied in Outlook. If the field is a text field, an InvalidDataFormat error is returned. If coercionType is not set, the result depends on the field: if the field is HTML then HTML is used; if the field is text, then plain text is used.
+         *        coercionType: If text, the current style is applied in Outlook Web App and Outlook. 
+         *                      If the field is an HTML editor, only the text data is inserted, even if the data is HTML. 
+         *                      If html and the field supports HTML (the subject doesn't), the current style is applied in Outlook Web App and the 
+         *                      default style is applied in Outlook. If the field is a text field, an InvalidDataFormat error is returned. 
+         *                      If coercionType is not set, the result depends on the field: if the field is HTML then HTML is used; 
+         *                      if the field is text, then plain text is used.
          */
         setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;
         /**
          * Asynchronously inserts data into the body or subject of a message.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is 
+         * selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. 
+         * After insertion, the cursor is placed at the end of the inserted content.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -1419,20 +1583,23 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
-         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. 
+         *             If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          */
-        setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;
+        setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;
     }
 
     /**
      * The appointment attendee mode of {@link Office.Item | Office.context.mailbox.item}.
      * 
-     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of 'Office.context.mailbox.item'. Refer to the Object Model pages for more information.
+     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. 
+     * You should treat this as a mode of 'Office.context.mailbox.item'. Refer to the Object Model pages for more information.
      */
     export interface AppointmentRead extends Appointment, ItemRead {
         /**
-         * Gets an array of attachments for the item.
+         * Gets the item's attachments as an array.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1442,7 +1609,8 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Appointment Attendee</td></tr></table>
          *
-         * Note: Certain types of files are blocked by Outlook due to potential security issues and are therefore not returned. For more information, see {@link https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519 | Blocked attachments in Outlook}.
+         * Note: Certain types of files are blocked by Outlook due to potential security issues and are therefore not returned. For more information, see 
+         * {@link https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519 | Blocked attachments in Outlook}.
          *
          */
         attachments: Office.AttachmentDetails[];
@@ -1487,9 +1655,11 @@ export declare namespace Office {
         /**
          * Gets the date and time that the appointment is to end.
          *
-         * The end property is a Date object expressed as a Coordinated Universal Time (UTC) date and time value. You can use the convertToLocalClientTime method to convert the end property value to the client's local date and time.
+         * The end property is a Date object expressed as a Coordinated Universal Time (UTC) date and time value. 
+         * You can use the convertToLocalClientTime method to convert the end property value to the client's local date and time.
          *
-         * When you use the Time.setAsync method to set the end time, you should use the convertToUtcClientTime method to convert the local time on the client to UTC for the server.
+         * When you use the Time.setAsync method to set the end time, you should use the convertToUtcClientTime method to convert the local time on 
+         * the client to UTC for the server.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1539,9 +1709,14 @@ export declare namespace Office {
         /**
          * Gets the Exchange Web Services item identifier for the current item.
          *
-         * The itemId property is not available in compose mode. If an item identifier is required, the saveAsync method can be used to save the item to the store, which will return the item identifier in the AsyncResult.value parameter in the callback function.
+         * The itemId property is not available in compose mode. 
+         * If an item identifier is required, the saveAsync method can be used to save the item to the store, which will return the item identifier 
+         * in the AsyncResult.value parameter in the callback function.
          *
-         * Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more details, see Use the Outlook REST APIs from an Outlook add-in.
+         * Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. 
+         * The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. 
+         * Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. 
+         * For more details, see {@link https://docs.microsoft.com/outlook/add-ins/use-rest-api#get-the-item-id | Use the Outlook REST APIs from an Outlook add-in}.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1583,7 +1758,8 @@ export declare namespace Office {
         /**
          * Gets the subject of an item, with all prefixes removed (including RE: and FWD:).
          *
-         * The normalizedSubject property gets the subject of the item, with any standard prefixes (such as RE: and FW:) that are added by email programs. To get the subject of the item with the prefixes intact, use the subject property.
+         * The normalizedSubject property gets the subject of the item, with any standard prefixes (such as RE: and FW:) that are added by email programs. 
+         * To get the subject of the item with the prefixes intact, use the subject property.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1597,7 +1773,8 @@ export declare namespace Office {
         /**
          * Provides access to the optional attendees of an event. The type of object and level of access depends on the mode of the current item.
          *
-         * The optionalAttendees property returns an array that contains an {@link Office.EmailAddressDetails} object for each optional attendee to the meeting.
+         * The optionalAttendees property returns an array that contains an {@link Office.EmailAddressDetails} object for each optional attendee to 
+         * the meeting.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1609,7 +1786,7 @@ export declare namespace Office {
          */
         optionalAttendees: EmailAddressDetails[];
         /**
-         * Gets the email address of the meeting organizer for a specified meeting. Read mode only.
+         * Gets the email address of the meeting organizer for a specified meeting.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1623,7 +1800,8 @@ export declare namespace Office {
         /**
          * Provides access to the required attendees of an event. The type of object and level of access depends on the mode of the current item.
          *
-         * The requiredAttendees property returns an array that contains an {@link Office.EmailAddressDetails} object for each required attendee to the meeting.
+         * The requiredAttendees property returns an array that contains an {@link Office.EmailAddressDetails} object for each required attendee to 
+         * the meeting.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1637,7 +1815,8 @@ export declare namespace Office {
         /**
          * Gets the date and time that the appointment is to begin.
          *
-         * The start property is a Date object expressed as a Coordinated Universal Time (UTC) date and time value. You can use the convertToLocalClientTime method to convert the value to the client's local date and time.
+         * The start property is a Date object expressed as a Coordinated Universal Time (UTC) date and time value. 
+         * You can use the convertToLocalClientTime method to convert the value to the client's local date and time.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1664,14 +1843,18 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Appointment Attendee</td></tr></table>
          */
         subject: string;
+
         /**
-         * Displays a reply form that includes the sender and all recipients of the selected message or the organizer and all attendees of the selected appointment.
+         * Displays a reply form that includes the sender and all recipients of the selected message or the organizer and all attendees of the 
+         * selected appointment.
          *
          * In Outlook Web App, the reply form is displayed as a pop-out form in the 3-column view and a pop-up form in the 2- or 1-column view.
          *
          * If any of the string parameters exceed their limits, displayReplyAllForm throws an exception.
          *
-         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. If this isn't possible, then no error message is thrown.
+         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and 
+         * attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. 
+         * If this isn't possible, then no error message is thrown.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -1694,7 +1877,9 @@ export declare namespace Office {
          *
          * If any of the string parameters exceed their limits, displayReplyForm throws an exception.
          *
-         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. If this isn't possible, then no error message is thrown.
+         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and 
+         * attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. 
+         * If this isn't possible, then no error message is thrown.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -1712,7 +1897,7 @@ export declare namespace Office {
          */
         displayReplyForm(formData: string | ReplyFormData): void;
         /**
-         * Gets the entities found in the selected item.
+         * Gets the entities found in the selected item's body.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -1726,7 +1911,7 @@ export declare namespace Office {
          */
         getEntities(): Entities;
         /**
-         * Gets an array of all the entities of the specified entity type found in the selected item.
+         * Gets an array of all the entities of the specified entity type found in the selected item's body.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -1735,7 +1920,9 @@ export declare namespace Office {
          * @param entityType - One of the EntityType enumeration values.
          *
          * @returns
-         * If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. If no entities of the specified type are present on the item, the method returns an empty array. Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter.
+         * If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. 
+         * If no entities of the specified type are present in the item's body, the method returns an empty array. 
+         * Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter.
          *
          * @remarks
          * <table><tr><td>{@link https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions | Minimum permission level}</td><td>Restricted</td></tr>
@@ -1791,7 +1978,8 @@ export declare namespace Office {
         /**
          * Returns well-known entities in the selected item that pass the named filter defined in the manifest XML file.
          *
-         * The getFilteredEntitiesByName method returns the entities that match the regular expression defined in the ItemHasKnownEntity rule element in the manifest XML file with the specified FilterName element value.
+         * The getFilteredEntitiesByName method returns the entities that match the regular expression defined in the ItemHasKnownEntity rule element 
+         * in the manifest XML file with the specified FilterName element value.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -1804,22 +1992,33 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Appointment Attendee</td></tr></table>
          *
          * @param name - The name of the ItemHasKnownEntity rule element that defines the filter to match.
-         * @returns If there is no ItemHasKnownEntity element in the manifest with a FilterName element value that matches the name parameter, the method returns null. If the name parameter does match an ItemHasKnownEntity element in the manifest, but there are no entities in the current item that match, the method return an empty array.
+         * @returns If there is no ItemHasKnownEntity element in the manifest with a FilterName element value that matches the name parameter, 
+         * the method returns null. 
+         * If the name parameter does match an ItemHasKnownEntity element in the manifest, but there are no entities in the current item that match, 
+         * the method return an empty array.
          */
         getFilteredEntitiesByName(name: string): (string | Contact | MeetingSuggestion | PhoneNumber | TaskSuggestion)[];
         /**
          * Returns string values in the selected item that match the regular expressions defined in the manifest XML file.
          *
-         * The getRegExMatches method returns the strings that match the regular expression defined in each ItemHasRegularExpressionMatch or ItemHasKnownEntity rule element in the manifest XML file. For an ItemHasRegularExpressionMatch rule, a matching string has to occur in the property of the item that is specified by that rule. The PropertyName simple type defines the supported properties.
+         * The getRegExMatches method returns the strings that match the regular expression defined in each ItemHasRegularExpressionMatch or 
+         * ItemHasKnownEntity rule element in the manifest XML file. 
+         * For an ItemHasRegularExpressionMatch rule, a matching string has to occur in the property of the item that is specified by that rule. 
+         * The PropertyName simple type defines the supported properties.
          *
-         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body and should not attempt to return the entire body of the item. Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results. Instead, use the Body.getAsync method to retrieve the entire body.
+         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body 
+         * and should not attempt to return the entire body of the item. 
+         * Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results. 
+         * Instead, use the Body.getAsync method to retrieve the entire body.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
          * [Api set: Mailbox 1.0]
          *
          * @returns
-         * An object that contains arrays of strings that match the regular expressions defined in the manifest XML file. The name of each array is equal to the corresponding value of the RegExName attribute of the matching ItemHasRegularExpressionMatch rule or the FilterName attribute of the matching ItemHasKnownEntity rule.
+         * An object that contains arrays of strings that match the regular expressions defined in the manifest XML file. 
+         * The name of each array is equal to the corresponding value of the RegExName attribute of the matching ItemHasRegularExpressionMatch rule 
+         * or the FilterName attribute of the matching ItemHasKnownEntity rule.
          *
          * @remarks
          *
@@ -1831,9 +2030,12 @@ export declare namespace Office {
         /**
          * Returns string values in the selected item that match the named regular expression defined in the manifest XML file.
          *
-         * The getRegExMatchesByName method returns the strings that match the regular expression defined in the ItemHasRegularExpressionMatch rule element in the manifest XML file with the specified RegExName element value.
+         * The getRegExMatchesByName method returns the strings that match the regular expression defined in the ItemHasRegularExpressionMatch rule 
+         * element in the manifest XML file with the specified RegExName element value.
          *
-         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body and should not attempt to return the entire body of the item. Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results.
+         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body 
+         * and should not attempt to return the entire body of the item. 
+         * Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -1851,12 +2053,16 @@ export declare namespace Office {
          * @param name - The name of the ItemHasRegularExpressionMatch rule element that defines the filter to match.
          */
         getRegExMatchesByName(name: string): string[];
-       /**
+        /**
         * Asynchronously loads custom properties for this add-in on the selected item.
         *
-        * Custom properties are stored as key/value pairs on a per-app, per-item basis. This method returns a CustomProperties object in the callback, which provides methods to access the custom properties specific to the current item and the current add-in. Custom properties are not encrypted on the item, so this should not be used as secure storage.
+        * Custom properties are stored as key/value pairs on a per-app, per-item basis. 
+        * This method returns a CustomProperties object in the callback, which provides methods to access the custom properties specific to the 
+        * current item and the current add-in. Custom properties are not encrypted on the item, so this should not be used as secure storage.
         *
-        * The custom properties are provided as a CustomProperties object in the asyncResult.value property. This object can be used to get, set, and remove custom properties from the item and save changes to the custom property set back to the server.
+        * The custom properties are provided as a CustomProperties object in the asyncResult.value property. 
+        * This object can be used to get, set, and remove custom properties from the item and save changes to the custom property set back to 
+        * the server.
         *
         * [Api set: Mailbox 1.0]
         *
@@ -1866,14 +2072,17 @@ export declare namespace Office {
         *
         * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Appointment Attendee</td></tr></table>
         *
-        * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
-        * @param userContext - Optional. Developers can provide any object they wish to access in the callback function. This object can be accessed by the asyncResult.asyncContext property in the callback function.
+        * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+        *                 type Office.AsyncResult.
+        * @param userContext - Optional. Developers can provide any object they wish to access in the callback function. 
+        *                    This object can be accessed by the asyncResult.asyncContext property in the callback function.
         */
-       loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;
+       loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any): void;
     }
 
     /**
-     * The item namespace is used to access the currently selected message, meeting request, or appointment. You can determine the type of the item by using the `itemType` property.
+     * The item namespace is used to access the currently selected message, meeting request, or appointment. 
+     * You can determine the type of the item by using the `itemType` property.
      *
      * [Api set: Mailbox 1.0]
      *
@@ -1924,7 +2133,8 @@ export declare namespace Office {
         /**
          * Gets the type of item that an instance represents.
          *
-         * The itemType property returns one of the ItemType enumeration values, indicating whether the item object instance is a message or an appointment.
+         * The itemType property returns one of the ItemType enumeration values, indicating whether the item object instance is a message or 
+         * an appointment.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1935,12 +2145,17 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          */
         itemType: Office.MailboxEnums.ItemType;
+
        /**
         * Asynchronously loads custom properties for this add-in on the selected item.
         *
-        * Custom properties are stored as key/value pairs on a per-app, per-item basis. This method returns a CustomProperties object in the callback, which provides methods to access the custom properties specific to the current item and the current add-in. Custom properties are not encrypted on the item, so this should not be used as secure storage.
+        * Custom properties are stored as key/value pairs on a per-app, per-item basis. 
+        * This method returns a CustomProperties object in the callback, which provides methods to access the custom properties specific to the 
+        * current item and the current add-in. Custom properties are not encrypted on the item, so this should not be used as secure storage.
         *
-        * The custom properties are provided as a CustomProperties object in the asyncResult.value property. This object can be used to get, set, and remove custom properties from the item and save changes to the custom property set back to the server.
+        * The custom properties are provided as a CustomProperties object in the asyncResult.value property. 
+        * This object can be used to get, set, and remove custom properties from the item and save changes to the custom property set back to 
+        * the server.
         *
         * [Api set: Mailbox 1.0]
         *
@@ -1950,15 +2165,18 @@ export declare namespace Office {
         *
         * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
         *
-        * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
-        * @param userContext - Optional. Developers can provide any object they wish to access in the callback function. This object can be accessed by the asyncResult.asyncContext property in the callback function.
+        * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+        *                 type Office.AsyncResult.
+        * @param userContext - Optional. Developers can provide any object they wish to access in the callback function. 
+        *                    This object can be accessed by the asyncResult.asyncContext property in the callback function.
         */
-       loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;
+       loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any): void;
     }
     /**
      * The compose mode of {@link Office.Item | Office.context.mailbox.item}.
      * 
-     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
+     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. 
+     * You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
      */
     export interface ItemCompose extends Item {
         /**
@@ -1999,16 +2217,20 @@ export declare namespace Office {
          * 
          * `addFileAttachmentAsync(uri: string, attachmentName: string, options: Office.AsyncContextOptions): void;`
          * 
-         * `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+         * `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;`
          *
          * @param uri - The URI that provides the location of the file to attach to the message or appointment. The maximum length is 2048 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         *        isInline: If true, indicates that the attachment will be shown inline in the message body, and should not be displayed in the attachment list.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type asyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         *        isInline: If true, indicates that the attachment will be shown inline in the message body, and should not be displayed in the 
+         *        attachment list.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type asyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of 
+         *                 the error.
          */
-        addFileAttachmentAsync(uri: string, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        addFileAttachmentAsync(uri: string, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;
         /**
          * Adds a file to a message or appointment as an attachment.
          *
@@ -2049,7 +2271,8 @@ export declare namespace Office {
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         *        isInline: If true, indicates that the attachment will be shown inline in the message body, and should not be displayed in the attachment list.
+         *        isInline: If true, indicates that the attachment will be shown inline in the message body, and should not be displayed in the 
+         *        attachment list.
          */
         addFileAttachmentAsync(uri: string, attachmentName: string, options: Office.AsyncContextOptions): void;
         /**
@@ -2070,18 +2293,25 @@ export declare namespace Office {
          *
          * @param uri - The URI that provides the location of the file to attach to the message or appointment. The maximum length is 2048 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type asyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of 
+         *                 the error.
          */
-        addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;
+        addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;
 
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the 
+         * callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -2092,29 +2322,36 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>NumberOfAttachmentsExceeded - The message or appointment has too many attachments.</td></tr></table>
          * 
-         * In addition to the main signature, this method also has these signatures:
+         * In addition to this signature, this method also has the following signatures:
          * 
          * `addItemAttachmentAsync(itemId: any, attachmentName: string): void;`
          * 
          * `addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;`
          * 
-         * `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+         * `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;`
          *
          * @param itemId - The Exchange identifier of the item to attach. The maximum length is 100 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
          * @param options - An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of 
+         *                 the error.
          */
-        addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the 
+         * callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -2132,11 +2369,15 @@ export declare namespace Office {
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the 
+         * callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -2156,11 +2397,15 @@ export declare namespace Office {
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the 
+         * callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -2173,15 +2418,20 @@ export declare namespace Office {
          *
          * @param itemId - The Exchange identifier of the item to attach. The maximum length is 100 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of 
+         *                 the error.
          */
-        addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;
+        addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;
         /**
          * Asynchronously returns selected data from the subject or body of a message.
          *
-         * If there is no selection but the cursor is in the body or subject, the method returns null for the selected data. If a field other than the body or subject is selected, the method returns the InvalidSelection error.
+         * If there is no selection but the cursor is in the body or subject, the method returns null for the selected data. 
+         * If a field other than the body or subject is selected, the method returns the InvalidSelection error.
          *
-         * To access the selected data from the callback method, call asyncResult.value.data. To access the source property that the selection comes from, call asyncResult.value.sourceProperty, which will be either body or subject.
+         * To access the selected data from the callback method, call asyncResult.value.data. To access the source property that the selection comes 
+         * from, call asyncResult.value.sourceProperty, which will be either body or subject.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -2194,16 +2444,20 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose</td></tr></table>
          *
-         * @param coercionType - Requests a format for the data. If Text, the method returns the plain text as a string , removing any HTML tags present. If HTML, the method returns the selected text, whether it is plaintext or HTML.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param coercionType - Requests a format for the data. If Text, the method returns the plain text as a string , removing any HTML tags present. 
+         *                     If HTML, the method returns the selected text, whether it is plaintext or HTML.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          */
-        getSelectedDataAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult) => void): void;
+        getSelectedDataAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult<any>) => void): void;
         /**
          * Asynchronously returns selected data from the subject or body of a message.
          *
-         * If there is no selection but the cursor is in the body or subject, the method returns null for the selected data. If a field other than the body or subject is selected, the method returns the InvalidSelection error.
+         * If there is no selection but the cursor is in the body or subject, the method returns null for the selected data. 
+         * If a field other than the body or subject is selected, the method returns the InvalidSelection error.
          *
-         * To access the selected data from the callback method, call asyncResult.value.data. To access the source property that the selection comes from, call asyncResult.value.sourceProperty, which will be either body or subject.
+         * To access the selected data from the callback method, call asyncResult.value.data. 
+         * To access the source property that the selection comes from, call asyncResult.value.sourceProperty, which will be either body or subject.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -2216,16 +2470,22 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose</td></tr></table>
          *
-         * @param coercionType - Requests a format for the data. If Text, the method returns the plain text as a string , removing any HTML tags present. If HTML, the method returns the selected text, whether it is plaintext or HTML.
+         * @param coercionType - Requests a format for the data. If Text, the method returns the plain text as a string, removing any HTML tags present. 
+         *                     If HTML, the method returns the selected text, whether it is plaintext or HTML.
          * @param options - An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          */
-        getSelectedDataAsync(coerciontype: Office.CoercionType, options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;
+        getSelectedDataAsync(coerciontype: Office.CoercionType, options: Office.AsyncContextOptions, callback: (result: AsyncResult<any>) => void): void;
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -2243,18 +2503,24 @@ export declare namespace Office {
          * 
          * `removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;`
          * 
-         * `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;`
+         * `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;`
          *
          * @param attachmentIndex - The identifier of the attachment to remove. The maximum length of the string is 100 characters.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. 
+         *                 If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
          */
-        removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -2272,7 +2538,11 @@ export declare namespace Office {
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -2292,7 +2562,11 @@ export declare namespace Office {
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -2305,13 +2579,17 @@ export declare namespace Office {
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
          * @param attachmentIndex - The identifier of the attachment to remove. The maximum length of the string is 100 characters.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type {@link Offfice.AsyncResult}. 
+         *                 If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
          */
-        removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;
+        removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;
         /**
          * Asynchronously inserts data into the body or subject of a message.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is 
+         * selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. 
+         * After insertion, the cursor is placed at the end of the inserted content.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -2329,19 +2607,29 @@ export declare namespace Office {
          * 
          * `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`
          * 
-         * `setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;`
+         * `setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;`
          *
-         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
+         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. 
+         *             If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         *        coercionType: If text, the current style is applied in Outlook Web App and Outlook. If the field is an HTML editor, only the text data is inserted, even if the data is HTML. If html and the field supports HTML (the subject doesn't), the current style is applied in Outlook Web App and the default style is applied in Outlook. If the field is a text field, an InvalidDataFormat error is returned. If coercionType is not set, the result depends on the field: if the field is HTML then HTML is used; if the field is text, then plain text is used.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         *        coercionType: If text, the current style is applied in Outlook Web App and Outlook. 
+         *        If the field is an HTML editor, only the text data is inserted, even if the data is HTML. 
+         *        If html and the field supports HTML (the subject doesn't), the current style is applied in Outlook Web App and the default style is 
+         *        applied in Outlook. 
+         *        If the field is a text field, an InvalidDataFormat error is returned. 
+         *        If coercionType is not set, the result depends on the field: if the field is HTML then HTML is used; 
+         *        if the field is text, then plain text is used.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. 
          */
-        setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult) => void): void;
+        setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Asynchronously inserts data into the body or subject of a message.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is 
+         * selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. 
+         * After insertion, the cursor is placed at the end of the inserted content.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -2353,13 +2641,16 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
-         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
+         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. 
+         *             If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
          */
         setSelectedDataAsync(data: string): void;
         /**
          * Asynchronously inserts data into the body or subject of a message.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is 
+         * selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. 
+         * After insertion, the cursor is placed at the end of the inserted content.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -2371,16 +2662,25 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
-         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
+         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. 
+         *             If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         *        coercionType: If text, the current style is applied in Outlook Web App and Outlook. If the field is an HTML editor, only the text data is inserted, even if the data is HTML. If html and the field supports HTML (the subject doesn't), the current style is applied in Outlook Web App and the default style is applied in Outlook. If the field is a text field, an InvalidDataFormat error is returned. If coercionType is not set, the result depends on the field: if the field is HTML then HTML is used; if the field is text, then plain text is used.
+         *        coercionType: If text, the current style is applied in Outlook Web App and Outlook. 
+         *        If the field is an HTML editor, only the text data is inserted, even if the data is HTML. 
+         *        If html and the field supports HTML (the subject doesn't), the current style is applied in Outlook Web App and the default style is 
+         *        applied in Outlook. 
+         *        If the field is a text field, an InvalidDataFormat error is returned. 
+         *        If coercionType is not set, the result depends on the field: if the field is HTML then HTML is used; 
+         *        if the field is text, then plain text is used.
          */
         setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;
         /**
          * Asynchronously inserts data into the body or subject of a message.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is 
+         * selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. 
+         * After insertion, the cursor is placed at the end of the inserted content.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -2392,19 +2692,22 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
-         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. 
+         *             If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. 
          */
-        setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;
+        setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;
     }
     /**
      * The read mode of {@link Office.Item | Office.context.mailbox.item}.
      * 
-     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
+     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. 
+     * You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
      */
     export interface ItemRead extends Item {
         /**
-         * Gets an array of attachments for the item.
+         * Gets the item's attachments as an array.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -2413,7 +2716,9 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Read</td></tr></table>
          *
-         * Note: Certain types of files are blocked by Outlook due to potential security issues and are therefore not returned. For more information, see {@link https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519 | Blocked attachments in Outlook}.
+         * Note: Certain types of files are blocked by Outlook due to potential security issues and are therefore not returned. 
+         * For more information, see 
+         * {@link https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519 | Blocked attachments in Outlook}.
          *
          */
         attachments: Office.AttachmentDetails[];
@@ -2421,7 +2726,8 @@ export declare namespace Office {
          * Gets the Exchange Web Services item class of the selected item.
          *
          *
-         * You can create custom message classes that extends a default message class, for example, a custom appointment message class IPM.Appointment.Contoso.
+         * You can create custom message classes that extends a default message class, for example, a custom appointment message class 
+         * IPM.Appointment.Contoso.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -2431,7 +2737,8 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Read</td></tr></table>
          * 
-         * The itemClass property specifies the message class of the selected item. The following are the default message classes for the message or appointment item.
+         * The itemClass property specifies the message class of the selected item. The following are the default message classes for the message or 
+         * appointment item.
          * 
          * <table>
          *   <tr>
@@ -2455,9 +2762,14 @@ export declare namespace Office {
         /**
          * Gets the Exchange Web Services item identifier for the current item.
          *
-         * The itemId property is not available in compose mode. If an item identifier is required, the saveAsync method can be used to save the item to the store, which will return the item identifier in the AsyncResult.value parameter in the callback function.
+         * The itemId property is not available in compose mode. 
+         * If an item identifier is required, the saveAsync method can be used to save the item to the store, which will return the item identifier 
+         * in the AsyncResult.value parameter in the callback function.
          *
-         * Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more details, see Use the Outlook REST APIs from an Outlook add-in.
+         * Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. 
+         * The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. 
+         * Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. 
+         * For more details, see {@link https://docs.microsoft.com/outlook/add-ins/use-rest-api#get-the-item-id | Use the Outlook REST APIs from an Outlook add-in}.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -2471,7 +2783,8 @@ export declare namespace Office {
         /**
          * Gets the subject of an item, with all prefixes removed (including RE: and FWD:).
          *
-         * The normalizedSubject property gets the subject of the item, with any standard prefixes (such as RE: and FW:) that are added by email programs. To get the subject of the item with the prefixes intact, use the subject property.
+         * The normalizedSubject property gets the subject of the item, with any standard prefixes (such as RE: and FW:) that are added by 
+         * email programs. To get the subject of the item with the prefixes intact, use the subject property.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -2499,13 +2812,16 @@ export declare namespace Office {
          */
         subject: string;
         /**
-         * Displays a reply form that includes the sender and all recipients of the selected message or the organizer and all attendees of the selected appointment.
+         * Displays a reply form that includes the sender and all recipients of the selected message or the organizer and all attendees of the 
+         * selected appointment.
          *
          * In Outlook Web App, the reply form is displayed as a pop-out form in the 3-column view and a pop-up form in the 2- or 1-column view.
          *
          * If any of the string parameters exceed their limits, displayReplyAllForm throws an exception.
          *
-         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. If this isn't possible, then no error message is thrown.
+         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and 
+         * attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. 
+         * If this isn't possible, then no error message is thrown.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -2528,7 +2844,9 @@ export declare namespace Office {
          *
          * If any of the string parameters exceed their limits, displayReplyForm throws an exception.
          *
-         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. If this isn't possible, then no error message is thrown.
+         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and 
+         * attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. 
+         * If this isn't possible, then no error message is thrown.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -2546,7 +2864,7 @@ export declare namespace Office {
          */
         displayReplyForm(formData: string | ReplyFormData): void;
         /**
-         * Gets the entities found in the selected item.
+         * Gets the entities found in the selected item's body.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -2560,7 +2878,7 @@ export declare namespace Office {
          */
         getEntities(): Entities;
         /**
-         * Gets an array of all the entities of the specified entity type found in the selected item.
+         * Gets an array of all the entities of the specified entity type found in the selected item's body.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -2569,14 +2887,17 @@ export declare namespace Office {
          * @param entityType - One of the EntityType enumeration values.
          *
          * @returns
-         * If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. If no entities of the specified type are present on the item, the method returns an empty array. Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter.
+         * If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. 
+         * If no entities of the specified type are present in the item's body, the method returns an empty array. 
+         * Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter.
          *
          * @remarks
          * <table><tr><td>{@link https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions | Minimum permission level}</td><td>Restricted</td></tr>
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Read</td></tr></table>
          * 
-         * While the minimum permission level to use this method is Restricted, some entity types require ReadItem to access, as specified in the following table.
+         * While the minimum permission level to use this method is Restricted, some entity types require ReadItem to access, as specified in the 
+         * following table.
          * 
          * <table>
          *   <tr>
@@ -2625,7 +2946,8 @@ export declare namespace Office {
         /**
          * Returns well-known entities in the selected item that pass the named filter defined in the manifest XML file.
          *
-         * The getFilteredEntitiesByName method returns the entities that match the regular expression defined in the ItemHasKnownEntity rule element in the manifest XML file with the specified FilterName element value.
+         * The getFilteredEntitiesByName method returns the entities that match the regular expression defined in the ItemHasKnownEntity rule element 
+         * in the manifest XML file with the specified FilterName element value.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -2638,22 +2960,33 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Read</td></tr></table>
          *
          * @param name - The name of the ItemHasKnownEntity rule element that defines the filter to match.
-         * @returns If there is no ItemHasKnownEntity element in the manifest with a FilterName element value that matches the name parameter, the method returns null. If the name parameter does match an ItemHasKnownEntity element in the manifest, but there are no entities in the current item that match, the method return an empty array.
+         * @returns If there is no ItemHasKnownEntity element in the manifest with a FilterName element value that matches the name parameter, 
+         * the method returns null. 
+         * If the name parameter does match an ItemHasKnownEntity element in the manifest, but there are no entities in the current item that match, 
+         * the method return an empty array.
          */
         getFilteredEntitiesByName(name: string): (string | Contact | MeetingSuggestion | PhoneNumber | TaskSuggestion)[];
         /**
          * Returns string values in the selected item that match the regular expressions defined in the manifest XML file.
          *
-         * The getRegExMatches method returns the strings that match the regular expression defined in each ItemHasRegularExpressionMatch or ItemHasKnownEntity rule element in the manifest XML file. For an ItemHasRegularExpressionMatch rule, a matching string has to occur in the property of the item that is specified by that rule. The PropertyName simple type defines the supported properties.
+         * The getRegExMatches method returns the strings that match the regular expression defined in each ItemHasRegularExpressionMatch or 
+         * ItemHasKnownEntity rule element in the manifest XML file. 
+         * For an ItemHasRegularExpressionMatch rule, a matching string has to occur in the property of the item that is specified by that rule. 
+         * The PropertyName simple type defines the supported properties.
          *
-         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body and should not attempt to return the entire body of the item. Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results. Instead, use the Body.getAsync method to retrieve the entire body.
+         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body 
+         * and should not attempt to return the entire body of the item. 
+         * Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results. 
+         * Instead, use the Body.getAsync method to retrieve the entire body.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
          * [Api set: Mailbox 1.0]
          *
          * @returns
-         * An object that contains arrays of strings that match the regular expressions defined in the manifest XML file. The name of each array is equal to the corresponding value of the RegExName attribute of the matching ItemHasRegularExpressionMatch rule or the FilterName attribute of the matching ItemHasKnownEntity rule.
+         * An object that contains arrays of strings that match the regular expressions defined in the manifest XML file. 
+         * The name of each array is equal to the corresponding value of the RegExName attribute of the matching ItemHasRegularExpressionMatch rule 
+         * or the FilterName attribute of the matching ItemHasKnownEntity rule.
          *
          * @remarks
          *
@@ -2665,9 +2998,12 @@ export declare namespace Office {
         /**
          * Returns string values in the selected item that match the named regular expression defined in the manifest XML file.
          *
-         * The getRegExMatchesByName method returns the strings that match the regular expression defined in the ItemHasRegularExpressionMatch rule element in the manifest XML file with the specified RegExName element value.
+         * The getRegExMatchesByName method returns the strings that match the regular expression defined in the ItemHasRegularExpressionMatch rule 
+         * element in the manifest XML file with the specified RegExName element value.
          *
-         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body and should not attempt to return the entire body of the item. Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results.
+         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body 
+         * and should not attempt to return the entire body of the item. 
+         * Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -2689,15 +3025,19 @@ export declare namespace Office {
     /**
      * A subclass of {@link Office.Item} for messages.
      * 
-     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
+     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. 
+     * You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
      */
     export interface Message extends Item {
         /**
          * Gets an identifier for the email conversation that contains a particular message.
          *
-         * You can get an integer for this property if your mail app is activated in read forms or responses in compose forms. If subsequently the user changes the subject of the reply message, upon sending the reply, the conversation ID for that message will change and that value you obtained earlier will no longer apply.
+         * You can get an integer for this property if your mail app is activated in read forms or responses in compose forms. 
+         * If subsequently the user changes the subject of the reply message, upon sending the reply, the conversation ID for that message will 
+         * change and that value you obtained earlier will no longer apply.
          *
-         * You get null for this property for a new item in a compose form. If the user sets a subject and saves the item, the conversationId property will return a value.
+         * You get null for this property for a new item in a compose form. 
+         * If the user sets a subject and saves the item, the conversationId property will return a value.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -2713,7 +3053,8 @@ export declare namespace Office {
      /**
      * The message compose mode of {@link Office.Item | Office.context.mailbox.item}.
      * 
-     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
+     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. 
+     * You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
      */
     export interface MessageCompose extends Message, ItemCompose {
         /**
@@ -2741,9 +3082,11 @@ export declare namespace Office {
          */
         body: Office.Body;
         /**
-         * Provides access to the Cc (carbon copy) recipients of a message. The type of object and level of access depends on the mode of the current item.
+         * Provides access to the Cc (carbon copy) recipients of a message. The type of object and level of access depends on the mode of the 
+         * current item.
          *
-         * The cc property returns a {@link Office.Recipients} object that provides methods to get or update the recipients on the Cc line of the message.
+         * The cc property returns a {@link Office.Recipients} object that provides methods to get or update the recipients on the Cc line of 
+         * the message.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -2757,9 +3100,12 @@ export declare namespace Office {
         /**
          * Gets an identifier for the email conversation that contains a particular message.
          *
-         * You can get an integer for this property if your mail app is activated in read forms or responses in compose forms. If subsequently the user changes the subject of the reply message, upon sending the reply, the conversation ID for that message will change and that value you obtained earlier will no longer apply.
+         * You can get an integer for this property if your mail app is activated in read forms or responses in compose forms. 
+         * If subsequently the user changes the subject of the reply message, upon sending the reply, the conversation ID for that message will change 
+         * and that value you obtained earlier will no longer apply.
          *
-         * You get null for this property for a new item in a compose form. If the user sets a subject and saves the item, the conversationId property will return a value.
+         * You get null for this property for a new item in a compose form. 
+         * If the user sets a subject and saves the item, the conversationId property will return a value.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -2799,7 +3145,8 @@ export declare namespace Office {
         /**
          * Gets the type of item that an instance represents.
          *
-         * The itemType property returns one of the ItemType enumeration values, indicating whether the item object instance is a message or an appointment.
+         * The itemType property returns one of the ItemType enumeration values, indicating whether the item object instance is a message or 
+         * an appointment.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -2827,7 +3174,8 @@ export declare namespace Office {
          */
         subject: Subject;
         /**
-         * Provides access to the recipients on the To line of a message. The type of object and level of access depends on the mode of the current item.
+         * Provides access to the recipients on the To line of a message. The type of object and level of access depends on the mode of the 
+         * current item.
          *
          * The to property returns a Recipients object that provides methods to get or update the recipients on the To line of the message.
          *
@@ -2863,16 +3211,20 @@ export declare namespace Office {
          * 
          * `addFileAttachmentAsync(uri: string, attachmentName: string, options: AsyncContextOptions): void;`
          * 
-         * `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+         * `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;`
          *
          * @param uri - The URI that provides the location of the file to attach to the message or appointment. The maximum length is 2048 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         *        isInline: If true, indicates that the attachment will be shown inline in the message body, and should not be displayed in the attachment list.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type asyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         *        isInline: If true, indicates that the attachment will be shown inline in the message body, and should not be displayed in the 
+         *        attachment list.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of 
+         *                 the error.
          */
-        addFileAttachmentAsync(uri: string, attachmentName: string, options?: AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        addFileAttachmentAsync(uri: string, attachmentName: string, options?: AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;
         /**
          * Adds a file to a message or appointment as an attachment.
          *
@@ -2913,7 +3265,7 @@ export declare namespace Office {
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         *        isInline: If true, indicates that the attachment will be shown inline in the message body, and should not be displayed in the attachment list.
+         *        isInline: If true, indicates that the attachment will be shown inline in the message body and should not be displayed in the attachment list.
          */
         addFileAttachmentAsync(uri: string, attachmentName: string, options: AsyncContextOptions): void;
         /**
@@ -2934,17 +3286,24 @@ export declare namespace Office {
          *
          * @param uri - The URI that provides the location of the file to attach to the message or appointment. The maximum length is 2048 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type asyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of 
+         *                 the error.
          */
-        addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;
+        addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the 
+         * callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -2955,29 +3314,36 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>NumberOfAttachmentsExceeded - The message or appointment has too many attachments.</td></tr></table>
          * 
-         * In addition to the main signature, this method also has these signatures:
+         * In addition to this signature, this method also has the following signatures:
          * 
          * `addItemAttachmentAsync(itemId: any, attachmentName: string): void;`
          * 
          * `addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;`
          * 
-         * `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+         * `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;`
          *
          * @param itemId - The Exchange identifier of the item to attach. The maximum length is 100 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
          * @param options - An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of 
+         *                 the error.
          */
-        addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. 
+         * You can use the options parameter to pass state information to the callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -2995,11 +3361,15 @@ export declare namespace Office {
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. 
+         * You can use the options parameter to pass state information to the callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -3019,11 +3389,15 @@ export declare namespace Office {
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. 
+         * You can use the options parameter to pass state information to the callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -3036,15 +3410,20 @@ export declare namespace Office {
          *
          * @param itemId - The Exchange identifier of the item to attach. The maximum length is 100 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of 
+         *                 the error.
          */
-        addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;
+        addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;
         /**
          * Asynchronously returns selected data from the subject or body of a message.
          *
-         * If there is no selection but the cursor is in the body or subject, the method returns null for the selected data. If a field other than the body or subject is selected, the method returns the InvalidSelection error.
+         * If there is no selection but the cursor is in the body or subject, the method returns null for the selected data. 
+         * If a field other than the body or subject is selected, the method returns the InvalidSelection error.
          *
-         * To access the selected data from the callback method, call asyncResult.value.data. To access the source property that the selection comes from, call asyncResult.value.sourceProperty, which will be either body or subject.
+         * To access the selected data from the callback method, call asyncResult.value.data. 
+         * To access the source property that the selection comes from, call asyncResult.value.sourceProperty, which will be either body or subject.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -3057,16 +3436,20 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Message Compose</td></tr></table>
          *
-         * @param coercionType - Requests a format for the data. If Text, the method returns the plain text as a string , removing any HTML tags present. If HTML, the method returns the selected text, whether it is plaintext or HTML.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param coercionType - Requests a format for the data. If Text, the method returns the plain text as a string, removing any HTML tags present. 
+         *                     If HTML, the method returns the selected text, whether it is plaintext or HTML.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          */
-        getSelectedDataAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult) => void): void;
+        getSelectedDataAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult<any>) => void): void;
         /**
          * Asynchronously returns selected data from the subject or body of a message.
          *
-         * If there is no selection but the cursor is in the body or subject, the method returns null for the selected data. If a field other than the body or subject is selected, the method returns the InvalidSelection error.
+         * If there is no selection but the cursor is in the body or subject, the method returns null for the selected data. 
+         * If a field other than the body or subject is selected, the method returns the InvalidSelection error.
          *
-         * To access the selected data from the callback method, call asyncResult.value.data. To access the source property that the selection comes from, call asyncResult.value.sourceProperty, which will be either body or subject.
+         * To access the selected data from the callback method, call asyncResult.value.data. 
+         * To access the source property that the selection comes from, call asyncResult.value.sourceProperty, which will be either body or subject.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -3079,18 +3462,24 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Message Compose</td></tr></table>
          *
-         * @param coercionType - Requests a format for the data. If Text, the method returns the plain text as a string , removing any HTML tags present. If HTML, the method returns the selected text, whether it is plaintext or HTML.
+         * @param coercionType - Requests a format for the data. If Text, the method returns the plain text as a string, removing any HTML tags present. 
+         *                     If HTML, the method returns the selected text, whether it is plaintext or HTML.
          * @param options - An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          */
-        getSelectedDataAsync(coerciontype: Office.CoercionType, options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;
+        getSelectedDataAsync(coerciontype: Office.CoercionType, options: Office.AsyncContextOptions, callback: (result: AsyncResult<any>) => void): void;
         /**
          * Asynchronously loads custom properties for this add-in on the selected item.
          *
-         * Custom properties are stored as key/value pairs on a per-app, per-item basis. This method returns a CustomProperties object in the callback, which provides methods to access the custom properties specific to the current item and the current add-in. Custom properties are not encrypted on the item, so this should not be used as secure storage.
+         * Custom properties are stored as key/value pairs on a per-app, per-item basis. 
+         * This method returns a CustomProperties object in the callback, which provides methods to access the custom properties specific to the 
+         * current item and the current add-in. Custom properties are not encrypted on the item, so this should not be used as secure storage.
          *
-         * The custom properties are provided as a CustomProperties object in the asyncResult.value property. This object can be used to get, set, and remove custom properties from the item and save changes to the custom property set back to the server.
+         * The custom properties are provided as a CustomProperties object in the asyncResult.value property. 
+         * This object can be used to get, set, and remove custom properties from the item and save changes to the custom property set back to 
+         * the server.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -3100,14 +3489,20 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Message Compose</td></tr></table>
          *
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
-         * @param userContext - Optional. Developers can provide any object they wish to access in the callback function. This object can be accessed by the asyncResult.asyncContext property in the callback function.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
+         * @param userContext - Optional. Developers can provide any object they wish to access in the callback function. 
+         *                    This object can be accessed by the asyncResult.asyncContext property in the callback function.
          */
-        loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;
+        loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any): void;
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -3125,18 +3520,24 @@ export declare namespace Office {
          * 
          * `removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;`
          * 
-         * `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;`
+         * `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;`
          *
          * @param attachmentIndex - The identifier of the attachment to remove. The maximum length of the string is 100 characters.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. 
+         *                 If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
          */
-        removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -3154,7 +3555,11 @@ export declare namespace Office {
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -3174,7 +3579,11 @@ export declare namespace Office {
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -3187,13 +3596,17 @@ export declare namespace Office {
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
          * @param attachmentIndex - The identifier of the attachment to remove. The maximum length of the string is 100 characters.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. 
+         *                 If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
          */
-        removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;
+        removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;
         /**
          * Asynchronously inserts data into the body or subject of a message.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is 
+         * selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. 
+         * After insertion, the cursor is placed at the end of the inserted content.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -3211,19 +3624,28 @@ export declare namespace Office {
          * 
          * `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`
          * 
-         * `setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;`
+         * `setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;`
          *
-         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
+         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. 
+         *             If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         *        coercionType: If text, the current style is applied in Outlook Web App and Outlook. If the field is an HTML editor, only the text data is inserted, even if the data is HTML. If html and the field supports HTML (the subject doesn't), the current style is applied in Outlook Web App and the default style is applied in Outlook. If the field is a text field, an InvalidDataFormat error is returned. If coercionType is not set, the result depends on the field: if the field is HTML then HTML is used; if the field is text, then plain text is used.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         *        coercionType: If text, the current style is applied in Outlook Web App and Outlook. 
+         *        If the field is an HTML editor, only the text data is inserted, even if the data is HTML. 
+         *        If html and the field supports HTML (the subject doesn't), the current style is applied in Outlook Web App and the default style is 
+         *        applied in Outlook. If the field is a text field, an InvalidDataFormat error is returned. 
+         *        If coercionType is not set, the result depends on the field: if the field is HTML then HTML is used; 
+         *        if the field is text, then plain text is used.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          */
-        setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult) => void): void;
+        setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Asynchronously inserts data into the body or subject of a message.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is 
+         * selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. 
+         * After insertion, the cursor is placed at the end of the inserted content.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -3235,13 +3657,16 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
-         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
+         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. 
+         *             If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
          */
         setSelectedDataAsync(data: string): void;
         /**
          * Asynchronously inserts data into the body or subject of a message.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is 
+         * selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. 
+         * After insertion, the cursor is placed at the end of the inserted content.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -3253,16 +3678,24 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
-         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
+         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. 
+         *             If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         *        coercionType: If text, the current style is applied in Outlook Web App and Outlook. If the field is an HTML editor, only the text data is inserted, even if the data is HTML. If html and the field supports HTML (the subject doesn't), the current style is applied in Outlook Web App and the default style is applied in Outlook. If the field is a text field, an InvalidDataFormat error is returned. If coercionType is not set, the result depends on the field: if the field is HTML then HTML is used; if the field is text, then plain text is used.
+         *        coercionType: If text, the current style is applied in Outlook Web App and Outlook. 
+         *        If the field is an HTML editor, only the text data is inserted, even if the data is HTML. 
+         *        If html and the field supports HTML (the subject doesn't), the current style is applied in Outlook Web App and the default style is 
+         *        applied in Outlook. If the field is a text field, an InvalidDataFormat error is returned. 
+         *        If coercionType is not set, the result depends on the field: if the field is HTML then HTML is used; 
+         *        if the field is text, then plain text is used.
          */
         setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;
         /**
          * Asynchronously inserts data into the body or subject of a message.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is 
+         * selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. 
+         * After insertion, the cursor is placed at the end of the inserted content.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -3274,19 +3707,22 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
-         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. 
+         *             If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 typeOffice.AsyncResult.
          */
-        setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;
+        setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;
     }
     /**
      * The message read mode of {@link Office.Item | Office.context.mailbox.item}.
      * 
-     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of Office.context.mailbox.item. Refer to the Object Model pages for more information.
+     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. 
+     * You should treat this as a mode of Office.context.mailbox.item. Refer to the Object Model pages for more information.
      */
     export interface MessageRead extends Message, ItemRead {
         /**
-         * Gets an array of attachments for the item.
+         * Gets the item's attachments as an array.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -3296,7 +3732,9 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Message Read</td></tr></table>
          * 
-         * Note: Certain types of files are blocked by Outlook due to potential security issues and are therefore not returned. For more information, see {@link https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519 | Blocked attachments in Outlook}.
+         * Note: Certain types of files are blocked by Outlook due to potential security issues and are therefore not returned. 
+         * For more information, see 
+         * {@link https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519 | Blocked attachments in Outlook}.
          *
          */
         attachments: Office.AttachmentDetails[];
@@ -3313,9 +3751,11 @@ export declare namespace Office {
          */
         body: Office.Body;
         /**
-         * Provides access to the Cc (carbon copy) recipients of a message. The type of object and level of access depends on the mode of the current item.
+         * Provides access to the Cc (carbon copy) recipients of a message. The type of object and level of access depends on the mode of the 
+         * current item.
          *
-         * The cc property returns an array that contains an EmailAddressDetails object for each recipient listed on the Cc line of the message. The collection is limited to a maximum of 100 members.
+         * The cc property returns an array that contains an EmailAddressDetails object for each recipient listed on the Cc line of the message. 
+         * The collection is limited to a maximum of 100 members.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -3329,9 +3769,12 @@ export declare namespace Office {
         /**
          * Gets an identifier for the email conversation that contains a particular message.
          *
-         * You can get an integer for this property if your mail app is activated in read forms or responses in compose forms. If subsequently the user changes the subject of the reply message, upon sending the reply, the conversation ID for that message will change and that value you obtained earlier will no longer apply.
+         * You can get an integer for this property if your mail app is activated in read forms or responses in compose forms. 
+         * If subsequently the user changes the subject of the reply message, upon sending the reply, the conversation ID for that message will change 
+         * and that value you obtained earlier will no longer apply.
          *
-         * You get null for this property for a new item in a compose form. If the user sets a subject and saves the item, the conversationId property will return a value.
+         * You get null for this property for a new item in a compose form. 
+         * If the user sets a subject and saves the item, the conversationId property will return a value.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -3371,7 +3814,8 @@ export declare namespace Office {
         /**
          * Gets the email address of the sender of a message.
          *
-         * The from and sender properties represent the same person unless the message is sent by a delegate. In that case, the from property represents the delegator, and the sender property represents the delegate.
+         * The from and sender properties represent the same person unless the message is sent by a delegate. 
+         * In that case, the from property represents the delegator, and the sender property represents the delegate.
          *
          * Note: The recipientType property of the EmailAddressDetails object in the from property is undefined.
          * 
@@ -3401,7 +3845,8 @@ export declare namespace Office {
         /**
          * Gets the Exchange Web Services item class of the selected item.
          * 
-         * You can create custom message classes that extends a default message class, for example, a custom appointment message class IPM.Appointment.Contoso.
+         * You can create custom message classes that extends a default message class, for example, a custom appointment message class 
+         * IPM.Appointment.Contoso.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -3411,7 +3856,8 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Message Read</td></tr></table>
 		 
-         * The itemClass property specifies the message class of the selected item. The following are the default message classes for the message or appointment item.
+         * The itemClass property specifies the message class of the selected item. 
+         * The following are the default message classes for the message or appointment item.
          * 
          * <table>
          *   <tr>
@@ -3436,9 +3882,14 @@ export declare namespace Office {
         /**
          * Gets the Exchange Web Services item identifier for the current item.
          *
-         * The itemId property is not available in compose mode. If an item identifier is required, the saveAsync method can be used to save the item to the store, which will return the item identifier in the AsyncResult.value parameter in the callback function.
+         * The itemId property is not available in compose mode. 
+         * If an item identifier is required, the saveAsync method can be used to save the item to the store, which will return the item identifier 
+         * in the AsyncResult.value parameter in the callback function.
          *
-         * Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more details, see Use the Outlook REST APIs from an Outlook add-in.
+         * Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. 
+         * The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. 
+         * Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. 
+         * For more details, see {@link https://docs.microsoft.com/outlook/add-ins/use-rest-api#get-the-item-id | Use the Outlook REST APIs from an Outlook add-in}.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -3452,7 +3903,8 @@ export declare namespace Office {
         /**
          * Gets the type of item that an instance represents.
          *
-         * The itemType property returns one of the ItemType enumeration values, indicating whether the item object instance is a message or an appointment.
+         * The itemType property returns one of the ItemType enumeration values, indicating whether the item object instance is a message or 
+         * an appointment.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -3466,7 +3918,9 @@ export declare namespace Office {
         /**
          * Gets the subject of an item, with all prefixes removed (including RE: and FWD:).
          *
-         * The normalizedSubject property gets the subject of the item, with any standard prefixes (such as RE: and FW:) that are added by email programs. To get the subject of the item with the prefixes intact, use the subject property.
+         * The normalizedSubject property gets the subject of the item, with any standard prefixes (such as RE: and FW:) that are added by 
+         * email programs. 
+         * To get the subject of the item with the prefixes intact, use the subject property.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -3480,7 +3934,8 @@ export declare namespace Office {
         /**
          * Gets the email address of the sender of an email message.
          *
-         * The from and sender properties represent the same person unless the message is sent by a delegate. In that case, the from property represents the delegator, and the sender property represents the delegate.
+         * The from and sender properties represent the same person unless the message is sent by a delegate. 
+         * In that case, the from property represents the delegator, and the sender property represents the delegate.
          *
          * Note: The recipientType property of the EmailAddressDetails object in the sender property is undefined.
          *
@@ -3510,9 +3965,11 @@ export declare namespace Office {
          */
         subject: string;
         /**
-         * Provides access to the recipients on the To line of a message. The type of object and level of access depends on the mode of the current item.
+         * Provides access to the recipients on the To line of a message. The type of object and level of access depends on the mode of the 
+         * current item.
          *
-         * The to property returns an array that contains an EmailAddressDetails object for each recipient listed on the To line of the message. The collection is limited to a maximum of 100 members.
+         * The to property returns an array that contains an EmailAddressDetails object for each recipient listed on the To line of the message. 
+         * The collection is limited to a maximum of 100 members.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -3523,14 +3980,18 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Message Read</td></tr></table>
          */
         to: EmailAddressDetails[];
+
         /**
-         * Displays a reply form that includes the sender and all recipients of the selected message or the organizer and all attendees of the selected appointment.
+         * Displays a reply form that includes the sender and all recipients of the selected message or the organizer and all attendees of the 
+         * selected appointment.
          *
          * In Outlook Web App, the reply form is displayed as a pop-out form in the 3-column view and a pop-up form in the 2- or 1-column view.
          *
          * If any of the string parameters exceed their limits, displayReplyAllForm throws an exception.
          *
-         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. If this isn't possible, then no error message is thrown.
+         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and 
+         * attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. 
+         * If this isn't possible, then no error message is thrown.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -3553,7 +4014,9 @@ export declare namespace Office {
          *
          * If any of the string parameters exceed their limits, displayReplyForm throws an exception.
          *
-         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. If this isn't possible, then no error message is thrown.
+         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and 
+         * attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. 
+         * If this isn't possible, then no error message is thrown.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -3571,7 +4034,7 @@ export declare namespace Office {
          */
         displayReplyForm(formData: string | ReplyFormData): void;
         /**
-         * Gets the entities found in the selected item.
+         * Gets the entities found in the selected item's body.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -3585,7 +4048,7 @@ export declare namespace Office {
          */
         getEntities(): Entities;
         /**
-         * Gets an array of all the entities of the specified entity type found in the selected item.
+         * Gets an array of all the entities of the specified entity type found in the selected item's body.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -3594,7 +4057,9 @@ export declare namespace Office {
          * @param entityType - One of the EntityType enumeration values.
          * 
          * @returns
-         * If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. If no entities of the specified type are present on the item, the method returns an empty array. Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter.
+         * If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. 
+         * If no entities of the specified type are present in the item's body, the method returns an empty array. 
+         * Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter.
          *
          * @remarks
          * 
@@ -3602,7 +4067,8 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Read</td></tr></table>
          * 
-         * While the minimum permission level to use this method is Restricted, some entity types require ReadItem to access, as specified in the following table.
+         * While the minimum permission level to use this method is Restricted, some entity types require ReadItem to access, as specified in the 
+         * following table.
          * 
          * <table>
          *   <tr>
@@ -3651,7 +4117,8 @@ export declare namespace Office {
         /**
          * Returns well-known entities in the selected item that pass the named filter defined in the manifest XML file.
          *
-         * The getFilteredEntitiesByName method returns the entities that match the regular expression defined in the ItemHasKnownEntity rule element in the manifest XML file with the specified FilterName element value.
+         * The getFilteredEntitiesByName method returns the entities that match the regular expression defined in the ItemHasKnownEntity rule element 
+         * in the manifest XML file with the specified FilterName element value.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -3664,22 +4131,33 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Message Read</td></tr></table>
          *
          * @param name - The name of the ItemHasKnownEntity rule element that defines the filter to match.
-         * @returns If there is no ItemHasKnownEntity element in the manifest with a FilterName element value that matches the name parameter, the method returns null. If the name parameter does match an ItemHasKnownEntity element in the manifest, but there are no entities in the current item that match, the method return an empty array.
+         * @returns If there is no ItemHasKnownEntity element in the manifest with a FilterName element value that matches the name parameter, 
+         * the method returns null. 
+         * If the name parameter does match an ItemHasKnownEntity element in the manifest, but there are no entities in the current item that match, 
+         * the method return an empty array.
          */
         getFilteredEntitiesByName(name: string): (string | Contact | MeetingSuggestion | PhoneNumber | TaskSuggestion)[];
         /**
          * Returns string values in the selected item that match the regular expressions defined in the manifest XML file.
          *
-         * The getRegExMatches method returns the strings that match the regular expression defined in each ItemHasRegularExpressionMatch or ItemHasKnownEntity rule element in the manifest XML file. For an ItemHasRegularExpressionMatch rule, a matching string has to occur in the property of the item that is specified by that rule. The PropertyName simple type defines the supported properties.
+         * The getRegExMatches method returns the strings that match the regular expression defined in each ItemHasRegularExpressionMatch or 
+         * ItemHasKnownEntity rule element in the manifest XML file. 
+         * For an ItemHasRegularExpressionMatch rule, a matching string has to occur in the property of the item that is specified by that rule. 
+         * The PropertyName simple type defines the supported properties.
          *
-         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body and should not attempt to return the entire body of the item. Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results. Instead, use the Body.getAsync method to retrieve the entire body.
+         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body 
+         * and should not attempt to return the entire body of the item. 
+         * Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results. 
+         * Instead, use the Body.getAsync method to retrieve the entire body.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
          * [Api set: Mailbox 1.0]
          *
          * @returns
-         * An object that contains arrays of strings that match the regular expressions defined in the manifest XML file. The name of each array is equal to the corresponding value of the RegExName attribute of the matching ItemHasRegularExpressionMatch rule or the FilterName attribute of the matching ItemHasKnownEntity rule.
+         * An object that contains arrays of strings that match the regular expressions defined in the manifest XML file. 
+         * The name of each array is equal to the corresponding value of the RegExName attribute of the matching ItemHasRegularExpressionMatch rule 
+         * or the FilterName attribute of the matching ItemHasKnownEntity rule.
          *
          * @remarks
          *
@@ -3691,9 +4169,12 @@ export declare namespace Office {
         /**
          * Returns string values in the selected item that match the named regular expression defined in the manifest XML file.
          *
-         * The getRegExMatchesByName method returns the strings that match the regular expression defined in the ItemHasRegularExpressionMatch rule element in the manifest XML file with the specified RegExName element value.
+         * The getRegExMatchesByName method returns the strings that match the regular expression defined in the ItemHasRegularExpressionMatch rule 
+         * element in the manifest XML file with the specified RegExName element value.
          *
-         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body and should not attempt to return the entire body of the item. Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results.
+         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body 
+         * and should not attempt to return the entire body of the item. 
+         * Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -3714,9 +4195,13 @@ export declare namespace Office {
         /**
          * Asynchronously loads custom properties for this add-in on the selected item.
          *
-         * Custom properties are stored as key/value pairs on a per-app, per-item basis. This method returns a CustomProperties object in the callback, which provides methods to access the custom properties specific to the current item and the current add-in. Custom properties are not encrypted on the item, so this should not be used as secure storage.
+         * Custom properties are stored as key/value pairs on a per-app, per-item basis. 
+         * This method returns a CustomProperties object in the callback, which provides methods to access the custom properties specific to the 
+         * current item and the current add-in. Custom properties are not encrypted on the item, so this should not be used as secure storage.
          *
-         * The custom properties are provided as a CustomProperties object in the asyncResult.value property. This object can be used to get, set, and remove custom properties from the item and save changes to the custom property set back to the server.
+         * The custom properties are provided as a CustomProperties object in the asyncResult.value property. 
+         * This object can be used to get, set, and remove custom properties from the item and save changes to the custom property set back to 
+         * the server.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -3726,10 +4211,12 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Message Read</td></tr></table>
          *
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
-         * @param userContext - Optional. Developers can provide any object they wish to access in the callback function. This object can be accessed by the asyncResult.asyncContext property in the callback function.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
+         * @param userContext - Optional. Developers can provide any object they wish to access in the callback function. 
+         *                    This object can be accessed by the asyncResult.asyncContext property in the callback function.
          */
-        loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;
+        loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any): void;
     }
 
     /**
@@ -3791,11 +4278,13 @@ export declare namespace Office {
         /**
          * Gets the location of an appointment.
          *
-         * The getAsync method starts an asynchronous call to the Exchange server to get the location of an appointment. The location of the appointment is provided as a string in the asyncResult.value property.
+         * The getAsync method starts an asynchronous call to the Exchange server to get the location of an appointment. 
+         * The location of the appointment is provided as a string in the asyncResult.value property.
          *
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -3806,16 +4295,18 @@ export declare namespace Office {
          * 
          * In addition to this signature, the method also has the following signature:
          * 
-         * `getAsync(callback: (result: AsyncResult) => void): void;`
+         * `getAsync(callback: (result: AsyncResult<string>) => void): void;`
          * 
          */
-        getAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        getAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;
         /**
          * Gets the location of an appointment.
          *
-         * The getAsync method starts an asynchronous call to the Exchange server to get the location of an appointment. The location of the appointment is provided as a string in the asyncResult.value property.
+         * The getAsync method starts an asynchronous call to the Exchange server to get the location of an appointment. 
+         * The location of the appointment is provided as a string in the asyncResult.value property.
          *
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -3824,16 +4315,18 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose</td></tr></table>
          */
-        getAsync(callback: (result: AsyncResult) => void): void;
+        getAsync(callback: (result: AsyncResult<string>) => void): void;
         /**
          * Sets the location of an appointment.
          *
-         * The setAsync method starts an asynchronous call to the Exchange server to set the location of an appointment. Setting the location of an appointment overwrites the current location.
+         * The setAsync method starts an asynchronous call to the Exchange server to set the location of an appointment. 
+         * Setting the location of an appointment overwrites the current location.
          *
          * @param location - The location of the appointment. The string is limited to 255 characters.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.  If setting the location fails, the asyncResult.error property will contain an error code.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. If setting the location fails, the asyncResult.error property will contain an error code.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -3850,13 +4343,14 @@ export declare namespace Office {
          * 
          * `setAsync(location: string, options: Office.AsyncContextOptions): void;`
          * 
-         * `setAsync(location: string, callback: (result: AsyncResult) => void): void;`
+         * `setAsync(location: string, callback: (result: AsyncResult<void>) => void): void;`
          */
-        setAsync(location: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        setAsync(location: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Sets the location of an appointment.
          *
-         * The setAsync method starts an asynchronous call to the Exchange server to set the location of an appointment. Setting the location of an appointment overwrites the current location.
+         * The setAsync method starts an asynchronous call to the Exchange server to set the location of an appointment. 
+         * Setting the location of an appointment overwrites the current location.
          *
          * @param location - The location of the appointment. The string is limited to 255 characters.
          *
@@ -3873,7 +4367,8 @@ export declare namespace Office {
         /**
          * Sets the location of an appointment.
          *
-         * The setAsync method starts an asynchronous call to the Exchange server to set the location of an appointment. Setting the location of an appointment overwrites the current location.
+         * The setAsync method starts an asynchronous call to the Exchange server to set the location of an appointment. 
+         * Setting the location of an appointment overwrites the current location.
          *
          * @param location - The location of the appointment. The string is limited to 255 characters.
          * @param options - Optional. An object literal that contains one or more of the following properties.
@@ -3892,10 +4387,12 @@ export declare namespace Office {
         /**
          * Sets the location of an appointment.
          *
-         * The setAsync method starts an asynchronous call to the Exchange server to set the location of an appointment. Setting the location of an appointment overwrites the current location.
+         * The setAsync method starts an asynchronous call to the Exchange server to set the location of an appointment. 
+         * Setting the location of an appointment overwrites the current location.
          *
          * @param location - The location of the appointment. The string is limited to 255 characters.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.  If setting the location fails, the asyncResult.error property will contain an error code.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. If setting the location fails, the asyncResult.error property will contain an error code.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -3906,10 +4403,10 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>DataExceedsMaximumSize - The location parameter is longer than 255 characters.</td></tr></table>
          */
-        setAsync(location: string, callback: (result: AsyncResult) => void): void;
+        setAsync(location: string, callback: (result: AsyncResult<void>) => void): void;
     }
     /**
-     * Provides access to the Outlook add-in object model for Microsoft Outlook and Microsoft Outlook on the web.
+     * Provides access to the Outlook Add-in object model for Microsoft Outlook and Microsoft Outlook on the web.
      *
      * Namespaces:
      *
@@ -3932,11 +4429,18 @@ export declare namespace Office {
          * 
          * Contains the following members:
          * 
-         *  - hostName (string): A string that represents the name of the host application. It be one of the following values: Outlook, Mac Outlook, OutlookIOS, or OutlookWebApp.
+         *  - hostName (string): A string that represents the name of the host application. 
+         * It be one of the following values: Outlook, Mac Outlook, OutlookIOS, or OutlookWebApp.
          * 
-         *  - hostVersion (string): A string that represents the version of either the host application or the Exchange Server. If the mail add-in is running on the Outlook desktop client or Outlook for iOS, the hostVersion property returns the version of the host application, Outlook. In Outlook Web App, the property returns the version of the Exchange Server. An example is the string 15.0.468.0.
+         *  - hostVersion (string): A string that represents the version of either the host application or the Exchange Server. 
+         * If the mail add-in is running on the Outlook desktop client or Outlook for iOS, the hostVersion property returns the version of the 
+         * host application, Outlook. In Outlook Web App, the property returns the version of the Exchange Server. An example is the string 15.0.468.0.
          * 
-         *  - OWAView (string): A string that represents the current view of Outlook Web App. If the host application is not Outlook Web App, then accessing this property results in undefined. Outlook Web App has three views (OneColumn - displayed when the screen is narrow, TwoColumns - displayed when the screen is wider, and ThreeColumns - displayed when the screen is wide.) that correspond to the width of the screen and the window, and the number of columns that can be displayed.
+         *  - OWAView (MailboxEnums.OWAView or string): An enum (or string literal) that represents the current view of Outlook Web App. 
+         * If the host application is not Outlook Web App, then accessing this property results in undefined. 
+         * Outlook Web App has three views (OneColumn - displayed when the screen is narrow, TwoColumns - displayed when the screen is wider, 
+         * and ThreeColumns - displayed when the screen is wide) that correspond to the width of the screen and the window, and the number of columns 
+         * that can be displayed.
          *
          *  More information is under {@link Office.Diagnostics}. 
          *
@@ -3953,7 +4457,8 @@ export declare namespace Office {
          *
          * Your app must have the ReadItem permission specified in its manifest to call the ewsUrl member in read mode.
          *
-         * In compose mode you must call the saveAsync method before you can use the ewsUrl member. Your app must have ReadWriteItem permissions to call the saveAsync method.
+         * In compose mode you must call the saveAsync method before you can use the ewsUrl member. 
+         * Your app must have ReadWriteItem permissions to call the saveAsync method.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -3975,7 +4480,7 @@ export declare namespace Office {
          */
         item: Item & ItemCompose & ItemRead & MessageRead & MessageCompose & AppointmentRead & AppointmentCompose;
         /**
-         * Information about the user associated with the mailbox. This includes their account type, display name, email adddress, and time zone.
+         * Information about the user associated with the mailbox. This includes their account type, display name, email address, and time zone.
          * 
          * More information is under {@link Office.UserProfile}
          */
@@ -3983,9 +4488,15 @@ export declare namespace Office {
         /**
          * Gets a dictionary containing time information in local client time.
          *
-         * The dates and times used by a mail app for Outlook or Outlook Web App can use different time zones. Outlook uses the client computer time zone; Outlook Web App uses the time zone set on the Exchange Admin Center (EAC). You should handle date and time values so that the values you display on the user interface are always consistent with the time zone that the user expects.
+         * The dates and times used by a mail app for Outlook or Outlook Web App can use different time zones. 
+         * Outlook uses the client computer time zone; Outlook Web App uses the time zone set on the Exchange Admin Center (EAC). 
+         * You should handle date and time values so that the values you display on the user interface are always consistent with the time zone that 
+         * the user expects.
          *
-         * If the mail app is running in Outlook, the convertToLocalClientTime method will return a dictionary object with the values set to the client computer time zone. If the mail app is running in Outlook Web App, the convertToLocalClientTime method will return a dictionary object with the values set to the time zone specified in the EAC.
+         * If the mail app is running in Outlook, the convertToLocalClientTime method will return a dictionary object with the values set to the 
+         * client computer time zone. 
+         * If the mail app is running in Outlook Web App, the convertToLocalClientTime method will return a dictionary object with the values set to 
+         * the time zone specified in the EAC.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -4001,7 +4512,8 @@ export declare namespace Office {
         /**
          * Gets a Date object from a dictionary containing time information.
          *
-         * The convertToUtcClientTime method converts a dictionary containing a local date and time to a Date object with the correct values for the local date and time.
+         * The convertToUtcClientTime method converts a dictionary containing a local date and time to a Date object with the correct values for the 
+         * local date and time.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -4018,13 +4530,17 @@ export declare namespace Office {
         /**
          * Displays an existing calendar appointment.
          *
-         * The displayAppointmentForm method opens an existing calendar appointment in a new window on the desktop or in a dialog box on mobile devices.
+         * The displayAppointmentForm method opens an existing calendar appointment in a new window on the desktop or in a dialog box on 
+         * mobile devices.
          *
-         * In Outlook for Mac, you can use this method to display a single appointment that is not part of a recurring series, or the master appointment of a recurring series, but you cannot display an instance of the series. This is because in Outlook for Mac, you cannot access the properties (including the item ID) of instances of a recurring series.
+         * In Outlook for Mac, you can use this method to display a single appointment that is not part of a recurring series, or the 
+         * master appointment of a recurring series, but you cannot display an instance of the series. 
+         * This is because in Outlook for Mac, you cannot access the properties (including the item ID) of instances of a recurring series.
          *
          * In Outlook Web App, this method opens the specified form only if the body of the form is less than or equal to 32KB number of characters.
          *
-         * If the specified item identifier does not identify an existing appointment, a blank pane opens on the client computer or device, and no error message will be returned.
+         * If the specified item identifier does not identify an existing appointment, a blank pane opens on the client computer or device, and 
+         * no error message will be returned.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -4046,9 +4562,11 @@ export declare namespace Office {
          *
          * In Outlook Web App, this method opens the specified form only if the body of the form is less than or equal to 32 KB number of characters.
          *
-         * If the specified item identifier does not identify an existing message, no message will be displayed on the client computer, and no error message will be returned.
+         * If the specified item identifier does not identify an existing message, no message will be displayed on the client computer, and 
+         * no error message will be returned.
          *
-         * Do not use the displayMessageForm with an itemId that represents an appointment. Use the displayAppointmentForm method to display an existing appointment, and displayNewAppointmentForm to display a form to create a new appointment.
+         * Do not use the displayMessageForm with an itemId that represents an appointment. Use the displayAppointmentForm method to display 
+         * an existing appointment, and displayNewAppointmentForm to display a form to create a new appointment.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -4066,11 +4584,16 @@ export declare namespace Office {
         /**
          * Displays a form for creating a new calendar appointment.
          *
-         * The displayNewAppointmentForm method opens a form that enables the user to create a new appointment or meeting. If parameters are specified, the appointment form fields are automatically populated with the contents of the parameters.
+         * The displayNewAppointmentForm method opens a form that enables the user to create a new appointment or meeting. 
+         * If parameters are specified, the appointment form fields are automatically populated with the contents of the parameters.
          *
-         * In Outlook Web App and OWA for Devices, this method always displays a form with an attendees field. If you do not specify any attendees as input arguments, the method displays a form with a Save button. If you have specified attendees, the form would include the attendees and a Send button.
+         * In Outlook Web App and OWA for Devices, this method always displays a form with an attendees field. 
+         * If you do not specify any attendees as input arguments, the method displays a form with a Save button. 
+         * If you have specified attendees, the form would include the attendees and a Send button.
          *
-         * In the Outlook rich client and Outlook RT, if you specify any attendees or resources in the requiredAttendees, optionalAttendees, or resources parameter, this method displays a meeting form with a Send button. If you don't specify any recipients, this method displays an appointment form with a Save & Close button.
+         * In the Outlook rich client and Outlook RT, if you specify any attendees or resources in the requiredAttendees, optionalAttendees, or 
+         * resources parameter, this method displays a meeting form with a Send button. 
+         * If you don't specify any recipients, this method displays an appointment form with a Save & Close button.
          *
          * If any of the parameters exceed the specified size limits, or if an unknown parameter name is specified, an exception is thrown.
          *
@@ -4100,12 +4623,15 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose and read</td></tr></table>
          *
-         * The getUserIdentityTokenAsync method returns a token that you can use to identify and {@link https://docs.microsoft.com/outlook/add-ins/authentication | authenticate the add-in and user with a third-party system}.
+         * The getUserIdentityTokenAsync method returns a token that you can use to identify and 
+         * {@link https://docs.microsoft.com/outlook/add-ins/authentication | authenticate the add-in and user with a third-party system}.
          *
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
+         *                 The token is provided as a string in the asyncResult.value property.
          * @param userContext - Optional. Any state data that is passed to the asynchronous method.|
          */
-        getUserIdentityTokenAsync(callback: (result: AsyncResult) => void, userContext?: any): void;
+        getUserIdentityTokenAsync(callback: (result: AsyncResult<string>) => void, userContext?: any): void;
         /**
          * Makes an asynchronous request to an Exchange Web Services (EWS) service on the Exchange server that hosts the user's mailbox.
          *
@@ -4117,21 +4643,32 @@ export declare namespace Office {
          *
          * The XML request must specify UTF-8 encoding. \<?xml version="1.0" encoding="utf-8"?\>
          *
-         * Your add-in must have the ReadWriteMailbox permission to use the makeEwsRequestAsync method. For information about using the ReadWriteMailbox permission and the EWS operations that you can call with the makeEwsRequestAsync method, see Specify permissions for mail add-in access to the user's mailbox.
+         * Your add-in must have the ReadWriteMailbox permission to use the makeEwsRequestAsync method. 
+         * For information about using the ReadWriteMailbox permission and the EWS operations that you can call with the makeEwsRequestAsync method, 
+         * see {@link https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions | Specify permissions for mail add-in access to the user's mailbox}.
          *
-         * The XML result of the EWS call is provided as a string in the asyncResult.value property. If the result exceeds 1 MB in size, an error message is returned instead.
+         * The XML result of the EWS call is provided as a string in the asyncResult.value property. 
+         * If the result exceeds 1 MB in size, an error message is returned instead.
          *
-         * Note: This method is not supported in the following scenarios. - In Outlook for iOS or Outlook for Android - When the add-in is loaded in a Gmail mailbox
+         * Note: This method is not supported in the following scenarios:
+         * 
+         * - In Outlook for iOS or Outlook for Android.
+         * 
+         * - When the add-in is loaded in a Gmail mailbox.
          *
-         * Note: The server administrator must set OAuthAuthentication to true on the Client Access Server EWS directory to enable the makeEwsRequestAsync method to make EWS requests.
+         * Note: The server administrator must set OAuthAuthentication to true on the Client Access Server EWS directory to enable the 
+         * makeEwsRequestAsync method to make EWS requests.
          *
          * *Version differences*
          *
-         * When you use the makeEwsRequestAsync method in mail apps running in Outlook versions earlier than version 15.0.4535.1004, you should set the encoding value to ISO-8859-1.
+         * When you use the makeEwsRequestAsync method in mail apps running in Outlook versions earlier than version 15.0.4535.1004, you should set 
+         * the encoding value to ISO-8859-1.
          *
          * `<?xml version="1.0" encoding="iso-8859-1"?>`
          *
-         * You do not need to set the encoding value when your mail app is running in Outlook on the web. You can determine whether your mail app is running in Outlook or Outlook on the web by using the mailbox.diagnostics.hostName property. You can determine what version of Outlook is running by using the mailbox.diagnostics.hostVersion property.
+         * You do not need to set the encoding value when your mail app is running in Outlook on the web. 
+         * You can determine whether your mail app is running in Outlook or Outlook on the web by using the mailbox.diagnostics.hostName property. 
+         * You can determine what version of Outlook is running by using the mailbox.diagnostics.hostVersion property.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -4142,18 +4679,23 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose and read</td></tr></table>
          *
          * @param data - The EWS request.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult.
+         *                 The `value` property of the result is the XML of the EWS request provided as a string. 
+         *                 If the result exceeds 1 MB in size, an error message is returned instead.
          * @param userContext - Optional. Any state data that is passed to the asynchronous method.
          */
-        makeEwsRequestAsync(data: any, callback: (result: AsyncResult) => void, userContext?: any): void;
+        makeEwsRequestAsync(data: any, callback: (result: AsyncResult<string>) => void, userContext?: any): void;
     }
 
     /**
      * Represents a suggested meeting found in an item. Read mode only.
      *
-     * The list of meetings suggested in an email message is returned in the meetingSuggestions property of the Entities object that is returned when the getEntities or getEntitiesByType method is called on the active item.
+     * The list of meetings suggested in an email message is returned in the meetingSuggestions property of the Entities object that is returned when 
+     * the getEntities or getEntitiesByType method is called on the active item.
      *
-     * The start and end values are string representations of a Date object that contains the date and time at which the suggested meeting is to begin and end. The values are in the default time zone specified for the current user.
+     * The start and end values are string representations of a Date object that contains the date and time at which the suggested meeting is to 
+     * begin and end. 
+     * The values are in the default time zone specified for the current user.
      *
      * [Api set: Mailbox 1.0]
      *
@@ -4191,7 +4733,8 @@ export declare namespace Office {
     /**
      * Represents a phone number identified in an item. Read mode only.
      *
-     * An array of PhoneNumber objects containing the phone numbers found in an email message is returned in the phoneNumbers property of the Entities object that is returned when you call the getEntities method on the selected item.
+     * An array of PhoneNumber objects containing the phone numbers found in an email message is returned in the phoneNumbers property of the 
+     * Entities object that is returned when you call the getEntities method on the selected item.
      *
      * [Api set: Mailbox 1.0]
      *
@@ -4243,20 +4786,21 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>NumberOfRecipientsExceeded - The number of recipients exceeded 100 entries.</td></tr></table>
          * 
-         * In addition to the main signature, this method also has these signatures:
+         * In addition to this signature, this method also has the following signatures:
          * 
          * `addAsync(recipients: (string | EmailUser | EmailAddressDetails)[]): void;`
          * 
          * `addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options: Office.AsyncContextOptions): void;`
          * 
-         * `addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult) => void): void;`
+         * `addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult<void>) => void): void;`
          *
          * @param recipients - The recipients to add to the recipients list.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If adding the recipients fails, the asyncResult.error property will contain an error code.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. If adding the recipients fails, the asyncResult.error property will contain an error code.
          */
-        addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Adds a recipient list to the existing recipients for an appointment or message.
          *
@@ -4326,13 +4870,14 @@ export declare namespace Office {
          * <tr><td>Errors</td><td>NumberOfRecipientsExceeded - The number of recipients exceeded 100 entries.</td></tr></table>
          *
          * @param recipients - The recipients to add to the recipients list.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If adding the recipients fails, the asyncResult.error property will contain an error code.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. If adding the recipients fails, the asyncResult.error property will contain an error code.
          */
-        addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult) => void): void;
+        addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult<void>) => void): void;
         /**
          * Gets a recipient list for an appointment or message.
          *
-         * When the call completes, the asyncResult.value property will contain an array of{@link Office.EmailAddressDetails} objects.
+         * When the call completes, the asyncResult.value property will contain an array of {@link Office.EmailAddressDetails} objects.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -4341,15 +4886,17 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose</td></tr></table>
          * 
-         * In addition to the main signature, this method also has this signature:
+         * In addition to this signature, this method also has the following signature:
          * 
-         * `getAsync(callback: (result: AsyncResult) => void): void;`
+         * `getAsync(callback: (result: AsyncResult<Office.EmailAddressDetails[]>) => void): void;`
          *
          * @param options - An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
+         *                 The `value` property of the result is an array of EmailAddressDetails objects.
          */
-        getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;
+        getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult<Office.EmailAddressDetails[]>) => void): void;
         /**
          * Gets a recipient list for an appointment or message.
          *
@@ -4362,9 +4909,11 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose</td></tr></table>
          *
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
+         *                 The `value` property of the result is an array of EmailAddressDetails objects.
          */
-        getAsync(callback: (result: AsyncResult) => void): void;
+        getAsync(callback: (result: AsyncResult<Office.EmailAddressDetails[]>) => void): void;
         /**
          * Sets a recipient list for an appointment or message.
          *
@@ -4387,20 +4936,23 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>NumberOfRecipientsExceeded - The number of recipients exceeded 100 entries.</td></tr></table>
          * 
-         * In addition to the main signature, this method also has these signatures:
+         * In addition to this signature, this method also has the following signatures:
          * 
          * `setAsync(recipients: (string | EmailUser | EmailAddressDetails)[]): void;`
          * 
          * `setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options: Office.AsyncContextOptions): void;`
          * 
-         * `setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult) => void): void;`
+         * `setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult<void>) => void): void;`
          *
          * @param recipients - The recipients to add to the recipients list.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.  If setting the recipients fails the asyncResult.error property will contain a code that indicates any error that occurred while adding the data.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
+         *                 If setting the recipients fails the asyncResult.error property will contain a code that indicates any error that occurred 
+         *                 while adding the data.
          */
-        setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Sets a recipient list for an appointment or message.
          *
@@ -4476,9 +5028,12 @@ export declare namespace Office {
          * <tr><td>Errors</td><td>NumberOfRecipientsExceeded - The number of recipients exceeded 100 entries.</td></tr></table>
          *
          * @param recipients - The recipients to add to the recipients list.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.  If setting the recipients fails the asyncResult.error property will contain a code that indicates any error that occurred while adding the data.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. 
+         *                 If setting the recipients fails the asyncResult.error property will contain a code that indicates any error that occurred 
+         *                 while adding the data.
          */
-        setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult) => void): void;
+        setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult<void>) => void): void;
 
     }
 
@@ -4499,7 +5054,8 @@ export declare namespace Office {
          */
         url?: string;
         /**
-         * Only used if type is set to file. If true, indicates that the attachment will be shown inline in the message body, and should not be displayed in the attachment list.
+         * Only used if type is set to file. If true, indicates that the attachment will be shown inline in the message body, and should not be 
+         * displayed in the attachment list.
          */
         inLine?: boolean;
         /**
@@ -4521,20 +5077,27 @@ export declare namespace Office {
          */
         attachments?: ReplyFormAttachment[];
         /**
-         * When the reply display call completes, the function passed in the callback parameter is called with a single parameter, asyncResult, which is an AsyncResult object.
+         * When the reply display call completes, the function passed in the callback parameter is called with a single parameter, 
+         * asyncResult, which is an Office.AsyncResult object.
          */
-        callback?: (result: AsyncResult) => void;
+        callback?: (result: AsyncResult<any>) => void;
     }
     /**
-     * The settings created by using the methods of the RoamingSettings object are saved per add-in and per user. That is, they are available only to the add-in that created them, and only from the user's mail box in which they are saved.
+     * The settings created by using the methods of the RoamingSettings object are saved per add-in and per user. 
+     * That is, they are available only to the add-in that created them, and only from the user's mail box in which they are saved.
      *
-     * While the Outlook add-in API limits access to these settings to only the add-in that created them, these settings should not be considered secure storage. They can be accessed by Exchange Web Services or Extended MAPI. They should not be used to store sensitive information such as user credentials or security tokens.
+     * While the Outlook Add-in API limits access to these settings to only the add-in that created them, these settings should not be considered 
+     * secure storage. They can be accessed by Exchange Web Services or Extended MAPI. 
+     * They should not be used to store sensitive information such as user credentials or security tokens.
      *
      * The name of a setting is a String, while the value can be a String, Number, Boolean, null, Object, or Array.
      *
      * The RoamingSettings object is accessible via the roamingSettings property in the Office.context namespace.
      *
-     * Important: The RoamingSettings object is initialized from the persisted storage only when the add-in is first loaded. For task panes, this means that it is only initialized when the task pane first opens. If the task pane navigates to another page or reloads the current page, the in-memory object is reset to its initial values, even if your add-in has persisted changes. The persisted changes will not be available until the task pane is closed and reopened.
+     * Important: The RoamingSettings object is initialized from the persisted storage only when the add-in is first loaded. 
+     * For task panes, this means that it is only initialized when the task pane first opens. 
+     * If the task pane navigates to another page or reloads the current page, the in-memory object is reset to its initial values, even if 
+     * your add-in has persisted changes. The persisted changes will not be available until the task pane is closed and reopened.
      *
      * [Api set: Mailbox 1.0]
      *
@@ -4574,7 +5137,9 @@ export declare namespace Office {
         /**
          * Saves the settings.
          *
-         * Any settings previously saved by an add-in are loaded when it is initialized, so during the lifetime of the session you can just use the set and get methods to work with the in-memory copy of the settings property bag. When you want to persist the settings so that they are available the next time the add-in is used, use the saveAsync method.
+         * Any settings previously saved by an add-in are loaded when it is initialized, so during the lifetime of the session you can just use 
+         * the set and get methods to work with the in-memory copy of the settings property bag. 
+         * When you want to persist the settings so that they are available the next time the add-in is used, use the saveAsync method.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -4583,13 +5148,15 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          *
-         * @param callback - Optional? When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          */
-        saveAsync(callback?: (result: AsyncResult) => void): void;
+        saveAsync(callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Sets or creates the specified setting.
          *
-         * The set method creates a new setting of the specified name if it does not already exist, or sets an existing setting of the specified name. The value is stored in the document as the serialized JSON representation of its data type.
+         * The set method creates a new setting of the specified name if it does not already exist, or sets an existing setting of the specified name. 
+         * The value is stored in the document as the serialized JSON representation of its data type.
          *
          * A maximum of 32KB is available for the settings of each add-in.
          *
@@ -4607,6 +5174,7 @@ export declare namespace Office {
          */
         set(name: string, value: any): void;
     }
+    
     /**
      * Provides methods to get and set the subject of an appointment or message in an Outlook add-in.
      *
@@ -4630,17 +5198,20 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose</td></tr></table>
          * 
-         * In addition to the main signature, this method also has this signature:
+         * In addition to this signature, this method also has the following signature:
          * 
-         * `getAsync(callback: (result: AsyncResult) => void): void;`
+         * `getAsync(callback: (result: AsyncResult<string>) => void): void;`
          *
          * @param options - An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
+         *                 The `value` property of the result is the subject of the item.
          */
-        getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;
+        getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult<string>) => void): void;
         /**
          * Gets the subject of an appointment or message.
+         * 
          * The getAsync method starts an asynchronous call to the Exchange server to get the subject of an appointment or message.
          *
          * [Api set: Mailbox 1.1]
@@ -4651,12 +5222,14 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose</td></tr></table>
          *
          * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         *                  The `value` property of the result is the subject of the item.
          */
-        getAsync(callback: (result: AsyncResult) => void): void;
+        getAsync(callback: (result: AsyncResult<string>) => void): void;
         /**
          * Sets the subject of an appointment or message.
          *
-         * The setAsync method starts an asynchronous call to the Exchange server to set the subject of an appointment or message. Setting the subject overwrites the current subject, but leaves any prefixes, such as "Fwd:" or "Re:" in place.
+         * The setAsync method starts an asynchronous call to the Exchange server to set the subject of an appointment or message. 
+         * Setting the subject overwrites the current subject, but leaves any prefixes, such as "Fwd:" or "Re:" in place.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -4667,24 +5240,26 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>DataExceedsMaximumSize - The subject parameter is longer than 255 characters.</td></tr></table>
          * 
-         * In addition to the main signature, this method also has these signatures:
+         * In addition to this signature, this method also has the following signatures:
          * 
          * `setAsync(subject: string): void;`
          * 
          * `setAsync(subject: string, options: Office.AsyncContextOptions): void;`
          * 
-         * `setAsync(subject: string, callback: (result: AsyncResult) => void): void;`
+         * `setAsync(subject: string, callback: (result: AsyncResult<void>) => void): void;`
          *
          * @param subject - The subject of the appointment or message. The string is limited to 255 characters.
          * @param options - An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If setting the subject fails, the asyncResult.error property will contain an error code.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. If setting the subject fails, the asyncResult.error property will contain an error code.
          */
-        setAsync(subject: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        setAsync(subject: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Sets the subject of an appointment or message.
          *
-         * The setAsync method starts an asynchronous call to the Exchange server to set the subject of an appointment or message. Setting the subject overwrites the current subject, but leaves any prefixes, such as "Fwd:" or "Re:" in place.
+         * The setAsync method starts an asynchronous call to the Exchange server to set the subject of an appointment or message. 
+         * Setting the subject overwrites the current subject, but leaves any prefixes, such as "Fwd:" or "Re:" in place.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -4701,7 +5276,8 @@ export declare namespace Office {
         /**
          * Sets the subject of an appointment or message.
          *
-         * The setAsync method starts an asynchronous call to the Exchange server to set the subject of an appointment or message. Setting the subject overwrites the current subject, but leaves any prefixes, such as "Fwd:" or "Re:" in place.
+         * The setAsync method starts an asynchronous call to the Exchange server to set the subject of an appointment or message. 
+         * Setting the subject overwrites the current subject, but leaves any prefixes, such as "Fwd:" or "Re:" in place.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -4720,7 +5296,8 @@ export declare namespace Office {
         /**
          * Sets the subject of an appointment or message.
          *
-         * The setAsync method starts an asynchronous call to the Exchange server to set the subject of an appointment or message. Setting the subject overwrites the current subject, but leaves any prefixes, such as "Fwd:" or "Re:" in place.
+         * The setAsync method starts an asynchronous call to the Exchange server to set the subject of an appointment or message. 
+         * Setting the subject overwrites the current subject, but leaves any prefixes, such as "Fwd:" or "Re:" in place.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -4732,15 +5309,17 @@ export declare namespace Office {
          * <tr><td>Errors</td><td>DataExceedsMaximumSize - The subject parameter is longer than 255 characters.</td></tr></table>
          *
          * @param subject - The subject of the appointment or message. The string is limited to 255 characters.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If setting the subject fails, the asyncResult.error property will contain an error code.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. If setting the subject fails, the asyncResult.error property will contain an error code.
          */
-        setAsync(data: string, callback: (result: AsyncResult) => void): void;
+        setAsync(data: string, callback: (result: AsyncResult<void>) => void): void;
 
     }
     /**
      * Represents a suggested task identified in an item. Read mode only.
      *
-     * The list of tasks suggested in an email message is returned in the taskSuggestions property of the [Entities]Entities object that is returned when the getEntities or getEntitiesByType method is called on the active item.
+     * The list of tasks suggested in an email message is returned in the taskSuggestions property of the {@link Office.Entities | Entities} object 
+     * that is returned when the getEntities or getEntitiesByType method is called on the active item.
      *
      * [Api set: Mailbox 1.0]
      *
@@ -4773,7 +5352,8 @@ export declare namespace Office {
         /**
          * Gets the start or end time of an appointment.
          *
-         * The date and time is provided as a Date object in the asyncResult.value property. The value is in Coordinated Universal Time (UTC). You can convert the UTC time to the local client time by using the convertToLocalClientTime method.
+         * The date and time is provided as a Date object in the asyncResult.value property. The value is in Coordinated Universal Time (UTC). 
+         * You can convert the UTC time to the local client time by using the convertToLocalClientTime method.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -4782,19 +5362,21 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose</td></tr></table>
          * 
-         * In addition to the main signature, this method also has this signature:
+         * In addition to this signature, this method also has the following signature:
          * 
-         * `getAsync(callback: (result: AsyncResult) => void): void;`
+         * `getAsync(callback: (result: AsyncResult<Date>) => void): void;`
          *
          * @param options - An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
          * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         *                  The `value` property of the result is a Date object.
          */
-        getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;
+        getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult<Date>) => void): void;
         /**
          * Gets the start or end time of an appointment.
          *
-         * The date and time is provided as a Date object in the asyncResult.value property. The value is in Coordinated Universal Time (UTC). You can convert the UTC time to the local client time by using the convertToLocalClientTime method.
+         * The date and time is provided as a Date object in the asyncResult.value property. The value is in Coordinated Universal Time (UTC). 
+         * You can convert the UTC time to the local client time by using the convertToLocalClientTime method.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -4804,12 +5386,14 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose</td></tr></table>
          *
          * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         *                  The `value` property of the result is a Date object.
          */
-        getAsync(callback: (result: AsyncResult) => void): void;
+        getAsync(callback: (result: AsyncResult<Date>) => void): void;
         /**
          * Sets the start or end time of an appointment.
          *
-         * If the setAsync method is called on the start property, the end property will be adjusted to maintain the duration of the appointment as previously set. If the setAsync method is called on the end property, the duration of the appointment will be extended to the new end time.
+         * If the setAsync method is called on the start property, the end property will be adjusted to maintain the duration of the appointment as 
+         * previously set. If the setAsync method is called on the end property, the duration of the appointment will be extended to the new end time.
          *
          * The time must be in UTC; you can get the correct UTC time by using the convertToUtcClientTime method.
          *
@@ -4822,24 +5406,27 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>InvalidEndTime - The appointment end time is before the appointment start time.</td></tr></table>
          * 
-         * In addition to the main signature, this method also has these signatures:
+         * In addition to this signature, this method also has the following signatures:
          * 
          * `setAsync(dateTime: Date): void;`
          * 
          * `setAsync(dateTime: Date, options: Office.AsyncContextOptions): void;`
          * 
-         * `setAsync(dateTime: Date, callback: (result: AsyncResult) => void): void;`
+         * `setAsync(dateTime: Date, callback: (result: AsyncResult<void>) => void): void;`
          *
          * @param dateTime - A date-time object in Coordinated Universal Time (UTC).
          * @param options - An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If setting the date and time fails, the asyncResult.error property will contain an error code.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. 
+         *                 If setting the date and time fails, the asyncResult.error property will contain an error code.
          */
-        setAsync(dateTime: Date, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        setAsync(dateTime: Date, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Sets the start or end time of an appointment.
          *
-         * If the setAsync method is called on the start property, the end property will be adjusted to maintain the duration of the appointment as previously set. If the setAsync method is called on the end property, the duration of the appointment will be extended to the new end time.
+         * If the setAsync method is called on the start property, the end property will be adjusted to maintain the duration of the appointment as 
+         * previously set. If the setAsync method is called on the end property, the duration of the appointment will be extended to the new end time.
          *
          * The time must be in UTC; you can get the correct UTC time by using the convertToUtcClientTime method.
          *
@@ -4858,7 +5445,8 @@ export declare namespace Office {
         /**
          * Sets the start or end time of an appointment.
          *
-         * If the setAsync method is called on the start property, the end property will be adjusted to maintain the duration of the appointment as previously set. If the setAsync method is called on the end property, the duration of the appointment will be extended to the new end time.
+         * If the setAsync method is called on the start property, the end property will be adjusted to maintain the duration of the appointment as 
+         * previously set. If the setAsync method is called on the end property, the duration of the appointment will be extended to the new end time.
          *
          * The time must be in UTC; you can get the correct UTC time by using the convertToUtcClientTime method.
          *
@@ -4879,7 +5467,8 @@ export declare namespace Office {
         /**
          * Sets the start or end time of an appointment.
          *
-         * If the setAsync method is called on the start property, the end property will be adjusted to maintain the duration of the appointment as previously set. If the setAsync method is called on the end property, the duration of the appointment will be extended to the new end time.
+         * If the setAsync method is called on the start property, the end property will be adjusted to maintain the duration of the appointment as 
+         * previously set. If the setAsync method is called on the end property, the duration of the appointment will be extended to the new end time.
          *
          * The time must be in UTC; you can get the correct UTC time by using the convertToUtcClientTime method.
          *
@@ -4893,9 +5482,11 @@ export declare namespace Office {
          * <tr><td>Errors</td><td>InvalidEndTime - The appointment end time is before the appointment start time.</td></tr></table>
          *
          * @param dateTime - A date-time object in Coordinated Universal Time (UTC).
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If setting the date and time fails, the asyncResult.error property will contain an error code.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. 
+         *                 If setting the date and time fails, the asyncResult.error property will contain an error code.
          */
-        setAsync(dateTime: Date, callback: (result: AsyncResult) => void): void;
+        setAsync(dateTime: Date, callback: (result: AsyncResult<void>) => void): void;
 
     }
     /**

--- a/generate-docs/api-extractor-inputs-outlook-legacy/Outlook_1_3/Outlook_1_3.d.ts
+++ b/generate-docs/api-extractor-inputs-outlook-legacy/Outlook_1_3/Outlook_1_3.d.ts
@@ -113,6 +113,24 @@ export declare namespace Office {
             Appointment = "appointment"
         }
         /**
+         * Represents the current view of Outlook Web App.
+         */
+        enum OWAView {
+            /**
+             * One column view. Displayed when the screen is narrow. Outlook Web App uses this single-column layout on the entire screen of a smartphone.
+             */
+            OneColumn = "OneColumn",
+            /**
+             * Two column view. Displayed when the screen is wider. Outlook Web App uses this view on most tablets.
+             */
+            TwoColumns = "TwoColumns",
+            /**
+             Three column view. Displayed when the screen is wide. For example, Outlook Web App uses this view in a full screen window on a desktop 
+             computer.
+             */
+            ThreeColumns = "ThreeColumns"
+        }
+        /**
          * Specifies the type of recipient for an appointment.
          *
          * [Api set: Mailbox 1.1]
@@ -140,7 +158,7 @@ export declare namespace Office {
              */
             Other = "other"
         }
-        /**  
+        /**
          * Specifies the type of response to a meeting invitation.
          *
          * [Api set: Mailbox 1.0]
@@ -236,7 +254,8 @@ export declare namespace Office {
         /**
          * Gets or sets the date and time that the appointment is to end.
          *
-         * The end property is expressed as a Coordinated Universal Time (UTC) date and time value. You can use the convertToLocalClientTime method to convert the end property value to the client's local date and time.
+         * The end property is expressed as a Coordinated Universal Time (UTC) date and time value. You can use the convertToLocalClientTime method to 
+         * convert the end property value to the client's local date and time.
          *
          * *Read mode*
          *
@@ -246,7 +265,8 @@ export declare namespace Office {
          *
          * The end property returns a Time object.
          *
-         * When you use the Time.setAsync method to set the end time, you should use the convertToUtcClientTime method to convert the local time on the client to UTC for the server.
+         * When you use the Time.setAsync method to set the end time, you should use the convertToUtcClientTime method to convert the local time on 
+         * the client to UTC for the server.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -320,7 +340,8 @@ export declare namespace Office {
         /**
          * Gets or sets the date and time that the appointment is to begin.
          *
-         * The start property is expressed as a Coordinated Universal Time (UTC) date and time value. You can use the convertToLocalClientTime method to convert the value to the client's local date and time.
+         * The start property is expressed as a Coordinated Universal Time (UTC) date and time value. You can use the convertToLocalClientTime method 
+         * to convert the value to the client's local date and time.
          *
          * *Read mode*
          *
@@ -330,7 +351,8 @@ export declare namespace Office {
          *
          * The start property returns a Time object.
          *
-         * When you use the Time.setAsync method to set the start time, you should use the convertToUtcClientTime method to convert the local time on the client to UTC for the server.
+         * When you use the Time.setAsync method to set the start time, you should use the convertToUtcClientTime method to convert the local time on 
+         * the client to UTC for the server.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -403,7 +425,8 @@ export declare namespace Office {
         size: number;
     }
     /**
-     * The body object provides methods for adding and updating the content of the message or appointment. It is returned in the body property of the selected item.
+     * The body object provides methods for adding and updating the content of the message or appointment. 
+     * It is returned in the body property of the selected item.
      *
      * [Api set: Mailbox 1.1]
      *
@@ -418,7 +441,9 @@ export declare namespace Office {
          *
          * This method returns the entire current body in the format specified by coercionType.
          *
-         * When working with HTML-formatted bodies, it is important to note that the Body.getAsync and Body.setAsync methods are not idempotent. The value returned from the getAsync method will not necessarily be exactly the same as the value that was passed in the setAsync method previously. The client may modify the value passed to setAsync in order to make it render efficiently with its rendering engine.
+         * When working with HTML-formatted bodies, it is important to note that the Body.getAsync and Body.setAsync methods are not idempotent. 
+         * The value returned from the getAsync method will not necessarily be exactly the same as the value that was passed in the setAsync method previously. 
+         * The client may modify the value passed to setAsync in order to make it render efficiently with its rendering engine.
          *
          * [Api set: Mailbox 1.3]
          *
@@ -427,22 +452,25 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          * 
-         * In addition to the main signature, this method also has this signature:
+         * In addition to this signature, this method also has the following signature:
          * 
-         * `getAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult) => void): void;`
+         * `getAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult<Office.Body>) => void): void;`
          * 
          * @param coercionType - The format for the returned body.
          * @param options - Optional. An object literal that contains one or more of the following properties:
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. The body is provided in the requested format in the asyncResult.value property.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. 
+         *                  The body is provided in the requested format in the asyncResult.value property.
          */
-        getAsync(coerciontype: Office.CoercionType, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        getAsync(coerciontype: Office.CoercionType, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<Office.Body>) => void): void;
         /**
          * Returns the current body in a specified format.
          *
          * This method returns the entire current body in the format specified by coercionType.
          *
-         * When working with HTML-formatted bodies, it is important to note that the Body.getAsync and Body.setAsync methods are not idempotent. The value returned from the getAsync method will not necessarily be exactly the same as the value that was passed in the setAsync method previously. The client may modify the value passed to setAsync in order to make it render efficiently with its rendering engine.
+         * When working with HTML-formatted bodies, it is important to note that the Body.getAsync and Body.setAsync methods are not idempotent. 
+         * The value returned from the getAsync method will not necessarily be exactly the same as the value that was passed in the setAsync method previously. 
+         * The client may modify the value passed to setAsync in order to make it render efficiently with its rendering engine.
          *
          * [Api set: Mailbox 1.3]
          *
@@ -452,9 +480,10 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          *
          * @param coercionType - The format for the returned body.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. The body is provided in the requested format in the asyncResult.value property.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult.
+         *                  The body is provided in the requested format in the asyncResult.value property.
          */
-        getAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult) => void): void;
+        getAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult<Office.Body>) => void): void;
 
         /**
          * Gets a value that indicates whether the content is in HTML or text format.
@@ -468,15 +497,18 @@ export declare namespace Office {
          *
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. The content type is returned as one of the CoercionType values in the asyncResult.value property.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult.
+         *                  The content type is returned as one of the CoercionType values in the asyncResult.value property.
          */
-        getTypeAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        getTypeAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<Office.CoercionType>) => void): void;
         /**
          * Adds the specified content to the beginning of the item body.
          *
-         * The prependAsync method inserts the specified string at the beginning of the item body. After insertion, the cursor is returned to its original place, relative to the inserted content.
+         * The prependAsync method inserts the specified string at the beginning of the item body. 
+         * After insertion, the cursor is returned to its original place, relative to the inserted content.
          *
-         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" (please see the Examples section for a sample).
+         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" 
+         * (please see the Examples section for a sample).
          *
          * [Api set: Mailbox 1.1]
          *
@@ -487,11 +519,11 @@ export declare namespace Office {
          * 
          * <tr><td>Errors</td><td>DataExceedsMaximumSize - The data parameter is longer than 1,000,000 characters.</td></tr></table>
          * 
-         * In addition to the main signature, this method also has these signatures:
+         * In addition to this signature, this method also has the following signatures:
          * 
          * `prependAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`
          * 
-         * `prependAsync(data: string, callback: (result: AsyncResult) => void): void;`
+         * `prependAsync(data: string, callback: (result: AsyncResult<void>) => void): void;`
          * 
          * `prependAsync(data: string): void;`
          *
@@ -499,15 +531,18 @@ export declare namespace Office {
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
          *        coercionType: The desired format for the body. The string in the data parameter will be converted to this format.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. Any errors encountered will be provided in the asyncResult.error property.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult.
+         *                  Any errors encountered will be provided in the asyncResult.error property.
          */
-        prependAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult) => void): void;
+        prependAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Adds the specified content to the beginning of the item body.
          *
-         * The prependAsync method inserts the specified string at the beginning of the item body. After insertion, the cursor is returned to its original place, relative to the inserted content.
+         * The prependAsync method inserts the specified string at the beginning of the item body. 
+         * After insertion, the cursor is returned to its original place, relative to the inserted content.
          *
-         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" (please see the Examples section for a sample).
+         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" 
+         * (please see the Examples section for a sample).
          *
          * [Api set: Mailbox 1.1]
          *
@@ -527,9 +562,11 @@ export declare namespace Office {
         /**
          * Adds the specified content to the beginning of the item body.
          *
-         * The prependAsync method inserts the specified string at the beginning of the item body. After insertion, the cursor is returned to its original place, relative to the inserted content.
+         * The prependAsync method inserts the specified string at the beginning of the item body. 
+         * After insertion, the cursor is returned to its original place, relative to the inserted content.
          *
-         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" (please see the Examples section for a sample).
+         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" 
+         * (please see the Examples section for a sample).
          *
          * [Api set: Mailbox 1.1]
          *
@@ -539,15 +576,18 @@ export declare namespace Office {
          * <tr><td>Errors</td><td>DataExceedsMaximumSize - The data parameter is longer than 1,000,000 characters.</td></tr></table>
          *
          * @param data - The string to be inserted at the beginning of the body. The string is limited to 1,000,000 characters.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. Any errors encountered will be provided in the asyncResult.error property.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult.
+         *                  Any errors encountered will be provided in the asyncResult.error property.
          */
-        prependAsync(data: string, callback: (result: AsyncResult) => void): void;
+        prependAsync(data: string, callback: (result: AsyncResult<void>) => void): void;
         /**
          * Adds the specified content to the beginning of the item body.
          *
-         * The prependAsync method inserts the specified string at the beginning of the item body. After insertion, the cursor is returned to its original place, relative to the inserted content.
+         * The prependAsync method inserts the specified string at the beginning of the item body. 
+         * After insertion, the cursor is returned to its original place, relative to the inserted content.
          *
-         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" (please see the Examples section for a sample).
+         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" 
+         * (please see the Examples section for a sample).
          *
          * [Api set: Mailbox 1.1]
          *
@@ -562,9 +602,12 @@ export declare namespace Office {
         /**
          * Replaces the entire body with the specified text.
          *
-         * When working with HTML-formatted bodies, it is important to note that the Body.getAsync and Body.setAsync methods are not idempotent. The value returned from the getAsync method will not necessarily be exactly the same as the value that was passed in the setAsync method previously. The client may modify the value passed to setAsync in order to make it render efficiently with its rendering engine.
+         * When working with HTML-formatted bodies, it is important to note that the Body.getAsync and Body.setAsync methods are not idempotent. 
+         * The value returned from the getAsync method will not necessarily be exactly the same as the value that was passed in the setAsync method 
+         * previously. The client may modify the value passed to setAsync in order to make it render efficiently with its rendering engine.
          *
-         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" (please see the Examples section for a sample).
+         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" 
+         * (please see the Examples section for a sample).
          *
          * [Api set: Mailbox 1.3]
          *
@@ -575,11 +618,11 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>DataExceedsMaximumSize - The data parameter is longer than 1,000,000 characters.</td></tr><tr><td></td><td>InvalidFormatError - The options.coercionType parameter is set to Office.CoercionType.Html and the message body is in plain text.</td></tr></table>
          * 
-         * In addition to the main signature, this method also has these signatures:
+         * In addition to this signature, this method also has the following signatures:
          * 
          * `setAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`
          * 
-         * `setAsync(data: string, callback: (result: AsyncResult) => void): void;`
+         * `setAsync(data: string, callback: (result: AsyncResult<void>) => void): void;`
          * 
          * `setAsync(data: string): void;`
          *
@@ -587,15 +630,19 @@ export declare namespace Office {
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
          *        coercionType: The desired format for the body. The string in the data parameter will be converted to this format.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.  Any errors encountered will be provided in the asyncResult.error property.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult.
+         *                  Any errors encountered will be provided in the asyncResult.error property.
          */
-        setAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult) => void): void;
+        setAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Replaces the entire body with the specified text.
          *
-         * When working with HTML-formatted bodies, it is important to note that the Body.getAsync and Body.setAsync methods are not idempotent. The value returned from the getAsync method will not necessarily be exactly the same as the value that was passed in the setAsync method previously. The client may modify the value passed to setAsync in order to make it render efficiently with its rendering engine.
+         * When working with HTML-formatted bodies, it is important to note that the Body.getAsync and Body.setAsync methods are not idempotent. 
+         * The value returned from the getAsync method will not necessarily be exactly the same as the value that was passed in the setAsync method 
+         * previously. The client may modify the value passed to setAsync in order to make it render efficiently with its rendering engine.
          *
-         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" (please see the Examples section for a sample).
+         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" 
+         * (please see the Examples section for a sample).
          *
          * [Api set: Mailbox 1.3]
          *
@@ -615,9 +662,12 @@ export declare namespace Office {
         /**
          * Replaces the entire body with the specified text.
          *
-         * When working with HTML-formatted bodies, it is important to note that the Body.getAsync and Body.setAsync methods are not idempotent. The value returned from the getAsync method will not necessarily be exactly the same as the value that was passed in the setAsync method previously. The client may modify the value passed to setAsync in order to make it render efficiently with its rendering engine.
+         * When working with HTML-formatted bodies, it is important to note that the Body.getAsync and Body.setAsync methods are not idempotent. 
+         * The value returned from the getAsync method will not necessarily be exactly the same as the value that was passed in the setAsync method 
+         * previously. The client may modify the value passed to setAsync in order to make it render efficiently with its rendering engine.
          *
-         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" (please see the Examples section for a sample).
+         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" 
+         * (please see the Examples section for a sample).
          *
          * [Api set: Mailbox 1.3]
          *
@@ -629,15 +679,19 @@ export declare namespace Office {
          * <tr><td>Errors</td><td>DataExceedsMaximumSize - The data parameter is longer than 1,000,000 characters.</td></tr><tr><td></td><td>InvalidFormatError - The options.coercionType parameter is set to Office.CoercionType.Html and the message body is in plain text.</td></tr></table>
          *
          * @param data - The string that will replace the existing body. The string is limited to 1,000,000 characters.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.  Any errors encountered will be provided in the asyncResult.error property.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult.
+         *                  Any errors encountered will be provided in the asyncResult.error property.
          */
-        setAsync(data: string, callback: (result: AsyncResult) => void): void;
+        setAsync(data: string, callback: (result: AsyncResult<void>) => void): void;
         /**
          * Replaces the entire body with the specified text.
          *
-         * When working with HTML-formatted bodies, it is important to note that the Body.getAsync and Body.setAsync methods are not idempotent. The value returned from the getAsync method will not necessarily be exactly the same as the value that was passed in the setAsync method previously. The client may modify the value passed to setAsync in order to make it render efficiently with its rendering engine.
+         * When working with HTML-formatted bodies, it is important to note that the Body.getAsync and Body.setAsync methods are not idempotent.
+         *  The value returned from the getAsync method will not necessarily be exactly the same as the value that was passed in the setAsync method 
+         * previously. The client may modify the value passed to setAsync in order to make it render efficiently with its rendering engine.
          *
-         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" (please see the Examples section for a sample).
+         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" 
+         * (please see the Examples section for a sample).
          *
          * [Api set: Mailbox 1.3]
          *
@@ -655,9 +709,12 @@ export declare namespace Office {
         /**
          * Replaces the selection in the body with the specified text.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor was never in the body of the item, or if the body of the item lost focus in the UI, the string will be inserted at the top of the body content. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the body of the item, or, if text is selected in 
+         * the editor, it replaces the selected text. If the cursor was never in the body of the item, or if the body of the item lost focus in the 
+         * UI, the string will be inserted at the top of the body content. After insertion, the cursor is placed at the end of the inserted content.
          *
-         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" (please see the Examples section for a sample).
+         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" 
+         * (please see the Examples section for a sample).
          *
          * [Api set: Mailbox 1.1]
          *
@@ -668,11 +725,11 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>DataExceedsMaximumSize - The data parameter is longer than 1,000,000 characters.</td></tr><tr><td></td><td>InvalidFormatError - The options.coercionType parameter is set to Office.CoercionType.Html and the message body is in plain text.</td></tr></table>
          * 
-         * In addition to the main signature, this method also has these signatures:
+         * In addition to this signature, this method also has the following signatures:
          * 
          * `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`
          * 
-         * `setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;`
+         * `setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;`
          * 
          * `setSelectedDataAsync(data: string): void;`
          *         
@@ -680,15 +737,19 @@ export declare namespace Office {
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
          *        coercionType: The desired format for the body. The string in the data parameter will be converted to this format.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.  Any errors encountered will be provided in the asyncResult.error property.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult.
+         *                  Any errors encountered will be provided in the asyncResult.error property.
          */
-        setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult) => void): void;
+        setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Replaces the selection in the body with the specified text.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor was never in the body of the item, or if the body of the item lost focus in the UI, the string will be inserted at the top of the body content. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the body of the item, or, if text is selected in 
+         * the editor, it replaces the selected text. If the cursor was never in the body of the item, or if the body of the item lost focus in the 
+         * UI, the string will be inserted at the top of the body content. After insertion, the cursor is placed at the end of the inserted content.
          *
-         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" (please see the Examples section for a sample).
+         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" 
+         * (please see the Examples section for a sample).
          *
          * [Api set: Mailbox 1.1]
          *
@@ -708,9 +769,12 @@ export declare namespace Office {
         /**
          * Replaces the selection in the body with the specified text.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor was never in the body of the item, or if the body of the item lost focus in the UI, the string will be inserted at the top of the body content. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the body of the item, or, if text is selected in 
+         * the editor, it replaces the selected text. If the cursor was never in the body of the item, or if the body of the item lost focus in the 
+         * UI, the string will be inserted at the top of the body content. After insertion, the cursor is placed at the end of the inserted content.
          *
-         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" (please see the Examples section for a sample).
+         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" 
+         * (please see the Examples section for a sample).
          *
          * [Api set: Mailbox 1.1]
          *
@@ -722,15 +786,19 @@ export declare namespace Office {
          * <tr><td>Errors</td><td>DataExceedsMaximumSize - The data parameter is longer than 1,000,000 characters.</td></tr><tr><td></td><td>InvalidFormatError - The options.coercionType parameter is set to Office.CoercionType.Html and the message body is in plain text.</td></tr></table>
          *
          * @param data - The string that will replace the existing body. The string is limited to 1,000,000 characters.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.  Any errors encountered will be provided in the asyncResult.error property.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult.
+         *                  Any errors encountered will be provided in the asyncResult.error property.
          */
-        setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;
+        setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;
         /**
          * Replaces the selection in the body with the specified text.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor was never in the body of the item, or if the body of the item lost focus in the UI, the string will be inserted at the top of the body content. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the body of the item, or, if text is selected in 
+         * the editor, it replaces the selected text. If the cursor was never in the body of the item, or if the body of the item lost focus in the 
+         * UI, the string will be inserted at the top of the body content. After insertion, the cursor is placed at the end of the inserted content.
          *
-         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" (please see the Examples section for a sample).
+         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" 
+         * (please see the Examples section for a sample).
          *
          * [Api set: Mailbox 1.1]
          *
@@ -748,7 +816,8 @@ export declare namespace Office {
     /**
      * Represents a contact stored on the server. Read mode only.
      *
-     * The list of contacts associated with an email message or appointment is returned in the contacts property of the {@link Office.Entities} object that is returned by the getEntities or getEntitiesByType method of the active item.
+     * The list of contacts associated with an email message or appointment is returned in the contacts property of the {@link Office.Entities} object 
+     * that is returned by the getEntities or getEntitiesByType method of the active item.
      *
      * [Api set: Mailbox 1.0]
      *
@@ -784,7 +853,10 @@ export declare namespace Office {
         urls: Array<string>;
     }
     /**
-     * The CustomProperties object represents custom properties that are specific to a particular item and specific to a mail add-in for Outlook. For example, there might be a need for a mail add-in to save some data that is specific to the current email message that activated the add-in. If the user revisits the same message in the future and activates the mail add-in again, the add-in will be able to retrieve the data that had been saved as custom properties.
+     * The CustomProperties object represents custom properties that are specific to a particular item and specific to a mail add-in for Outlook. 
+     * For example, there might be a need for a mail add-in to save some data that is specific to the current email message that activated the add-in. 
+     * If the user revisits the same message in the future and activates the mail add-in again, the add-in will be able to retrieve the data that had 
+     * been saved as custom properties.
      *
      * Because Outlook for Mac doesn't cache custom properties, if the user's network goes down, mail add-ins cannot access their custom properties.
      *
@@ -814,7 +886,9 @@ export declare namespace Office {
          *
          * The set method sets the specified property to the specified value. You must use the saveAsync method to save the property to the server.
          *
-         * The set method creates a new property if the specified property does not already exist; otherwise, the existing value is replaced with the new value. The value parameter can be of any type; however, it is always passed to the server as a string.
+         * The set method creates a new property if the specified property does not already exist; 
+         * otherwise, the existing value is replaced with the new value. 
+         * The value parameter can be of any type; however, it is always passed to the server as a string.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -844,11 +918,17 @@ export declare namespace Office {
         /**
          * Saves item-specific custom properties to the server.
          *
-         * You must call the saveAsync method to persist any changes made with the set method or the remove method of the CustomProperties object. The saving action is asynchronous.
+         * You must call the saveAsync method to persist any changes made with the set method or the remove method of the CustomProperties object. 
+         * The saving action is asynchronous.
          *
-         * It's a good practice to have your callback function check for and handle errors from saveAsync. In particular, a read add-in can be activated while the user is in a connected state in a read form, and subsequently the user becomes disconnected. If the add-in calls saveAsync while in the disconnected state, saveAsync would return an error. Your callback method should handle this error accordingly.
+         * It's a good practice to have your callback function check for and handle errors from saveAsync. 
+         * In particular, a read add-in can be activated while the user is in a connected state in a read form, and subsequently the user becomes 
+         * disconnected. 
+         * If the add-in calls saveAsync while in the disconnected state, saveAsync would return an error. 
+         * Your callback method should handle this error accordingly.
          *
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          * @param asyncContext - Optional. Any state data that is passed to the callback method.
          *
          * [Api set: Mailbox 1.0]
@@ -858,7 +938,7 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          */
-        saveAsync(callback?: (result: AsyncResult) => void, asyncContext?: any): void;
+        saveAsync(callback?: (result: AsyncResult<void>) => void, asyncContext?: any): void;
     }
     /**
      * Provides diagnostic information to an Outlook add-in.
@@ -887,7 +967,8 @@ export declare namespace Office {
         /**
          * Gets a string that represents the version of either the host application or the Exchange Server.
          *
-         * If the mail add-in is running on the Outlook desktop client or Outlook for iOS, the hostVersion property returns the version of the host application, Outlook. In Outlook Web App, the property returns the version of the Exchange Server. An example is the string 15.0.468.0.
+         * If the mail add-in is running on the Outlook desktop client or Outlook for iOS, the hostVersion property returns the version of the host 
+         * application, Outlook. In Outlook Web App, the property returns the version of the Exchange Server. An example is the string 15.0.468.0.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -906,11 +987,13 @@ export declare namespace Office {
          *
          * Outlook Web App has three views that correspond to the width of the screen and the window, and the number of columns that can be displayed:
          *
-         * - OneColumn, which is displayed when the screen is narrow. Outlook Web App uses this single-column layout on the entire screen of a smartphone.
+         * - OneColumn, which is displayed when the screen is narrow. Outlook Web App uses this single-column layout on the entire screen of a 
+         * smartphone.
          *
          * - TwoColumns, which is displayed when the screen is wider. Outlook Web App uses this view on most tablets.
          *
-         * - ThreeColumns, which is displayed when the screen is wide. For example, Outlook Web App uses this view in a full screen window on a desktop computer.
+         * - ThreeColumns, which is displayed when the screen is wide. For example, Outlook Web App uses this view in a full screen window on a 
+         * desktop computer.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -919,7 +1002,7 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          */
-        OWAView: "string";
+        OWAView: MailboxEnums.OWAView | "OneColumn" | "TwoColumns" | "ThreeColumns";
     }
     /**
      * Provides the email properties of the sender or specified recipients of an email message or appointment.
@@ -941,7 +1024,9 @@ export declare namespace Office {
          */
         displayName: string;
         /**
-         * Gets the response that an attendee returned for an appointment. This property applies to only an attendee of an appointment, as represented by the optionalAttendees or requiredAttendees property. This property returns undefined in other scenarios.
+         * Gets the response that an attendee returned for an appointment. 
+         * This property applies to only an attendee of an appointment, as represented by the optionalAttendees or requiredAttendees property. 
+         * This property returns undefined in other scenarios.
          */
         appointmentResponse: Office.MailboxEnums.ResponseType;
         /**
@@ -972,17 +1057,25 @@ export declare namespace Office {
     /**
      * Represents a collection of entities found in an email message or appointment. Read mode only.
      *
-     * The Entities object is a container for the entity arrays returned by the getEntities and getEntitiesByType methods when the item (either an email message or an appointment) contains one or more entities that have been found by the server. You can use these entities in your code to provide additional context information to the viewer, such as a map to an address found in the item, or to open a dialer for a phone number found in the item.
+     * The Entities object is a container for the entity arrays returned by the getEntities and getEntitiesByType methods when the item 
+     * (either an email message or an appointment) contains one or more entities that have been found by the server. 
+     * You can use these entities in your code to provide additional context information to the viewer, such as a map to an address found in the item, 
+     * or to open a dialer for a phone number found in the item.
      *
-     * If no entities of the type specified in the property are present in the item, the property associated with that entity is null. For example, if a message contains a street address and a phone number, the addresses property and phoneNumbers property would contain information, and the other properties would be null.
+     * If no entities of the type specified in the property are present in the item, the property associated with that entity is null. 
+     * For example, if a message contains a street address and a phone number, the addresses property and phoneNumbers property would contain 
+     * information, and the other properties would be null.
      *
-     * To be recognized as an address, the string must contain a United States postal address that has at least a subset of the elements of a street number, street name, city, state, and zip code.
+     * To be recognized as an address, the string must contain a United States postal address that has at least a subset of the elements of a street 
+     * number, street name, city, state, and zip code.
      *
      * To be recognized as a phone number, the string must contain a North American phone number format.
      *
-     * Entity recognition relies on natural language recognition that is based on machine learning of large amounts of data. The recognition of an entity is non-deterministic and success sometimes relies on the particular context in the item.
+     * Entity recognition relies on natural language recognition that is based on machine learning of large amounts of data. 
+     * The recognition of an entity is non-deterministic and success sometimes relies on the particular context in the item.
      *
-     * When the property arrays are returned by the getEntitiesByType method, only the property for the specified entity contains data; all other properties are null.
+     * When the property arrays are returned by the getEntitiesByType method, only the property for the specified entity contains data; 
+     * all other properties are null.
      *
      * [Api set: Mailbox 1.0]
      *
@@ -1024,14 +1117,16 @@ export declare namespace Office {
     /**
      * The subclass of {@link Office.Item} dealing with appointments.
      * 
-     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of Office.context.mailbox.item. Refer to the Object Model pages for more information.
+     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. 
+     * You should treat this as a mode of Office.context.mailbox.item. Refer to the Object Model pages for more information.
      */
     export interface Appointment extends Item {
     }
     /**
      * The appointment organizer mode of {@link Office.Item | Office.context.mailbox.item}.
      * 
-     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
+     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. 
+     * You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
      */
     export interface AppointmentCompose extends Appointment, ItemCompose {
          /**
@@ -1075,9 +1170,11 @@ export declare namespace Office {
         /**
          * Gets or sets the date and time that the appointment is to end.
          *
-         * The end property is an {@link Office.Time} object expressed as a Coordinated Universal Time (UTC) date and time value. You can use the convertToLocalClientTime method to convert the end property value to the client's local date and time.
+         * The end property is an {@link Office.Time} object expressed as a Coordinated Universal Time (UTC) date and time value. 
+         * You can use the convertToLocalClientTime method to convert the end property value to the client's local date and time.
          *
-         * When you use the Time.setAsync method to set the end time, you should use the convertToUtcClientTime method to convert the local time on the client to UTC for the server.
+         * When you use the Time.setAsync method to set the end time, you should use the convertToUtcClientTime method to convert the local time on 
+         * the client to UTC for the server.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1103,7 +1200,8 @@ export declare namespace Office {
          */
         itemType: Office.MailboxEnums.ItemType;
         /**
-         * Gets or sets the {@link Office.Location} of an appointment. The location property returns a Location object that provides methods that are used to get and set the location of the appointment.
+         * Gets or sets the {@link Office.Location} of an appointment. The location property returns a Location object that provides methods that are 
+         * used to get and set the location of the appointment.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1127,7 +1225,9 @@ export declare namespace Office {
          */
         notificationMessages: Office.NotificationMessages;
         /**
-         * Provides access to the optional attendees of an event. The type of object and level of access depends on the mode of the current item. The optionalAttendees property returns an {@link Office.Recipients} object that provides methods to get or update the optional attendees for a meeting.
+         * Provides access to the optional attendees of an event. The type of object and level of access depends on the mode of the current item. 
+         * The optionalAttendees property returns an {@link Office.Recipients} object that provides methods to get or update the optional attendees 
+         * for a meeting.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1139,7 +1239,9 @@ export declare namespace Office {
          */
         optionalAttendees: Recipients;
         /**
-         * Provides access to the required attendees of an event. The type of object and level of access depends on the mode of the current item. The requiredAttendees property returns an {@link Office.Recipients} object that provides methods to get or update the required attendees for a meeting.
+         * Provides access to the required attendees of an event. The type of object and level of access depends on the mode of the current item. 
+         * The requiredAttendees property returns an {@link Office.Recipients} object that provides methods to get or update the required attendees 
+         * for a meeting.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1153,9 +1255,11 @@ export declare namespace Office {
         /**
          * Gets or sets the date and time that the appointment is to begin.
          *
-         * The start property is an {@link Office.Time} object expressed as a Coordinated Universal Time (UTC) date and time value. You can use the convertToLocalClientTime method to convert the value to the client's local date and time.
+         * The start property is an {@link Office.Time} object expressed as a Coordinated Universal Time (UTC) date and time value. 
+         * You can use the convertToLocalClientTime method to convert the value to the client's local date and time.
          *
-         * When you use the Time.setAsync method to set the start time, you should use the convertToUtcClientTime method to convert the local time on the client to UTC for the server.
+         * When you use the Time.setAsync method to set the start time, you should use the convertToUtcClientTime method to convert the local time on 
+         * the client to UTC for the server.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1204,16 +1308,18 @@ export declare namespace Office {
          * 
          * `addFileAttachmentAsync(uri: string, attachmentName: string, options: Office.AsyncContextOptions): void;`
          * 
-         * `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+         * `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;`
          *
          * @param uri - The URI that provides the location of the file to attach to the message or appointment. The maximum length is 2048 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
          *        isInline: If true, indicates that the attachment will be shown inline in the message body, and should not be displayed in the attachment list.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type asyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type asyncResult. 
+         *                 On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
          */
-        addFileAttachmentAsync(uri: string, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        addFileAttachmentAsync(uri: string, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;
         /**
          * Adds a file to a message or appointment as an attachment.
          *
@@ -1254,7 +1360,7 @@ export declare namespace Office {
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         *        isInline: If true, indicates that the attachment will be shown inline in the message body, and should not be displayed in the attachment list.
+         *        isInline: If true, indicates that the attachment will be shown inline in the message body and should not be displayed in the attachment list.
          */
         addFileAttachmentAsync(uri: string, attachmentName: string, options: Office.AsyncContextOptions): void;
         /**
@@ -1275,17 +1381,23 @@ export declare namespace Office {
          *
          * @param uri - The URI that provides the location of the file to attach to the message or appointment. The maximum length is 2048 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type asyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type asyncResult. 
+         *                 On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
          */
-        addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;
+        addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. 
+         * You can use the options parameter to pass state information to the callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -1296,29 +1408,35 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>NumberOfAttachmentsExceeded - The message or appointment has too many attachments.</td></tr></table>
          * 
-         * In addition to the main signature, this method also has these signatures:
+         * In addition to this signature, this method also has the following signatures:
          * 
          * `addItemAttachmentAsync(itemId: any, attachmentName: string): void;`
          * 
          * `addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;`
          * 
-         * `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+         * `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;`
          *
          * @param itemId - The Exchange identifier of the item to attach. The maximum length is 100 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
          * @param options - An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. 
+         *                 On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
          */
-        addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. 
+         * You can use the options parameter to pass state information to the callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -1336,11 +1454,15 @@ export declare namespace Office {
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. 
+         * You can use the options parameter to pass state information to the callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -1360,11 +1482,15 @@ export declare namespace Office {
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. 
+         * You can use the options parameter to pass state information to the callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -1377,17 +1503,21 @@ export declare namespace Office {
          *
          * @param itemId - The Exchange identifier of the item to attach. The maximum length is 100 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. 
+         *                 On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
          */
-        addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;
+        addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;
         /**
          * Closes the current item that is being composed
          *
-         * The behaviors of the close method depends on the current state of the item being composed. If the item has unsaved changes, the client prompts the user to save, discard, or close the action.
+         * The behaviors of the close method depends on the current state of the item being composed. 
+         * If the item has unsaved changes, the client prompts the user to save, discard, or close the action.
          *
          * In the Outlook desktop client, if the message is an inline reply, the close method has no effect.
          *
-         * Note: In Outlook on the web, if the item is an appointment and it has previously been saved using saveAsync, the user is prompted to save, discard, or cancel even if no changes have occurred since the item was last saved.
+         * Note: In Outlook on the web, if the item is an appointment and it has previously been saved using saveAsync, the user is prompted to save, 
+         * discard, or cancel even if no changes have occurred since the item was last saved.
          *
          * [Api set: Mailbox 1.3]
          *
@@ -1401,9 +1531,11 @@ export declare namespace Office {
         /**
          * Asynchronously returns selected data from the subject or body of a message.
          *
-         * If there is no selection but the cursor is in the body or subject, the method returns null for the selected data. If a field other than the body or subject is selected, the method returns the InvalidSelection error.
+         * If there is no selection but the cursor is in the body or subject, the method returns null for the selected data. 
+         * If a field other than the body or subject is selected, the method returns the InvalidSelection error.
          *
-         * To access the selected data from the callback method, call asyncResult.value.data. To access the source property that the selection comes from, call asyncResult.value.sourceProperty, which will be either body or subject.
+         * To access the selected data from the callback method, call asyncResult.value.data. 
+         * To access the source property that the selection comes from, call asyncResult.value.sourceProperty, which will be either body or subject.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -1416,18 +1548,21 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Appointment Organizer</td></tr></table>
          *
-         * @param coercionType - Requests a format for the data. If Text, the method returns the plain text as a string , removing any HTML tags present. If HTML, the method returns the selected text, whether it is plaintext or HTML.
+         * @param coercionType - Requests a format for the data. If Text, the method returns the plain text as a string , removing any HTML tags present. 
+         *                     If HTML, the method returns the selected text, whether it is plaintext or HTML.
          * @param options - An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
          * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
          */
-        getSelectedDataAsync(coerciontype: Office.CoercionType, options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;
+        getSelectedDataAsync(coerciontype: Office.CoercionType, options: Office.AsyncContextOptions, callback: (result: AsyncResult<any>) => void): void;
          /**
          * Asynchronously returns selected data from the subject or body of a message.
          *
-         * If there is no selection but the cursor is in the body or subject, the method returns null for the selected data. If a field other than the body or subject is selected, the method returns the InvalidSelection error.
+         * If there is no selection but the cursor is in the body or subject, the method returns null for the selected data. 
+         * If a field other than the body or subject is selected, the method returns the InvalidSelection error.
          *
-         * To access the selected data from the callback method, call asyncResult.value.data. To access the source property that the selection comes from, call asyncResult.value.sourceProperty, which will be either body or subject.
+         * To access the selected data from the callback method, call asyncResult.value.data. 
+         * To access the source property that the selection comes from, call asyncResult.value.sourceProperty, which will be either body or subject.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -1440,16 +1575,22 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Appointment Organizer</td></tr></table>
          *
-         * @param coercionType - Requests a format for the data. If Text, the method returns the plain text as a string , removing any HTML tags present. If HTML, the method returns the selected text, whether it is plaintext or HTML.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param coercionType - Requests a format for the data. If Text, the method returns the plain text as a string , removing any HTML tags present. 
+         *                     If HTML, the method returns the selected text, whether it is plaintext or HTML.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          */
-        getSelectedDataAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult) => void): void;
+        getSelectedDataAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult<string>) => void): void;
         /**
          * Asynchronously loads custom properties for this add-in on the selected item.
          *
-         * Custom properties are stored as key/value pairs on a per-app, per-item basis. This method returns a CustomProperties object in the callback, which provides methods to access the custom properties specific to the current item and the current add-in. Custom properties are not encrypted on the item, so this should not be used as secure storage.
+         * Custom properties are stored as key/value pairs on a per-app, per-item basis. 
+         * This method returns a CustomProperties object in the callback, which provides methods to access the custom properties specific to the 
+         * current item and the current add-in. Custom properties are not encrypted on the item, so this should not be used as secure storage.
          *
-         * The custom properties are provided as a CustomProperties object in the asyncResult.value property. This object can be used to get, set, and remove custom properties from the item and save changes to the custom property set back to the server.
+         * The custom properties are provided as a CustomProperties object in the asyncResult.value property. 
+         * This object can be used to get, set, and remove custom properties from the item and save changes to the custom property set back to 
+         * the server.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1459,14 +1600,20 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Appointment Organizer</td></tr></table>
          *
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
-         * @param userContext - Optional. Developers can provide any object they wish to access in the callback function. This object can be accessed by the asyncResult.asyncContext property in the callback function.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
+         * @param userContext - Optional. Developers can provide any object they wish to access in the callback function. 
+         *                    This object can be accessed by the asyncResult.asyncContext property in the callback function.
          */
-        loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;
+        loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any): void;
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -1484,18 +1631,23 @@ export declare namespace Office {
          * 
          * `removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;`
          * 
-         * `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;`
+         * `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;`
          *
          * @param attachmentIndex - The identifier of the attachment to remove. The maximum length of the string is 100 characters.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. 
+         *                 If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
          */
-        removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -1513,7 +1665,11 @@ export declare namespace Office {
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -1533,7 +1689,12 @@ export declare namespace Office {
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. 
+         * In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -1546,17 +1707,25 @@ export declare namespace Office {
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
          * @param attachmentIndex - The identifier of the attachment to remove. The maximum length of the string is 100 characters.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. 
+         *                 If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
          */
-        removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;
+        removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;
         /**
          * Asynchronously saves an item.
          *
-         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. In Outlook Web App or Outlook in online mode, the item is saved to the server. In Outlook in cached mode, the item is saved to the local cache.
+         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. 
+         * In Outlook Web App or Outlook in online mode, the item is saved to the server. 
+         * In Outlook in cached mode, the item is saved to the local cache.
          *
-         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. Saving an existing appointment will send an update to added or removed attendees.
+         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal 
+         * appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. 
+         * Saving an existing appointment will send an update to added or removed attendees.
          *
-         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that when Outlook is in cached mode, it may take some time before the item is actually synced to the server. Until the item is synced, using the itemId will return an error.
+         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that 
+         * when Outlook is in cached mode, it may take some time before the item is actually synced to the server. 
+         * Until the item is synced, using the itemId will return an error.
          *
          * Note: The following clients have different behavior for saveAsync on appointments in compose mode:
          *
@@ -1580,21 +1749,27 @@ export declare namespace Office {
          * 
          * `saveAsync(options: Office.AsyncContextOptions): void;`
          * 
-         * `saveAsync(callback: (result: AsyncResult) => void): void;`
+         * `saveAsync(callback: (result: AsyncResult<void>) => void): void;`
          *
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. 
          */
-        saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Asynchronously saves an item.
          *
-         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. In Outlook Web App or Outlook in online mode, the item is saved to the server. In Outlook in cached mode, the item is saved to the local cache.
+         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. 
+         * In Outlook Web App or Outlook in online mode, the item is saved to the server. 
+         * In Outlook in cached mode, the item is saved to the local cache.
          *
-         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. Saving an existing appointment will send an update to added or removed attendees.
+         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal 
+         * appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. 
+         * Saving an existing appointment will send an update to added or removed attendees.
          *
-         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that when Outlook is in cached mode, it may take some time before the item is actually synced to the server. Until the item is synced, using the itemId will return an error.
+         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that 
+         * when Outlook is in cached mode, it may take some time before the item is actually synced to the server. 
+         * Until the item is synced, using the itemId will return an error.
          *
          * Note: The following clients have different behavior for saveAsync on appointments in compose mode:
          *
@@ -1617,11 +1792,17 @@ export declare namespace Office {
         /**
          * Asynchronously saves an item.
          *
-         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. In Outlook Web App or Outlook in online mode, the item is saved to the server. In Outlook in cached mode, the item is saved to the local cache.
+         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. 
+         * In Outlook Web App or Outlook in online mode, the item is saved to the server. 
+         * In Outlook in cached mode, the item is saved to the local cache.
          *
-         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. Saving an existing appointment will send an update to added or removed attendees.
+         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal 
+         * appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. 
+         * Saving an existing appointment will send an update to added or removed attendees.
          *
-         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that when Outlook is in cached mode, it may take some time before the item is actually synced to the server. Until the item is synced, using the itemId will return an error.
+         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that 
+         * when Outlook is in cached mode, it may take some time before the item is actually synced to the server. 
+         * Until the item is synced, using the itemId will return an error.
          *
          * Note: The following clients have different behavior for saveAsync on appointments in compose mode:
          *
@@ -1646,11 +1827,16 @@ export declare namespace Office {
         /**
          * Asynchronously saves an item.
          *
-         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. In Outlook Web App or Outlook in online mode, the item is saved to the server. In Outlook in cached mode, the item is saved to the local cache.
+         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. 
+         * In Outlook Web App or Outlook in online mode, the item is saved to the server. In Outlook in cached mode, the item is saved to the local cache.
          *
-         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. Saving an existing appointment will send an update to added or removed attendees.
+         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal 
+         * appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. 
+         * Saving an existing appointment will send an update to added or removed attendees.
          *
-         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that when Outlook is in cached mode, it may take some time before the item is actually synced to the server. Until the item is synced, using the itemId will return an error.
+         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that 
+         * when Outlook is in cached mode, it may take some time before the item is actually synced to the server. 
+         * Until the item is synced, using the itemId will return an error.
          *
          * Note: The following clients have different behavior for saveAsync on appointments in compose mode:
          *
@@ -1668,13 +1854,15 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult.
          */
-        saveAsync(callback: (result: AsyncResult) => void): void;
+        saveAsync(callback: (result: AsyncResult<void>) => void): void;
         /**
          * Asynchronously inserts data into the body or subject of a message.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is 
+         * selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. 
+         * After insertion, the cursor is placed at the end of the inserted content.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -1692,19 +1880,29 @@ export declare namespace Office {
          * 
          * `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`
          * 
-         * `setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;`
+         * `setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;`
          *
-         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
+         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. 
+         *             If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         *        coercionType: If text, the current style is applied in Outlook Web App and Outlook. If the field is an HTML editor, only the text data is inserted, even if the data is HTML. If html and the field supports HTML (the subject doesn't), the current style is applied in Outlook Web App and the default style is applied in Outlook. If the field is a text field, an InvalidDataFormat error is returned. If coercionType is not set, the result depends on the field: if the field is HTML then HTML is used; if the field is text, then plain text is used.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         *        coercionType: If text, the current style is applied in Outlook Web App and Outlook. 
+         *                      If the field is an HTML editor, only the text data is inserted, even if the data is HTML. 
+         *                      If html and the field supports HTML (the subject doesn't), the current style is applied in Outlook Web App and the 
+         *                      default style is applied in Outlook. 
+         *                      If the field is a text field, an InvalidDataFormat error is returned. 
+         *                      If coercionType is not set, the result depends on the field: if the field is HTML then HTML is used; 
+         *                      if the field is text, then plain text is used.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          */
-        setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult) => void): void;
+        setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Asynchronously inserts data into the body or subject of a message.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is 
+         * selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. 
+         * After insertion, the cursor is placed at the end of the inserted content.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -1716,13 +1914,16 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
-         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
+         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. 
+         *             If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
          */
         setSelectedDataAsync(data: string): void;
         /**
          * Asynchronously inserts data into the body or subject of a message.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is 
+         * selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. 
+         * After insertion, the cursor is placed at the end of the inserted content.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -1734,16 +1935,24 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
-         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
+         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. 
+         *             If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         *        coercionType: If text, the current style is applied in Outlook Web App and Outlook. If the field is an HTML editor, only the text data is inserted, even if the data is HTML. If html and the field supports HTML (the subject doesn't), the current style is applied in Outlook Web App and the default style is applied in Outlook. If the field is a text field, an InvalidDataFormat error is returned. If coercionType is not set, the result depends on the field: if the field is HTML then HTML is used; if the field is text, then plain text is used.
+         *        coercionType: If text, the current style is applied in Outlook Web App and Outlook. 
+         *                      If the field is an HTML editor, only the text data is inserted, even if the data is HTML. 
+         *                      If html and the field supports HTML (the subject doesn't), the current style is applied in Outlook Web App and the 
+         *                      default style is applied in Outlook. If the field is a text field, an InvalidDataFormat error is returned. 
+         *                      If coercionType is not set, the result depends on the field: if the field is HTML then HTML is used; 
+         *                      if the field is text, then plain text is used.
          */
         setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;
         /**
          * Asynchronously inserts data into the body or subject of a message.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is 
+         * selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. 
+         * After insertion, the cursor is placed at the end of the inserted content.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -1755,20 +1964,23 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
-         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. 
+         *             If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          */
-        setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;
+        setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;
     }
 
     /**
      * The appointment attendee mode of {@link Office.Item | Office.context.mailbox.item}.
      * 
-     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of 'Office.context.mailbox.item'. Refer to the Object Model pages for more information.
+     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. 
+     * You should treat this as a mode of 'Office.context.mailbox.item'. Refer to the Object Model pages for more information.
      */
     export interface AppointmentRead extends Appointment, ItemRead {
         /**
-         * Gets an array of attachments for the item.
+         * Gets the item's attachments as an array.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1778,7 +1990,8 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Appointment Attendee</td></tr></table>
          *
-         * Note: Certain types of files are blocked by Outlook due to potential security issues and are therefore not returned. For more information, see {@link https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519 | Blocked attachments in Outlook}.
+         * Note: Certain types of files are blocked by Outlook due to potential security issues and are therefore not returned. For more information, see 
+         * {@link https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519 | Blocked attachments in Outlook}.
          *
          */
         attachments: Office.AttachmentDetails[];
@@ -1823,9 +2036,11 @@ export declare namespace Office {
         /**
          * Gets the date and time that the appointment is to end.
          *
-         * The end property is a Date object expressed as a Coordinated Universal Time (UTC) date and time value. You can use the convertToLocalClientTime method to convert the end property value to the client's local date and time.
+         * The end property is a Date object expressed as a Coordinated Universal Time (UTC) date and time value. 
+         * You can use the convertToLocalClientTime method to convert the end property value to the client's local date and time.
          *
-         * When you use the Time.setAsync method to set the end time, you should use the convertToUtcClientTime method to convert the local time on the client to UTC for the server.
+         * When you use the Time.setAsync method to set the end time, you should use the convertToUtcClientTime method to convert the local time on 
+         * the client to UTC for the server.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1875,9 +2090,14 @@ export declare namespace Office {
         /**
          * Gets the Exchange Web Services item identifier for the current item.
          *
-         * The itemId property is not available in compose mode. If an item identifier is required, the saveAsync method can be used to save the item to the store, which will return the item identifier in the AsyncResult.value parameter in the callback function.
+         * The itemId property is not available in compose mode. 
+         * If an item identifier is required, the saveAsync method can be used to save the item to the store, which will return the item identifier 
+         * in the AsyncResult.value parameter in the callback function.
          *
-         * Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more details, see Use the Outlook REST APIs from an Outlook add-in.
+         * Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. 
+         * The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. 
+         * Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. 
+         * For more details, see {@link https://docs.microsoft.com/outlook/add-ins/use-rest-api#get-the-item-id | Use the Outlook REST APIs from an Outlook add-in}.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1919,7 +2139,8 @@ export declare namespace Office {
         /**
          * Gets the subject of an item, with all prefixes removed (including RE: and FWD:).
          *
-         * The normalizedSubject property gets the subject of the item, with any standard prefixes (such as RE: and FW:) that are added by email programs. To get the subject of the item with the prefixes intact, use the subject property.
+         * The normalizedSubject property gets the subject of the item, with any standard prefixes (such as RE: and FW:) that are added by email programs. 
+         * To get the subject of the item with the prefixes intact, use the subject property.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1945,7 +2166,8 @@ export declare namespace Office {
         /**
          * Provides access to the optional attendees of an event. The type of object and level of access depends on the mode of the current item.
          *
-         * The optionalAttendees property returns an array that contains an {@link Office.EmailAddressDetails} object for each optional attendee to the meeting.
+         * The optionalAttendees property returns an array that contains an {@link Office.EmailAddressDetails} object for each optional attendee to 
+         * the meeting.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1957,7 +2179,7 @@ export declare namespace Office {
          */
         optionalAttendees: EmailAddressDetails[];
         /**
-         * Gets the email address of the meeting organizer for a specified meeting. Read mode only.
+         * Gets the email address of the meeting organizer for a specified meeting.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1971,7 +2193,8 @@ export declare namespace Office {
         /**
          * Provides access to the required attendees of an event. The type of object and level of access depends on the mode of the current item.
          *
-         * The requiredAttendees property returns an array that contains an {@link Office.EmailAddressDetails} object for each required attendee to the meeting.
+         * The requiredAttendees property returns an array that contains an {@link Office.EmailAddressDetails} object for each required attendee to 
+         * the meeting.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1985,7 +2208,8 @@ export declare namespace Office {
         /**
          * Gets the date and time that the appointment is to begin.
          *
-         * The start property is a Date object expressed as a Coordinated Universal Time (UTC) date and time value. You can use the convertToLocalClientTime method to convert the value to the client's local date and time.
+         * The start property is a Date object expressed as a Coordinated Universal Time (UTC) date and time value. 
+         * You can use the convertToLocalClientTime method to convert the value to the client's local date and time.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -2012,14 +2236,18 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Appointment Attendee</td></tr></table>
          */
         subject: string;
+
         /**
-         * Displays a reply form that includes the sender and all recipients of the selected message or the organizer and all attendees of the selected appointment.
+         * Displays a reply form that includes the sender and all recipients of the selected message or the organizer and all attendees of the 
+         * selected appointment.
          *
          * In Outlook Web App, the reply form is displayed as a pop-out form in the 3-column view and a pop-up form in the 2- or 1-column view.
          *
          * If any of the string parameters exceed their limits, displayReplyAllForm throws an exception.
          *
-         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. If this isn't possible, then no error message is thrown.
+         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and 
+         * attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. 
+         * If this isn't possible, then no error message is thrown.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -2042,7 +2270,9 @@ export declare namespace Office {
          *
          * If any of the string parameters exceed their limits, displayReplyForm throws an exception.
          *
-         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. If this isn't possible, then no error message is thrown.
+         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and 
+         * attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. 
+         * If this isn't possible, then no error message is thrown.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -2060,7 +2290,7 @@ export declare namespace Office {
          */
         displayReplyForm(formData: string | ReplyFormData): void;
         /**
-         * Gets the entities found in the selected item.
+         * Gets the entities found in the selected item's body.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -2074,7 +2304,7 @@ export declare namespace Office {
          */
         getEntities(): Entities;
         /**
-         * Gets an array of all the entities of the specified entity type found in the selected item.
+         * Gets an array of all the entities of the specified entity type found in the selected item's body.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -2083,7 +2313,9 @@ export declare namespace Office {
          * @param entityType - One of the EntityType enumeration values.
          *
          * @returns
-         * If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. If no entities of the specified type are present on the item, the method returns an empty array. Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter.
+         * If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. 
+         * If no entities of the specified type are present in the item's body, the method returns an empty array. 
+         * Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter.
          *
          * @remarks
          * <table><tr><td>{@link https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions | Minimum permission level}</td><td>Restricted</td></tr>
@@ -2139,7 +2371,8 @@ export declare namespace Office {
         /**
          * Returns well-known entities in the selected item that pass the named filter defined in the manifest XML file.
          *
-         * The getFilteredEntitiesByName method returns the entities that match the regular expression defined in the ItemHasKnownEntity rule element in the manifest XML file with the specified FilterName element value.
+         * The getFilteredEntitiesByName method returns the entities that match the regular expression defined in the ItemHasKnownEntity rule element 
+         * in the manifest XML file with the specified FilterName element value.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -2152,22 +2385,33 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Appointment Attendee</td></tr></table>
          *
          * @param name - The name of the ItemHasKnownEntity rule element that defines the filter to match.
-         * @returns If there is no ItemHasKnownEntity element in the manifest with a FilterName element value that matches the name parameter, the method returns null. If the name parameter does match an ItemHasKnownEntity element in the manifest, but there are no entities in the current item that match, the method return an empty array.
+         * @returns If there is no ItemHasKnownEntity element in the manifest with a FilterName element value that matches the name parameter, 
+         * the method returns null. 
+         * If the name parameter does match an ItemHasKnownEntity element in the manifest, but there are no entities in the current item that match, 
+         * the method return an empty array.
          */
         getFilteredEntitiesByName(name: string): (string | Contact | MeetingSuggestion | PhoneNumber | TaskSuggestion)[];
         /**
          * Returns string values in the selected item that match the regular expressions defined in the manifest XML file.
          *
-         * The getRegExMatches method returns the strings that match the regular expression defined in each ItemHasRegularExpressionMatch or ItemHasKnownEntity rule element in the manifest XML file. For an ItemHasRegularExpressionMatch rule, a matching string has to occur in the property of the item that is specified by that rule. The PropertyName simple type defines the supported properties.
+         * The getRegExMatches method returns the strings that match the regular expression defined in each ItemHasRegularExpressionMatch or 
+         * ItemHasKnownEntity rule element in the manifest XML file. 
+         * For an ItemHasRegularExpressionMatch rule, a matching string has to occur in the property of the item that is specified by that rule. 
+         * The PropertyName simple type defines the supported properties.
          *
-         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body and should not attempt to return the entire body of the item. Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results. Instead, use the Body.getAsync method to retrieve the entire body.
+         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body 
+         * and should not attempt to return the entire body of the item. 
+         * Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results. 
+         * Instead, use the Body.getAsync method to retrieve the entire body.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
          * [Api set: Mailbox 1.0]
          *
          * @returns
-         * An object that contains arrays of strings that match the regular expressions defined in the manifest XML file. The name of each array is equal to the corresponding value of the RegExName attribute of the matching ItemHasRegularExpressionMatch rule or the FilterName attribute of the matching ItemHasKnownEntity rule.
+         * An object that contains arrays of strings that match the regular expressions defined in the manifest XML file. 
+         * The name of each array is equal to the corresponding value of the RegExName attribute of the matching ItemHasRegularExpressionMatch rule 
+         * or the FilterName attribute of the matching ItemHasKnownEntity rule.
          *
          * @remarks
          *
@@ -2179,9 +2423,12 @@ export declare namespace Office {
         /**
          * Returns string values in the selected item that match the named regular expression defined in the manifest XML file.
          *
-         * The getRegExMatchesByName method returns the strings that match the regular expression defined in the ItemHasRegularExpressionMatch rule element in the manifest XML file with the specified RegExName element value.
+         * The getRegExMatchesByName method returns the strings that match the regular expression defined in the ItemHasRegularExpressionMatch rule 
+         * element in the manifest XML file with the specified RegExName element value.
          *
-         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body and should not attempt to return the entire body of the item. Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results.
+         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body 
+         * and should not attempt to return the entire body of the item. 
+         * Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -2199,12 +2446,16 @@ export declare namespace Office {
          * @param name - The name of the ItemHasRegularExpressionMatch rule element that defines the filter to match.
          */
         getRegExMatchesByName(name: string): string[];
-       /**
+        /**
         * Asynchronously loads custom properties for this add-in on the selected item.
         *
-        * Custom properties are stored as key/value pairs on a per-app, per-item basis. This method returns a CustomProperties object in the callback, which provides methods to access the custom properties specific to the current item and the current add-in. Custom properties are not encrypted on the item, so this should not be used as secure storage.
+        * Custom properties are stored as key/value pairs on a per-app, per-item basis. 
+        * This method returns a CustomProperties object in the callback, which provides methods to access the custom properties specific to the 
+        * current item and the current add-in. Custom properties are not encrypted on the item, so this should not be used as secure storage.
         *
-        * The custom properties are provided as a CustomProperties object in the asyncResult.value property. This object can be used to get, set, and remove custom properties from the item and save changes to the custom property set back to the server.
+        * The custom properties are provided as a CustomProperties object in the asyncResult.value property. 
+        * This object can be used to get, set, and remove custom properties from the item and save changes to the custom property set back to 
+        * the server.
         *
         * [Api set: Mailbox 1.0]
         *
@@ -2214,14 +2465,17 @@ export declare namespace Office {
         *
         * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Appointment Attendee</td></tr></table>
         *
-        * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
-        * @param userContext - Optional. Developers can provide any object they wish to access in the callback function. This object can be accessed by the asyncResult.asyncContext property in the callback function.
+        * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+        *                 type Office.AsyncResult.
+        * @param userContext - Optional. Developers can provide any object they wish to access in the callback function. 
+        *                    This object can be accessed by the asyncResult.asyncContext property in the callback function.
         */
-       loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;
+       loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any): void;
     }
 
     /**
-     * The item namespace is used to access the currently selected message, meeting request, or appointment. You can determine the type of the item by using the `itemType` property.
+     * The item namespace is used to access the currently selected message, meeting request, or appointment. 
+     * You can determine the type of the item by using the `itemType` property.
      *
      * [Api set: Mailbox 1.0]
      *
@@ -2272,7 +2526,8 @@ export declare namespace Office {
         /**
          * Gets the type of item that an instance represents.
          *
-         * The itemType property returns one of the ItemType enumeration values, indicating whether the item object instance is a message or an appointment.
+         * The itemType property returns one of the ItemType enumeration values, indicating whether the item object instance is a message or 
+         * an appointment.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -2299,9 +2554,13 @@ export declare namespace Office {
        /**
         * Asynchronously loads custom properties for this add-in on the selected item.
         *
-        * Custom properties are stored as key/value pairs on a per-app, per-item basis. This method returns a CustomProperties object in the callback, which provides methods to access the custom properties specific to the current item and the current add-in. Custom properties are not encrypted on the item, so this should not be used as secure storage.
+        * Custom properties are stored as key/value pairs on a per-app, per-item basis. 
+        * This method returns a CustomProperties object in the callback, which provides methods to access the custom properties specific to the 
+        * current item and the current add-in. Custom properties are not encrypted on the item, so this should not be used as secure storage.
         *
-        * The custom properties are provided as a CustomProperties object in the asyncResult.value property. This object can be used to get, set, and remove custom properties from the item and save changes to the custom property set back to the server.
+        * The custom properties are provided as a CustomProperties object in the asyncResult.value property. 
+        * This object can be used to get, set, and remove custom properties from the item and save changes to the custom property set back to 
+        * the server.
         *
         * [Api set: Mailbox 1.0]
         *
@@ -2311,15 +2570,18 @@ export declare namespace Office {
         *
         * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
         *
-        * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
-        * @param userContext - Optional. Developers can provide any object they wish to access in the callback function. This object can be accessed by the asyncResult.asyncContext property in the callback function.
+        * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+        *                 type Office.AsyncResult.
+        * @param userContext - Optional. Developers can provide any object they wish to access in the callback function. 
+        *                    This object can be accessed by the asyncResult.asyncContext property in the callback function.
         */
-       loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;
+       loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any): void;
     }
     /**
      * The compose mode of {@link Office.Item | Office.context.mailbox.item}.
      * 
-     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
+     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. 
+     * You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
      */
     export interface ItemCompose extends Item {
         /**
@@ -2360,16 +2622,20 @@ export declare namespace Office {
          * 
          * `addFileAttachmentAsync(uri: string, attachmentName: string, options: Office.AsyncContextOptions): void;`
          * 
-         * `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+         * `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;`
          *
          * @param uri - The URI that provides the location of the file to attach to the message or appointment. The maximum length is 2048 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         *        isInline: If true, indicates that the attachment will be shown inline in the message body, and should not be displayed in the attachment list.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type asyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         *        isInline: If true, indicates that the attachment will be shown inline in the message body, and should not be displayed in the 
+         *        attachment list.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type asyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of 
+         *                 the error.
          */
-        addFileAttachmentAsync(uri: string, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        addFileAttachmentAsync(uri: string, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;
         /**
          * Adds a file to a message or appointment as an attachment.
          *
@@ -2410,7 +2676,8 @@ export declare namespace Office {
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         *        isInline: If true, indicates that the attachment will be shown inline in the message body, and should not be displayed in the attachment list.
+         *        isInline: If true, indicates that the attachment will be shown inline in the message body, and should not be displayed in the 
+         *        attachment list.
          */
         addFileAttachmentAsync(uri: string, attachmentName: string, options: Office.AsyncContextOptions): void;
         /**
@@ -2431,18 +2698,25 @@ export declare namespace Office {
          *
          * @param uri - The URI that provides the location of the file to attach to the message or appointment. The maximum length is 2048 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type asyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of 
+         *                 the error.
          */
-        addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;
+        addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;
 
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the 
+         * callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -2453,29 +2727,36 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>NumberOfAttachmentsExceeded - The message or appointment has too many attachments.</td></tr></table>
          * 
-         * In addition to the main signature, this method also has these signatures:
+         * In addition to this signature, this method also has the following signatures:
          * 
          * `addItemAttachmentAsync(itemId: any, attachmentName: string): void;`
          * 
          * `addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;`
          * 
-         * `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+         * `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;`
          *
          * @param itemId - The Exchange identifier of the item to attach. The maximum length is 100 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
          * @param options - An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of 
+         *                 the error.
          */
-        addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the 
+         * callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -2493,11 +2774,15 @@ export declare namespace Office {
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the 
+         * callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -2517,11 +2802,15 @@ export declare namespace Office {
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the 
+         * callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -2534,18 +2823,23 @@ export declare namespace Office {
          *
          * @param itemId - The Exchange identifier of the item to attach. The maximum length is 100 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of 
+         *                 the error.
          */
-        addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;
+        addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;
 
         /**
          * Closes the current item that is being composed
          *
-         * The behaviors of the close method depends on the current state of the item being composed. If the item has unsaved changes, the client prompts the user to save, discard, or close the action.
+         * The behaviors of the close method depends on the current state of the item being composed. 
+         * If the item has unsaved changes, the client prompts the user to save, discard, or close the action.
          *
          * In the Outlook desktop client, if the message is an inline reply, the close method has no effect.
          *
-         * Note: In Outlook on the web, if the item is an appointment and it has previously been saved using saveAsync, the user is prompted to save, discard, or cancel even if no changes have occurred since the item was last saved.
+         * Note: In Outlook on the web, if the item is an appointment and it has previously been saved using saveAsync, the user is prompted to save, 
+         * discard, or cancel even if no changes have occurred since the item was last saved.
          *
          * [Api set: Mailbox 1.3]
          *
@@ -2559,9 +2853,11 @@ export declare namespace Office {
         /**
          * Asynchronously returns selected data from the subject or body of a message.
          *
-         * If there is no selection but the cursor is in the body or subject, the method returns null for the selected data. If a field other than the body or subject is selected, the method returns the InvalidSelection error.
+         * If there is no selection but the cursor is in the body or subject, the method returns null for the selected data. 
+         * If a field other than the body or subject is selected, the method returns the InvalidSelection error.
          *
-         * To access the selected data from the callback method, call asyncResult.value.data. To access the source property that the selection comes from, call asyncResult.value.sourceProperty, which will be either body or subject.
+         * To access the selected data from the callback method, call asyncResult.value.data. To access the source property that the selection comes 
+         * from, call asyncResult.value.sourceProperty, which will be either body or subject.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -2574,16 +2870,20 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose</td></tr></table>
          *
-         * @param coercionType - Requests a format for the data. If Text, the method returns the plain text as a string , removing any HTML tags present. If HTML, the method returns the selected text, whether it is plaintext or HTML.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param coercionType - Requests a format for the data. If Text, the method returns the plain text as a string , removing any HTML tags present. 
+         *                     If HTML, the method returns the selected text, whether it is plaintext or HTML.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          */
-        getSelectedDataAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult) => void): void;
+        getSelectedDataAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult<any>) => void): void;
         /**
          * Asynchronously returns selected data from the subject or body of a message.
          *
-         * If there is no selection but the cursor is in the body or subject, the method returns null for the selected data. If a field other than the body or subject is selected, the method returns the InvalidSelection error.
+         * If there is no selection but the cursor is in the body or subject, the method returns null for the selected data. 
+         * If a field other than the body or subject is selected, the method returns the InvalidSelection error.
          *
-         * To access the selected data from the callback method, call asyncResult.value.data. To access the source property that the selection comes from, call asyncResult.value.sourceProperty, which will be either body or subject.
+         * To access the selected data from the callback method, call asyncResult.value.data. 
+         * To access the source property that the selection comes from, call asyncResult.value.sourceProperty, which will be either body or subject.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -2596,16 +2896,22 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose</td></tr></table>
          *
-         * @param coercionType - Requests a format for the data. If Text, the method returns the plain text as a string , removing any HTML tags present. If HTML, the method returns the selected text, whether it is plaintext or HTML.
+         * @param coercionType - Requests a format for the data. If Text, the method returns the plain text as a string, removing any HTML tags present. 
+         *                     If HTML, the method returns the selected text, whether it is plaintext or HTML.
          * @param options - An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          */
-        getSelectedDataAsync(coerciontype: Office.CoercionType, options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;
+        getSelectedDataAsync(coerciontype: Office.CoercionType, options: Office.AsyncContextOptions, callback: (result: AsyncResult<any>) => void): void;
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -2623,18 +2929,24 @@ export declare namespace Office {
          * 
          * `removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;`
          * 
-         * `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;`
+         * `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;`
          *
          * @param attachmentIndex - The identifier of the attachment to remove. The maximum length of the string is 100 characters.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. 
+         *                 If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
          */
-        removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -2652,7 +2964,11 @@ export declare namespace Office {
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -2672,7 +2988,11 @@ export declare namespace Office {
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -2685,18 +3005,26 @@ export declare namespace Office {
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
          * @param attachmentIndex - The identifier of the attachment to remove. The maximum length of the string is 100 characters.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type {@link Offfice.AsyncResult}. 
+         *                 If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
          */
-        removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;
+        removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;
 
         /**
          * Asynchronously saves an item.
          *
-         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. In Outlook Web App or Outlook in online mode, the item is saved to the server. In Outlook in cached mode, the item is saved to the local cache.
+         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. 
+         * In Outlook Web App or Outlook in online mode, the item is saved to the server. 
+         * In Outlook in cached mode, the item is saved to the local cache.
          *
-         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. Saving an existing appointment will send an update to added or removed attendees.
+         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal 
+         * appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. 
+         * Saving an existing appointment will send an update to added or removed attendees.
          *
-         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that when Outlook is in cached mode, it may take some time before the item is actually synced to the server. Until the item is synced, using the itemId will return an error.
+         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that 
+         * when Outlook is in cached mode, it may take some time before the item is actually synced to the server. 
+         * Until the item is synced, using the itemId will return an error.
          *
          * Note: The following clients have different behavior for saveAsync on appointments in compose mode:
          *
@@ -2720,21 +3048,29 @@ export declare namespace Office {
          * 
          * `saveAsync(options: Office.AsyncContextOptions): void;`
          * 
-         * `saveAsync(callback: (result: AsyncResult) => void): void;`
+         * `saveAsync(callback: (result: AsyncResult<void>) => void): void;`
          *
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. 
+         *                 If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
          */
-        saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Asynchronously saves an item.
          *
-         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. In Outlook Web App or Outlook in online mode, the item is saved to the server. In Outlook in cached mode, the item is saved to the local cache.
+         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. 
+         * In Outlook Web App or Outlook in online mode, the item is saved to the server. 
+         * In Outlook in cached mode, the item is saved to the local cache.
          *
-         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. Saving an existing appointment will send an update to added or removed attendees.
+         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal 
+         * appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. 
+         * Saving an existing appointment will send an update to added or removed attendees.
          *
-         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that when Outlook is in cached mode, it may take some time before the item is actually synced to the server. Until the item is synced, using the itemId will return an error.
+         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that 
+         * when Outlook is in cached mode, it may take some time before the item is actually synced to the server. 
+         * Until the item is synced, using the itemId will return an error.
          *
          * Note: The following clients have different behavior for saveAsync on appointments in compose mode:
          *
@@ -2757,11 +3093,17 @@ export declare namespace Office {
         /**
          * Asynchronously saves an item.
          *
-         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. In Outlook Web App or Outlook in online mode, the item is saved to the server. In Outlook in cached mode, the item is saved to the local cache.
+         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. 
+         * In Outlook Web App or Outlook in online mode, the item is saved to the server. 
+         * In Outlook in cached mode, the item is saved to the local cache.
          *
-         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. Saving an existing appointment will send an update to added or removed attendees.
+         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal 
+         * appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. 
+         * Saving an existing appointment will send an update to added or removed attendees.
          *
-         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that when Outlook is in cached mode, it may take some time before the item is actually synced to the server. Until the item is synced, using the itemId will return an error.
+         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that 
+         * when Outlook is in cached mode, it may take some time before the item is actually synced to the server. 
+         * Until the item is synced, using the itemId will return an error.
          *
          * Note: The following clients have different behavior for saveAsync on appointments in compose mode:
          *
@@ -2786,11 +3128,17 @@ export declare namespace Office {
         /**
          * Asynchronously saves an item.
          *
-         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. In Outlook Web App or Outlook in online mode, the item is saved to the server. In Outlook in cached mode, the item is saved to the local cache.
+         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. 
+         * In Outlook Web App or Outlook in online mode, the item is saved to the server. 
+         * In Outlook in cached mode, the item is saved to the local cache.
          *
-         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. Saving an existing appointment will send an update to added or removed attendees.
+         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal 
+         * appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. 
+         * Saving an existing appointment will send an update to added or removed attendees.
          *
-         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that when Outlook is in cached mode, it may take some time before the item is actually synced to the server. Until the item is synced, using the itemId will return an error.
+         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that 
+         * when Outlook is in cached mode, it may take some time before the item is actually synced to the server. 
+         * Until the item is synced, using the itemId will return an error.
          *
          * Note: The following clients have different behavior for saveAsync on appointments in compose mode:
          *
@@ -2808,13 +3156,17 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. 
+         *                 If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
          */
-        saveAsync(callback: (result: AsyncResult) => void): void;
+        saveAsync(callback: (result: AsyncResult<void>) => void): void;
         /**
          * Asynchronously inserts data into the body or subject of a message.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is 
+         * selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. 
+         * After insertion, the cursor is placed at the end of the inserted content.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -2832,19 +3184,29 @@ export declare namespace Office {
          * 
          * `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`
          * 
-         * `setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;`
+         * `setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;`
          *
-         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
+         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. 
+         *             If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         *        coercionType: If text, the current style is applied in Outlook Web App and Outlook. If the field is an HTML editor, only the text data is inserted, even if the data is HTML. If html and the field supports HTML (the subject doesn't), the current style is applied in Outlook Web App and the default style is applied in Outlook. If the field is a text field, an InvalidDataFormat error is returned. If coercionType is not set, the result depends on the field: if the field is HTML then HTML is used; if the field is text, then plain text is used.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         *        coercionType: If text, the current style is applied in Outlook Web App and Outlook. 
+         *        If the field is an HTML editor, only the text data is inserted, even if the data is HTML. 
+         *        If html and the field supports HTML (the subject doesn't), the current style is applied in Outlook Web App and the default style is 
+         *        applied in Outlook. 
+         *        If the field is a text field, an InvalidDataFormat error is returned. 
+         *        If coercionType is not set, the result depends on the field: if the field is HTML then HTML is used; 
+         *        if the field is text, then plain text is used.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. 
          */
-        setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult) => void): void;
+        setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Asynchronously inserts data into the body or subject of a message.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is 
+         * selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. 
+         * After insertion, the cursor is placed at the end of the inserted content.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -2856,13 +3218,16 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
-         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
+         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. 
+         *             If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
          */
         setSelectedDataAsync(data: string): void;
         /**
          * Asynchronously inserts data into the body or subject of a message.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is 
+         * selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. 
+         * After insertion, the cursor is placed at the end of the inserted content.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -2874,16 +3239,25 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
-         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
+         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. 
+         *             If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         *        coercionType: If text, the current style is applied in Outlook Web App and Outlook. If the field is an HTML editor, only the text data is inserted, even if the data is HTML. If html and the field supports HTML (the subject doesn't), the current style is applied in Outlook Web App and the default style is applied in Outlook. If the field is a text field, an InvalidDataFormat error is returned. If coercionType is not set, the result depends on the field: if the field is HTML then HTML is used; if the field is text, then plain text is used.
+         *        coercionType: If text, the current style is applied in Outlook Web App and Outlook. 
+         *        If the field is an HTML editor, only the text data is inserted, even if the data is HTML. 
+         *        If html and the field supports HTML (the subject doesn't), the current style is applied in Outlook Web App and the default style is 
+         *        applied in Outlook. 
+         *        If the field is a text field, an InvalidDataFormat error is returned. 
+         *        If coercionType is not set, the result depends on the field: if the field is HTML then HTML is used; 
+         *        if the field is text, then plain text is used.
          */
         setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;
         /**
          * Asynchronously inserts data into the body or subject of a message.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is 
+         * selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. 
+         * After insertion, the cursor is placed at the end of the inserted content.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -2895,19 +3269,22 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
-         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. 
+         *             If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. 
          */
-        setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;
+        setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;
     }
     /**
      * The read mode of {@link Office.Item | Office.context.mailbox.item}.
      * 
-     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
+     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. 
+     * You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
      */
     export interface ItemRead extends Item {
         /**
-         * Gets an array of attachments for the item.
+         * Gets the item's attachments as an array.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -2916,7 +3293,9 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Read</td></tr></table>
          *
-         * Note: Certain types of files are blocked by Outlook due to potential security issues and are therefore not returned. For more information, see {@link https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519 | Blocked attachments in Outlook}.
+         * Note: Certain types of files are blocked by Outlook due to potential security issues and are therefore not returned. 
+         * For more information, see 
+         * {@link https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519 | Blocked attachments in Outlook}.
          *
          */
         attachments: Office.AttachmentDetails[];
@@ -2924,7 +3303,8 @@ export declare namespace Office {
          * Gets the Exchange Web Services item class of the selected item.
          *
          *
-         * You can create custom message classes that extends a default message class, for example, a custom appointment message class IPM.Appointment.Contoso.
+         * You can create custom message classes that extends a default message class, for example, a custom appointment message class 
+         * IPM.Appointment.Contoso.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -2934,7 +3314,8 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Read</td></tr></table>
          * 
-         * The itemClass property specifies the message class of the selected item. The following are the default message classes for the message or appointment item.
+         * The itemClass property specifies the message class of the selected item. The following are the default message classes for the message or 
+         * appointment item.
          * 
          * <table>
          *   <tr>
@@ -2958,9 +3339,14 @@ export declare namespace Office {
         /**
          * Gets the Exchange Web Services item identifier for the current item.
          *
-         * The itemId property is not available in compose mode. If an item identifier is required, the saveAsync method can be used to save the item to the store, which will return the item identifier in the AsyncResult.value parameter in the callback function.
+         * The itemId property is not available in compose mode. 
+         * If an item identifier is required, the saveAsync method can be used to save the item to the store, which will return the item identifier 
+         * in the AsyncResult.value parameter in the callback function.
          *
-         * Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more details, see Use the Outlook REST APIs from an Outlook add-in.
+         * Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. 
+         * The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. 
+         * Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. 
+         * For more details, see {@link https://docs.microsoft.com/outlook/add-ins/use-rest-api#get-the-item-id | Use the Outlook REST APIs from an Outlook add-in}.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -2974,7 +3360,8 @@ export declare namespace Office {
         /**
          * Gets the subject of an item, with all prefixes removed (including RE: and FWD:).
          *
-         * The normalizedSubject property gets the subject of the item, with any standard prefixes (such as RE: and FW:) that are added by email programs. To get the subject of the item with the prefixes intact, use the subject property.
+         * The normalizedSubject property gets the subject of the item, with any standard prefixes (such as RE: and FW:) that are added by 
+         * email programs. To get the subject of the item with the prefixes intact, use the subject property.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -3002,13 +3389,16 @@ export declare namespace Office {
          */
         subject: string;
         /**
-         * Displays a reply form that includes the sender and all recipients of the selected message or the organizer and all attendees of the selected appointment.
+         * Displays a reply form that includes the sender and all recipients of the selected message or the organizer and all attendees of the 
+         * selected appointment.
          *
          * In Outlook Web App, the reply form is displayed as a pop-out form in the 3-column view and a pop-up form in the 2- or 1-column view.
          *
          * If any of the string parameters exceed their limits, displayReplyAllForm throws an exception.
          *
-         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. If this isn't possible, then no error message is thrown.
+         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and 
+         * attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. 
+         * If this isn't possible, then no error message is thrown.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -3031,7 +3421,9 @@ export declare namespace Office {
          *
          * If any of the string parameters exceed their limits, displayReplyForm throws an exception.
          *
-         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. If this isn't possible, then no error message is thrown.
+         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and 
+         * attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. 
+         * If this isn't possible, then no error message is thrown.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -3049,7 +3441,7 @@ export declare namespace Office {
          */
         displayReplyForm(formData: string | ReplyFormData): void;
         /**
-         * Gets the entities found in the selected item.
+         * Gets the entities found in the selected item's body.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -3063,7 +3455,7 @@ export declare namespace Office {
          */
         getEntities(): Entities;
         /**
-         * Gets an array of all the entities of the specified entity type found in the selected item.
+         * Gets an array of all the entities of the specified entity type found in the selected item's body.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -3072,14 +3464,17 @@ export declare namespace Office {
          * @param entityType - One of the EntityType enumeration values.
          *
          * @returns
-         * If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. If no entities of the specified type are present on the item, the method returns an empty array. Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter.
+         * If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. 
+         * If no entities of the specified type are present in the item's body, the method returns an empty array. 
+         * Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter.
          *
          * @remarks
          * <table><tr><td>{@link https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions | Minimum permission level}</td><td>Restricted</td></tr>
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Read</td></tr></table>
          * 
-         * While the minimum permission level to use this method is Restricted, some entity types require ReadItem to access, as specified in the following table.
+         * While the minimum permission level to use this method is Restricted, some entity types require ReadItem to access, as specified in the 
+         * following table.
          * 
          * <table>
          *   <tr>
@@ -3128,7 +3523,8 @@ export declare namespace Office {
         /**
          * Returns well-known entities in the selected item that pass the named filter defined in the manifest XML file.
          *
-         * The getFilteredEntitiesByName method returns the entities that match the regular expression defined in the ItemHasKnownEntity rule element in the manifest XML file with the specified FilterName element value.
+         * The getFilteredEntitiesByName method returns the entities that match the regular expression defined in the ItemHasKnownEntity rule element 
+         * in the manifest XML file with the specified FilterName element value.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -3141,22 +3537,33 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Read</td></tr></table>
          *
          * @param name - The name of the ItemHasKnownEntity rule element that defines the filter to match.
-         * @returns If there is no ItemHasKnownEntity element in the manifest with a FilterName element value that matches the name parameter, the method returns null. If the name parameter does match an ItemHasKnownEntity element in the manifest, but there are no entities in the current item that match, the method return an empty array.
+         * @returns If there is no ItemHasKnownEntity element in the manifest with a FilterName element value that matches the name parameter, 
+         * the method returns null. 
+         * If the name parameter does match an ItemHasKnownEntity element in the manifest, but there are no entities in the current item that match, 
+         * the method return an empty array.
          */
         getFilteredEntitiesByName(name: string): (string | Contact | MeetingSuggestion | PhoneNumber | TaskSuggestion)[];
         /**
          * Returns string values in the selected item that match the regular expressions defined in the manifest XML file.
          *
-         * The getRegExMatches method returns the strings that match the regular expression defined in each ItemHasRegularExpressionMatch or ItemHasKnownEntity rule element in the manifest XML file. For an ItemHasRegularExpressionMatch rule, a matching string has to occur in the property of the item that is specified by that rule. The PropertyName simple type defines the supported properties.
+         * The getRegExMatches method returns the strings that match the regular expression defined in each ItemHasRegularExpressionMatch or 
+         * ItemHasKnownEntity rule element in the manifest XML file. 
+         * For an ItemHasRegularExpressionMatch rule, a matching string has to occur in the property of the item that is specified by that rule. 
+         * The PropertyName simple type defines the supported properties.
          *
-         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body and should not attempt to return the entire body of the item. Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results. Instead, use the Body.getAsync method to retrieve the entire body.
+         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body 
+         * and should not attempt to return the entire body of the item. 
+         * Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results. 
+         * Instead, use the Body.getAsync method to retrieve the entire body.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
          * [Api set: Mailbox 1.0]
          *
          * @returns
-         * An object that contains arrays of strings that match the regular expressions defined in the manifest XML file. The name of each array is equal to the corresponding value of the RegExName attribute of the matching ItemHasRegularExpressionMatch rule or the FilterName attribute of the matching ItemHasKnownEntity rule.
+         * An object that contains arrays of strings that match the regular expressions defined in the manifest XML file. 
+         * The name of each array is equal to the corresponding value of the RegExName attribute of the matching ItemHasRegularExpressionMatch rule 
+         * or the FilterName attribute of the matching ItemHasKnownEntity rule.
          *
          * @remarks
          *
@@ -3168,9 +3575,12 @@ export declare namespace Office {
         /**
          * Returns string values in the selected item that match the named regular expression defined in the manifest XML file.
          *
-         * The getRegExMatchesByName method returns the strings that match the regular expression defined in the ItemHasRegularExpressionMatch rule element in the manifest XML file with the specified RegExName element value.
+         * The getRegExMatchesByName method returns the strings that match the regular expression defined in the ItemHasRegularExpressionMatch rule 
+         * element in the manifest XML file with the specified RegExName element value.
          *
-         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body and should not attempt to return the entire body of the item. Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results.
+         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body 
+         * and should not attempt to return the entire body of the item. 
+         * Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -3192,15 +3602,19 @@ export declare namespace Office {
     /**
      * A subclass of {@link Office.Item} for messages.
      * 
-     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
+     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. 
+     * You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
      */
     export interface Message extends Item {
         /**
          * Gets an identifier for the email conversation that contains a particular message.
          *
-         * You can get an integer for this property if your mail app is activated in read forms or responses in compose forms. If subsequently the user changes the subject of the reply message, upon sending the reply, the conversation ID for that message will change and that value you obtained earlier will no longer apply.
+         * You can get an integer for this property if your mail app is activated in read forms or responses in compose forms. 
+         * If subsequently the user changes the subject of the reply message, upon sending the reply, the conversation ID for that message will 
+         * change and that value you obtained earlier will no longer apply.
          *
-         * You get null for this property for a new item in a compose form. If the user sets a subject and saves the item, the conversationId property will return a value.
+         * You get null for this property for a new item in a compose form. 
+         * If the user sets a subject and saves the item, the conversationId property will return a value.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -3216,7 +3630,8 @@ export declare namespace Office {
      /**
      * The message compose mode of {@link Office.Item | Office.context.mailbox.item}.
      * 
-     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
+     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. 
+     * You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
      */
     export interface MessageCompose extends Message, ItemCompose {
         /**
@@ -3244,9 +3659,11 @@ export declare namespace Office {
          */
         body: Office.Body;
         /**
-         * Provides access to the Cc (carbon copy) recipients of a message. The type of object and level of access depends on the mode of the current item.
+         * Provides access to the Cc (carbon copy) recipients of a message. The type of object and level of access depends on the mode of the 
+         * current item.
          *
-         * The cc property returns a {@link Office.Recipients} object that provides methods to get or update the recipients on the Cc line of the message.
+         * The cc property returns a {@link Office.Recipients} object that provides methods to get or update the recipients on the Cc line of 
+         * the message.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -3260,9 +3677,12 @@ export declare namespace Office {
         /**
          * Gets an identifier for the email conversation that contains a particular message.
          *
-         * You can get an integer for this property if your mail app is activated in read forms or responses in compose forms. If subsequently the user changes the subject of the reply message, upon sending the reply, the conversation ID for that message will change and that value you obtained earlier will no longer apply.
+         * You can get an integer for this property if your mail app is activated in read forms or responses in compose forms. 
+         * If subsequently the user changes the subject of the reply message, upon sending the reply, the conversation ID for that message will change 
+         * and that value you obtained earlier will no longer apply.
          *
-         * You get null for this property for a new item in a compose form. If the user sets a subject and saves the item, the conversationId property will return a value.
+         * You get null for this property for a new item in a compose form. 
+         * If the user sets a subject and saves the item, the conversationId property will return a value.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -3302,7 +3722,8 @@ export declare namespace Office {
         /**
          * Gets the type of item that an instance represents.
          *
-         * The itemType property returns one of the ItemType enumeration values, indicating whether the item object instance is a message or an appointment.
+         * The itemType property returns one of the ItemType enumeration values, indicating whether the item object instance is a message or 
+         * an appointment.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -3342,7 +3763,8 @@ export declare namespace Office {
          */
         subject: Subject;
         /**
-         * Provides access to the recipients on the To line of a message. The type of object and level of access depends on the mode of the current item.
+         * Provides access to the recipients on the To line of a message. The type of object and level of access depends on the mode of the 
+         * current item.
          *
          * The to property returns a Recipients object that provides methods to get or update the recipients on the To line of the message.
          *
@@ -3378,16 +3800,20 @@ export declare namespace Office {
          * 
          * `addFileAttachmentAsync(uri: string, attachmentName: string, options: AsyncContextOptions): void;`
          * 
-         * `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+         * `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;`
          *
          * @param uri - The URI that provides the location of the file to attach to the message or appointment. The maximum length is 2048 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         *        isInline: If true, indicates that the attachment will be shown inline in the message body, and should not be displayed in the attachment list.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type asyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         *        isInline: If true, indicates that the attachment will be shown inline in the message body, and should not be displayed in the 
+         *        attachment list.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of 
+         *                 the error.
          */
-        addFileAttachmentAsync(uri: string, attachmentName: string, options?: AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        addFileAttachmentAsync(uri: string, attachmentName: string, options?: AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;
         /**
          * Adds a file to a message or appointment as an attachment.
          *
@@ -3428,7 +3854,7 @@ export declare namespace Office {
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         *        isInline: If true, indicates that the attachment will be shown inline in the message body, and should not be displayed in the attachment list.
+         *        isInline: If true, indicates that the attachment will be shown inline in the message body and should not be displayed in the attachment list.
          */
         addFileAttachmentAsync(uri: string, attachmentName: string, options: AsyncContextOptions): void;
         /**
@@ -3449,17 +3875,24 @@ export declare namespace Office {
          *
          * @param uri - The URI that provides the location of the file to attach to the message or appointment. The maximum length is 2048 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type asyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of 
+         *                 the error.
          */
-        addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;
+        addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the 
+         * callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -3470,29 +3903,36 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>NumberOfAttachmentsExceeded - The message or appointment has too many attachments.</td></tr></table>
          * 
-         * In addition to the main signature, this method also has these signatures:
+         * In addition to this signature, this method also has the following signatures:
          * 
          * `addItemAttachmentAsync(itemId: any, attachmentName: string): void;`
          * 
          * `addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;`
          * 
-         * `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+         * `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;`
          *
          * @param itemId - The Exchange identifier of the item to attach. The maximum length is 100 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
          * @param options - An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of 
+         *                 the error.
          */
-        addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. 
+         * You can use the options parameter to pass state information to the callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -3510,11 +3950,15 @@ export declare namespace Office {
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. 
+         * You can use the options parameter to pass state information to the callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -3534,11 +3978,15 @@ export declare namespace Office {
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. 
+         * You can use the options parameter to pass state information to the callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -3551,17 +3999,22 @@ export declare namespace Office {
          *
          * @param itemId - The Exchange identifier of the item to attach. The maximum length is 100 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of 
+         *                 the error.
          */
-        addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;
+        addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;
         /**
          * Closes the current item that is being composed
          *
-         * The behaviors of the close method depends on the current state of the item being composed. If the item has unsaved changes, the client prompts the user to save, discard, or close the action.
+         * The behaviors of the close method depends on the current state of the item being composed. 
+         * If the item has unsaved changes, the client prompts the user to save, discard, or close the action.
          *
          * In the Outlook desktop client, if the message is an inline reply, the close method has no effect.
          *
-         * Note: In Outlook on the web, if the item is an appointment and it has previously been saved using saveAsync, the user is prompted to save, discard, or cancel even if no changes have occurred since the item was last saved.
+         * Note: In Outlook on the web, if the item is an appointment and it has previously been saved using saveAsync, the user is prompted to save, 
+         * discard, or cancel even if no changes have occurred since the item was last saved.
          *
          * [Api set: Mailbox 1.3]
          *
@@ -3575,9 +4028,11 @@ export declare namespace Office {
         /**
          * Asynchronously returns selected data from the subject or body of a message.
          *
-         * If there is no selection but the cursor is in the body or subject, the method returns null for the selected data. If a field other than the body or subject is selected, the method returns the InvalidSelection error.
+         * If there is no selection but the cursor is in the body or subject, the method returns null for the selected data. 
+         * If a field other than the body or subject is selected, the method returns the InvalidSelection error.
          *
-         * To access the selected data from the callback method, call asyncResult.value.data. To access the source property that the selection comes from, call asyncResult.value.sourceProperty, which will be either body or subject.
+         * To access the selected data from the callback method, call asyncResult.value.data. 
+         * To access the source property that the selection comes from, call asyncResult.value.sourceProperty, which will be either body or subject.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -3590,16 +4045,20 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Message Compose</td></tr></table>
          *
-         * @param coercionType - Requests a format for the data. If Text, the method returns the plain text as a string , removing any HTML tags present. If HTML, the method returns the selected text, whether it is plaintext or HTML.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param coercionType - Requests a format for the data. If Text, the method returns the plain text as a string, removing any HTML tags present. 
+         *                     If HTML, the method returns the selected text, whether it is plaintext or HTML.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          */
-        getSelectedDataAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult) => void): void;
+        getSelectedDataAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult<any>) => void): void;
         /**
          * Asynchronously returns selected data from the subject or body of a message.
          *
-         * If there is no selection but the cursor is in the body or subject, the method returns null for the selected data. If a field other than the body or subject is selected, the method returns the InvalidSelection error.
+         * If there is no selection but the cursor is in the body or subject, the method returns null for the selected data. 
+         * If a field other than the body or subject is selected, the method returns the InvalidSelection error.
          *
-         * To access the selected data from the callback method, call asyncResult.value.data. To access the source property that the selection comes from, call asyncResult.value.sourceProperty, which will be either body or subject.
+         * To access the selected data from the callback method, call asyncResult.value.data. 
+         * To access the source property that the selection comes from, call asyncResult.value.sourceProperty, which will be either body or subject.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -3612,18 +4071,24 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Message Compose</td></tr></table>
          *
-         * @param coercionType - Requests a format for the data. If Text, the method returns the plain text as a string , removing any HTML tags present. If HTML, the method returns the selected text, whether it is plaintext or HTML.
+         * @param coercionType - Requests a format for the data. If Text, the method returns the plain text as a string, removing any HTML tags present. 
+         *                     If HTML, the method returns the selected text, whether it is plaintext or HTML.
          * @param options - An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          */
-        getSelectedDataAsync(coerciontype: Office.CoercionType, options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;
+        getSelectedDataAsync(coerciontype: Office.CoercionType, options: Office.AsyncContextOptions, callback: (result: AsyncResult<any>) => void): void;
         /**
          * Asynchronously loads custom properties for this add-in on the selected item.
          *
-         * Custom properties are stored as key/value pairs on a per-app, per-item basis. This method returns a CustomProperties object in the callback, which provides methods to access the custom properties specific to the current item and the current add-in. Custom properties are not encrypted on the item, so this should not be used as secure storage.
+         * Custom properties are stored as key/value pairs on a per-app, per-item basis. 
+         * This method returns a CustomProperties object in the callback, which provides methods to access the custom properties specific to the 
+         * current item and the current add-in. Custom properties are not encrypted on the item, so this should not be used as secure storage.
          *
-         * The custom properties are provided as a CustomProperties object in the asyncResult.value property. This object can be used to get, set, and remove custom properties from the item and save changes to the custom property set back to the server.
+         * The custom properties are provided as a CustomProperties object in the asyncResult.value property. 
+         * This object can be used to get, set, and remove custom properties from the item and save changes to the custom property set back to 
+         * the server.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -3633,14 +4098,20 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Message Compose</td></tr></table>
          *
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
-         * @param userContext - Optional. Developers can provide any object they wish to access in the callback function. This object can be accessed by the asyncResult.asyncContext property in the callback function.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
+         * @param userContext - Optional. Developers can provide any object they wish to access in the callback function. 
+         *                    This object can be accessed by the asyncResult.asyncContext property in the callback function.
          */
-        loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;
+        loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any): void;
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -3658,18 +4129,24 @@ export declare namespace Office {
          * 
          * `removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;`
          * 
-         * `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;`
+         * `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;`
          *
          * @param attachmentIndex - The identifier of the attachment to remove. The maximum length of the string is 100 characters.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. 
+         *                 If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
          */
-        removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -3687,7 +4164,11 @@ export declare namespace Office {
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -3707,7 +4188,11 @@ export declare namespace Office {
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -3720,17 +4205,25 @@ export declare namespace Office {
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
          * @param attachmentIndex - The identifier of the attachment to remove. The maximum length of the string is 100 characters.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. 
+         *                 If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
          */
-        removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;
+        removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;
         /**
          * Asynchronously saves an item.
          *
-         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. In Outlook Web App or Outlook in online mode, the item is saved to the server. In Outlook in cached mode, the item is saved to the local cache.
+         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. 
+         * In Outlook Web App or Outlook in online mode, the item is saved to the server. 
+         * In Outlook in cached mode, the item is saved to the local cache.
          *
-         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. Saving an existing appointment will send an update to added or removed attendees.
+         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal 
+         * appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. 
+         * Saving an existing appointment will send an update to added or removed attendees.
          *
-         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that when Outlook is in cached mode, it may take some time before the item is actually synced to the server. Until the item is synced, using the itemId will return an error.
+         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that 
+         * when Outlook is in cached mode, it may take some time before the item is actually synced to the server. 
+         * Until the item is synced, using the itemId will return an error.
          *
          * Note: The following clients have different behavior for saveAsync on appointments in compose mode:
          *
@@ -3754,21 +4247,28 @@ export declare namespace Office {
          * 
          * `saveAsync(options: Office.AsyncContextOptions): void;`
          * 
-         * `saveAsync(callback: (result: AsyncResult) => void): void;`
+         * `saveAsync(callback: (result: AsyncResult<void>) => void): void;`
          *
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. 
          */
-        saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Asynchronously saves an item.
          *
-         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. In Outlook Web App or Outlook in online mode, the item is saved to the server. In Outlook in cached mode, the item is saved to the local cache.
+         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. 
+         * In Outlook Web App or Outlook in online mode, the item is saved to the server. 
+         * In Outlook in cached mode, the item is saved to the local cache.
          *
-         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. Saving an existing appointment will send an update to added or removed attendees.
+         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal 
+         * appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. 
+         * Saving an existing appointment will send an update to added or removed attendees.
          *
-         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that when Outlook is in cached mode, it may take some time before the item is actually synced to the server. Until the item is synced, using the itemId will return an error.
+         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that 
+         * when Outlook is in cached mode, it may take some time before the item is actually synced to the server. 
+         * Until the item is synced, using the itemId will return an error.
          *
          * Note: The following clients have different behavior for saveAsync on appointments in compose mode:
          *
@@ -3791,11 +4291,16 @@ export declare namespace Office {
         /**
          * Asynchronously saves an item.
          *
-         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. In Outlook Web App or Outlook in online mode, the item is saved to the server. In Outlook in cached mode, the item is saved to the local cache.
+         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. 
+         * In Outlook Web App or Outlook in online mode, the item is saved to the server. 
+         * In Outlook in cached mode, the item is saved to the local cache.
          *
-         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. Saving an existing appointment will send an update to added or removed attendees.
+         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal 
+         * appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. Saving an existing appointment will send an update to added or removed attendees.
          *
-         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that when Outlook is in cached mode, it may take some time before the item is actually synced to the server. Until the item is synced, using the itemId will return an error.
+         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that 
+         * when Outlook is in cached mode, it may take some time before the item is actually synced to the server. 
+         * Until the item is synced, using the itemId will return an error.
          *
          * Note: The following clients have different behavior for saveAsync on appointments in compose mode:
          *
@@ -3820,11 +4325,17 @@ export declare namespace Office {
         /**
          * Asynchronously saves an item.
          *
-         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. In Outlook Web App or Outlook in online mode, the item is saved to the server. In Outlook in cached mode, the item is saved to the local cache.
+         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. 
+         * In Outlook Web App or Outlook in online mode, the item is saved to the server. 
+         * In Outlook in cached mode, the item is saved to the local cache.
          *
-         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. Saving an existing appointment will send an update to added or removed attendees.
+         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal 
+         * appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. 
+         * Saving an existing appointment will send an update to added or removed attendees.
          *
-         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that when Outlook is in cached mode, it may take some time before the item is actually synced to the server. Until the item is synced, using the itemId will return an error.
+         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that 
+         * when Outlook is in cached mode, it may take some time before the item is actually synced to the server. 
+         * Until the item is synced, using the itemId will return an error.
          *
          * Note: The following clients have different behavior for saveAsync on appointments in compose mode:
          *
@@ -3842,13 +4353,16 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. 
          */
-        saveAsync(callback: (result: AsyncResult) => void): void;
+        saveAsync(callback: (result: AsyncResult<void>) => void): void;
         /**
          * Asynchronously inserts data into the body or subject of a message.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is 
+         * selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. 
+         * After insertion, the cursor is placed at the end of the inserted content.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -3866,19 +4380,28 @@ export declare namespace Office {
          * 
          * `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`
          * 
-         * `setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;`
+         * `setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;`
          *
-         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
+         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. 
+         *             If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         *        coercionType: If text, the current style is applied in Outlook Web App and Outlook. If the field is an HTML editor, only the text data is inserted, even if the data is HTML. If html and the field supports HTML (the subject doesn't), the current style is applied in Outlook Web App and the default style is applied in Outlook. If the field is a text field, an InvalidDataFormat error is returned. If coercionType is not set, the result depends on the field: if the field is HTML then HTML is used; if the field is text, then plain text is used.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         *        coercionType: If text, the current style is applied in Outlook Web App and Outlook. 
+         *        If the field is an HTML editor, only the text data is inserted, even if the data is HTML. 
+         *        If html and the field supports HTML (the subject doesn't), the current style is applied in Outlook Web App and the default style is 
+         *        applied in Outlook. If the field is a text field, an InvalidDataFormat error is returned. 
+         *        If coercionType is not set, the result depends on the field: if the field is HTML then HTML is used; 
+         *        if the field is text, then plain text is used.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          */
-        setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult) => void): void;
+        setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Asynchronously inserts data into the body or subject of a message.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is 
+         * selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. 
+         * After insertion, the cursor is placed at the end of the inserted content.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -3890,13 +4413,16 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
-         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
+         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. 
+         *             If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
          */
         setSelectedDataAsync(data: string): void;
         /**
          * Asynchronously inserts data into the body or subject of a message.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is 
+         * selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. 
+         * After insertion, the cursor is placed at the end of the inserted content.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -3908,16 +4434,24 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
-         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
+         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. 
+         *             If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         *        coercionType: If text, the current style is applied in Outlook Web App and Outlook. If the field is an HTML editor, only the text data is inserted, even if the data is HTML. If html and the field supports HTML (the subject doesn't), the current style is applied in Outlook Web App and the default style is applied in Outlook. If the field is a text field, an InvalidDataFormat error is returned. If coercionType is not set, the result depends on the field: if the field is HTML then HTML is used; if the field is text, then plain text is used.
+         *        coercionType: If text, the current style is applied in Outlook Web App and Outlook. 
+         *        If the field is an HTML editor, only the text data is inserted, even if the data is HTML. 
+         *        If html and the field supports HTML (the subject doesn't), the current style is applied in Outlook Web App and the default style is 
+         *        applied in Outlook. If the field is a text field, an InvalidDataFormat error is returned. 
+         *        If coercionType is not set, the result depends on the field: if the field is HTML then HTML is used; 
+         *        if the field is text, then plain text is used.
          */
         setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;
         /**
          * Asynchronously inserts data into the body or subject of a message.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is 
+         * selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. 
+         * After insertion, the cursor is placed at the end of the inserted content.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -3929,19 +4463,22 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
-         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. 
+         *             If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 typeOffice.AsyncResult.
          */
-        setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;
+        setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;
     }
     /**
      * The message read mode of {@link Office.Item | Office.context.mailbox.item}.
      * 
-     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of Office.context.mailbox.item. Refer to the Object Model pages for more information.
+     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. 
+     * You should treat this as a mode of Office.context.mailbox.item. Refer to the Object Model pages for more information.
      */
     export interface MessageRead extends Message, ItemRead {
         /**
-         * Gets an array of attachments for the item.
+         * Gets the item's attachments as an array.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -3951,7 +4488,9 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Message Read</td></tr></table>
          * 
-         * Note: Certain types of files are blocked by Outlook due to potential security issues and are therefore not returned. For more information, see {@link https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519 | Blocked attachments in Outlook}.
+         * Note: Certain types of files are blocked by Outlook due to potential security issues and are therefore not returned. 
+         * For more information, see 
+         * {@link https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519 | Blocked attachments in Outlook}.
          *
          */
         attachments: Office.AttachmentDetails[];
@@ -3968,9 +4507,11 @@ export declare namespace Office {
          */
         body: Office.Body;
         /**
-         * Provides access to the Cc (carbon copy) recipients of a message. The type of object and level of access depends on the mode of the current item.
+         * Provides access to the Cc (carbon copy) recipients of a message. The type of object and level of access depends on the mode of the 
+         * current item.
          *
-         * The cc property returns an array that contains an EmailAddressDetails object for each recipient listed on the Cc line of the message. The collection is limited to a maximum of 100 members.
+         * The cc property returns an array that contains an EmailAddressDetails object for each recipient listed on the Cc line of the message. 
+         * The collection is limited to a maximum of 100 members.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -3984,9 +4525,12 @@ export declare namespace Office {
         /**
          * Gets an identifier for the email conversation that contains a particular message.
          *
-         * You can get an integer for this property if your mail app is activated in read forms or responses in compose forms. If subsequently the user changes the subject of the reply message, upon sending the reply, the conversation ID for that message will change and that value you obtained earlier will no longer apply.
+         * You can get an integer for this property if your mail app is activated in read forms or responses in compose forms. 
+         * If subsequently the user changes the subject of the reply message, upon sending the reply, the conversation ID for that message will change 
+         * and that value you obtained earlier will no longer apply.
          *
-         * You get null for this property for a new item in a compose form. If the user sets a subject and saves the item, the conversationId property will return a value.
+         * You get null for this property for a new item in a compose form. 
+         * If the user sets a subject and saves the item, the conversationId property will return a value.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -4026,7 +4570,8 @@ export declare namespace Office {
         /**
          * Gets the email address of the sender of a message.
          *
-         * The from and sender properties represent the same person unless the message is sent by a delegate. In that case, the from property represents the delegator, and the sender property represents the delegate.
+         * The from and sender properties represent the same person unless the message is sent by a delegate. 
+         * In that case, the from property represents the delegator, and the sender property represents the delegate.
          *
          * Note: The recipientType property of the EmailAddressDetails object in the from property is undefined.
          * 
@@ -4056,7 +4601,8 @@ export declare namespace Office {
         /**
          * Gets the Exchange Web Services item class of the selected item.
          * 
-         * You can create custom message classes that extends a default message class, for example, a custom appointment message class IPM.Appointment.Contoso.
+         * You can create custom message classes that extends a default message class, for example, a custom appointment message class 
+         * IPM.Appointment.Contoso.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -4066,7 +4612,8 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Message Read</td></tr></table>
 		 
-         * The itemClass property specifies the message class of the selected item. The following are the default message classes for the message or appointment item.
+         * The itemClass property specifies the message class of the selected item. 
+         * The following are the default message classes for the message or appointment item.
          * 
          * <table>
          *   <tr>
@@ -4091,9 +4638,14 @@ export declare namespace Office {
         /**
          * Gets the Exchange Web Services item identifier for the current item.
          *
-         * The itemId property is not available in compose mode. If an item identifier is required, the saveAsync method can be used to save the item to the store, which will return the item identifier in the AsyncResult.value parameter in the callback function.
+         * The itemId property is not available in compose mode. 
+         * If an item identifier is required, the saveAsync method can be used to save the item to the store, which will return the item identifier 
+         * in the AsyncResult.value parameter in the callback function.
          *
-         * Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more details, see Use the Outlook REST APIs from an Outlook add-in.
+         * Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. 
+         * The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. 
+         * Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. 
+         * For more details, see {@link https://docs.microsoft.com/outlook/add-ins/use-rest-api#get-the-item-id | Use the Outlook REST APIs from an Outlook add-in}.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -4107,7 +4659,8 @@ export declare namespace Office {
         /**
          * Gets the type of item that an instance represents.
          *
-         * The itemType property returns one of the ItemType enumeration values, indicating whether the item object instance is a message or an appointment.
+         * The itemType property returns one of the ItemType enumeration values, indicating whether the item object instance is a message or 
+         * an appointment.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -4121,7 +4674,9 @@ export declare namespace Office {
         /**
          * Gets the subject of an item, with all prefixes removed (including RE: and FWD:).
          *
-         * The normalizedSubject property gets the subject of the item, with any standard prefixes (such as RE: and FW:) that are added by email programs. To get the subject of the item with the prefixes intact, use the subject property.
+         * The normalizedSubject property gets the subject of the item, with any standard prefixes (such as RE: and FW:) that are added by 
+         * email programs. 
+         * To get the subject of the item with the prefixes intact, use the subject property.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -4147,7 +4702,8 @@ export declare namespace Office {
         /**
          * Gets the email address of the sender of an email message.
          *
-         * The from and sender properties represent the same person unless the message is sent by a delegate. In that case, the from property represents the delegator, and the sender property represents the delegate.
+         * The from and sender properties represent the same person unless the message is sent by a delegate. 
+         * In that case, the from property represents the delegator, and the sender property represents the delegate.
          *
          * Note: The recipientType property of the EmailAddressDetails object in the sender property is undefined.
          *
@@ -4177,9 +4733,11 @@ export declare namespace Office {
          */
         subject: string;
         /**
-         * Provides access to the recipients on the To line of a message. The type of object and level of access depends on the mode of the current item.
+         * Provides access to the recipients on the To line of a message. The type of object and level of access depends on the mode of the 
+         * current item.
          *
-         * The to property returns an array that contains an EmailAddressDetails object for each recipient listed on the To line of the message. The collection is limited to a maximum of 100 members.
+         * The to property returns an array that contains an EmailAddressDetails object for each recipient listed on the To line of the message. 
+         * The collection is limited to a maximum of 100 members.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -4190,14 +4748,18 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Message Read</td></tr></table>
          */
         to: EmailAddressDetails[];
+
         /**
-         * Displays a reply form that includes the sender and all recipients of the selected message or the organizer and all attendees of the selected appointment.
+         * Displays a reply form that includes the sender and all recipients of the selected message or the organizer and all attendees of the 
+         * selected appointment.
          *
          * In Outlook Web App, the reply form is displayed as a pop-out form in the 3-column view and a pop-up form in the 2- or 1-column view.
          *
          * If any of the string parameters exceed their limits, displayReplyAllForm throws an exception.
          *
-         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. If this isn't possible, then no error message is thrown.
+         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and 
+         * attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. 
+         * If this isn't possible, then no error message is thrown.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -4220,7 +4782,9 @@ export declare namespace Office {
          *
          * If any of the string parameters exceed their limits, displayReplyForm throws an exception.
          *
-         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. If this isn't possible, then no error message is thrown.
+         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and 
+         * attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. 
+         * If this isn't possible, then no error message is thrown.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -4238,7 +4802,7 @@ export declare namespace Office {
          */
         displayReplyForm(formData: string | ReplyFormData): void;
         /**
-         * Gets the entities found in the selected item.
+         * Gets the entities found in the selected item's body.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -4252,7 +4816,7 @@ export declare namespace Office {
          */
         getEntities(): Entities;
         /**
-         * Gets an array of all the entities of the specified entity type found in the selected item.
+         * Gets an array of all the entities of the specified entity type found in the selected item's body.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -4261,7 +4825,9 @@ export declare namespace Office {
          * @param entityType - One of the EntityType enumeration values.
          * 
          * @returns
-         * If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. If no entities of the specified type are present on the item, the method returns an empty array. Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter.
+         * If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. 
+         * If no entities of the specified type are present in the item's body, the method returns an empty array. 
+         * Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter.
          *
          * @remarks
          * 
@@ -4269,7 +4835,8 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Read</td></tr></table>
          * 
-         * While the minimum permission level to use this method is Restricted, some entity types require ReadItem to access, as specified in the following table.
+         * While the minimum permission level to use this method is Restricted, some entity types require ReadItem to access, as specified in the 
+         * following table.
          * 
          * <table>
          *   <tr>
@@ -4318,7 +4885,8 @@ export declare namespace Office {
         /**
          * Returns well-known entities in the selected item that pass the named filter defined in the manifest XML file.
          *
-         * The getFilteredEntitiesByName method returns the entities that match the regular expression defined in the ItemHasKnownEntity rule element in the manifest XML file with the specified FilterName element value.
+         * The getFilteredEntitiesByName method returns the entities that match the regular expression defined in the ItemHasKnownEntity rule element 
+         * in the manifest XML file with the specified FilterName element value.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -4331,22 +4899,33 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Message Read</td></tr></table>
          *
          * @param name - The name of the ItemHasKnownEntity rule element that defines the filter to match.
-         * @returns If there is no ItemHasKnownEntity element in the manifest with a FilterName element value that matches the name parameter, the method returns null. If the name parameter does match an ItemHasKnownEntity element in the manifest, but there are no entities in the current item that match, the method return an empty array.
+         * @returns If there is no ItemHasKnownEntity element in the manifest with a FilterName element value that matches the name parameter, 
+         * the method returns null. 
+         * If the name parameter does match an ItemHasKnownEntity element in the manifest, but there are no entities in the current item that match, 
+         * the method return an empty array.
          */
         getFilteredEntitiesByName(name: string): (string | Contact | MeetingSuggestion | PhoneNumber | TaskSuggestion)[];
         /**
          * Returns string values in the selected item that match the regular expressions defined in the manifest XML file.
          *
-         * The getRegExMatches method returns the strings that match the regular expression defined in each ItemHasRegularExpressionMatch or ItemHasKnownEntity rule element in the manifest XML file. For an ItemHasRegularExpressionMatch rule, a matching string has to occur in the property of the item that is specified by that rule. The PropertyName simple type defines the supported properties.
+         * The getRegExMatches method returns the strings that match the regular expression defined in each ItemHasRegularExpressionMatch or 
+         * ItemHasKnownEntity rule element in the manifest XML file. 
+         * For an ItemHasRegularExpressionMatch rule, a matching string has to occur in the property of the item that is specified by that rule. 
+         * The PropertyName simple type defines the supported properties.
          *
-         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body and should not attempt to return the entire body of the item. Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results. Instead, use the Body.getAsync method to retrieve the entire body.
+         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body 
+         * and should not attempt to return the entire body of the item. 
+         * Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results. 
+         * Instead, use the Body.getAsync method to retrieve the entire body.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
          * [Api set: Mailbox 1.0]
          *
          * @returns
-         * An object that contains arrays of strings that match the regular expressions defined in the manifest XML file. The name of each array is equal to the corresponding value of the RegExName attribute of the matching ItemHasRegularExpressionMatch rule or the FilterName attribute of the matching ItemHasKnownEntity rule.
+         * An object that contains arrays of strings that match the regular expressions defined in the manifest XML file. 
+         * The name of each array is equal to the corresponding value of the RegExName attribute of the matching ItemHasRegularExpressionMatch rule 
+         * or the FilterName attribute of the matching ItemHasKnownEntity rule.
          *
          * @remarks
          *
@@ -4358,9 +4937,12 @@ export declare namespace Office {
         /**
          * Returns string values in the selected item that match the named regular expression defined in the manifest XML file.
          *
-         * The getRegExMatchesByName method returns the strings that match the regular expression defined in the ItemHasRegularExpressionMatch rule element in the manifest XML file with the specified RegExName element value.
+         * The getRegExMatchesByName method returns the strings that match the regular expression defined in the ItemHasRegularExpressionMatch rule 
+         * element in the manifest XML file with the specified RegExName element value.
          *
-         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body and should not attempt to return the entire body of the item. Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results.
+         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body 
+         * and should not attempt to return the entire body of the item. 
+         * Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -4381,9 +4963,13 @@ export declare namespace Office {
         /**
          * Asynchronously loads custom properties for this add-in on the selected item.
          *
-         * Custom properties are stored as key/value pairs on a per-app, per-item basis. This method returns a CustomProperties object in the callback, which provides methods to access the custom properties specific to the current item and the current add-in. Custom properties are not encrypted on the item, so this should not be used as secure storage.
+         * Custom properties are stored as key/value pairs on a per-app, per-item basis. 
+         * This method returns a CustomProperties object in the callback, which provides methods to access the custom properties specific to the 
+         * current item and the current add-in. Custom properties are not encrypted on the item, so this should not be used as secure storage.
          *
-         * The custom properties are provided as a CustomProperties object in the asyncResult.value property. This object can be used to get, set, and remove custom properties from the item and save changes to the custom property set back to the server.
+         * The custom properties are provided as a CustomProperties object in the asyncResult.value property. 
+         * This object can be used to get, set, and remove custom properties from the item and save changes to the custom property set back to 
+         * the server.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -4393,10 +4979,12 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Message Read</td></tr></table>
          *
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
-         * @param userContext - Optional. Developers can provide any object they wish to access in the callback function. This object can be accessed by the asyncResult.asyncContext property in the callback function.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
+         * @param userContext - Optional. Developers can provide any object they wish to access in the callback function. 
+         *                    This object can be accessed by the asyncResult.asyncContext property in the callback function.
          */
-        loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;
+        loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any): void;
     }
 
     /**
@@ -4458,11 +5046,13 @@ export declare namespace Office {
         /**
          * Gets the location of an appointment.
          *
-         * The getAsync method starts an asynchronous call to the Exchange server to get the location of an appointment. The location of the appointment is provided as a string in the asyncResult.value property.
+         * The getAsync method starts an asynchronous call to the Exchange server to get the location of an appointment. 
+         * The location of the appointment is provided as a string in the asyncResult.value property.
          *
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -4473,16 +5063,18 @@ export declare namespace Office {
          * 
          * In addition to this signature, the method also has the following signature:
          * 
-         * `getAsync(callback: (result: AsyncResult) => void): void;`
+         * `getAsync(callback: (result: AsyncResult<string>) => void): void;`
          * 
          */
-        getAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        getAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;
         /**
          * Gets the location of an appointment.
          *
-         * The getAsync method starts an asynchronous call to the Exchange server to get the location of an appointment. The location of the appointment is provided as a string in the asyncResult.value property.
+         * The getAsync method starts an asynchronous call to the Exchange server to get the location of an appointment. 
+         * The location of the appointment is provided as a string in the asyncResult.value property.
          *
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -4491,16 +5083,18 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose</td></tr></table>
          */
-        getAsync(callback: (result: AsyncResult) => void): void;
+        getAsync(callback: (result: AsyncResult<string>) => void): void;
         /**
          * Sets the location of an appointment.
          *
-         * The setAsync method starts an asynchronous call to the Exchange server to set the location of an appointment. Setting the location of an appointment overwrites the current location.
+         * The setAsync method starts an asynchronous call to the Exchange server to set the location of an appointment. 
+         * Setting the location of an appointment overwrites the current location.
          *
          * @param location - The location of the appointment. The string is limited to 255 characters.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.  If setting the location fails, the asyncResult.error property will contain an error code.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. If setting the location fails, the asyncResult.error property will contain an error code.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -4517,13 +5111,14 @@ export declare namespace Office {
          * 
          * `setAsync(location: string, options: Office.AsyncContextOptions): void;`
          * 
-         * `setAsync(location: string, callback: (result: AsyncResult) => void): void;`
+         * `setAsync(location: string, callback: (result: AsyncResult<void>) => void): void;`
          */
-        setAsync(location: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        setAsync(location: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Sets the location of an appointment.
          *
-         * The setAsync method starts an asynchronous call to the Exchange server to set the location of an appointment. Setting the location of an appointment overwrites the current location.
+         * The setAsync method starts an asynchronous call to the Exchange server to set the location of an appointment. 
+         * Setting the location of an appointment overwrites the current location.
          *
          * @param location - The location of the appointment. The string is limited to 255 characters.
          *
@@ -4540,7 +5135,8 @@ export declare namespace Office {
         /**
          * Sets the location of an appointment.
          *
-         * The setAsync method starts an asynchronous call to the Exchange server to set the location of an appointment. Setting the location of an appointment overwrites the current location.
+         * The setAsync method starts an asynchronous call to the Exchange server to set the location of an appointment. 
+         * Setting the location of an appointment overwrites the current location.
          *
          * @param location - The location of the appointment. The string is limited to 255 characters.
          * @param options - Optional. An object literal that contains one or more of the following properties.
@@ -4559,10 +5155,12 @@ export declare namespace Office {
         /**
          * Sets the location of an appointment.
          *
-         * The setAsync method starts an asynchronous call to the Exchange server to set the location of an appointment. Setting the location of an appointment overwrites the current location.
+         * The setAsync method starts an asynchronous call to the Exchange server to set the location of an appointment. 
+         * Setting the location of an appointment overwrites the current location.
          *
          * @param location - The location of the appointment. The string is limited to 255 characters.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.  If setting the location fails, the asyncResult.error property will contain an error code.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. If setting the location fails, the asyncResult.error property will contain an error code.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -4573,10 +5171,10 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>DataExceedsMaximumSize - The location parameter is longer than 255 characters.</td></tr></table>
          */
-        setAsync(location: string, callback: (result: AsyncResult) => void): void;
+        setAsync(location: string, callback: (result: AsyncResult<void>) => void): void;
     }
     /**
-     * Provides access to the Outlook add-in object model for Microsoft Outlook and Microsoft Outlook on the web.
+     * Provides access to the Outlook Add-in object model for Microsoft Outlook and Microsoft Outlook on the web.
      *
      * Namespaces:
      *
@@ -4599,11 +5197,18 @@ export declare namespace Office {
          * 
          * Contains the following members:
          * 
-         *  - hostName (string): A string that represents the name of the host application. It be one of the following values: Outlook, Mac Outlook, OutlookIOS, or OutlookWebApp.
+         *  - hostName (string): A string that represents the name of the host application. 
+         * It be one of the following values: Outlook, Mac Outlook, OutlookIOS, or OutlookWebApp.
          * 
-         *  - hostVersion (string): A string that represents the version of either the host application or the Exchange Server. If the mail add-in is running on the Outlook desktop client or Outlook for iOS, the hostVersion property returns the version of the host application, Outlook. In Outlook Web App, the property returns the version of the Exchange Server. An example is the string 15.0.468.0.
+         *  - hostVersion (string): A string that represents the version of either the host application or the Exchange Server. 
+         * If the mail add-in is running on the Outlook desktop client or Outlook for iOS, the hostVersion property returns the version of the 
+         * host application, Outlook. In Outlook Web App, the property returns the version of the Exchange Server. An example is the string 15.0.468.0.
          * 
-         *  - OWAView (string): A string that represents the current view of Outlook Web App. If the host application is not Outlook Web App, then accessing this property results in undefined. Outlook Web App has three views (OneColumn - displayed when the screen is narrow, TwoColumns - displayed when the screen is wider, and ThreeColumns - displayed when the screen is wide.) that correspond to the width of the screen and the window, and the number of columns that can be displayed.
+         *  - OWAView (MailboxEnums.OWAView or string): An enum (or string literal) that represents the current view of Outlook Web App. 
+         * If the host application is not Outlook Web App, then accessing this property results in undefined. 
+         * Outlook Web App has three views (OneColumn - displayed when the screen is narrow, TwoColumns - displayed when the screen is wider, 
+         * and ThreeColumns - displayed when the screen is wide) that correspond to the width of the screen and the window, and the number of columns 
+         * that can be displayed.
          *
          *  More information is under {@link Office.Diagnostics}. 
          *
@@ -4620,7 +5225,8 @@ export declare namespace Office {
          *
          * Your app must have the ReadItem permission specified in its manifest to call the ewsUrl member in read mode.
          *
-         * In compose mode you must call the saveAsync method before you can use the ewsUrl member. Your app must have ReadWriteItem permissions to call the saveAsync method.
+         * In compose mode you must call the saveAsync method before you can use the ewsUrl member. 
+         * Your app must have ReadWriteItem permissions to call the saveAsync method.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -4642,7 +5248,7 @@ export declare namespace Office {
          */
         item: Item & ItemCompose & ItemRead & MessageRead & MessageCompose & AppointmentRead & AppointmentCompose;
         /**
-         * Information about the user associated with the mailbox. This includes their account type, display name, email adddress, and time zone.
+         * Information about the user associated with the mailbox. This includes their account type, display name, email address, and time zone.
          * 
          * More information is under {@link Office.UserProfile}
          */
@@ -4650,7 +5256,8 @@ export declare namespace Office {
         /**
          * Converts an item ID formatted for REST into EWS format.
          *
-         * Item IDs retrieved via a REST API (such as the Outlook Mail API or the Microsoft Graph) use a different format than the format used by Exchange Web Services (EWS). The convertToEwsId method converts a REST-formatted ID into the proper format for EWS.
+         * Item IDs retrieved via a REST API (such as the Outlook Mail API or the Microsoft Graph) use a different format than the format used by 
+         * Exchange Web Services (EWS). The convertToEwsId method converts a REST-formatted ID into the proper format for EWS.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -4669,9 +5276,15 @@ export declare namespace Office {
         /**
          * Gets a dictionary containing time information in local client time.
          *
-         * The dates and times used by a mail app for Outlook or Outlook Web App can use different time zones. Outlook uses the client computer time zone; Outlook Web App uses the time zone set on the Exchange Admin Center (EAC). You should handle date and time values so that the values you display on the user interface are always consistent with the time zone that the user expects.
+         * The dates and times used by a mail app for Outlook or Outlook Web App can use different time zones. 
+         * Outlook uses the client computer time zone; Outlook Web App uses the time zone set on the Exchange Admin Center (EAC). 
+         * You should handle date and time values so that the values you display on the user interface are always consistent with the time zone that 
+         * the user expects.
          *
-         * If the mail app is running in Outlook, the convertToLocalClientTime method will return a dictionary object with the values set to the client computer time zone. If the mail app is running in Outlook Web App, the convertToLocalClientTime method will return a dictionary object with the values set to the time zone specified in the EAC.
+         * If the mail app is running in Outlook, the convertToLocalClientTime method will return a dictionary object with the values set to the 
+         * client computer time zone. 
+         * If the mail app is running in Outlook Web App, the convertToLocalClientTime method will return a dictionary object with the values set to 
+         * the time zone specified in the EAC.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -4697,7 +5310,9 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          *
-         * Item IDs retrieved via EWS or via the itemId property use a different format than the format used by REST APIs (such as the {@link https://docs.microsoft.com/previous-versions/office/office-365-api/api/version-2.0/mail-rest-operations | Outlook Mail API} or the {@link http://graph.microsoft.io/ | Microsoft Graph}. The convertToRestId method converts an EWS-formatted ID into the proper format for REST.
+         * Item IDs retrieved via EWS or via the itemId property use a different format than the format used by REST APIs (such as the 
+         * {@link https://docs.microsoft.com/previous-versions/office/office-365-api/api/version-2.0/mail-rest-operations | Outlook Mail API} or the {@link http://graph.microsoft.io/ | Microsoft Graph}. 
+         * The convertToRestId method converts an EWS-formatted ID into the proper format for REST.
          *
          * @param itemId - An item ID formatted for Exchange Web Services (EWS)
          * @param restVersion - A value indicating the version of the Outlook REST API that the converted ID will be used with.
@@ -4706,7 +5321,8 @@ export declare namespace Office {
         /**
          * Gets a Date object from a dictionary containing time information.
          *
-         * The convertToUtcClientTime method converts a dictionary containing a local date and time to a Date object with the correct values for the local date and time.
+         * The convertToUtcClientTime method converts a dictionary containing a local date and time to a Date object with the correct values for the 
+         * local date and time.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -4723,13 +5339,17 @@ export declare namespace Office {
         /**
          * Displays an existing calendar appointment.
          *
-         * The displayAppointmentForm method opens an existing calendar appointment in a new window on the desktop or in a dialog box on mobile devices.
+         * The displayAppointmentForm method opens an existing calendar appointment in a new window on the desktop or in a dialog box on 
+         * mobile devices.
          *
-         * In Outlook for Mac, you can use this method to display a single appointment that is not part of a recurring series, or the master appointment of a recurring series, but you cannot display an instance of the series. This is because in Outlook for Mac, you cannot access the properties (including the item ID) of instances of a recurring series.
+         * In Outlook for Mac, you can use this method to display a single appointment that is not part of a recurring series, or the 
+         * master appointment of a recurring series, but you cannot display an instance of the series. 
+         * This is because in Outlook for Mac, you cannot access the properties (including the item ID) of instances of a recurring series.
          *
          * In Outlook Web App, this method opens the specified form only if the body of the form is less than or equal to 32KB number of characters.
          *
-         * If the specified item identifier does not identify an existing appointment, a blank pane opens on the client computer or device, and no error message will be returned.
+         * If the specified item identifier does not identify an existing appointment, a blank pane opens on the client computer or device, and 
+         * no error message will be returned.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -4751,9 +5371,11 @@ export declare namespace Office {
          *
          * In Outlook Web App, this method opens the specified form only if the body of the form is less than or equal to 32 KB number of characters.
          *
-         * If the specified item identifier does not identify an existing message, no message will be displayed on the client computer, and no error message will be returned.
+         * If the specified item identifier does not identify an existing message, no message will be displayed on the client computer, and 
+         * no error message will be returned.
          *
-         * Do not use the displayMessageForm with an itemId that represents an appointment. Use the displayAppointmentForm method to display an existing appointment, and displayNewAppointmentForm to display a form to create a new appointment.
+         * Do not use the displayMessageForm with an itemId that represents an appointment. Use the displayAppointmentForm method to display 
+         * an existing appointment, and displayNewAppointmentForm to display a form to create a new appointment.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -4771,11 +5393,16 @@ export declare namespace Office {
         /**
          * Displays a form for creating a new calendar appointment.
          *
-         * The displayNewAppointmentForm method opens a form that enables the user to create a new appointment or meeting. If parameters are specified, the appointment form fields are automatically populated with the contents of the parameters.
+         * The displayNewAppointmentForm method opens a form that enables the user to create a new appointment or meeting. 
+         * If parameters are specified, the appointment form fields are automatically populated with the contents of the parameters.
          *
-         * In Outlook Web App and OWA for Devices, this method always displays a form with an attendees field. If you do not specify any attendees as input arguments, the method displays a form with a Save button. If you have specified attendees, the form would include the attendees and a Send button.
+         * In Outlook Web App and OWA for Devices, this method always displays a form with an attendees field. 
+         * If you do not specify any attendees as input arguments, the method displays a form with a Save button. 
+         * If you have specified attendees, the form would include the attendees and a Send button.
          *
-         * In the Outlook rich client and Outlook RT, if you specify any attendees or resources in the requiredAttendees, optionalAttendees, or resources parameter, this method displays a meeting form with a Send button. If you don't specify any recipients, this method displays an appointment form with a Save & Close button.
+         * In the Outlook rich client and Outlook RT, if you specify any attendees or resources in the requiredAttendees, optionalAttendees, or 
+         * resources parameter, this method displays a meeting form with a Send button. 
+         * If you don't specify any recipients, this method displays an appointment form with a Save & Close button.
          *
          * If any of the parameters exceed the specified size limits, or if an unknown parameter name is specified, an exception is thrown.
          *
@@ -4795,13 +5422,17 @@ export declare namespace Office {
         /**
          * Gets a string that contains a token used to get an attachment or item from an Exchange Server.
          *
-         * The getCallbackTokenAsync method makes an asynchronous call to get an opaque token from the Exchange Server that hosts the user's mailbox. The lifetime of the callback token is 5 minutes.
+         * The getCallbackTokenAsync method makes an asynchronous call to get an opaque token from the Exchange Server that hosts the user's mailbox. 
+         * The lifetime of the callback token is 5 minutes.
          *
-         * You can pass the token and an attachment identifier or item identifier to a third-party system. The third-party system uses the token as a bearer authorization token to call the Exchange Web Services (EWS) GetAttachment or GetItem operation to return an attachment or item. For example, you can create a remote service to get attachments from the selected item.
+         * You can pass the token and an attachment identifier or item identifier to a third-party system. 
+         * The third-party system uses the token as a bearer authorization token to call the Exchange Web Services (EWS) GetAttachment or 
+         * GetItem operation to return an attachment or item. For example, you can create a remote service to get attachments from the selected item.
          *
          * Your app must have the ReadItem permission specified in its manifest to call the getCallbackTokenAsync method in read mode.
          *
-         * In compose mode you must call the saveAsync method to get an item identifier to pass to the getCallbackTokenAsync method. Your app must have ReadWriteItem permissions to call the saveAsync method.
+         * In compose mode you must call the saveAsync method to get an item identifier to pass to the getCallbackTokenAsync method. 
+         * Your app must have ReadWriteItem permissions to call the saveAsync method.
          *
          * [Api set: Mailbox 1.3]
          *
@@ -4811,10 +5442,11 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose and read</td></tr></table>
          *
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. The token is provided as a string in the asyncResult.value property.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. The token is provided as a string in the asyncResult.value property.
          * @param userContext - Optional. Any state data that is passed to the asynchronous method.
          */
-        getCallbackTokenAsync(callback: (result: AsyncResult) => void, userContext?: any): void;
+        getCallbackTokenAsync(callback: (result: AsyncResult<string>) => void, userContext?: any): void;
         /**
          * Gets a token identifying the user and the Office Add-in.
          *
@@ -4828,12 +5460,15 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose and read</td></tr></table>
          *
-         * The getUserIdentityTokenAsync method returns a token that you can use to identify and {@link https://docs.microsoft.com/outlook/add-ins/authentication | authenticate the add-in and user with a third-party system}.
+         * The getUserIdentityTokenAsync method returns a token that you can use to identify and 
+         * {@link https://docs.microsoft.com/outlook/add-ins/authentication | authenticate the add-in and user with a third-party system}.
          *
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
+         *                 The token is provided as a string in the asyncResult.value property.
          * @param userContext - Optional. Any state data that is passed to the asynchronous method.|
          */
-        getUserIdentityTokenAsync(callback: (result: AsyncResult) => void, userContext?: any): void;
+        getUserIdentityTokenAsync(callback: (result: AsyncResult<string>) => void, userContext?: any): void;
         /**
          * Makes an asynchronous request to an Exchange Web Services (EWS) service on the Exchange server that hosts the user's mailbox.
          *
@@ -4845,21 +5480,32 @@ export declare namespace Office {
          *
          * The XML request must specify UTF-8 encoding. \<?xml version="1.0" encoding="utf-8"?\>
          *
-         * Your add-in must have the ReadWriteMailbox permission to use the makeEwsRequestAsync method. For information about using the ReadWriteMailbox permission and the EWS operations that you can call with the makeEwsRequestAsync method, see Specify permissions for mail add-in access to the user's mailbox.
+         * Your add-in must have the ReadWriteMailbox permission to use the makeEwsRequestAsync method. 
+         * For information about using the ReadWriteMailbox permission and the EWS operations that you can call with the makeEwsRequestAsync method, 
+         * see {@link https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions | Specify permissions for mail add-in access to the user's mailbox}.
          *
-         * The XML result of the EWS call is provided as a string in the asyncResult.value property. If the result exceeds 1 MB in size, an error message is returned instead.
+         * The XML result of the EWS call is provided as a string in the asyncResult.value property. 
+         * If the result exceeds 1 MB in size, an error message is returned instead.
          *
-         * Note: This method is not supported in the following scenarios. - In Outlook for iOS or Outlook for Android - When the add-in is loaded in a Gmail mailbox
+         * Note: This method is not supported in the following scenarios:
+         * 
+         * - In Outlook for iOS or Outlook for Android.
+         * 
+         * - When the add-in is loaded in a Gmail mailbox.
          *
-         * Note: The server administrator must set OAuthAuthentication to true on the Client Access Server EWS directory to enable the makeEwsRequestAsync method to make EWS requests.
+         * Note: The server administrator must set OAuthAuthentication to true on the Client Access Server EWS directory to enable the 
+         * makeEwsRequestAsync method to make EWS requests.
          *
          * *Version differences*
          *
-         * When you use the makeEwsRequestAsync method in mail apps running in Outlook versions earlier than version 15.0.4535.1004, you should set the encoding value to ISO-8859-1.
+         * When you use the makeEwsRequestAsync method in mail apps running in Outlook versions earlier than version 15.0.4535.1004, you should set 
+         * the encoding value to ISO-8859-1.
          *
          * `<?xml version="1.0" encoding="iso-8859-1"?>`
          *
-         * You do not need to set the encoding value when your mail app is running in Outlook on the web. You can determine whether your mail app is running in Outlook or Outlook on the web by using the mailbox.diagnostics.hostName property. You can determine what version of Outlook is running by using the mailbox.diagnostics.hostVersion property.
+         * You do not need to set the encoding value when your mail app is running in Outlook on the web. 
+         * You can determine whether your mail app is running in Outlook or Outlook on the web by using the mailbox.diagnostics.hostName property. 
+         * You can determine what version of Outlook is running by using the mailbox.diagnostics.hostVersion property.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -4870,18 +5516,23 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose and read</td></tr></table>
          *
          * @param data - The EWS request.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult.
+         *                 The `value` property of the result is the XML of the EWS request provided as a string. 
+         *                 If the result exceeds 1 MB in size, an error message is returned instead.
          * @param userContext - Optional. Any state data that is passed to the asynchronous method.
          */
-        makeEwsRequestAsync(data: any, callback: (result: AsyncResult) => void, userContext?: any): void;
+        makeEwsRequestAsync(data: any, callback: (result: AsyncResult<string>) => void, userContext?: any): void;
     }
 
     /**
      * Represents a suggested meeting found in an item. Read mode only.
      *
-     * The list of meetings suggested in an email message is returned in the meetingSuggestions property of the Entities object that is returned when the getEntities or getEntitiesByType method is called on the active item.
+     * The list of meetings suggested in an email message is returned in the meetingSuggestions property of the Entities object that is returned when 
+     * the getEntities or getEntitiesByType method is called on the active item.
      *
-     * The start and end values are string representations of a Date object that contains the date and time at which the suggested meeting is to begin and end. The values are in the default time zone specified for the current user.
+     * The start and end values are string representations of a Date object that contains the date and time at which the suggested meeting is to 
+     * begin and end. 
+     * The values are in the default time zone specified for the current user.
      *
      * [Api set: Mailbox 1.0]
      *
@@ -4932,19 +5583,27 @@ export declare namespace Office {
          */
         key?: string;
         /**
-         * Specifies the ItemNotificationMessageType of message. If type is ProgressIndicator or ErrorMessage, an icon is automatically supplied and the message is not persistent. Therefore the icon and persistent properties are not valid for these types of messages. Including them will result in an ArgumentException. If type is ProgressIndicator, the developer should remove or replace the progress indicator when the action is complete.
+         * Specifies the ItemNotificationMessageType of message. If type is ProgressIndicator or ErrorMessage, an icon is automatically supplied and 
+         * the message is not persistent. Therefore the icon and persistent properties are not valid for these types of messages. 
+         * Including them will result in an ArgumentException. 
+         * If type is ProgressIndicator, the developer should remove or replace the progress indicator when the action is complete.
          */
         type: Office.MailboxEnums.ItemNotificationMessageType;
         /**
-         * A reference to an icon that is defined in the manifest in the Resources section. It appears in the infobar area. It is only applicable if the type is InformationalMessage. Specifying this parameter for an unsupported type results in an exception.
+         * A reference to an icon that is defined in the manifest in the Resources section. It appears in the infobar area. 
+         * It is only applicable if the type is InformationalMessage. Specifying this parameter for an unsupported type results in an exception.
          */
         icon?: string;
         /**
-         * The text of the notification message. Maximum length is 150 characters. If the developer passes in a longer string, an ArgumentOutOfRange exception is thrown.
+         * The text of the notification message. Maximum length is 150 characters. 
+         * If the developer passes in a longer string, an ArgumentOutOfRange exception is thrown.
          */
         message: string;
         /**
-         * Only applicable when type is InformationalMessage. If true, the message remains until removed by this add-in or dismissed by the user. If false, it is removed when the user navigates to a different item. For error notifications, the message persists until the user sees it once. Specifying this parameter for an unsupported type throws an exception.
+         * Only applicable when type is InformationalMessage. If true, the message remains until removed by this add-in or dismissed by the user. 
+         * If false, it is removed when the user navigates to a different item. 
+         * For error notifications, the message persists until the user sees it once. 
+         * Specifying this parameter for an unsupported type throws an exception.
          */
         persistent?: Boolean;
     }
@@ -4964,11 +5623,14 @@ export declare namespace Office {
          *
          * There are a maximum of 5 notifications per message. Setting more will return a NumberOfNotificationMessagesExceeded error.
          *
-         * @param key - A developer-specified key used to reference this notification message. Developers can use it to modify this message later. It can't be longer than 32 characters.
-         * @param JSONmessage - A JSON object that contains the notification message to be added to the item. It contains a NotificationMessageDetails object.
+         * @param key - A developer-specified key used to reference this notification message. 
+         *             Developers can use it to modify this message later. It can't be longer than 32 characters.
+         * @param JSONmessage - A JSON object that contains the notification message to be added to the item. 
+         *                    It contains a NotificationMessageDetails object.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          *
          * [Api set: Mailbox 1.3]
          *
@@ -4983,17 +5645,19 @@ export declare namespace Office {
          * 
          * `addAsync(key: string, JSONmessage: NotificationMessageDetails, options: Office.AsyncContextOptions): void;`
          * 
-         * `addAsync(key: string, JSONmessage: NotificationMessageDetails, callback: (result: AsyncResult) => void): void;`
+         * `addAsync(key: string, JSONmessage: NotificationMessageDetails, callback: (result: AsyncResult<void>) => void): void;`
          * 
          */
-        addAsync(key: string, JSONmessage: NotificationMessageDetails, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        addAsync(key: string, JSONmessage: NotificationMessageDetails, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Adds a notification to an item.
          *
          * There are a maximum of 5 notifications per message. Setting more will return a NumberOfNotificationMessagesExceeded error.
          *
-         * @param key - A developer-specified key used to reference this notification message. Developers can use it to modify this message later. It can't be longer than 32 characters.
-         * @param JSONmessage - A JSON object that contains the notification message to be added to the item. It contains a NotificationMessageDetails object.
+         * @param key - A developer-specified key used to reference this notification message. Developers can use it to modify this message later. 
+         *             It can't be longer than 32 characters.
+         * @param JSONmessage - A JSON object that contains the notification message to be added to the item. 
+         *                    It contains a NotificationMessageDetails object.
          *
          * [Api set: Mailbox 1.3]
          *
@@ -5008,8 +5672,10 @@ export declare namespace Office {
          *
          * There are a maximum of 5 notifications per message. Setting more will return a NumberOfNotificationMessagesExceeded error.
          *
-         * @param key - A developer-specified key used to reference this notification message. Developers can use it to modify this message later. It can't be longer than 32 characters.
-         * @param JSONmessage - A JSON object that contains the notification message to be added to the item. It contains a NotificationMessageDetails object.
+         * @param key - A developer-specified key used to reference this notification message. Developers can use it to modify this message later. 
+         *             It can't be longer than 32 characters.
+         * @param JSONmessage - A JSON object that contains the notification message to be added to the item. 
+         *                    It contains a NotificationMessageDetails object.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
          *
@@ -5026,9 +5692,12 @@ export declare namespace Office {
          *
          * There are a maximum of 5 notifications per message. Setting more will return a NumberOfNotificationMessagesExceeded error.
          *
-         * @param key - A developer-specified key used to reference this notification message. Developers can use it to modify this message later. It can't be longer than 32 characters.
-         * @param JSONmessage - A JSON object that contains the notification message to be added to the item. It contains a NotificationMessageDetails object.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param key - A developer-specified key used to reference this notification message. Developers can use it to modify this message later. 
+         *             It can't be longer than 32 characters.
+         * @param JSONmessage - A JSON object that contains the notification message to be added to the item. 
+         *                    It contains a NotificationMessageDetails object.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          *
          * [Api set: Mailbox 1.3]
          *
@@ -5037,7 +5706,7 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          */
-        addAsync(key: string, JSONmessage: NotificationMessageDetails, callback: (result: AsyncResult) => void): void;
+        addAsync(key: string, JSONmessage: NotificationMessageDetails, callback: (result: AsyncResult<void>) => void): void;
         /**
          * Returns all keys and messages for an item.
          *
@@ -5048,15 +5717,16 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          * 
-         * In addition to the main signature, this method also has this signature:
+         * In addition to this signature, this method also has the following signature:
          * 
-         * `getAllAsync(callback: (result: AsyncResult) => void): void;`
+         * `getAllAsync(callback: (result: AsyncResult<Office.NotificationMessageDetails[]>) => void): void;`
          *
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult.
+         *                 The `value` property of the result is an array of NotificationMessageDetails objects.
          */
-        getAllAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        getAllAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<Office.NotificationMessageDetails[]>) => void): void;
         /**
          * Returns all keys and messages for an item.
          *
@@ -5067,9 +5737,10 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          *
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult.
+         *                 The `value` property of the result is an array of NotificationMessageDetails objects.
          */
-        getAllAsync(callback: (result: AsyncResult) => void): void;
+        getAllAsync(callback: (result: AsyncResult<Office.NotificationMessageDetails[]>) => void): void;
         /**
          * Removes a notification message for an item.
          *
@@ -5080,20 +5751,21 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          * 
-         * In addition to the main signature, this method also has these signatures:
+         * In addition to this signature, this method also has the following signatures:
          * 
          * `removeAsync(key: string): void;`
          * 
          * `removeAsync(key: string, options: Office.AsyncContextOptions): void;`
          * 
-         * `removeAsync(key: string, callback: (result: AsyncResult) => void): void;`
+         * `removeAsync(key: string, callback: (result: AsyncResult<void>) => void): void;`
          *
          * @param key - The key for the notification message to remove.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          */
-        removeAsync(key: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        removeAsync(key: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Removes a notification message for an item.
          *
@@ -5133,9 +5805,10 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          *
          * @param key - The key for the notification message to remove.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          */
-        removeAsync(key: string, callback: (result: AsyncResult) => void): void;
+        removeAsync(key: string, callback: (result: AsyncResult<void>) => void): void;
         /**
          * Replaces a notification message that has a given key with another message.
          *
@@ -5148,21 +5821,23 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          * 
-         * In addition to the main signature, this method also has these signatures:
+         * In addition to this signature, this method also has the following signatures:
          * 
          * `replaceAsync(key: string, JSONmessage: NotificationMessageDetails): void;`
          * 
          * `replaceAsync(key: string, JSONmessage: NotificationMessageDetails, options: Office.AsyncContextOptions): void;`
          * 
-         * `replaceAsync(key: string, JSONmessage: NotificationMessageDetails, callback: (result: AsyncResult) => void): void;`
+         * `replaceAsync(key: string, JSONmessage: NotificationMessageDetails, callback: (result: AsyncResult<void>) => void): void;`
          *
          * @param key - The key for the notification message to replace. It can't be longer than 32 characters.
-         * @param JSONmessage - A JSON object that contains the new notification message to replace the existing message. It contains a NotificationMessageDetails object.
+         * @param JSONmessage - A JSON object that contains the new notification message to replace the existing message. 
+         *                    It contains a NotificationMessageDetails object.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          */
-        replaceAsync(key: string, JSONmessage: NotificationMessageDetails, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        replaceAsync(key: string, JSONmessage: NotificationMessageDetails, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Replaces a notification message that has a given key with another message.
          *
@@ -5176,7 +5851,8 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          *
          * @param key - The key for the notification message to replace. It can't be longer than 32 characters.
-         * @param JSONmessage - A JSON object that contains the new notification message to replace the existing message. It contains a NotificationMessageDetails object.
+         * @param JSONmessage - A JSON object that contains the new notification message to replace the existing message. 
+         *                    It contains a NotificationMessageDetails object.
          */
         replaceAsync(key: string, JSONmessage: NotificationMessageDetails): void;
         /**
@@ -5192,7 +5868,8 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          *
          * @param key - The key for the notification message to replace. It can't be longer than 32 characters.
-         * @param JSONmessage - A JSON object that contains the new notification message to replace the existing message. It contains a NotificationMessageDetails object.
+         * @param JSONmessage - A JSON object that contains the new notification message to replace the existing message. 
+         *                    It contains a NotificationMessageDetails object.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
          */
@@ -5210,15 +5887,18 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          *
          * @param key - The key for the notification message to replace. It can't be longer than 32 characters.
-         * @param JSONmessage - A JSON object that contains the new notification message to replace the existing message. It contains a NotificationMessageDetails object.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param JSONmessage - A JSON object that contains the new notification message to replace the existing message. 
+         *                    It contains a NotificationMessageDetails object.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          */
-        replaceAsync(key: string, JSONmessage: NotificationMessageDetails, callback: (result: AsyncResult) => void): void;
+        replaceAsync(key: string, JSONmessage: NotificationMessageDetails, callback: (result: AsyncResult<void>) => void): void;
     }
     /**
      * Represents a phone number identified in an item. Read mode only.
      *
-     * An array of PhoneNumber objects containing the phone numbers found in an email message is returned in the phoneNumbers property of the Entities object that is returned when you call the getEntities method on the selected item.
+     * An array of PhoneNumber objects containing the phone numbers found in an email message is returned in the phoneNumbers property of the 
+     * Entities object that is returned when you call the getEntities method on the selected item.
      *
      * [Api set: Mailbox 1.0]
      *
@@ -5270,20 +5950,21 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>NumberOfRecipientsExceeded - The number of recipients exceeded 100 entries.</td></tr></table>
          * 
-         * In addition to the main signature, this method also has these signatures:
+         * In addition to this signature, this method also has the following signatures:
          * 
          * `addAsync(recipients: (string | EmailUser | EmailAddressDetails)[]): void;`
          * 
          * `addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options: Office.AsyncContextOptions): void;`
          * 
-         * `addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult) => void): void;`
+         * `addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult<void>) => void): void;`
          *
          * @param recipients - The recipients to add to the recipients list.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If adding the recipients fails, the asyncResult.error property will contain an error code.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. If adding the recipients fails, the asyncResult.error property will contain an error code.
          */
-        addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Adds a recipient list to the existing recipients for an appointment or message.
          *
@@ -5353,13 +6034,14 @@ export declare namespace Office {
          * <tr><td>Errors</td><td>NumberOfRecipientsExceeded - The number of recipients exceeded 100 entries.</td></tr></table>
          *
          * @param recipients - The recipients to add to the recipients list.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If adding the recipients fails, the asyncResult.error property will contain an error code.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. If adding the recipients fails, the asyncResult.error property will contain an error code.
          */
-        addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult) => void): void;
+        addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult<void>) => void): void;
         /**
          * Gets a recipient list for an appointment or message.
          *
-         * When the call completes, the asyncResult.value property will contain an array of{@link Office.EmailAddressDetails} objects.
+         * When the call completes, the asyncResult.value property will contain an array of {@link Office.EmailAddressDetails} objects.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -5368,15 +6050,17 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose</td></tr></table>
          * 
-         * In addition to the main signature, this method also has this signature:
+         * In addition to this signature, this method also has the following signature:
          * 
-         * `getAsync(callback: (result: AsyncResult) => void): void;`
+         * `getAsync(callback: (result: AsyncResult<Office.EmailAddressDetails[]>) => void): void;`
          *
          * @param options - An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
+         *                 The `value` property of the result is an array of EmailAddressDetails objects.
          */
-        getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;
+        getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult<Office.EmailAddressDetails[]>) => void): void;
         /**
          * Gets a recipient list for an appointment or message.
          *
@@ -5389,9 +6073,11 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose</td></tr></table>
          *
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
+         *                 The `value` property of the result is an array of EmailAddressDetails objects.
          */
-        getAsync(callback: (result: AsyncResult) => void): void;
+        getAsync(callback: (result: AsyncResult<Office.EmailAddressDetails[]>) => void): void;
         /**
          * Sets a recipient list for an appointment or message.
          *
@@ -5414,20 +6100,23 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>NumberOfRecipientsExceeded - The number of recipients exceeded 100 entries.</td></tr></table>
          * 
-         * In addition to the main signature, this method also has these signatures:
+         * In addition to this signature, this method also has the following signatures:
          * 
          * `setAsync(recipients: (string | EmailUser | EmailAddressDetails)[]): void;`
          * 
          * `setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options: Office.AsyncContextOptions): void;`
          * 
-         * `setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult) => void): void;`
+         * `setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult<void>) => void): void;`
          *
          * @param recipients - The recipients to add to the recipients list.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.  If setting the recipients fails the asyncResult.error property will contain a code that indicates any error that occurred while adding the data.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
+         *                 If setting the recipients fails the asyncResult.error property will contain a code that indicates any error that occurred 
+         *                 while adding the data.
          */
-        setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Sets a recipient list for an appointment or message.
          *
@@ -5503,9 +6192,12 @@ export declare namespace Office {
          * <tr><td>Errors</td><td>NumberOfRecipientsExceeded - The number of recipients exceeded 100 entries.</td></tr></table>
          *
          * @param recipients - The recipients to add to the recipients list.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.  If setting the recipients fails the asyncResult.error property will contain a code that indicates any error that occurred while adding the data.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. 
+         *                 If setting the recipients fails the asyncResult.error property will contain a code that indicates any error that occurred 
+         *                 while adding the data.
          */
-        setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult) => void): void;
+        setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult<void>) => void): void;
 
     }
 
@@ -5526,7 +6218,8 @@ export declare namespace Office {
          */
         url?: string;
         /**
-         * Only used if type is set to file. If true, indicates that the attachment will be shown inline in the message body, and should not be displayed in the attachment list.
+         * Only used if type is set to file. If true, indicates that the attachment will be shown inline in the message body, and should not be 
+         * displayed in the attachment list.
          */
         inLine?: boolean;
         /**
@@ -5548,20 +6241,27 @@ export declare namespace Office {
          */
         attachments?: ReplyFormAttachment[];
         /**
-         * When the reply display call completes, the function passed in the callback parameter is called with a single parameter, asyncResult, which is an AsyncResult object.
+         * When the reply display call completes, the function passed in the callback parameter is called with a single parameter, 
+         * asyncResult, which is an Office.AsyncResult object.
          */
-        callback?: (result: AsyncResult) => void;
+        callback?: (result: AsyncResult<any>) => void;
     }
     /**
-     * The settings created by using the methods of the RoamingSettings object are saved per add-in and per user. That is, they are available only to the add-in that created them, and only from the user's mail box in which they are saved.
+     * The settings created by using the methods of the RoamingSettings object are saved per add-in and per user. 
+     * That is, they are available only to the add-in that created them, and only from the user's mail box in which they are saved.
      *
-     * While the Outlook add-in API limits access to these settings to only the add-in that created them, these settings should not be considered secure storage. They can be accessed by Exchange Web Services or Extended MAPI. They should not be used to store sensitive information such as user credentials or security tokens.
+     * While the Outlook Add-in API limits access to these settings to only the add-in that created them, these settings should not be considered 
+     * secure storage. They can be accessed by Exchange Web Services or Extended MAPI. 
+     * They should not be used to store sensitive information such as user credentials or security tokens.
      *
      * The name of a setting is a String, while the value can be a String, Number, Boolean, null, Object, or Array.
      *
      * The RoamingSettings object is accessible via the roamingSettings property in the Office.context namespace.
      *
-     * Important: The RoamingSettings object is initialized from the persisted storage only when the add-in is first loaded. For task panes, this means that it is only initialized when the task pane first opens. If the task pane navigates to another page or reloads the current page, the in-memory object is reset to its initial values, even if your add-in has persisted changes. The persisted changes will not be available until the task pane is closed and reopened.
+     * Important: The RoamingSettings object is initialized from the persisted storage only when the add-in is first loaded. 
+     * For task panes, this means that it is only initialized when the task pane first opens. 
+     * If the task pane navigates to another page or reloads the current page, the in-memory object is reset to its initial values, even if 
+     * your add-in has persisted changes. The persisted changes will not be available until the task pane is closed and reopened.
      *
      * [Api set: Mailbox 1.0]
      *
@@ -5601,7 +6301,9 @@ export declare namespace Office {
         /**
          * Saves the settings.
          *
-         * Any settings previously saved by an add-in are loaded when it is initialized, so during the lifetime of the session you can just use the set and get methods to work with the in-memory copy of the settings property bag. When you want to persist the settings so that they are available the next time the add-in is used, use the saveAsync method.
+         * Any settings previously saved by an add-in are loaded when it is initialized, so during the lifetime of the session you can just use 
+         * the set and get methods to work with the in-memory copy of the settings property bag. 
+         * When you want to persist the settings so that they are available the next time the add-in is used, use the saveAsync method.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -5610,13 +6312,15 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          *
-         * @param callback - Optional? When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          */
-        saveAsync(callback?: (result: AsyncResult) => void): void;
+        saveAsync(callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Sets or creates the specified setting.
          *
-         * The set method creates a new setting of the specified name if it does not already exist, or sets an existing setting of the specified name. The value is stored in the document as the serialized JSON representation of its data type.
+         * The set method creates a new setting of the specified name if it does not already exist, or sets an existing setting of the specified name. 
+         * The value is stored in the document as the serialized JSON representation of its data type.
          *
          * A maximum of 32KB is available for the settings of each add-in.
          *
@@ -5634,6 +6338,7 @@ export declare namespace Office {
          */
         set(name: string, value: any): void;
     }
+    
     /**
      * Provides methods to get and set the subject of an appointment or message in an Outlook add-in.
      *
@@ -5657,17 +6362,20 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose</td></tr></table>
          * 
-         * In addition to the main signature, this method also has this signature:
+         * In addition to this signature, this method also has the following signature:
          * 
-         * `getAsync(callback: (result: AsyncResult) => void): void;`
+         * `getAsync(callback: (result: AsyncResult<string>) => void): void;`
          *
          * @param options - An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
+         *                 The `value` property of the result is the subject of the item.
          */
-        getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;
+        getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult<string>) => void): void;
         /**
          * Gets the subject of an appointment or message.
+         * 
          * The getAsync method starts an asynchronous call to the Exchange server to get the subject of an appointment or message.
          *
          * [Api set: Mailbox 1.1]
@@ -5678,12 +6386,14 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose</td></tr></table>
          *
          * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         *                  The `value` property of the result is the subject of the item.
          */
-        getAsync(callback: (result: AsyncResult) => void): void;
+        getAsync(callback: (result: AsyncResult<string>) => void): void;
         /**
          * Sets the subject of an appointment or message.
          *
-         * The setAsync method starts an asynchronous call to the Exchange server to set the subject of an appointment or message. Setting the subject overwrites the current subject, but leaves any prefixes, such as "Fwd:" or "Re:" in place.
+         * The setAsync method starts an asynchronous call to the Exchange server to set the subject of an appointment or message. 
+         * Setting the subject overwrites the current subject, but leaves any prefixes, such as "Fwd:" or "Re:" in place.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -5694,24 +6404,26 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>DataExceedsMaximumSize - The subject parameter is longer than 255 characters.</td></tr></table>
          * 
-         * In addition to the main signature, this method also has these signatures:
+         * In addition to this signature, this method also has the following signatures:
          * 
          * `setAsync(subject: string): void;`
          * 
          * `setAsync(subject: string, options: Office.AsyncContextOptions): void;`
          * 
-         * `setAsync(subject: string, callback: (result: AsyncResult) => void): void;`
+         * `setAsync(subject: string, callback: (result: AsyncResult<void>) => void): void;`
          *
          * @param subject - The subject of the appointment or message. The string is limited to 255 characters.
          * @param options - An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If setting the subject fails, the asyncResult.error property will contain an error code.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. If setting the subject fails, the asyncResult.error property will contain an error code.
          */
-        setAsync(subject: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        setAsync(subject: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Sets the subject of an appointment or message.
          *
-         * The setAsync method starts an asynchronous call to the Exchange server to set the subject of an appointment or message. Setting the subject overwrites the current subject, but leaves any prefixes, such as "Fwd:" or "Re:" in place.
+         * The setAsync method starts an asynchronous call to the Exchange server to set the subject of an appointment or message. 
+         * Setting the subject overwrites the current subject, but leaves any prefixes, such as "Fwd:" or "Re:" in place.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -5728,7 +6440,8 @@ export declare namespace Office {
         /**
          * Sets the subject of an appointment or message.
          *
-         * The setAsync method starts an asynchronous call to the Exchange server to set the subject of an appointment or message. Setting the subject overwrites the current subject, but leaves any prefixes, such as "Fwd:" or "Re:" in place.
+         * The setAsync method starts an asynchronous call to the Exchange server to set the subject of an appointment or message. 
+         * Setting the subject overwrites the current subject, but leaves any prefixes, such as "Fwd:" or "Re:" in place.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -5747,7 +6460,8 @@ export declare namespace Office {
         /**
          * Sets the subject of an appointment or message.
          *
-         * The setAsync method starts an asynchronous call to the Exchange server to set the subject of an appointment or message. Setting the subject overwrites the current subject, but leaves any prefixes, such as "Fwd:" or "Re:" in place.
+         * The setAsync method starts an asynchronous call to the Exchange server to set the subject of an appointment or message. 
+         * Setting the subject overwrites the current subject, but leaves any prefixes, such as "Fwd:" or "Re:" in place.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -5759,15 +6473,17 @@ export declare namespace Office {
          * <tr><td>Errors</td><td>DataExceedsMaximumSize - The subject parameter is longer than 255 characters.</td></tr></table>
          *
          * @param subject - The subject of the appointment or message. The string is limited to 255 characters.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If setting the subject fails, the asyncResult.error property will contain an error code.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. If setting the subject fails, the asyncResult.error property will contain an error code.
          */
-        setAsync(data: string, callback: (result: AsyncResult) => void): void;
+        setAsync(data: string, callback: (result: AsyncResult<void>) => void): void;
 
     }
     /**
      * Represents a suggested task identified in an item. Read mode only.
      *
-     * The list of tasks suggested in an email message is returned in the taskSuggestions property of the [Entities]Entities object that is returned when the getEntities or getEntitiesByType method is called on the active item.
+     * The list of tasks suggested in an email message is returned in the taskSuggestions property of the {@link Office.Entities | Entities} object 
+     * that is returned when the getEntities or getEntitiesByType method is called on the active item.
      *
      * [Api set: Mailbox 1.0]
      *
@@ -5800,7 +6516,8 @@ export declare namespace Office {
         /**
          * Gets the start or end time of an appointment.
          *
-         * The date and time is provided as a Date object in the asyncResult.value property. The value is in Coordinated Universal Time (UTC). You can convert the UTC time to the local client time by using the convertToLocalClientTime method.
+         * The date and time is provided as a Date object in the asyncResult.value property. The value is in Coordinated Universal Time (UTC). 
+         * You can convert the UTC time to the local client time by using the convertToLocalClientTime method.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -5809,19 +6526,21 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose</td></tr></table>
          * 
-         * In addition to the main signature, this method also has this signature:
+         * In addition to this signature, this method also has the following signature:
          * 
-         * `getAsync(callback: (result: AsyncResult) => void): void;`
+         * `getAsync(callback: (result: AsyncResult<Date>) => void): void;`
          *
          * @param options - An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
          * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         *                  The `value` property of the result is a Date object.
          */
-        getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;
+        getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult<Date>) => void): void;
         /**
          * Gets the start or end time of an appointment.
          *
-         * The date and time is provided as a Date object in the asyncResult.value property. The value is in Coordinated Universal Time (UTC). You can convert the UTC time to the local client time by using the convertToLocalClientTime method.
+         * The date and time is provided as a Date object in the asyncResult.value property. The value is in Coordinated Universal Time (UTC). 
+         * You can convert the UTC time to the local client time by using the convertToLocalClientTime method.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -5831,12 +6550,14 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose</td></tr></table>
          *
          * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         *                  The `value` property of the result is a Date object.
          */
-        getAsync(callback: (result: AsyncResult) => void): void;
+        getAsync(callback: (result: AsyncResult<Date>) => void): void;
         /**
          * Sets the start or end time of an appointment.
          *
-         * If the setAsync method is called on the start property, the end property will be adjusted to maintain the duration of the appointment as previously set. If the setAsync method is called on the end property, the duration of the appointment will be extended to the new end time.
+         * If the setAsync method is called on the start property, the end property will be adjusted to maintain the duration of the appointment as 
+         * previously set. If the setAsync method is called on the end property, the duration of the appointment will be extended to the new end time.
          *
          * The time must be in UTC; you can get the correct UTC time by using the convertToUtcClientTime method.
          *
@@ -5849,24 +6570,27 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>InvalidEndTime - The appointment end time is before the appointment start time.</td></tr></table>
          * 
-         * In addition to the main signature, this method also has these signatures:
+         * In addition to this signature, this method also has the following signatures:
          * 
          * `setAsync(dateTime: Date): void;`
          * 
          * `setAsync(dateTime: Date, options: Office.AsyncContextOptions): void;`
          * 
-         * `setAsync(dateTime: Date, callback: (result: AsyncResult) => void): void;`
+         * `setAsync(dateTime: Date, callback: (result: AsyncResult<void>) => void): void;`
          *
          * @param dateTime - A date-time object in Coordinated Universal Time (UTC).
          * @param options - An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If setting the date and time fails, the asyncResult.error property will contain an error code.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. 
+         *                 If setting the date and time fails, the asyncResult.error property will contain an error code.
          */
-        setAsync(dateTime: Date, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        setAsync(dateTime: Date, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Sets the start or end time of an appointment.
          *
-         * If the setAsync method is called on the start property, the end property will be adjusted to maintain the duration of the appointment as previously set. If the setAsync method is called on the end property, the duration of the appointment will be extended to the new end time.
+         * If the setAsync method is called on the start property, the end property will be adjusted to maintain the duration of the appointment as 
+         * previously set. If the setAsync method is called on the end property, the duration of the appointment will be extended to the new end time.
          *
          * The time must be in UTC; you can get the correct UTC time by using the convertToUtcClientTime method.
          *
@@ -5885,7 +6609,8 @@ export declare namespace Office {
         /**
          * Sets the start or end time of an appointment.
          *
-         * If the setAsync method is called on the start property, the end property will be adjusted to maintain the duration of the appointment as previously set. If the setAsync method is called on the end property, the duration of the appointment will be extended to the new end time.
+         * If the setAsync method is called on the start property, the end property will be adjusted to maintain the duration of the appointment as 
+         * previously set. If the setAsync method is called on the end property, the duration of the appointment will be extended to the new end time.
          *
          * The time must be in UTC; you can get the correct UTC time by using the convertToUtcClientTime method.
          *
@@ -5906,7 +6631,8 @@ export declare namespace Office {
         /**
          * Sets the start or end time of an appointment.
          *
-         * If the setAsync method is called on the start property, the end property will be adjusted to maintain the duration of the appointment as previously set. If the setAsync method is called on the end property, the duration of the appointment will be extended to the new end time.
+         * If the setAsync method is called on the start property, the end property will be adjusted to maintain the duration of the appointment as 
+         * previously set. If the setAsync method is called on the end property, the duration of the appointment will be extended to the new end time.
          *
          * The time must be in UTC; you can get the correct UTC time by using the convertToUtcClientTime method.
          *
@@ -5920,9 +6646,11 @@ export declare namespace Office {
          * <tr><td>Errors</td><td>InvalidEndTime - The appointment end time is before the appointment start time.</td></tr></table>
          *
          * @param dateTime - A date-time object in Coordinated Universal Time (UTC).
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If setting the date and time fails, the asyncResult.error property will contain an error code.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. 
+         *                 If setting the date and time fails, the asyncResult.error property will contain an error code.
          */
-        setAsync(dateTime: Date, callback: (result: AsyncResult) => void): void;
+        setAsync(dateTime: Date, callback: (result: AsyncResult<void>) => void): void;
 
     }
     /**

--- a/generate-docs/api-extractor-inputs-outlook-legacy/Outlook_1_4/Outlook_1_4.d.ts
+++ b/generate-docs/api-extractor-inputs-outlook-legacy/Outlook_1_4/Outlook_1_4.d.ts
@@ -113,6 +113,24 @@ export declare namespace Office {
             Appointment = "appointment"
         }
         /**
+         * Represents the current view of Outlook Web App.
+         */
+        enum OWAView {
+            /**
+             * One column view. Displayed when the screen is narrow. Outlook Web App uses this single-column layout on the entire screen of a smartphone.
+             */
+            OneColumn = "OneColumn",
+            /**
+             * Two column view. Displayed when the screen is wider. Outlook Web App uses this view on most tablets.
+             */
+            TwoColumns = "TwoColumns",
+            /**
+             Three column view. Displayed when the screen is wide. For example, Outlook Web App uses this view in a full screen window on a desktop 
+             computer.
+             */
+            ThreeColumns = "ThreeColumns"
+        }
+        /**
          * Specifies the type of recipient for an appointment.
          *
          * [Api set: Mailbox 1.1]
@@ -140,7 +158,7 @@ export declare namespace Office {
              */
             Other = "other"
         }
-        /**  
+        /**
          * Specifies the type of response to a meeting invitation.
          *
          * [Api set: Mailbox 1.0]
@@ -236,7 +254,8 @@ export declare namespace Office {
         /**
          * Gets or sets the date and time that the appointment is to end.
          *
-         * The end property is expressed as a Coordinated Universal Time (UTC) date and time value. You can use the convertToLocalClientTime method to convert the end property value to the client's local date and time.
+         * The end property is expressed as a Coordinated Universal Time (UTC) date and time value. You can use the convertToLocalClientTime method to 
+         * convert the end property value to the client's local date and time.
          *
          * *Read mode*
          *
@@ -246,7 +265,8 @@ export declare namespace Office {
          *
          * The end property returns a Time object.
          *
-         * When you use the Time.setAsync method to set the end time, you should use the convertToUtcClientTime method to convert the local time on the client to UTC for the server.
+         * When you use the Time.setAsync method to set the end time, you should use the convertToUtcClientTime method to convert the local time on 
+         * the client to UTC for the server.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -320,7 +340,8 @@ export declare namespace Office {
         /**
          * Gets or sets the date and time that the appointment is to begin.
          *
-         * The start property is expressed as a Coordinated Universal Time (UTC) date and time value. You can use the convertToLocalClientTime method to convert the value to the client's local date and time.
+         * The start property is expressed as a Coordinated Universal Time (UTC) date and time value. You can use the convertToLocalClientTime method 
+         * to convert the value to the client's local date and time.
          *
          * *Read mode*
          *
@@ -330,7 +351,8 @@ export declare namespace Office {
          *
          * The start property returns a Time object.
          *
-         * When you use the Time.setAsync method to set the start time, you should use the convertToUtcClientTime method to convert the local time on the client to UTC for the server.
+         * When you use the Time.setAsync method to set the start time, you should use the convertToUtcClientTime method to convert the local time on 
+         * the client to UTC for the server.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -403,7 +425,8 @@ export declare namespace Office {
         size: number;
     }
     /**
-     * The body object provides methods for adding and updating the content of the message or appointment. It is returned in the body property of the selected item.
+     * The body object provides methods for adding and updating the content of the message or appointment. 
+     * It is returned in the body property of the selected item.
      *
      * [Api set: Mailbox 1.1]
      *
@@ -418,7 +441,9 @@ export declare namespace Office {
          *
          * This method returns the entire current body in the format specified by coercionType.
          *
-         * When working with HTML-formatted bodies, it is important to note that the Body.getAsync and Body.setAsync methods are not idempotent. The value returned from the getAsync method will not necessarily be exactly the same as the value that was passed in the setAsync method previously. The client may modify the value passed to setAsync in order to make it render efficiently with its rendering engine.
+         * When working with HTML-formatted bodies, it is important to note that the Body.getAsync and Body.setAsync methods are not idempotent. 
+         * The value returned from the getAsync method will not necessarily be exactly the same as the value that was passed in the setAsync method previously. 
+         * The client may modify the value passed to setAsync in order to make it render efficiently with its rendering engine.
          *
          * [Api set: Mailbox 1.3]
          *
@@ -427,22 +452,25 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          * 
-         * In addition to the main signature, this method also has this signature:
+         * In addition to this signature, this method also has the following signature:
          * 
-         * `getAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult) => void): void;`
+         * `getAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult<Office.Body>) => void): void;`
          * 
          * @param coercionType - The format for the returned body.
          * @param options - Optional. An object literal that contains one or more of the following properties:
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. The body is provided in the requested format in the asyncResult.value property.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. 
+         *                  The body is provided in the requested format in the asyncResult.value property.
          */
-        getAsync(coerciontype: Office.CoercionType, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        getAsync(coerciontype: Office.CoercionType, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<Office.Body>) => void): void;
         /**
          * Returns the current body in a specified format.
          *
          * This method returns the entire current body in the format specified by coercionType.
          *
-         * When working with HTML-formatted bodies, it is important to note that the Body.getAsync and Body.setAsync methods are not idempotent. The value returned from the getAsync method will not necessarily be exactly the same as the value that was passed in the setAsync method previously. The client may modify the value passed to setAsync in order to make it render efficiently with its rendering engine.
+         * When working with HTML-formatted bodies, it is important to note that the Body.getAsync and Body.setAsync methods are not idempotent. 
+         * The value returned from the getAsync method will not necessarily be exactly the same as the value that was passed in the setAsync method previously. 
+         * The client may modify the value passed to setAsync in order to make it render efficiently with its rendering engine.
          *
          * [Api set: Mailbox 1.3]
          *
@@ -452,9 +480,10 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          *
          * @param coercionType - The format for the returned body.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. The body is provided in the requested format in the asyncResult.value property.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult.
+         *                  The body is provided in the requested format in the asyncResult.value property.
          */
-        getAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult) => void): void;
+        getAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult<Office.Body>) => void): void;
 
         /**
          * Gets a value that indicates whether the content is in HTML or text format.
@@ -468,15 +497,18 @@ export declare namespace Office {
          *
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. The content type is returned as one of the CoercionType values in the asyncResult.value property.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult.
+         *                  The content type is returned as one of the CoercionType values in the asyncResult.value property.
          */
-        getTypeAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        getTypeAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<Office.CoercionType>) => void): void;
         /**
          * Adds the specified content to the beginning of the item body.
          *
-         * The prependAsync method inserts the specified string at the beginning of the item body. After insertion, the cursor is returned to its original place, relative to the inserted content.
+         * The prependAsync method inserts the specified string at the beginning of the item body. 
+         * After insertion, the cursor is returned to its original place, relative to the inserted content.
          *
-         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" (please see the Examples section for a sample).
+         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" 
+         * (please see the Examples section for a sample).
          *
          * [Api set: Mailbox 1.1]
          *
@@ -487,11 +519,11 @@ export declare namespace Office {
          * 
          * <tr><td>Errors</td><td>DataExceedsMaximumSize - The data parameter is longer than 1,000,000 characters.</td></tr></table>
          * 
-         * In addition to the main signature, this method also has these signatures:
+         * In addition to this signature, this method also has the following signatures:
          * 
          * `prependAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`
          * 
-         * `prependAsync(data: string, callback: (result: AsyncResult) => void): void;`
+         * `prependAsync(data: string, callback: (result: AsyncResult<void>) => void): void;`
          * 
          * `prependAsync(data: string): void;`
          *
@@ -499,15 +531,18 @@ export declare namespace Office {
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
          *        coercionType: The desired format for the body. The string in the data parameter will be converted to this format.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. Any errors encountered will be provided in the asyncResult.error property.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult.
+         *                  Any errors encountered will be provided in the asyncResult.error property.
          */
-        prependAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult) => void): void;
+        prependAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Adds the specified content to the beginning of the item body.
          *
-         * The prependAsync method inserts the specified string at the beginning of the item body. After insertion, the cursor is returned to its original place, relative to the inserted content.
+         * The prependAsync method inserts the specified string at the beginning of the item body. 
+         * After insertion, the cursor is returned to its original place, relative to the inserted content.
          *
-         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" (please see the Examples section for a sample).
+         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" 
+         * (please see the Examples section for a sample).
          *
          * [Api set: Mailbox 1.1]
          *
@@ -527,9 +562,11 @@ export declare namespace Office {
         /**
          * Adds the specified content to the beginning of the item body.
          *
-         * The prependAsync method inserts the specified string at the beginning of the item body. After insertion, the cursor is returned to its original place, relative to the inserted content.
+         * The prependAsync method inserts the specified string at the beginning of the item body. 
+         * After insertion, the cursor is returned to its original place, relative to the inserted content.
          *
-         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" (please see the Examples section for a sample).
+         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" 
+         * (please see the Examples section for a sample).
          *
          * [Api set: Mailbox 1.1]
          *
@@ -539,15 +576,18 @@ export declare namespace Office {
          * <tr><td>Errors</td><td>DataExceedsMaximumSize - The data parameter is longer than 1,000,000 characters.</td></tr></table>
          *
          * @param data - The string to be inserted at the beginning of the body. The string is limited to 1,000,000 characters.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. Any errors encountered will be provided in the asyncResult.error property.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult.
+         *                  Any errors encountered will be provided in the asyncResult.error property.
          */
-        prependAsync(data: string, callback: (result: AsyncResult) => void): void;
+        prependAsync(data: string, callback: (result: AsyncResult<void>) => void): void;
         /**
          * Adds the specified content to the beginning of the item body.
          *
-         * The prependAsync method inserts the specified string at the beginning of the item body. After insertion, the cursor is returned to its original place, relative to the inserted content.
+         * The prependAsync method inserts the specified string at the beginning of the item body. 
+         * After insertion, the cursor is returned to its original place, relative to the inserted content.
          *
-         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" (please see the Examples section for a sample).
+         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" 
+         * (please see the Examples section for a sample).
          *
          * [Api set: Mailbox 1.1]
          *
@@ -562,9 +602,12 @@ export declare namespace Office {
         /**
          * Replaces the entire body with the specified text.
          *
-         * When working with HTML-formatted bodies, it is important to note that the Body.getAsync and Body.setAsync methods are not idempotent. The value returned from the getAsync method will not necessarily be exactly the same as the value that was passed in the setAsync method previously. The client may modify the value passed to setAsync in order to make it render efficiently with its rendering engine.
+         * When working with HTML-formatted bodies, it is important to note that the Body.getAsync and Body.setAsync methods are not idempotent. 
+         * The value returned from the getAsync method will not necessarily be exactly the same as the value that was passed in the setAsync method 
+         * previously. The client may modify the value passed to setAsync in order to make it render efficiently with its rendering engine.
          *
-         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" (please see the Examples section for a sample).
+         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" 
+         * (please see the Examples section for a sample).
          *
          * [Api set: Mailbox 1.3]
          *
@@ -575,11 +618,11 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>DataExceedsMaximumSize - The data parameter is longer than 1,000,000 characters.</td></tr><tr><td></td><td>InvalidFormatError - The options.coercionType parameter is set to Office.CoercionType.Html and the message body is in plain text.</td></tr></table>
          * 
-         * In addition to the main signature, this method also has these signatures:
+         * In addition to this signature, this method also has the following signatures:
          * 
          * `setAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`
          * 
-         * `setAsync(data: string, callback: (result: AsyncResult) => void): void;`
+         * `setAsync(data: string, callback: (result: AsyncResult<void>) => void): void;`
          * 
          * `setAsync(data: string): void;`
          *
@@ -587,15 +630,19 @@ export declare namespace Office {
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
          *        coercionType: The desired format for the body. The string in the data parameter will be converted to this format.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.  Any errors encountered will be provided in the asyncResult.error property.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult.
+         *                  Any errors encountered will be provided in the asyncResult.error property.
          */
-        setAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult) => void): void;
+        setAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Replaces the entire body with the specified text.
          *
-         * When working with HTML-formatted bodies, it is important to note that the Body.getAsync and Body.setAsync methods are not idempotent. The value returned from the getAsync method will not necessarily be exactly the same as the value that was passed in the setAsync method previously. The client may modify the value passed to setAsync in order to make it render efficiently with its rendering engine.
+         * When working with HTML-formatted bodies, it is important to note that the Body.getAsync and Body.setAsync methods are not idempotent. 
+         * The value returned from the getAsync method will not necessarily be exactly the same as the value that was passed in the setAsync method 
+         * previously. The client may modify the value passed to setAsync in order to make it render efficiently with its rendering engine.
          *
-         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" (please see the Examples section for a sample).
+         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" 
+         * (please see the Examples section for a sample).
          *
          * [Api set: Mailbox 1.3]
          *
@@ -615,9 +662,12 @@ export declare namespace Office {
         /**
          * Replaces the entire body with the specified text.
          *
-         * When working with HTML-formatted bodies, it is important to note that the Body.getAsync and Body.setAsync methods are not idempotent. The value returned from the getAsync method will not necessarily be exactly the same as the value that was passed in the setAsync method previously. The client may modify the value passed to setAsync in order to make it render efficiently with its rendering engine.
+         * When working with HTML-formatted bodies, it is important to note that the Body.getAsync and Body.setAsync methods are not idempotent. 
+         * The value returned from the getAsync method will not necessarily be exactly the same as the value that was passed in the setAsync method 
+         * previously. The client may modify the value passed to setAsync in order to make it render efficiently with its rendering engine.
          *
-         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" (please see the Examples section for a sample).
+         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" 
+         * (please see the Examples section for a sample).
          *
          * [Api set: Mailbox 1.3]
          *
@@ -629,15 +679,19 @@ export declare namespace Office {
          * <tr><td>Errors</td><td>DataExceedsMaximumSize - The data parameter is longer than 1,000,000 characters.</td></tr><tr><td></td><td>InvalidFormatError - The options.coercionType parameter is set to Office.CoercionType.Html and the message body is in plain text.</td></tr></table>
          *
          * @param data - The string that will replace the existing body. The string is limited to 1,000,000 characters.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.  Any errors encountered will be provided in the asyncResult.error property.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult.
+         *                  Any errors encountered will be provided in the asyncResult.error property.
          */
-        setAsync(data: string, callback: (result: AsyncResult) => void): void;
+        setAsync(data: string, callback: (result: AsyncResult<void>) => void): void;
         /**
          * Replaces the entire body with the specified text.
          *
-         * When working with HTML-formatted bodies, it is important to note that the Body.getAsync and Body.setAsync methods are not idempotent. The value returned from the getAsync method will not necessarily be exactly the same as the value that was passed in the setAsync method previously. The client may modify the value passed to setAsync in order to make it render efficiently with its rendering engine.
+         * When working with HTML-formatted bodies, it is important to note that the Body.getAsync and Body.setAsync methods are not idempotent.
+         *  The value returned from the getAsync method will not necessarily be exactly the same as the value that was passed in the setAsync method 
+         * previously. The client may modify the value passed to setAsync in order to make it render efficiently with its rendering engine.
          *
-         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" (please see the Examples section for a sample).
+         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" 
+         * (please see the Examples section for a sample).
          *
          * [Api set: Mailbox 1.3]
          *
@@ -655,9 +709,12 @@ export declare namespace Office {
         /**
          * Replaces the selection in the body with the specified text.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor was never in the body of the item, or if the body of the item lost focus in the UI, the string will be inserted at the top of the body content. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the body of the item, or, if text is selected in 
+         * the editor, it replaces the selected text. If the cursor was never in the body of the item, or if the body of the item lost focus in the 
+         * UI, the string will be inserted at the top of the body content. After insertion, the cursor is placed at the end of the inserted content.
          *
-         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" (please see the Examples section for a sample).
+         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" 
+         * (please see the Examples section for a sample).
          *
          * [Api set: Mailbox 1.1]
          *
@@ -668,11 +725,11 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>DataExceedsMaximumSize - The data parameter is longer than 1,000,000 characters.</td></tr><tr><td></td><td>InvalidFormatError - The options.coercionType parameter is set to Office.CoercionType.Html and the message body is in plain text.</td></tr></table>
          * 
-         * In addition to the main signature, this method also has these signatures:
+         * In addition to this signature, this method also has the following signatures:
          * 
          * `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`
          * 
-         * `setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;`
+         * `setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;`
          * 
          * `setSelectedDataAsync(data: string): void;`
          *         
@@ -680,15 +737,19 @@ export declare namespace Office {
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
          *        coercionType: The desired format for the body. The string in the data parameter will be converted to this format.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.  Any errors encountered will be provided in the asyncResult.error property.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult.
+         *                  Any errors encountered will be provided in the asyncResult.error property.
          */
-        setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult) => void): void;
+        setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Replaces the selection in the body with the specified text.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor was never in the body of the item, or if the body of the item lost focus in the UI, the string will be inserted at the top of the body content. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the body of the item, or, if text is selected in 
+         * the editor, it replaces the selected text. If the cursor was never in the body of the item, or if the body of the item lost focus in the 
+         * UI, the string will be inserted at the top of the body content. After insertion, the cursor is placed at the end of the inserted content.
          *
-         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" (please see the Examples section for a sample).
+         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" 
+         * (please see the Examples section for a sample).
          *
          * [Api set: Mailbox 1.1]
          *
@@ -708,9 +769,12 @@ export declare namespace Office {
         /**
          * Replaces the selection in the body with the specified text.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor was never in the body of the item, or if the body of the item lost focus in the UI, the string will be inserted at the top of the body content. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the body of the item, or, if text is selected in 
+         * the editor, it replaces the selected text. If the cursor was never in the body of the item, or if the body of the item lost focus in the 
+         * UI, the string will be inserted at the top of the body content. After insertion, the cursor is placed at the end of the inserted content.
          *
-         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" (please see the Examples section for a sample).
+         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" 
+         * (please see the Examples section for a sample).
          *
          * [Api set: Mailbox 1.1]
          *
@@ -722,15 +786,19 @@ export declare namespace Office {
          * <tr><td>Errors</td><td>DataExceedsMaximumSize - The data parameter is longer than 1,000,000 characters.</td></tr><tr><td></td><td>InvalidFormatError - The options.coercionType parameter is set to Office.CoercionType.Html and the message body is in plain text.</td></tr></table>
          *
          * @param data - The string that will replace the existing body. The string is limited to 1,000,000 characters.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.  Any errors encountered will be provided in the asyncResult.error property.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult.
+         *                  Any errors encountered will be provided in the asyncResult.error property.
          */
-        setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;
+        setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;
         /**
          * Replaces the selection in the body with the specified text.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor was never in the body of the item, or if the body of the item lost focus in the UI, the string will be inserted at the top of the body content. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the body of the item, or, if text is selected in 
+         * the editor, it replaces the selected text. If the cursor was never in the body of the item, or if the body of the item lost focus in the 
+         * UI, the string will be inserted at the top of the body content. After insertion, the cursor is placed at the end of the inserted content.
          *
-         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" (please see the Examples section for a sample).
+         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" 
+         * (please see the Examples section for a sample).
          *
          * [Api set: Mailbox 1.1]
          *
@@ -748,7 +816,8 @@ export declare namespace Office {
     /**
      * Represents a contact stored on the server. Read mode only.
      *
-     * The list of contacts associated with an email message or appointment is returned in the contacts property of the {@link Office.Entities} object that is returned by the getEntities or getEntitiesByType method of the active item.
+     * The list of contacts associated with an email message or appointment is returned in the contacts property of the {@link Office.Entities} object 
+     * that is returned by the getEntities or getEntitiesByType method of the active item.
      *
      * [Api set: Mailbox 1.0]
      *
@@ -784,7 +853,10 @@ export declare namespace Office {
         urls: Array<string>;
     }
     /**
-     * The CustomProperties object represents custom properties that are specific to a particular item and specific to a mail add-in for Outlook. For example, there might be a need for a mail add-in to save some data that is specific to the current email message that activated the add-in. If the user revisits the same message in the future and activates the mail add-in again, the add-in will be able to retrieve the data that had been saved as custom properties.
+     * The CustomProperties object represents custom properties that are specific to a particular item and specific to a mail add-in for Outlook. 
+     * For example, there might be a need for a mail add-in to save some data that is specific to the current email message that activated the add-in. 
+     * If the user revisits the same message in the future and activates the mail add-in again, the add-in will be able to retrieve the data that had 
+     * been saved as custom properties.
      *
      * Because Outlook for Mac doesn't cache custom properties, if the user's network goes down, mail add-ins cannot access their custom properties.
      *
@@ -814,7 +886,9 @@ export declare namespace Office {
          *
          * The set method sets the specified property to the specified value. You must use the saveAsync method to save the property to the server.
          *
-         * The set method creates a new property if the specified property does not already exist; otherwise, the existing value is replaced with the new value. The value parameter can be of any type; however, it is always passed to the server as a string.
+         * The set method creates a new property if the specified property does not already exist; 
+         * otherwise, the existing value is replaced with the new value. 
+         * The value parameter can be of any type; however, it is always passed to the server as a string.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -844,11 +918,17 @@ export declare namespace Office {
         /**
          * Saves item-specific custom properties to the server.
          *
-         * You must call the saveAsync method to persist any changes made with the set method or the remove method of the CustomProperties object. The saving action is asynchronous.
+         * You must call the saveAsync method to persist any changes made with the set method or the remove method of the CustomProperties object. 
+         * The saving action is asynchronous.
          *
-         * It's a good practice to have your callback function check for and handle errors from saveAsync. In particular, a read add-in can be activated while the user is in a connected state in a read form, and subsequently the user becomes disconnected. If the add-in calls saveAsync while in the disconnected state, saveAsync would return an error. Your callback method should handle this error accordingly.
+         * It's a good practice to have your callback function check for and handle errors from saveAsync. 
+         * In particular, a read add-in can be activated while the user is in a connected state in a read form, and subsequently the user becomes 
+         * disconnected. 
+         * If the add-in calls saveAsync while in the disconnected state, saveAsync would return an error. 
+         * Your callback method should handle this error accordingly.
          *
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          * @param asyncContext - Optional. Any state data that is passed to the callback method.
          *
          * [Api set: Mailbox 1.0]
@@ -858,7 +938,7 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          */
-        saveAsync(callback?: (result: AsyncResult) => void, asyncContext?: any): void;
+        saveAsync(callback?: (result: AsyncResult<void>) => void, asyncContext?: any): void;
     }
     /**
      * Provides diagnostic information to an Outlook add-in.
@@ -887,7 +967,8 @@ export declare namespace Office {
         /**
          * Gets a string that represents the version of either the host application or the Exchange Server.
          *
-         * If the mail add-in is running on the Outlook desktop client or Outlook for iOS, the hostVersion property returns the version of the host application, Outlook. In Outlook Web App, the property returns the version of the Exchange Server. An example is the string 15.0.468.0.
+         * If the mail add-in is running on the Outlook desktop client or Outlook for iOS, the hostVersion property returns the version of the host 
+         * application, Outlook. In Outlook Web App, the property returns the version of the Exchange Server. An example is the string 15.0.468.0.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -906,11 +987,13 @@ export declare namespace Office {
          *
          * Outlook Web App has three views that correspond to the width of the screen and the window, and the number of columns that can be displayed:
          *
-         * - OneColumn, which is displayed when the screen is narrow. Outlook Web App uses this single-column layout on the entire screen of a smartphone.
+         * - OneColumn, which is displayed when the screen is narrow. Outlook Web App uses this single-column layout on the entire screen of a 
+         * smartphone.
          *
          * - TwoColumns, which is displayed when the screen is wider. Outlook Web App uses this view on most tablets.
          *
-         * - ThreeColumns, which is displayed when the screen is wide. For example, Outlook Web App uses this view in a full screen window on a desktop computer.
+         * - ThreeColumns, which is displayed when the screen is wide. For example, Outlook Web App uses this view in a full screen window on a 
+         * desktop computer.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -919,7 +1002,7 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          */
-        OWAView: "string";
+        OWAView: MailboxEnums.OWAView | "OneColumn" | "TwoColumns" | "ThreeColumns";
     }
     /**
      * Provides the email properties of the sender or specified recipients of an email message or appointment.
@@ -941,7 +1024,9 @@ export declare namespace Office {
          */
         displayName: string;
         /**
-         * Gets the response that an attendee returned for an appointment. This property applies to only an attendee of an appointment, as represented by the optionalAttendees or requiredAttendees property. This property returns undefined in other scenarios.
+         * Gets the response that an attendee returned for an appointment. 
+         * This property applies to only an attendee of an appointment, as represented by the optionalAttendees or requiredAttendees property. 
+         * This property returns undefined in other scenarios.
          */
         appointmentResponse: Office.MailboxEnums.ResponseType;
         /**
@@ -972,17 +1057,25 @@ export declare namespace Office {
     /**
      * Represents a collection of entities found in an email message or appointment. Read mode only.
      *
-     * The Entities object is a container for the entity arrays returned by the getEntities and getEntitiesByType methods when the item (either an email message or an appointment) contains one or more entities that have been found by the server. You can use these entities in your code to provide additional context information to the viewer, such as a map to an address found in the item, or to open a dialer for a phone number found in the item.
+     * The Entities object is a container for the entity arrays returned by the getEntities and getEntitiesByType methods when the item 
+     * (either an email message or an appointment) contains one or more entities that have been found by the server. 
+     * You can use these entities in your code to provide additional context information to the viewer, such as a map to an address found in the item, 
+     * or to open a dialer for a phone number found in the item.
      *
-     * If no entities of the type specified in the property are present in the item, the property associated with that entity is null. For example, if a message contains a street address and a phone number, the addresses property and phoneNumbers property would contain information, and the other properties would be null.
+     * If no entities of the type specified in the property are present in the item, the property associated with that entity is null. 
+     * For example, if a message contains a street address and a phone number, the addresses property and phoneNumbers property would contain 
+     * information, and the other properties would be null.
      *
-     * To be recognized as an address, the string must contain a United States postal address that has at least a subset of the elements of a street number, street name, city, state, and zip code.
+     * To be recognized as an address, the string must contain a United States postal address that has at least a subset of the elements of a street 
+     * number, street name, city, state, and zip code.
      *
      * To be recognized as a phone number, the string must contain a North American phone number format.
      *
-     * Entity recognition relies on natural language recognition that is based on machine learning of large amounts of data. The recognition of an entity is non-deterministic and success sometimes relies on the particular context in the item.
+     * Entity recognition relies on natural language recognition that is based on machine learning of large amounts of data. 
+     * The recognition of an entity is non-deterministic and success sometimes relies on the particular context in the item.
      *
-     * When the property arrays are returned by the getEntitiesByType method, only the property for the specified entity contains data; all other properties are null.
+     * When the property arrays are returned by the getEntitiesByType method, only the property for the specified entity contains data; 
+     * all other properties are null.
      *
      * [Api set: Mailbox 1.0]
      *
@@ -1024,14 +1117,16 @@ export declare namespace Office {
     /**
      * The subclass of {@link Office.Item} dealing with appointments.
      * 
-     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of Office.context.mailbox.item. Refer to the Object Model pages for more information.
+     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. 
+     * You should treat this as a mode of Office.context.mailbox.item. Refer to the Object Model pages for more information.
      */
     export interface Appointment extends Item {
     }
     /**
      * The appointment organizer mode of {@link Office.Item | Office.context.mailbox.item}.
      * 
-     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
+     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. 
+     * You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
      */
     export interface AppointmentCompose extends Appointment, ItemCompose {
          /**
@@ -1075,9 +1170,11 @@ export declare namespace Office {
         /**
          * Gets or sets the date and time that the appointment is to end.
          *
-         * The end property is an {@link Office.Time} object expressed as a Coordinated Universal Time (UTC) date and time value. You can use the convertToLocalClientTime method to convert the end property value to the client's local date and time.
+         * The end property is an {@link Office.Time} object expressed as a Coordinated Universal Time (UTC) date and time value. 
+         * You can use the convertToLocalClientTime method to convert the end property value to the client's local date and time.
          *
-         * When you use the Time.setAsync method to set the end time, you should use the convertToUtcClientTime method to convert the local time on the client to UTC for the server.
+         * When you use the Time.setAsync method to set the end time, you should use the convertToUtcClientTime method to convert the local time on 
+         * the client to UTC for the server.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1103,7 +1200,8 @@ export declare namespace Office {
          */
         itemType: Office.MailboxEnums.ItemType;
         /**
-         * Gets or sets the {@link Office.Location} of an appointment. The location property returns a Location object that provides methods that are used to get and set the location of the appointment.
+         * Gets or sets the {@link Office.Location} of an appointment. The location property returns a Location object that provides methods that are 
+         * used to get and set the location of the appointment.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1127,7 +1225,9 @@ export declare namespace Office {
          */
         notificationMessages: Office.NotificationMessages;
         /**
-         * Provides access to the optional attendees of an event. The type of object and level of access depends on the mode of the current item. The optionalAttendees property returns an {@link Office.Recipients} object that provides methods to get or update the optional attendees for a meeting.
+         * Provides access to the optional attendees of an event. The type of object and level of access depends on the mode of the current item. 
+         * The optionalAttendees property returns an {@link Office.Recipients} object that provides methods to get or update the optional attendees 
+         * for a meeting.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1139,7 +1239,9 @@ export declare namespace Office {
          */
         optionalAttendees: Recipients;
         /**
-         * Provides access to the required attendees of an event. The type of object and level of access depends on the mode of the current item. The requiredAttendees property returns an {@link Office.Recipients} object that provides methods to get or update the required attendees for a meeting.
+         * Provides access to the required attendees of an event. The type of object and level of access depends on the mode of the current item. 
+         * The requiredAttendees property returns an {@link Office.Recipients} object that provides methods to get or update the required attendees 
+         * for a meeting.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1153,9 +1255,11 @@ export declare namespace Office {
         /**
          * Gets or sets the date and time that the appointment is to begin.
          *
-         * The start property is an {@link Office.Time} object expressed as a Coordinated Universal Time (UTC) date and time value. You can use the convertToLocalClientTime method to convert the value to the client's local date and time.
+         * The start property is an {@link Office.Time} object expressed as a Coordinated Universal Time (UTC) date and time value. 
+         * You can use the convertToLocalClientTime method to convert the value to the client's local date and time.
          *
-         * When you use the Time.setAsync method to set the start time, you should use the convertToUtcClientTime method to convert the local time on the client to UTC for the server.
+         * When you use the Time.setAsync method to set the start time, you should use the convertToUtcClientTime method to convert the local time on 
+         * the client to UTC for the server.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1204,16 +1308,18 @@ export declare namespace Office {
          * 
          * `addFileAttachmentAsync(uri: string, attachmentName: string, options: Office.AsyncContextOptions): void;`
          * 
-         * `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+         * `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;`
          *
          * @param uri - The URI that provides the location of the file to attach to the message or appointment. The maximum length is 2048 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
          *        isInline: If true, indicates that the attachment will be shown inline in the message body, and should not be displayed in the attachment list.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type asyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type asyncResult. 
+         *                 On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
          */
-        addFileAttachmentAsync(uri: string, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        addFileAttachmentAsync(uri: string, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;
         /**
          * Adds a file to a message or appointment as an attachment.
          *
@@ -1254,7 +1360,7 @@ export declare namespace Office {
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         *        isInline: If true, indicates that the attachment will be shown inline in the message body, and should not be displayed in the attachment list.
+         *        isInline: If true, indicates that the attachment will be shown inline in the message body and should not be displayed in the attachment list.
          */
         addFileAttachmentAsync(uri: string, attachmentName: string, options: Office.AsyncContextOptions): void;
         /**
@@ -1275,17 +1381,23 @@ export declare namespace Office {
          *
          * @param uri - The URI that provides the location of the file to attach to the message or appointment. The maximum length is 2048 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type asyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type asyncResult. 
+         *                 On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
          */
-        addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;
+        addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. 
+         * You can use the options parameter to pass state information to the callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -1296,29 +1408,35 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>NumberOfAttachmentsExceeded - The message or appointment has too many attachments.</td></tr></table>
          * 
-         * In addition to the main signature, this method also has these signatures:
+         * In addition to this signature, this method also has the following signatures:
          * 
          * `addItemAttachmentAsync(itemId: any, attachmentName: string): void;`
          * 
          * `addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;`
          * 
-         * `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+         * `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;`
          *
          * @param itemId - The Exchange identifier of the item to attach. The maximum length is 100 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
          * @param options - An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. 
+         *                 On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
          */
-        addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. 
+         * You can use the options parameter to pass state information to the callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -1336,11 +1454,15 @@ export declare namespace Office {
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. 
+         * You can use the options parameter to pass state information to the callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -1360,11 +1482,15 @@ export declare namespace Office {
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. 
+         * You can use the options parameter to pass state information to the callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -1377,17 +1503,21 @@ export declare namespace Office {
          *
          * @param itemId - The Exchange identifier of the item to attach. The maximum length is 100 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. 
+         *                 On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
          */
-        addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;
+        addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;
         /**
          * Closes the current item that is being composed
          *
-         * The behaviors of the close method depends on the current state of the item being composed. If the item has unsaved changes, the client prompts the user to save, discard, or close the action.
+         * The behaviors of the close method depends on the current state of the item being composed. 
+         * If the item has unsaved changes, the client prompts the user to save, discard, or close the action.
          *
          * In the Outlook desktop client, if the message is an inline reply, the close method has no effect.
          *
-         * Note: In Outlook on the web, if the item is an appointment and it has previously been saved using saveAsync, the user is prompted to save, discard, or cancel even if no changes have occurred since the item was last saved.
+         * Note: In Outlook on the web, if the item is an appointment and it has previously been saved using saveAsync, the user is prompted to save, 
+         * discard, or cancel even if no changes have occurred since the item was last saved.
          *
          * [Api set: Mailbox 1.3]
          *
@@ -1401,9 +1531,11 @@ export declare namespace Office {
         /**
          * Asynchronously returns selected data from the subject or body of a message.
          *
-         * If there is no selection but the cursor is in the body or subject, the method returns null for the selected data. If a field other than the body or subject is selected, the method returns the InvalidSelection error.
+         * If there is no selection but the cursor is in the body or subject, the method returns null for the selected data. 
+         * If a field other than the body or subject is selected, the method returns the InvalidSelection error.
          *
-         * To access the selected data from the callback method, call asyncResult.value.data. To access the source property that the selection comes from, call asyncResult.value.sourceProperty, which will be either body or subject.
+         * To access the selected data from the callback method, call asyncResult.value.data. 
+         * To access the source property that the selection comes from, call asyncResult.value.sourceProperty, which will be either body or subject.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -1416,18 +1548,21 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Appointment Organizer</td></tr></table>
          *
-         * @param coercionType - Requests a format for the data. If Text, the method returns the plain text as a string , removing any HTML tags present. If HTML, the method returns the selected text, whether it is plaintext or HTML.
+         * @param coercionType - Requests a format for the data. If Text, the method returns the plain text as a string , removing any HTML tags present. 
+         *                     If HTML, the method returns the selected text, whether it is plaintext or HTML.
          * @param options - An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
          * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
          */
-        getSelectedDataAsync(coerciontype: Office.CoercionType, options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;
+        getSelectedDataAsync(coerciontype: Office.CoercionType, options: Office.AsyncContextOptions, callback: (result: AsyncResult<any>) => void): void;
          /**
          * Asynchronously returns selected data from the subject or body of a message.
          *
-         * If there is no selection but the cursor is in the body or subject, the method returns null for the selected data. If a field other than the body or subject is selected, the method returns the InvalidSelection error.
+         * If there is no selection but the cursor is in the body or subject, the method returns null for the selected data. 
+         * If a field other than the body or subject is selected, the method returns the InvalidSelection error.
          *
-         * To access the selected data from the callback method, call asyncResult.value.data. To access the source property that the selection comes from, call asyncResult.value.sourceProperty, which will be either body or subject.
+         * To access the selected data from the callback method, call asyncResult.value.data. 
+         * To access the source property that the selection comes from, call asyncResult.value.sourceProperty, which will be either body or subject.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -1440,16 +1575,22 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Appointment Organizer</td></tr></table>
          *
-         * @param coercionType - Requests a format for the data. If Text, the method returns the plain text as a string , removing any HTML tags present. If HTML, the method returns the selected text, whether it is plaintext or HTML.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param coercionType - Requests a format for the data. If Text, the method returns the plain text as a string , removing any HTML tags present. 
+         *                     If HTML, the method returns the selected text, whether it is plaintext or HTML.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          */
-        getSelectedDataAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult) => void): void;
+        getSelectedDataAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult<string>) => void): void;
         /**
          * Asynchronously loads custom properties for this add-in on the selected item.
          *
-         * Custom properties are stored as key/value pairs on a per-app, per-item basis. This method returns a CustomProperties object in the callback, which provides methods to access the custom properties specific to the current item and the current add-in. Custom properties are not encrypted on the item, so this should not be used as secure storage.
+         * Custom properties are stored as key/value pairs on a per-app, per-item basis. 
+         * This method returns a CustomProperties object in the callback, which provides methods to access the custom properties specific to the 
+         * current item and the current add-in. Custom properties are not encrypted on the item, so this should not be used as secure storage.
          *
-         * The custom properties are provided as a CustomProperties object in the asyncResult.value property. This object can be used to get, set, and remove custom properties from the item and save changes to the custom property set back to the server.
+         * The custom properties are provided as a CustomProperties object in the asyncResult.value property. 
+         * This object can be used to get, set, and remove custom properties from the item and save changes to the custom property set back to 
+         * the server.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1459,14 +1600,20 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Appointment Organizer</td></tr></table>
          *
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
-         * @param userContext - Optional. Developers can provide any object they wish to access in the callback function. This object can be accessed by the asyncResult.asyncContext property in the callback function.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
+         * @param userContext - Optional. Developers can provide any object they wish to access in the callback function. 
+         *                    This object can be accessed by the asyncResult.asyncContext property in the callback function.
          */
-        loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;
+        loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any): void;
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -1484,18 +1631,23 @@ export declare namespace Office {
          * 
          * `removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;`
          * 
-         * `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;`
+         * `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;`
          *
          * @param attachmentIndex - The identifier of the attachment to remove. The maximum length of the string is 100 characters.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. 
+         *                 If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
          */
-        removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -1513,7 +1665,11 @@ export declare namespace Office {
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -1533,7 +1689,12 @@ export declare namespace Office {
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. 
+         * In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -1546,17 +1707,25 @@ export declare namespace Office {
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
          * @param attachmentIndex - The identifier of the attachment to remove. The maximum length of the string is 100 characters.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. 
+         *                 If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
          */
-        removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;
+        removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;
         /**
          * Asynchronously saves an item.
          *
-         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. In Outlook Web App or Outlook in online mode, the item is saved to the server. In Outlook in cached mode, the item is saved to the local cache.
+         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. 
+         * In Outlook Web App or Outlook in online mode, the item is saved to the server. 
+         * In Outlook in cached mode, the item is saved to the local cache.
          *
-         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. Saving an existing appointment will send an update to added or removed attendees.
+         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal 
+         * appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. 
+         * Saving an existing appointment will send an update to added or removed attendees.
          *
-         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that when Outlook is in cached mode, it may take some time before the item is actually synced to the server. Until the item is synced, using the itemId will return an error.
+         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that 
+         * when Outlook is in cached mode, it may take some time before the item is actually synced to the server. 
+         * Until the item is synced, using the itemId will return an error.
          *
          * Note: The following clients have different behavior for saveAsync on appointments in compose mode:
          *
@@ -1580,21 +1749,27 @@ export declare namespace Office {
          * 
          * `saveAsync(options: Office.AsyncContextOptions): void;`
          * 
-         * `saveAsync(callback: (result: AsyncResult) => void): void;`
+         * `saveAsync(callback: (result: AsyncResult<void>) => void): void;`
          *
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. 
          */
-        saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Asynchronously saves an item.
          *
-         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. In Outlook Web App or Outlook in online mode, the item is saved to the server. In Outlook in cached mode, the item is saved to the local cache.
+         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. 
+         * In Outlook Web App or Outlook in online mode, the item is saved to the server. 
+         * In Outlook in cached mode, the item is saved to the local cache.
          *
-         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. Saving an existing appointment will send an update to added or removed attendees.
+         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal 
+         * appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. 
+         * Saving an existing appointment will send an update to added or removed attendees.
          *
-         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that when Outlook is in cached mode, it may take some time before the item is actually synced to the server. Until the item is synced, using the itemId will return an error.
+         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that 
+         * when Outlook is in cached mode, it may take some time before the item is actually synced to the server. 
+         * Until the item is synced, using the itemId will return an error.
          *
          * Note: The following clients have different behavior for saveAsync on appointments in compose mode:
          *
@@ -1617,11 +1792,17 @@ export declare namespace Office {
         /**
          * Asynchronously saves an item.
          *
-         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. In Outlook Web App or Outlook in online mode, the item is saved to the server. In Outlook in cached mode, the item is saved to the local cache.
+         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. 
+         * In Outlook Web App or Outlook in online mode, the item is saved to the server. 
+         * In Outlook in cached mode, the item is saved to the local cache.
          *
-         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. Saving an existing appointment will send an update to added or removed attendees.
+         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal 
+         * appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. 
+         * Saving an existing appointment will send an update to added or removed attendees.
          *
-         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that when Outlook is in cached mode, it may take some time before the item is actually synced to the server. Until the item is synced, using the itemId will return an error.
+         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that 
+         * when Outlook is in cached mode, it may take some time before the item is actually synced to the server. 
+         * Until the item is synced, using the itemId will return an error.
          *
          * Note: The following clients have different behavior for saveAsync on appointments in compose mode:
          *
@@ -1646,11 +1827,16 @@ export declare namespace Office {
         /**
          * Asynchronously saves an item.
          *
-         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. In Outlook Web App or Outlook in online mode, the item is saved to the server. In Outlook in cached mode, the item is saved to the local cache.
+         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. 
+         * In Outlook Web App or Outlook in online mode, the item is saved to the server. In Outlook in cached mode, the item is saved to the local cache.
          *
-         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. Saving an existing appointment will send an update to added or removed attendees.
+         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal 
+         * appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. 
+         * Saving an existing appointment will send an update to added or removed attendees.
          *
-         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that when Outlook is in cached mode, it may take some time before the item is actually synced to the server. Until the item is synced, using the itemId will return an error.
+         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that 
+         * when Outlook is in cached mode, it may take some time before the item is actually synced to the server. 
+         * Until the item is synced, using the itemId will return an error.
          *
          * Note: The following clients have different behavior for saveAsync on appointments in compose mode:
          *
@@ -1668,13 +1854,15 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult.
          */
-        saveAsync(callback: (result: AsyncResult) => void): void;
+        saveAsync(callback: (result: AsyncResult<void>) => void): void;
         /**
          * Asynchronously inserts data into the body or subject of a message.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is 
+         * selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. 
+         * After insertion, the cursor is placed at the end of the inserted content.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -1692,19 +1880,29 @@ export declare namespace Office {
          * 
          * `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`
          * 
-         * `setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;`
+         * `setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;`
          *
-         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
+         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. 
+         *             If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         *        coercionType: If text, the current style is applied in Outlook Web App and Outlook. If the field is an HTML editor, only the text data is inserted, even if the data is HTML. If html and the field supports HTML (the subject doesn't), the current style is applied in Outlook Web App and the default style is applied in Outlook. If the field is a text field, an InvalidDataFormat error is returned. If coercionType is not set, the result depends on the field: if the field is HTML then HTML is used; if the field is text, then plain text is used.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         *        coercionType: If text, the current style is applied in Outlook Web App and Outlook. 
+         *                      If the field is an HTML editor, only the text data is inserted, even if the data is HTML. 
+         *                      If html and the field supports HTML (the subject doesn't), the current style is applied in Outlook Web App and the 
+         *                      default style is applied in Outlook. 
+         *                      If the field is a text field, an InvalidDataFormat error is returned. 
+         *                      If coercionType is not set, the result depends on the field: if the field is HTML then HTML is used; 
+         *                      if the field is text, then plain text is used.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          */
-        setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult) => void): void;
+        setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Asynchronously inserts data into the body or subject of a message.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is 
+         * selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. 
+         * After insertion, the cursor is placed at the end of the inserted content.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -1716,13 +1914,16 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
-         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
+         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. 
+         *             If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
          */
         setSelectedDataAsync(data: string): void;
         /**
          * Asynchronously inserts data into the body or subject of a message.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is 
+         * selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. 
+         * After insertion, the cursor is placed at the end of the inserted content.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -1734,16 +1935,24 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
-         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
+         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. 
+         *             If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         *        coercionType: If text, the current style is applied in Outlook Web App and Outlook. If the field is an HTML editor, only the text data is inserted, even if the data is HTML. If html and the field supports HTML (the subject doesn't), the current style is applied in Outlook Web App and the default style is applied in Outlook. If the field is a text field, an InvalidDataFormat error is returned. If coercionType is not set, the result depends on the field: if the field is HTML then HTML is used; if the field is text, then plain text is used.
+         *        coercionType: If text, the current style is applied in Outlook Web App and Outlook. 
+         *                      If the field is an HTML editor, only the text data is inserted, even if the data is HTML. 
+         *                      If html and the field supports HTML (the subject doesn't), the current style is applied in Outlook Web App and the 
+         *                      default style is applied in Outlook. If the field is a text field, an InvalidDataFormat error is returned. 
+         *                      If coercionType is not set, the result depends on the field: if the field is HTML then HTML is used; 
+         *                      if the field is text, then plain text is used.
          */
         setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;
         /**
          * Asynchronously inserts data into the body or subject of a message.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is 
+         * selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. 
+         * After insertion, the cursor is placed at the end of the inserted content.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -1755,20 +1964,23 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
-         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. 
+         *             If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          */
-        setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;
+        setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;
     }
 
     /**
      * The appointment attendee mode of {@link Office.Item | Office.context.mailbox.item}.
      * 
-     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of 'Office.context.mailbox.item'. Refer to the Object Model pages for more information.
+     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. 
+     * You should treat this as a mode of 'Office.context.mailbox.item'. Refer to the Object Model pages for more information.
      */
     export interface AppointmentRead extends Appointment, ItemRead {
         /**
-         * Gets an array of attachments for the item.
+         * Gets the item's attachments as an array.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1778,7 +1990,8 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Appointment Attendee</td></tr></table>
          *
-         * Note: Certain types of files are blocked by Outlook due to potential security issues and are therefore not returned. For more information, see {@link https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519 | Blocked attachments in Outlook}.
+         * Note: Certain types of files are blocked by Outlook due to potential security issues and are therefore not returned. For more information, see 
+         * {@link https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519 | Blocked attachments in Outlook}.
          *
          */
         attachments: Office.AttachmentDetails[];
@@ -1823,9 +2036,11 @@ export declare namespace Office {
         /**
          * Gets the date and time that the appointment is to end.
          *
-         * The end property is a Date object expressed as a Coordinated Universal Time (UTC) date and time value. You can use the convertToLocalClientTime method to convert the end property value to the client's local date and time.
+         * The end property is a Date object expressed as a Coordinated Universal Time (UTC) date and time value. 
+         * You can use the convertToLocalClientTime method to convert the end property value to the client's local date and time.
          *
-         * When you use the Time.setAsync method to set the end time, you should use the convertToUtcClientTime method to convert the local time on the client to UTC for the server.
+         * When you use the Time.setAsync method to set the end time, you should use the convertToUtcClientTime method to convert the local time on 
+         * the client to UTC for the server.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1875,9 +2090,14 @@ export declare namespace Office {
         /**
          * Gets the Exchange Web Services item identifier for the current item.
          *
-         * The itemId property is not available in compose mode. If an item identifier is required, the saveAsync method can be used to save the item to the store, which will return the item identifier in the AsyncResult.value parameter in the callback function.
+         * The itemId property is not available in compose mode. 
+         * If an item identifier is required, the saveAsync method can be used to save the item to the store, which will return the item identifier 
+         * in the AsyncResult.value parameter in the callback function.
          *
-         * Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more details, see Use the Outlook REST APIs from an Outlook add-in.
+         * Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. 
+         * The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. 
+         * Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. 
+         * For more details, see {@link https://docs.microsoft.com/outlook/add-ins/use-rest-api#get-the-item-id | Use the Outlook REST APIs from an Outlook add-in}.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1919,7 +2139,8 @@ export declare namespace Office {
         /**
          * Gets the subject of an item, with all prefixes removed (including RE: and FWD:).
          *
-         * The normalizedSubject property gets the subject of the item, with any standard prefixes (such as RE: and FW:) that are added by email programs. To get the subject of the item with the prefixes intact, use the subject property.
+         * The normalizedSubject property gets the subject of the item, with any standard prefixes (such as RE: and FW:) that are added by email programs. 
+         * To get the subject of the item with the prefixes intact, use the subject property.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1945,7 +2166,8 @@ export declare namespace Office {
         /**
          * Provides access to the optional attendees of an event. The type of object and level of access depends on the mode of the current item.
          *
-         * The optionalAttendees property returns an array that contains an {@link Office.EmailAddressDetails} object for each optional attendee to the meeting.
+         * The optionalAttendees property returns an array that contains an {@link Office.EmailAddressDetails} object for each optional attendee to 
+         * the meeting.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1957,7 +2179,7 @@ export declare namespace Office {
          */
         optionalAttendees: EmailAddressDetails[];
         /**
-         * Gets the email address of the meeting organizer for a specified meeting. Read mode only.
+         * Gets the email address of the meeting organizer for a specified meeting.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1971,7 +2193,8 @@ export declare namespace Office {
         /**
          * Provides access to the required attendees of an event. The type of object and level of access depends on the mode of the current item.
          *
-         * The requiredAttendees property returns an array that contains an {@link Office.EmailAddressDetails} object for each required attendee to the meeting.
+         * The requiredAttendees property returns an array that contains an {@link Office.EmailAddressDetails} object for each required attendee to 
+         * the meeting.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1985,7 +2208,8 @@ export declare namespace Office {
         /**
          * Gets the date and time that the appointment is to begin.
          *
-         * The start property is a Date object expressed as a Coordinated Universal Time (UTC) date and time value. You can use the convertToLocalClientTime method to convert the value to the client's local date and time.
+         * The start property is a Date object expressed as a Coordinated Universal Time (UTC) date and time value. 
+         * You can use the convertToLocalClientTime method to convert the value to the client's local date and time.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -2012,14 +2236,18 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Appointment Attendee</td></tr></table>
          */
         subject: string;
+
         /**
-         * Displays a reply form that includes the sender and all recipients of the selected message or the organizer and all attendees of the selected appointment.
+         * Displays a reply form that includes the sender and all recipients of the selected message or the organizer and all attendees of the 
+         * selected appointment.
          *
          * In Outlook Web App, the reply form is displayed as a pop-out form in the 3-column view and a pop-up form in the 2- or 1-column view.
          *
          * If any of the string parameters exceed their limits, displayReplyAllForm throws an exception.
          *
-         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. If this isn't possible, then no error message is thrown.
+         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and 
+         * attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. 
+         * If this isn't possible, then no error message is thrown.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -2042,7 +2270,9 @@ export declare namespace Office {
          *
          * If any of the string parameters exceed their limits, displayReplyForm throws an exception.
          *
-         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. If this isn't possible, then no error message is thrown.
+         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and 
+         * attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. 
+         * If this isn't possible, then no error message is thrown.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -2060,7 +2290,7 @@ export declare namespace Office {
          */
         displayReplyForm(formData: string | ReplyFormData): void;
         /**
-         * Gets the entities found in the selected item.
+         * Gets the entities found in the selected item's body.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -2074,7 +2304,7 @@ export declare namespace Office {
          */
         getEntities(): Entities;
         /**
-         * Gets an array of all the entities of the specified entity type found in the selected item.
+         * Gets an array of all the entities of the specified entity type found in the selected item's body.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -2083,7 +2313,9 @@ export declare namespace Office {
          * @param entityType - One of the EntityType enumeration values.
          *
          * @returns
-         * If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. If no entities of the specified type are present on the item, the method returns an empty array. Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter.
+         * If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. 
+         * If no entities of the specified type are present in the item's body, the method returns an empty array. 
+         * Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter.
          *
          * @remarks
          * <table><tr><td>{@link https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions | Minimum permission level}</td><td>Restricted</td></tr>
@@ -2139,7 +2371,8 @@ export declare namespace Office {
         /**
          * Returns well-known entities in the selected item that pass the named filter defined in the manifest XML file.
          *
-         * The getFilteredEntitiesByName method returns the entities that match the regular expression defined in the ItemHasKnownEntity rule element in the manifest XML file with the specified FilterName element value.
+         * The getFilteredEntitiesByName method returns the entities that match the regular expression defined in the ItemHasKnownEntity rule element 
+         * in the manifest XML file with the specified FilterName element value.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -2152,22 +2385,33 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Appointment Attendee</td></tr></table>
          *
          * @param name - The name of the ItemHasKnownEntity rule element that defines the filter to match.
-         * @returns If there is no ItemHasKnownEntity element in the manifest with a FilterName element value that matches the name parameter, the method returns null. If the name parameter does match an ItemHasKnownEntity element in the manifest, but there are no entities in the current item that match, the method return an empty array.
+         * @returns If there is no ItemHasKnownEntity element in the manifest with a FilterName element value that matches the name parameter, 
+         * the method returns null. 
+         * If the name parameter does match an ItemHasKnownEntity element in the manifest, but there are no entities in the current item that match, 
+         * the method return an empty array.
          */
         getFilteredEntitiesByName(name: string): (string | Contact | MeetingSuggestion | PhoneNumber | TaskSuggestion)[];
         /**
          * Returns string values in the selected item that match the regular expressions defined in the manifest XML file.
          *
-         * The getRegExMatches method returns the strings that match the regular expression defined in each ItemHasRegularExpressionMatch or ItemHasKnownEntity rule element in the manifest XML file. For an ItemHasRegularExpressionMatch rule, a matching string has to occur in the property of the item that is specified by that rule. The PropertyName simple type defines the supported properties.
+         * The getRegExMatches method returns the strings that match the regular expression defined in each ItemHasRegularExpressionMatch or 
+         * ItemHasKnownEntity rule element in the manifest XML file. 
+         * For an ItemHasRegularExpressionMatch rule, a matching string has to occur in the property of the item that is specified by that rule. 
+         * The PropertyName simple type defines the supported properties.
          *
-         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body and should not attempt to return the entire body of the item. Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results. Instead, use the Body.getAsync method to retrieve the entire body.
+         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body 
+         * and should not attempt to return the entire body of the item. 
+         * Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results. 
+         * Instead, use the Body.getAsync method to retrieve the entire body.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
          * [Api set: Mailbox 1.0]
          *
          * @returns
-         * An object that contains arrays of strings that match the regular expressions defined in the manifest XML file. The name of each array is equal to the corresponding value of the RegExName attribute of the matching ItemHasRegularExpressionMatch rule or the FilterName attribute of the matching ItemHasKnownEntity rule.
+         * An object that contains arrays of strings that match the regular expressions defined in the manifest XML file. 
+         * The name of each array is equal to the corresponding value of the RegExName attribute of the matching ItemHasRegularExpressionMatch rule 
+         * or the FilterName attribute of the matching ItemHasKnownEntity rule.
          *
          * @remarks
          *
@@ -2179,9 +2423,12 @@ export declare namespace Office {
         /**
          * Returns string values in the selected item that match the named regular expression defined in the manifest XML file.
          *
-         * The getRegExMatchesByName method returns the strings that match the regular expression defined in the ItemHasRegularExpressionMatch rule element in the manifest XML file with the specified RegExName element value.
+         * The getRegExMatchesByName method returns the strings that match the regular expression defined in the ItemHasRegularExpressionMatch rule 
+         * element in the manifest XML file with the specified RegExName element value.
          *
-         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body and should not attempt to return the entire body of the item. Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results.
+         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body 
+         * and should not attempt to return the entire body of the item. 
+         * Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -2199,12 +2446,16 @@ export declare namespace Office {
          * @param name - The name of the ItemHasRegularExpressionMatch rule element that defines the filter to match.
          */
         getRegExMatchesByName(name: string): string[];
-       /**
+        /**
         * Asynchronously loads custom properties for this add-in on the selected item.
         *
-        * Custom properties are stored as key/value pairs on a per-app, per-item basis. This method returns a CustomProperties object in the callback, which provides methods to access the custom properties specific to the current item and the current add-in. Custom properties are not encrypted on the item, so this should not be used as secure storage.
+        * Custom properties are stored as key/value pairs on a per-app, per-item basis. 
+        * This method returns a CustomProperties object in the callback, which provides methods to access the custom properties specific to the 
+        * current item and the current add-in. Custom properties are not encrypted on the item, so this should not be used as secure storage.
         *
-        * The custom properties are provided as a CustomProperties object in the asyncResult.value property. This object can be used to get, set, and remove custom properties from the item and save changes to the custom property set back to the server.
+        * The custom properties are provided as a CustomProperties object in the asyncResult.value property. 
+        * This object can be used to get, set, and remove custom properties from the item and save changes to the custom property set back to 
+        * the server.
         *
         * [Api set: Mailbox 1.0]
         *
@@ -2214,14 +2465,17 @@ export declare namespace Office {
         *
         * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Appointment Attendee</td></tr></table>
         *
-        * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
-        * @param userContext - Optional. Developers can provide any object they wish to access in the callback function. This object can be accessed by the asyncResult.asyncContext property in the callback function.
+        * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+        *                 type Office.AsyncResult.
+        * @param userContext - Optional. Developers can provide any object they wish to access in the callback function. 
+        *                    This object can be accessed by the asyncResult.asyncContext property in the callback function.
         */
-       loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;
+       loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any): void;
     }
 
     /**
-     * The item namespace is used to access the currently selected message, meeting request, or appointment. You can determine the type of the item by using the `itemType` property.
+     * The item namespace is used to access the currently selected message, meeting request, or appointment. 
+     * You can determine the type of the item by using the `itemType` property.
      *
      * [Api set: Mailbox 1.0]
      *
@@ -2272,7 +2526,8 @@ export declare namespace Office {
         /**
          * Gets the type of item that an instance represents.
          *
-         * The itemType property returns one of the ItemType enumeration values, indicating whether the item object instance is a message or an appointment.
+         * The itemType property returns one of the ItemType enumeration values, indicating whether the item object instance is a message or 
+         * an appointment.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -2299,9 +2554,13 @@ export declare namespace Office {
        /**
         * Asynchronously loads custom properties for this add-in on the selected item.
         *
-        * Custom properties are stored as key/value pairs on a per-app, per-item basis. This method returns a CustomProperties object in the callback, which provides methods to access the custom properties specific to the current item and the current add-in. Custom properties are not encrypted on the item, so this should not be used as secure storage.
+        * Custom properties are stored as key/value pairs on a per-app, per-item basis. 
+        * This method returns a CustomProperties object in the callback, which provides methods to access the custom properties specific to the 
+        * current item and the current add-in. Custom properties are not encrypted on the item, so this should not be used as secure storage.
         *
-        * The custom properties are provided as a CustomProperties object in the asyncResult.value property. This object can be used to get, set, and remove custom properties from the item and save changes to the custom property set back to the server.
+        * The custom properties are provided as a CustomProperties object in the asyncResult.value property. 
+        * This object can be used to get, set, and remove custom properties from the item and save changes to the custom property set back to 
+        * the server.
         *
         * [Api set: Mailbox 1.0]
         *
@@ -2311,15 +2570,18 @@ export declare namespace Office {
         *
         * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
         *
-        * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
-        * @param userContext - Optional. Developers can provide any object they wish to access in the callback function. This object can be accessed by the asyncResult.asyncContext property in the callback function.
+        * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+        *                 type Office.AsyncResult.
+        * @param userContext - Optional. Developers can provide any object they wish to access in the callback function. 
+        *                    This object can be accessed by the asyncResult.asyncContext property in the callback function.
         */
-       loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;
+       loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any): void;
     }
     /**
      * The compose mode of {@link Office.Item | Office.context.mailbox.item}.
      * 
-     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
+     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. 
+     * You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
      */
     export interface ItemCompose extends Item {
         /**
@@ -2360,16 +2622,20 @@ export declare namespace Office {
          * 
          * `addFileAttachmentAsync(uri: string, attachmentName: string, options: Office.AsyncContextOptions): void;`
          * 
-         * `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+         * `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;`
          *
          * @param uri - The URI that provides the location of the file to attach to the message or appointment. The maximum length is 2048 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         *        isInline: If true, indicates that the attachment will be shown inline in the message body, and should not be displayed in the attachment list.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type asyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         *        isInline: If true, indicates that the attachment will be shown inline in the message body, and should not be displayed in the 
+         *        attachment list.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type asyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of 
+         *                 the error.
          */
-        addFileAttachmentAsync(uri: string, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        addFileAttachmentAsync(uri: string, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;
         /**
          * Adds a file to a message or appointment as an attachment.
          *
@@ -2410,7 +2676,8 @@ export declare namespace Office {
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         *        isInline: If true, indicates that the attachment will be shown inline in the message body, and should not be displayed in the attachment list.
+         *        isInline: If true, indicates that the attachment will be shown inline in the message body, and should not be displayed in the 
+         *        attachment list.
          */
         addFileAttachmentAsync(uri: string, attachmentName: string, options: Office.AsyncContextOptions): void;
         /**
@@ -2431,18 +2698,25 @@ export declare namespace Office {
          *
          * @param uri - The URI that provides the location of the file to attach to the message or appointment. The maximum length is 2048 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type asyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of 
+         *                 the error.
          */
-        addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;
+        addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;
 
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the 
+         * callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -2453,29 +2727,36 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>NumberOfAttachmentsExceeded - The message or appointment has too many attachments.</td></tr></table>
          * 
-         * In addition to the main signature, this method also has these signatures:
+         * In addition to this signature, this method also has the following signatures:
          * 
          * `addItemAttachmentAsync(itemId: any, attachmentName: string): void;`
          * 
          * `addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;`
          * 
-         * `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+         * `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;`
          *
          * @param itemId - The Exchange identifier of the item to attach. The maximum length is 100 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
          * @param options - An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of 
+         *                 the error.
          */
-        addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the 
+         * callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -2493,11 +2774,15 @@ export declare namespace Office {
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the 
+         * callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -2517,11 +2802,15 @@ export declare namespace Office {
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the 
+         * callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -2534,18 +2823,23 @@ export declare namespace Office {
          *
          * @param itemId - The Exchange identifier of the item to attach. The maximum length is 100 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of 
+         *                 the error.
          */
-        addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;
+        addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;
 
         /**
          * Closes the current item that is being composed
          *
-         * The behaviors of the close method depends on the current state of the item being composed. If the item has unsaved changes, the client prompts the user to save, discard, or close the action.
+         * The behaviors of the close method depends on the current state of the item being composed. 
+         * If the item has unsaved changes, the client prompts the user to save, discard, or close the action.
          *
          * In the Outlook desktop client, if the message is an inline reply, the close method has no effect.
          *
-         * Note: In Outlook on the web, if the item is an appointment and it has previously been saved using saveAsync, the user is prompted to save, discard, or cancel even if no changes have occurred since the item was last saved.
+         * Note: In Outlook on the web, if the item is an appointment and it has previously been saved using saveAsync, the user is prompted to save, 
+         * discard, or cancel even if no changes have occurred since the item was last saved.
          *
          * [Api set: Mailbox 1.3]
          *
@@ -2559,9 +2853,11 @@ export declare namespace Office {
         /**
          * Asynchronously returns selected data from the subject or body of a message.
          *
-         * If there is no selection but the cursor is in the body or subject, the method returns null for the selected data. If a field other than the body or subject is selected, the method returns the InvalidSelection error.
+         * If there is no selection but the cursor is in the body or subject, the method returns null for the selected data. 
+         * If a field other than the body or subject is selected, the method returns the InvalidSelection error.
          *
-         * To access the selected data from the callback method, call asyncResult.value.data. To access the source property that the selection comes from, call asyncResult.value.sourceProperty, which will be either body or subject.
+         * To access the selected data from the callback method, call asyncResult.value.data. To access the source property that the selection comes 
+         * from, call asyncResult.value.sourceProperty, which will be either body or subject.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -2574,16 +2870,20 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose</td></tr></table>
          *
-         * @param coercionType - Requests a format for the data. If Text, the method returns the plain text as a string , removing any HTML tags present. If HTML, the method returns the selected text, whether it is plaintext or HTML.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param coercionType - Requests a format for the data. If Text, the method returns the plain text as a string , removing any HTML tags present. 
+         *                     If HTML, the method returns the selected text, whether it is plaintext or HTML.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          */
-        getSelectedDataAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult) => void): void;
+        getSelectedDataAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult<any>) => void): void;
         /**
          * Asynchronously returns selected data from the subject or body of a message.
          *
-         * If there is no selection but the cursor is in the body or subject, the method returns null for the selected data. If a field other than the body or subject is selected, the method returns the InvalidSelection error.
+         * If there is no selection but the cursor is in the body or subject, the method returns null for the selected data. 
+         * If a field other than the body or subject is selected, the method returns the InvalidSelection error.
          *
-         * To access the selected data from the callback method, call asyncResult.value.data. To access the source property that the selection comes from, call asyncResult.value.sourceProperty, which will be either body or subject.
+         * To access the selected data from the callback method, call asyncResult.value.data. 
+         * To access the source property that the selection comes from, call asyncResult.value.sourceProperty, which will be either body or subject.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -2596,16 +2896,22 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose</td></tr></table>
          *
-         * @param coercionType - Requests a format for the data. If Text, the method returns the plain text as a string , removing any HTML tags present. If HTML, the method returns the selected text, whether it is plaintext or HTML.
+         * @param coercionType - Requests a format for the data. If Text, the method returns the plain text as a string, removing any HTML tags present. 
+         *                     If HTML, the method returns the selected text, whether it is plaintext or HTML.
          * @param options - An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          */
-        getSelectedDataAsync(coerciontype: Office.CoercionType, options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;
+        getSelectedDataAsync(coerciontype: Office.CoercionType, options: Office.AsyncContextOptions, callback: (result: AsyncResult<any>) => void): void;
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -2623,18 +2929,24 @@ export declare namespace Office {
          * 
          * `removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;`
          * 
-         * `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;`
+         * `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;`
          *
          * @param attachmentIndex - The identifier of the attachment to remove. The maximum length of the string is 100 characters.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. 
+         *                 If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
          */
-        removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -2652,7 +2964,11 @@ export declare namespace Office {
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -2672,7 +2988,11 @@ export declare namespace Office {
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -2685,18 +3005,26 @@ export declare namespace Office {
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
          * @param attachmentIndex - The identifier of the attachment to remove. The maximum length of the string is 100 characters.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type {@link Offfice.AsyncResult}. 
+         *                 If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
          */
-        removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;
+        removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;
 
         /**
          * Asynchronously saves an item.
          *
-         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. In Outlook Web App or Outlook in online mode, the item is saved to the server. In Outlook in cached mode, the item is saved to the local cache.
+         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. 
+         * In Outlook Web App or Outlook in online mode, the item is saved to the server. 
+         * In Outlook in cached mode, the item is saved to the local cache.
          *
-         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. Saving an existing appointment will send an update to added or removed attendees.
+         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal 
+         * appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. 
+         * Saving an existing appointment will send an update to added or removed attendees.
          *
-         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that when Outlook is in cached mode, it may take some time before the item is actually synced to the server. Until the item is synced, using the itemId will return an error.
+         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that 
+         * when Outlook is in cached mode, it may take some time before the item is actually synced to the server. 
+         * Until the item is synced, using the itemId will return an error.
          *
          * Note: The following clients have different behavior for saveAsync on appointments in compose mode:
          *
@@ -2720,21 +3048,29 @@ export declare namespace Office {
          * 
          * `saveAsync(options: Office.AsyncContextOptions): void;`
          * 
-         * `saveAsync(callback: (result: AsyncResult) => void): void;`
+         * `saveAsync(callback: (result: AsyncResult<void>) => void): void;`
          *
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. 
+         *                 If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
          */
-        saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Asynchronously saves an item.
          *
-         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. In Outlook Web App or Outlook in online mode, the item is saved to the server. In Outlook in cached mode, the item is saved to the local cache.
+         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. 
+         * In Outlook Web App or Outlook in online mode, the item is saved to the server. 
+         * In Outlook in cached mode, the item is saved to the local cache.
          *
-         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. Saving an existing appointment will send an update to added or removed attendees.
+         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal 
+         * appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. 
+         * Saving an existing appointment will send an update to added or removed attendees.
          *
-         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that when Outlook is in cached mode, it may take some time before the item is actually synced to the server. Until the item is synced, using the itemId will return an error.
+         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that 
+         * when Outlook is in cached mode, it may take some time before the item is actually synced to the server. 
+         * Until the item is synced, using the itemId will return an error.
          *
          * Note: The following clients have different behavior for saveAsync on appointments in compose mode:
          *
@@ -2757,11 +3093,17 @@ export declare namespace Office {
         /**
          * Asynchronously saves an item.
          *
-         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. In Outlook Web App or Outlook in online mode, the item is saved to the server. In Outlook in cached mode, the item is saved to the local cache.
+         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. 
+         * In Outlook Web App or Outlook in online mode, the item is saved to the server. 
+         * In Outlook in cached mode, the item is saved to the local cache.
          *
-         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. Saving an existing appointment will send an update to added or removed attendees.
+         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal 
+         * appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. 
+         * Saving an existing appointment will send an update to added or removed attendees.
          *
-         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that when Outlook is in cached mode, it may take some time before the item is actually synced to the server. Until the item is synced, using the itemId will return an error.
+         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that 
+         * when Outlook is in cached mode, it may take some time before the item is actually synced to the server. 
+         * Until the item is synced, using the itemId will return an error.
          *
          * Note: The following clients have different behavior for saveAsync on appointments in compose mode:
          *
@@ -2786,11 +3128,17 @@ export declare namespace Office {
         /**
          * Asynchronously saves an item.
          *
-         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. In Outlook Web App or Outlook in online mode, the item is saved to the server. In Outlook in cached mode, the item is saved to the local cache.
+         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. 
+         * In Outlook Web App or Outlook in online mode, the item is saved to the server. 
+         * In Outlook in cached mode, the item is saved to the local cache.
          *
-         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. Saving an existing appointment will send an update to added or removed attendees.
+         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal 
+         * appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. 
+         * Saving an existing appointment will send an update to added or removed attendees.
          *
-         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that when Outlook is in cached mode, it may take some time before the item is actually synced to the server. Until the item is synced, using the itemId will return an error.
+         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that 
+         * when Outlook is in cached mode, it may take some time before the item is actually synced to the server. 
+         * Until the item is synced, using the itemId will return an error.
          *
          * Note: The following clients have different behavior for saveAsync on appointments in compose mode:
          *
@@ -2808,13 +3156,17 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. 
+         *                 If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
          */
-        saveAsync(callback: (result: AsyncResult) => void): void;
+        saveAsync(callback: (result: AsyncResult<void>) => void): void;
         /**
          * Asynchronously inserts data into the body or subject of a message.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is 
+         * selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. 
+         * After insertion, the cursor is placed at the end of the inserted content.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -2832,19 +3184,29 @@ export declare namespace Office {
          * 
          * `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`
          * 
-         * `setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;`
+         * `setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;`
          *
-         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
+         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. 
+         *             If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         *        coercionType: If text, the current style is applied in Outlook Web App and Outlook. If the field is an HTML editor, only the text data is inserted, even if the data is HTML. If html and the field supports HTML (the subject doesn't), the current style is applied in Outlook Web App and the default style is applied in Outlook. If the field is a text field, an InvalidDataFormat error is returned. If coercionType is not set, the result depends on the field: if the field is HTML then HTML is used; if the field is text, then plain text is used.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         *        coercionType: If text, the current style is applied in Outlook Web App and Outlook. 
+         *        If the field is an HTML editor, only the text data is inserted, even if the data is HTML. 
+         *        If html and the field supports HTML (the subject doesn't), the current style is applied in Outlook Web App and the default style is 
+         *        applied in Outlook. 
+         *        If the field is a text field, an InvalidDataFormat error is returned. 
+         *        If coercionType is not set, the result depends on the field: if the field is HTML then HTML is used; 
+         *        if the field is text, then plain text is used.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. 
          */
-        setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult) => void): void;
+        setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Asynchronously inserts data into the body or subject of a message.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is 
+         * selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. 
+         * After insertion, the cursor is placed at the end of the inserted content.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -2856,13 +3218,16 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
-         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
+         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. 
+         *             If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
          */
         setSelectedDataAsync(data: string): void;
         /**
          * Asynchronously inserts data into the body or subject of a message.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is 
+         * selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. 
+         * After insertion, the cursor is placed at the end of the inserted content.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -2874,16 +3239,25 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
-         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
+         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. 
+         *             If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         *        coercionType: If text, the current style is applied in Outlook Web App and Outlook. If the field is an HTML editor, only the text data is inserted, even if the data is HTML. If html and the field supports HTML (the subject doesn't), the current style is applied in Outlook Web App and the default style is applied in Outlook. If the field is a text field, an InvalidDataFormat error is returned. If coercionType is not set, the result depends on the field: if the field is HTML then HTML is used; if the field is text, then plain text is used.
+         *        coercionType: If text, the current style is applied in Outlook Web App and Outlook. 
+         *        If the field is an HTML editor, only the text data is inserted, even if the data is HTML. 
+         *        If html and the field supports HTML (the subject doesn't), the current style is applied in Outlook Web App and the default style is 
+         *        applied in Outlook. 
+         *        If the field is a text field, an InvalidDataFormat error is returned. 
+         *        If coercionType is not set, the result depends on the field: if the field is HTML then HTML is used; 
+         *        if the field is text, then plain text is used.
          */
         setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;
         /**
          * Asynchronously inserts data into the body or subject of a message.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is 
+         * selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. 
+         * After insertion, the cursor is placed at the end of the inserted content.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -2895,19 +3269,22 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
-         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. 
+         *             If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. 
          */
-        setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;
+        setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;
     }
     /**
      * The read mode of {@link Office.Item | Office.context.mailbox.item}.
      * 
-     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
+     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. 
+     * You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
      */
     export interface ItemRead extends Item {
         /**
-         * Gets an array of attachments for the item.
+         * Gets the item's attachments as an array.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -2916,7 +3293,9 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Read</td></tr></table>
          *
-         * Note: Certain types of files are blocked by Outlook due to potential security issues and are therefore not returned. For more information, see {@link https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519 | Blocked attachments in Outlook}.
+         * Note: Certain types of files are blocked by Outlook due to potential security issues and are therefore not returned. 
+         * For more information, see 
+         * {@link https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519 | Blocked attachments in Outlook}.
          *
          */
         attachments: Office.AttachmentDetails[];
@@ -2924,7 +3303,8 @@ export declare namespace Office {
          * Gets the Exchange Web Services item class of the selected item.
          *
          *
-         * You can create custom message classes that extends a default message class, for example, a custom appointment message class IPM.Appointment.Contoso.
+         * You can create custom message classes that extends a default message class, for example, a custom appointment message class 
+         * IPM.Appointment.Contoso.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -2934,7 +3314,8 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Read</td></tr></table>
          * 
-         * The itemClass property specifies the message class of the selected item. The following are the default message classes for the message or appointment item.
+         * The itemClass property specifies the message class of the selected item. The following are the default message classes for the message or 
+         * appointment item.
          * 
          * <table>
          *   <tr>
@@ -2958,9 +3339,14 @@ export declare namespace Office {
         /**
          * Gets the Exchange Web Services item identifier for the current item.
          *
-         * The itemId property is not available in compose mode. If an item identifier is required, the saveAsync method can be used to save the item to the store, which will return the item identifier in the AsyncResult.value parameter in the callback function.
+         * The itemId property is not available in compose mode. 
+         * If an item identifier is required, the saveAsync method can be used to save the item to the store, which will return the item identifier 
+         * in the AsyncResult.value parameter in the callback function.
          *
-         * Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more details, see Use the Outlook REST APIs from an Outlook add-in.
+         * Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. 
+         * The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. 
+         * Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. 
+         * For more details, see {@link https://docs.microsoft.com/outlook/add-ins/use-rest-api#get-the-item-id | Use the Outlook REST APIs from an Outlook add-in}.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -2974,7 +3360,8 @@ export declare namespace Office {
         /**
          * Gets the subject of an item, with all prefixes removed (including RE: and FWD:).
          *
-         * The normalizedSubject property gets the subject of the item, with any standard prefixes (such as RE: and FW:) that are added by email programs. To get the subject of the item with the prefixes intact, use the subject property.
+         * The normalizedSubject property gets the subject of the item, with any standard prefixes (such as RE: and FW:) that are added by 
+         * email programs. To get the subject of the item with the prefixes intact, use the subject property.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -3002,13 +3389,16 @@ export declare namespace Office {
          */
         subject: string;
         /**
-         * Displays a reply form that includes the sender and all recipients of the selected message or the organizer and all attendees of the selected appointment.
+         * Displays a reply form that includes the sender and all recipients of the selected message or the organizer and all attendees of the 
+         * selected appointment.
          *
          * In Outlook Web App, the reply form is displayed as a pop-out form in the 3-column view and a pop-up form in the 2- or 1-column view.
          *
          * If any of the string parameters exceed their limits, displayReplyAllForm throws an exception.
          *
-         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. If this isn't possible, then no error message is thrown.
+         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and 
+         * attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. 
+         * If this isn't possible, then no error message is thrown.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -3031,7 +3421,9 @@ export declare namespace Office {
          *
          * If any of the string parameters exceed their limits, displayReplyForm throws an exception.
          *
-         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. If this isn't possible, then no error message is thrown.
+         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and 
+         * attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. 
+         * If this isn't possible, then no error message is thrown.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -3049,7 +3441,7 @@ export declare namespace Office {
          */
         displayReplyForm(formData: string | ReplyFormData): void;
         /**
-         * Gets the entities found in the selected item.
+         * Gets the entities found in the selected item's body.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -3063,7 +3455,7 @@ export declare namespace Office {
          */
         getEntities(): Entities;
         /**
-         * Gets an array of all the entities of the specified entity type found in the selected item.
+         * Gets an array of all the entities of the specified entity type found in the selected item's body.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -3072,14 +3464,17 @@ export declare namespace Office {
          * @param entityType - One of the EntityType enumeration values.
          *
          * @returns
-         * If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. If no entities of the specified type are present on the item, the method returns an empty array. Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter.
+         * If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. 
+         * If no entities of the specified type are present in the item's body, the method returns an empty array. 
+         * Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter.
          *
          * @remarks
          * <table><tr><td>{@link https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions | Minimum permission level}</td><td>Restricted</td></tr>
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Read</td></tr></table>
          * 
-         * While the minimum permission level to use this method is Restricted, some entity types require ReadItem to access, as specified in the following table.
+         * While the minimum permission level to use this method is Restricted, some entity types require ReadItem to access, as specified in the 
+         * following table.
          * 
          * <table>
          *   <tr>
@@ -3128,7 +3523,8 @@ export declare namespace Office {
         /**
          * Returns well-known entities in the selected item that pass the named filter defined in the manifest XML file.
          *
-         * The getFilteredEntitiesByName method returns the entities that match the regular expression defined in the ItemHasKnownEntity rule element in the manifest XML file with the specified FilterName element value.
+         * The getFilteredEntitiesByName method returns the entities that match the regular expression defined in the ItemHasKnownEntity rule element 
+         * in the manifest XML file with the specified FilterName element value.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -3141,22 +3537,33 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Read</td></tr></table>
          *
          * @param name - The name of the ItemHasKnownEntity rule element that defines the filter to match.
-         * @returns If there is no ItemHasKnownEntity element in the manifest with a FilterName element value that matches the name parameter, the method returns null. If the name parameter does match an ItemHasKnownEntity element in the manifest, but there are no entities in the current item that match, the method return an empty array.
+         * @returns If there is no ItemHasKnownEntity element in the manifest with a FilterName element value that matches the name parameter, 
+         * the method returns null. 
+         * If the name parameter does match an ItemHasKnownEntity element in the manifest, but there are no entities in the current item that match, 
+         * the method return an empty array.
          */
         getFilteredEntitiesByName(name: string): (string | Contact | MeetingSuggestion | PhoneNumber | TaskSuggestion)[];
         /**
          * Returns string values in the selected item that match the regular expressions defined in the manifest XML file.
          *
-         * The getRegExMatches method returns the strings that match the regular expression defined in each ItemHasRegularExpressionMatch or ItemHasKnownEntity rule element in the manifest XML file. For an ItemHasRegularExpressionMatch rule, a matching string has to occur in the property of the item that is specified by that rule. The PropertyName simple type defines the supported properties.
+         * The getRegExMatches method returns the strings that match the regular expression defined in each ItemHasRegularExpressionMatch or 
+         * ItemHasKnownEntity rule element in the manifest XML file. 
+         * For an ItemHasRegularExpressionMatch rule, a matching string has to occur in the property of the item that is specified by that rule. 
+         * The PropertyName simple type defines the supported properties.
          *
-         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body and should not attempt to return the entire body of the item. Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results. Instead, use the Body.getAsync method to retrieve the entire body.
+         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body 
+         * and should not attempt to return the entire body of the item. 
+         * Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results. 
+         * Instead, use the Body.getAsync method to retrieve the entire body.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
          * [Api set: Mailbox 1.0]
          *
          * @returns
-         * An object that contains arrays of strings that match the regular expressions defined in the manifest XML file. The name of each array is equal to the corresponding value of the RegExName attribute of the matching ItemHasRegularExpressionMatch rule or the FilterName attribute of the matching ItemHasKnownEntity rule.
+         * An object that contains arrays of strings that match the regular expressions defined in the manifest XML file. 
+         * The name of each array is equal to the corresponding value of the RegExName attribute of the matching ItemHasRegularExpressionMatch rule 
+         * or the FilterName attribute of the matching ItemHasKnownEntity rule.
          *
          * @remarks
          *
@@ -3168,9 +3575,12 @@ export declare namespace Office {
         /**
          * Returns string values in the selected item that match the named regular expression defined in the manifest XML file.
          *
-         * The getRegExMatchesByName method returns the strings that match the regular expression defined in the ItemHasRegularExpressionMatch rule element in the manifest XML file with the specified RegExName element value.
+         * The getRegExMatchesByName method returns the strings that match the regular expression defined in the ItemHasRegularExpressionMatch rule 
+         * element in the manifest XML file with the specified RegExName element value.
          *
-         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body and should not attempt to return the entire body of the item. Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results.
+         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body 
+         * and should not attempt to return the entire body of the item. 
+         * Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -3192,15 +3602,19 @@ export declare namespace Office {
     /**
      * A subclass of {@link Office.Item} for messages.
      * 
-     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
+     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. 
+     * You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
      */
     export interface Message extends Item {
         /**
          * Gets an identifier for the email conversation that contains a particular message.
          *
-         * You can get an integer for this property if your mail app is activated in read forms or responses in compose forms. If subsequently the user changes the subject of the reply message, upon sending the reply, the conversation ID for that message will change and that value you obtained earlier will no longer apply.
+         * You can get an integer for this property if your mail app is activated in read forms or responses in compose forms. 
+         * If subsequently the user changes the subject of the reply message, upon sending the reply, the conversation ID for that message will 
+         * change and that value you obtained earlier will no longer apply.
          *
-         * You get null for this property for a new item in a compose form. If the user sets a subject and saves the item, the conversationId property will return a value.
+         * You get null for this property for a new item in a compose form. 
+         * If the user sets a subject and saves the item, the conversationId property will return a value.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -3216,7 +3630,8 @@ export declare namespace Office {
      /**
      * The message compose mode of {@link Office.Item | Office.context.mailbox.item}.
      * 
-     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
+     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. 
+     * You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
      */
     export interface MessageCompose extends Message, ItemCompose {
         /**
@@ -3244,9 +3659,11 @@ export declare namespace Office {
          */
         body: Office.Body;
         /**
-         * Provides access to the Cc (carbon copy) recipients of a message. The type of object and level of access depends on the mode of the current item.
+         * Provides access to the Cc (carbon copy) recipients of a message. The type of object and level of access depends on the mode of the 
+         * current item.
          *
-         * The cc property returns a {@link Office.Recipients} object that provides methods to get or update the recipients on the Cc line of the message.
+         * The cc property returns a {@link Office.Recipients} object that provides methods to get or update the recipients on the Cc line of 
+         * the message.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -3260,9 +3677,12 @@ export declare namespace Office {
         /**
          * Gets an identifier for the email conversation that contains a particular message.
          *
-         * You can get an integer for this property if your mail app is activated in read forms or responses in compose forms. If subsequently the user changes the subject of the reply message, upon sending the reply, the conversation ID for that message will change and that value you obtained earlier will no longer apply.
+         * You can get an integer for this property if your mail app is activated in read forms or responses in compose forms. 
+         * If subsequently the user changes the subject of the reply message, upon sending the reply, the conversation ID for that message will change 
+         * and that value you obtained earlier will no longer apply.
          *
-         * You get null for this property for a new item in a compose form. If the user sets a subject and saves the item, the conversationId property will return a value.
+         * You get null for this property for a new item in a compose form. 
+         * If the user sets a subject and saves the item, the conversationId property will return a value.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -3302,7 +3722,8 @@ export declare namespace Office {
         /**
          * Gets the type of item that an instance represents.
          *
-         * The itemType property returns one of the ItemType enumeration values, indicating whether the item object instance is a message or an appointment.
+         * The itemType property returns one of the ItemType enumeration values, indicating whether the item object instance is a message or 
+         * an appointment.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -3342,7 +3763,8 @@ export declare namespace Office {
          */
         subject: Subject;
         /**
-         * Provides access to the recipients on the To line of a message. The type of object and level of access depends on the mode of the current item.
+         * Provides access to the recipients on the To line of a message. The type of object and level of access depends on the mode of the 
+         * current item.
          *
          * The to property returns a Recipients object that provides methods to get or update the recipients on the To line of the message.
          *
@@ -3378,16 +3800,20 @@ export declare namespace Office {
          * 
          * `addFileAttachmentAsync(uri: string, attachmentName: string, options: AsyncContextOptions): void;`
          * 
-         * `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+         * `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;`
          *
          * @param uri - The URI that provides the location of the file to attach to the message or appointment. The maximum length is 2048 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         *        isInline: If true, indicates that the attachment will be shown inline in the message body, and should not be displayed in the attachment list.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type asyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         *        isInline: If true, indicates that the attachment will be shown inline in the message body, and should not be displayed in the 
+         *        attachment list.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of 
+         *                 the error.
          */
-        addFileAttachmentAsync(uri: string, attachmentName: string, options?: AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        addFileAttachmentAsync(uri: string, attachmentName: string, options?: AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;
         /**
          * Adds a file to a message or appointment as an attachment.
          *
@@ -3428,7 +3854,7 @@ export declare namespace Office {
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         *        isInline: If true, indicates that the attachment will be shown inline in the message body, and should not be displayed in the attachment list.
+         *        isInline: If true, indicates that the attachment will be shown inline in the message body and should not be displayed in the attachment list.
          */
         addFileAttachmentAsync(uri: string, attachmentName: string, options: AsyncContextOptions): void;
         /**
@@ -3449,17 +3875,24 @@ export declare namespace Office {
          *
          * @param uri - The URI that provides the location of the file to attach to the message or appointment. The maximum length is 2048 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type asyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of 
+         *                 the error.
          */
-        addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;
+        addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the 
+         * callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -3470,29 +3903,36 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>NumberOfAttachmentsExceeded - The message or appointment has too many attachments.</td></tr></table>
          * 
-         * In addition to the main signature, this method also has these signatures:
+         * In addition to this signature, this method also has the following signatures:
          * 
          * `addItemAttachmentAsync(itemId: any, attachmentName: string): void;`
          * 
          * `addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;`
          * 
-         * `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+         * `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;`
          *
          * @param itemId - The Exchange identifier of the item to attach. The maximum length is 100 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
          * @param options - An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of 
+         *                 the error.
          */
-        addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. 
+         * You can use the options parameter to pass state information to the callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -3510,11 +3950,15 @@ export declare namespace Office {
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. 
+         * You can use the options parameter to pass state information to the callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -3534,11 +3978,15 @@ export declare namespace Office {
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. 
+         * You can use the options parameter to pass state information to the callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -3551,17 +3999,22 @@ export declare namespace Office {
          *
          * @param itemId - The Exchange identifier of the item to attach. The maximum length is 100 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of 
+         *                 the error.
          */
-        addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;
+        addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;
         /**
          * Closes the current item that is being composed
          *
-         * The behaviors of the close method depends on the current state of the item being composed. If the item has unsaved changes, the client prompts the user to save, discard, or close the action.
+         * The behaviors of the close method depends on the current state of the item being composed. 
+         * If the item has unsaved changes, the client prompts the user to save, discard, or close the action.
          *
          * In the Outlook desktop client, if the message is an inline reply, the close method has no effect.
          *
-         * Note: In Outlook on the web, if the item is an appointment and it has previously been saved using saveAsync, the user is prompted to save, discard, or cancel even if no changes have occurred since the item was last saved.
+         * Note: In Outlook on the web, if the item is an appointment and it has previously been saved using saveAsync, the user is prompted to save, 
+         * discard, or cancel even if no changes have occurred since the item was last saved.
          *
          * [Api set: Mailbox 1.3]
          *
@@ -3575,9 +4028,11 @@ export declare namespace Office {
         /**
          * Asynchronously returns selected data from the subject or body of a message.
          *
-         * If there is no selection but the cursor is in the body or subject, the method returns null for the selected data. If a field other than the body or subject is selected, the method returns the InvalidSelection error.
+         * If there is no selection but the cursor is in the body or subject, the method returns null for the selected data. 
+         * If a field other than the body or subject is selected, the method returns the InvalidSelection error.
          *
-         * To access the selected data from the callback method, call asyncResult.value.data. To access the source property that the selection comes from, call asyncResult.value.sourceProperty, which will be either body or subject.
+         * To access the selected data from the callback method, call asyncResult.value.data. 
+         * To access the source property that the selection comes from, call asyncResult.value.sourceProperty, which will be either body or subject.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -3590,16 +4045,20 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Message Compose</td></tr></table>
          *
-         * @param coercionType - Requests a format for the data. If Text, the method returns the plain text as a string , removing any HTML tags present. If HTML, the method returns the selected text, whether it is plaintext or HTML.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param coercionType - Requests a format for the data. If Text, the method returns the plain text as a string, removing any HTML tags present. 
+         *                     If HTML, the method returns the selected text, whether it is plaintext or HTML.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          */
-        getSelectedDataAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult) => void): void;
+        getSelectedDataAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult<any>) => void): void;
         /**
          * Asynchronously returns selected data from the subject or body of a message.
          *
-         * If there is no selection but the cursor is in the body or subject, the method returns null for the selected data. If a field other than the body or subject is selected, the method returns the InvalidSelection error.
+         * If there is no selection but the cursor is in the body or subject, the method returns null for the selected data. 
+         * If a field other than the body or subject is selected, the method returns the InvalidSelection error.
          *
-         * To access the selected data from the callback method, call asyncResult.value.data. To access the source property that the selection comes from, call asyncResult.value.sourceProperty, which will be either body or subject.
+         * To access the selected data from the callback method, call asyncResult.value.data. 
+         * To access the source property that the selection comes from, call asyncResult.value.sourceProperty, which will be either body or subject.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -3612,18 +4071,24 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Message Compose</td></tr></table>
          *
-         * @param coercionType - Requests a format for the data. If Text, the method returns the plain text as a string , removing any HTML tags present. If HTML, the method returns the selected text, whether it is plaintext or HTML.
+         * @param coercionType - Requests a format for the data. If Text, the method returns the plain text as a string, removing any HTML tags present. 
+         *                     If HTML, the method returns the selected text, whether it is plaintext or HTML.
          * @param options - An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          */
-        getSelectedDataAsync(coerciontype: Office.CoercionType, options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;
+        getSelectedDataAsync(coerciontype: Office.CoercionType, options: Office.AsyncContextOptions, callback: (result: AsyncResult<any>) => void): void;
         /**
          * Asynchronously loads custom properties for this add-in on the selected item.
          *
-         * Custom properties are stored as key/value pairs on a per-app, per-item basis. This method returns a CustomProperties object in the callback, which provides methods to access the custom properties specific to the current item and the current add-in. Custom properties are not encrypted on the item, so this should not be used as secure storage.
+         * Custom properties are stored as key/value pairs on a per-app, per-item basis. 
+         * This method returns a CustomProperties object in the callback, which provides methods to access the custom properties specific to the 
+         * current item and the current add-in. Custom properties are not encrypted on the item, so this should not be used as secure storage.
          *
-         * The custom properties are provided as a CustomProperties object in the asyncResult.value property. This object can be used to get, set, and remove custom properties from the item and save changes to the custom property set back to the server.
+         * The custom properties are provided as a CustomProperties object in the asyncResult.value property. 
+         * This object can be used to get, set, and remove custom properties from the item and save changes to the custom property set back to 
+         * the server.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -3633,14 +4098,20 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Message Compose</td></tr></table>
          *
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
-         * @param userContext - Optional. Developers can provide any object they wish to access in the callback function. This object can be accessed by the asyncResult.asyncContext property in the callback function.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
+         * @param userContext - Optional. Developers can provide any object they wish to access in the callback function. 
+         *                    This object can be accessed by the asyncResult.asyncContext property in the callback function.
          */
-        loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;
+        loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any): void;
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -3658,18 +4129,24 @@ export declare namespace Office {
          * 
          * `removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;`
          * 
-         * `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;`
+         * `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;`
          *
          * @param attachmentIndex - The identifier of the attachment to remove. The maximum length of the string is 100 characters.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. 
+         *                 If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
          */
-        removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -3687,7 +4164,11 @@ export declare namespace Office {
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -3707,7 +4188,11 @@ export declare namespace Office {
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -3720,17 +4205,25 @@ export declare namespace Office {
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
          * @param attachmentIndex - The identifier of the attachment to remove. The maximum length of the string is 100 characters.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. 
+         *                 If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
          */
-        removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;
+        removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;
         /**
          * Asynchronously saves an item.
          *
-         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. In Outlook Web App or Outlook in online mode, the item is saved to the server. In Outlook in cached mode, the item is saved to the local cache.
+         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. 
+         * In Outlook Web App or Outlook in online mode, the item is saved to the server. 
+         * In Outlook in cached mode, the item is saved to the local cache.
          *
-         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. Saving an existing appointment will send an update to added or removed attendees.
+         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal 
+         * appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. 
+         * Saving an existing appointment will send an update to added or removed attendees.
          *
-         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that when Outlook is in cached mode, it may take some time before the item is actually synced to the server. Until the item is synced, using the itemId will return an error.
+         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that 
+         * when Outlook is in cached mode, it may take some time before the item is actually synced to the server. 
+         * Until the item is synced, using the itemId will return an error.
          *
          * Note: The following clients have different behavior for saveAsync on appointments in compose mode:
          *
@@ -3754,21 +4247,28 @@ export declare namespace Office {
          * 
          * `saveAsync(options: Office.AsyncContextOptions): void;`
          * 
-         * `saveAsync(callback: (result: AsyncResult) => void): void;`
+         * `saveAsync(callback: (result: AsyncResult<void>) => void): void;`
          *
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. 
          */
-        saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Asynchronously saves an item.
          *
-         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. In Outlook Web App or Outlook in online mode, the item is saved to the server. In Outlook in cached mode, the item is saved to the local cache.
+         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. 
+         * In Outlook Web App or Outlook in online mode, the item is saved to the server. 
+         * In Outlook in cached mode, the item is saved to the local cache.
          *
-         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. Saving an existing appointment will send an update to added or removed attendees.
+         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal 
+         * appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. 
+         * Saving an existing appointment will send an update to added or removed attendees.
          *
-         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that when Outlook is in cached mode, it may take some time before the item is actually synced to the server. Until the item is synced, using the itemId will return an error.
+         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that 
+         * when Outlook is in cached mode, it may take some time before the item is actually synced to the server. 
+         * Until the item is synced, using the itemId will return an error.
          *
          * Note: The following clients have different behavior for saveAsync on appointments in compose mode:
          *
@@ -3791,11 +4291,16 @@ export declare namespace Office {
         /**
          * Asynchronously saves an item.
          *
-         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. In Outlook Web App or Outlook in online mode, the item is saved to the server. In Outlook in cached mode, the item is saved to the local cache.
+         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. 
+         * In Outlook Web App or Outlook in online mode, the item is saved to the server. 
+         * In Outlook in cached mode, the item is saved to the local cache.
          *
-         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. Saving an existing appointment will send an update to added or removed attendees.
+         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal 
+         * appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. Saving an existing appointment will send an update to added or removed attendees.
          *
-         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that when Outlook is in cached mode, it may take some time before the item is actually synced to the server. Until the item is synced, using the itemId will return an error.
+         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that 
+         * when Outlook is in cached mode, it may take some time before the item is actually synced to the server. 
+         * Until the item is synced, using the itemId will return an error.
          *
          * Note: The following clients have different behavior for saveAsync on appointments in compose mode:
          *
@@ -3820,11 +4325,17 @@ export declare namespace Office {
         /**
          * Asynchronously saves an item.
          *
-         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. In Outlook Web App or Outlook in online mode, the item is saved to the server. In Outlook in cached mode, the item is saved to the local cache.
+         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. 
+         * In Outlook Web App or Outlook in online mode, the item is saved to the server. 
+         * In Outlook in cached mode, the item is saved to the local cache.
          *
-         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. Saving an existing appointment will send an update to added or removed attendees.
+         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal 
+         * appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. 
+         * Saving an existing appointment will send an update to added or removed attendees.
          *
-         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that when Outlook is in cached mode, it may take some time before the item is actually synced to the server. Until the item is synced, using the itemId will return an error.
+         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that 
+         * when Outlook is in cached mode, it may take some time before the item is actually synced to the server. 
+         * Until the item is synced, using the itemId will return an error.
          *
          * Note: The following clients have different behavior for saveAsync on appointments in compose mode:
          *
@@ -3842,13 +4353,16 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. 
          */
-        saveAsync(callback: (result: AsyncResult) => void): void;
+        saveAsync(callback: (result: AsyncResult<void>) => void): void;
         /**
          * Asynchronously inserts data into the body or subject of a message.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is 
+         * selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. 
+         * After insertion, the cursor is placed at the end of the inserted content.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -3866,19 +4380,28 @@ export declare namespace Office {
          * 
          * `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`
          * 
-         * `setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;`
+         * `setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;`
          *
-         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
+         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. 
+         *             If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         *        coercionType: If text, the current style is applied in Outlook Web App and Outlook. If the field is an HTML editor, only the text data is inserted, even if the data is HTML. If html and the field supports HTML (the subject doesn't), the current style is applied in Outlook Web App and the default style is applied in Outlook. If the field is a text field, an InvalidDataFormat error is returned. If coercionType is not set, the result depends on the field: if the field is HTML then HTML is used; if the field is text, then plain text is used.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         *        coercionType: If text, the current style is applied in Outlook Web App and Outlook. 
+         *        If the field is an HTML editor, only the text data is inserted, even if the data is HTML. 
+         *        If html and the field supports HTML (the subject doesn't), the current style is applied in Outlook Web App and the default style is 
+         *        applied in Outlook. If the field is a text field, an InvalidDataFormat error is returned. 
+         *        If coercionType is not set, the result depends on the field: if the field is HTML then HTML is used; 
+         *        if the field is text, then plain text is used.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          */
-        setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult) => void): void;
+        setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Asynchronously inserts data into the body or subject of a message.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is 
+         * selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. 
+         * After insertion, the cursor is placed at the end of the inserted content.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -3890,13 +4413,16 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
-         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
+         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. 
+         *             If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
          */
         setSelectedDataAsync(data: string): void;
         /**
          * Asynchronously inserts data into the body or subject of a message.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is 
+         * selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. 
+         * After insertion, the cursor is placed at the end of the inserted content.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -3908,16 +4434,24 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
-         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
+         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. 
+         *             If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         *        coercionType: If text, the current style is applied in Outlook Web App and Outlook. If the field is an HTML editor, only the text data is inserted, even if the data is HTML. If html and the field supports HTML (the subject doesn't), the current style is applied in Outlook Web App and the default style is applied in Outlook. If the field is a text field, an InvalidDataFormat error is returned. If coercionType is not set, the result depends on the field: if the field is HTML then HTML is used; if the field is text, then plain text is used.
+         *        coercionType: If text, the current style is applied in Outlook Web App and Outlook. 
+         *        If the field is an HTML editor, only the text data is inserted, even if the data is HTML. 
+         *        If html and the field supports HTML (the subject doesn't), the current style is applied in Outlook Web App and the default style is 
+         *        applied in Outlook. If the field is a text field, an InvalidDataFormat error is returned. 
+         *        If coercionType is not set, the result depends on the field: if the field is HTML then HTML is used; 
+         *        if the field is text, then plain text is used.
          */
         setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;
         /**
          * Asynchronously inserts data into the body or subject of a message.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is 
+         * selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. 
+         * After insertion, the cursor is placed at the end of the inserted content.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -3929,19 +4463,22 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
-         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. 
+         *             If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 typeOffice.AsyncResult.
          */
-        setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;
+        setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;
     }
     /**
      * The message read mode of {@link Office.Item | Office.context.mailbox.item}.
      * 
-     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of Office.context.mailbox.item. Refer to the Object Model pages for more information.
+     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. 
+     * You should treat this as a mode of Office.context.mailbox.item. Refer to the Object Model pages for more information.
      */
     export interface MessageRead extends Message, ItemRead {
         /**
-         * Gets an array of attachments for the item.
+         * Gets the item's attachments as an array.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -3951,7 +4488,9 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Message Read</td></tr></table>
          * 
-         * Note: Certain types of files are blocked by Outlook due to potential security issues and are therefore not returned. For more information, see {@link https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519 | Blocked attachments in Outlook}.
+         * Note: Certain types of files are blocked by Outlook due to potential security issues and are therefore not returned. 
+         * For more information, see 
+         * {@link https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519 | Blocked attachments in Outlook}.
          *
          */
         attachments: Office.AttachmentDetails[];
@@ -3968,9 +4507,11 @@ export declare namespace Office {
          */
         body: Office.Body;
         /**
-         * Provides access to the Cc (carbon copy) recipients of a message. The type of object and level of access depends on the mode of the current item.
+         * Provides access to the Cc (carbon copy) recipients of a message. The type of object and level of access depends on the mode of the 
+         * current item.
          *
-         * The cc property returns an array that contains an EmailAddressDetails object for each recipient listed on the Cc line of the message. The collection is limited to a maximum of 100 members.
+         * The cc property returns an array that contains an EmailAddressDetails object for each recipient listed on the Cc line of the message. 
+         * The collection is limited to a maximum of 100 members.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -3984,9 +4525,12 @@ export declare namespace Office {
         /**
          * Gets an identifier for the email conversation that contains a particular message.
          *
-         * You can get an integer for this property if your mail app is activated in read forms or responses in compose forms. If subsequently the user changes the subject of the reply message, upon sending the reply, the conversation ID for that message will change and that value you obtained earlier will no longer apply.
+         * You can get an integer for this property if your mail app is activated in read forms or responses in compose forms. 
+         * If subsequently the user changes the subject of the reply message, upon sending the reply, the conversation ID for that message will change 
+         * and that value you obtained earlier will no longer apply.
          *
-         * You get null for this property for a new item in a compose form. If the user sets a subject and saves the item, the conversationId property will return a value.
+         * You get null for this property for a new item in a compose form. 
+         * If the user sets a subject and saves the item, the conversationId property will return a value.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -4026,7 +4570,8 @@ export declare namespace Office {
         /**
          * Gets the email address of the sender of a message.
          *
-         * The from and sender properties represent the same person unless the message is sent by a delegate. In that case, the from property represents the delegator, and the sender property represents the delegate.
+         * The from and sender properties represent the same person unless the message is sent by a delegate. 
+         * In that case, the from property represents the delegator, and the sender property represents the delegate.
          *
          * Note: The recipientType property of the EmailAddressDetails object in the from property is undefined.
          * 
@@ -4056,7 +4601,8 @@ export declare namespace Office {
         /**
          * Gets the Exchange Web Services item class of the selected item.
          * 
-         * You can create custom message classes that extends a default message class, for example, a custom appointment message class IPM.Appointment.Contoso.
+         * You can create custom message classes that extends a default message class, for example, a custom appointment message class 
+         * IPM.Appointment.Contoso.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -4066,7 +4612,8 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Message Read</td></tr></table>
 		 
-         * The itemClass property specifies the message class of the selected item. The following are the default message classes for the message or appointment item.
+         * The itemClass property specifies the message class of the selected item. 
+         * The following are the default message classes for the message or appointment item.
          * 
          * <table>
          *   <tr>
@@ -4091,9 +4638,14 @@ export declare namespace Office {
         /**
          * Gets the Exchange Web Services item identifier for the current item.
          *
-         * The itemId property is not available in compose mode. If an item identifier is required, the saveAsync method can be used to save the item to the store, which will return the item identifier in the AsyncResult.value parameter in the callback function.
+         * The itemId property is not available in compose mode. 
+         * If an item identifier is required, the saveAsync method can be used to save the item to the store, which will return the item identifier 
+         * in the AsyncResult.value parameter in the callback function.
          *
-         * Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more details, see Use the Outlook REST APIs from an Outlook add-in.
+         * Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. 
+         * The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. 
+         * Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. 
+         * For more details, see {@link https://docs.microsoft.com/outlook/add-ins/use-rest-api#get-the-item-id | Use the Outlook REST APIs from an Outlook add-in}.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -4107,7 +4659,8 @@ export declare namespace Office {
         /**
          * Gets the type of item that an instance represents.
          *
-         * The itemType property returns one of the ItemType enumeration values, indicating whether the item object instance is a message or an appointment.
+         * The itemType property returns one of the ItemType enumeration values, indicating whether the item object instance is a message or 
+         * an appointment.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -4121,7 +4674,9 @@ export declare namespace Office {
         /**
          * Gets the subject of an item, with all prefixes removed (including RE: and FWD:).
          *
-         * The normalizedSubject property gets the subject of the item, with any standard prefixes (such as RE: and FW:) that are added by email programs. To get the subject of the item with the prefixes intact, use the subject property.
+         * The normalizedSubject property gets the subject of the item, with any standard prefixes (such as RE: and FW:) that are added by 
+         * email programs. 
+         * To get the subject of the item with the prefixes intact, use the subject property.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -4147,7 +4702,8 @@ export declare namespace Office {
         /**
          * Gets the email address of the sender of an email message.
          *
-         * The from and sender properties represent the same person unless the message is sent by a delegate. In that case, the from property represents the delegator, and the sender property represents the delegate.
+         * The from and sender properties represent the same person unless the message is sent by a delegate. 
+         * In that case, the from property represents the delegator, and the sender property represents the delegate.
          *
          * Note: The recipientType property of the EmailAddressDetails object in the sender property is undefined.
          *
@@ -4177,9 +4733,11 @@ export declare namespace Office {
          */
         subject: string;
         /**
-         * Provides access to the recipients on the To line of a message. The type of object and level of access depends on the mode of the current item.
+         * Provides access to the recipients on the To line of a message. The type of object and level of access depends on the mode of the 
+         * current item.
          *
-         * The to property returns an array that contains an EmailAddressDetails object for each recipient listed on the To line of the message. The collection is limited to a maximum of 100 members.
+         * The to property returns an array that contains an EmailAddressDetails object for each recipient listed on the To line of the message. 
+         * The collection is limited to a maximum of 100 members.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -4190,14 +4748,18 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Message Read</td></tr></table>
          */
         to: EmailAddressDetails[];
+
         /**
-         * Displays a reply form that includes the sender and all recipients of the selected message or the organizer and all attendees of the selected appointment.
+         * Displays a reply form that includes the sender and all recipients of the selected message or the organizer and all attendees of the 
+         * selected appointment.
          *
          * In Outlook Web App, the reply form is displayed as a pop-out form in the 3-column view and a pop-up form in the 2- or 1-column view.
          *
          * If any of the string parameters exceed their limits, displayReplyAllForm throws an exception.
          *
-         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. If this isn't possible, then no error message is thrown.
+         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and 
+         * attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. 
+         * If this isn't possible, then no error message is thrown.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -4220,7 +4782,9 @@ export declare namespace Office {
          *
          * If any of the string parameters exceed their limits, displayReplyForm throws an exception.
          *
-         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. If this isn't possible, then no error message is thrown.
+         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and 
+         * attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. 
+         * If this isn't possible, then no error message is thrown.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -4238,7 +4802,7 @@ export declare namespace Office {
          */
         displayReplyForm(formData: string | ReplyFormData): void;
         /**
-         * Gets the entities found in the selected item.
+         * Gets the entities found in the selected item's body.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -4252,7 +4816,7 @@ export declare namespace Office {
          */
         getEntities(): Entities;
         /**
-         * Gets an array of all the entities of the specified entity type found in the selected item.
+         * Gets an array of all the entities of the specified entity type found in the selected item's body.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -4261,7 +4825,9 @@ export declare namespace Office {
          * @param entityType - One of the EntityType enumeration values.
          * 
          * @returns
-         * If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. If no entities of the specified type are present on the item, the method returns an empty array. Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter.
+         * If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. 
+         * If no entities of the specified type are present in the item's body, the method returns an empty array. 
+         * Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter.
          *
          * @remarks
          * 
@@ -4269,7 +4835,8 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Read</td></tr></table>
          * 
-         * While the minimum permission level to use this method is Restricted, some entity types require ReadItem to access, as specified in the following table.
+         * While the minimum permission level to use this method is Restricted, some entity types require ReadItem to access, as specified in the 
+         * following table.
          * 
          * <table>
          *   <tr>
@@ -4318,7 +4885,8 @@ export declare namespace Office {
         /**
          * Returns well-known entities in the selected item that pass the named filter defined in the manifest XML file.
          *
-         * The getFilteredEntitiesByName method returns the entities that match the regular expression defined in the ItemHasKnownEntity rule element in the manifest XML file with the specified FilterName element value.
+         * The getFilteredEntitiesByName method returns the entities that match the regular expression defined in the ItemHasKnownEntity rule element 
+         * in the manifest XML file with the specified FilterName element value.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -4331,22 +4899,33 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Message Read</td></tr></table>
          *
          * @param name - The name of the ItemHasKnownEntity rule element that defines the filter to match.
-         * @returns If there is no ItemHasKnownEntity element in the manifest with a FilterName element value that matches the name parameter, the method returns null. If the name parameter does match an ItemHasKnownEntity element in the manifest, but there are no entities in the current item that match, the method return an empty array.
+         * @returns If there is no ItemHasKnownEntity element in the manifest with a FilterName element value that matches the name parameter, 
+         * the method returns null. 
+         * If the name parameter does match an ItemHasKnownEntity element in the manifest, but there are no entities in the current item that match, 
+         * the method return an empty array.
          */
         getFilteredEntitiesByName(name: string): (string | Contact | MeetingSuggestion | PhoneNumber | TaskSuggestion)[];
         /**
          * Returns string values in the selected item that match the regular expressions defined in the manifest XML file.
          *
-         * The getRegExMatches method returns the strings that match the regular expression defined in each ItemHasRegularExpressionMatch or ItemHasKnownEntity rule element in the manifest XML file. For an ItemHasRegularExpressionMatch rule, a matching string has to occur in the property of the item that is specified by that rule. The PropertyName simple type defines the supported properties.
+         * The getRegExMatches method returns the strings that match the regular expression defined in each ItemHasRegularExpressionMatch or 
+         * ItemHasKnownEntity rule element in the manifest XML file. 
+         * For an ItemHasRegularExpressionMatch rule, a matching string has to occur in the property of the item that is specified by that rule. 
+         * The PropertyName simple type defines the supported properties.
          *
-         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body and should not attempt to return the entire body of the item. Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results. Instead, use the Body.getAsync method to retrieve the entire body.
+         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body 
+         * and should not attempt to return the entire body of the item. 
+         * Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results. 
+         * Instead, use the Body.getAsync method to retrieve the entire body.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
          * [Api set: Mailbox 1.0]
          *
          * @returns
-         * An object that contains arrays of strings that match the regular expressions defined in the manifest XML file. The name of each array is equal to the corresponding value of the RegExName attribute of the matching ItemHasRegularExpressionMatch rule or the FilterName attribute of the matching ItemHasKnownEntity rule.
+         * An object that contains arrays of strings that match the regular expressions defined in the manifest XML file. 
+         * The name of each array is equal to the corresponding value of the RegExName attribute of the matching ItemHasRegularExpressionMatch rule 
+         * or the FilterName attribute of the matching ItemHasKnownEntity rule.
          *
          * @remarks
          *
@@ -4358,9 +4937,12 @@ export declare namespace Office {
         /**
          * Returns string values in the selected item that match the named regular expression defined in the manifest XML file.
          *
-         * The getRegExMatchesByName method returns the strings that match the regular expression defined in the ItemHasRegularExpressionMatch rule element in the manifest XML file with the specified RegExName element value.
+         * The getRegExMatchesByName method returns the strings that match the regular expression defined in the ItemHasRegularExpressionMatch rule 
+         * element in the manifest XML file with the specified RegExName element value.
          *
-         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body and should not attempt to return the entire body of the item. Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results.
+         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body 
+         * and should not attempt to return the entire body of the item. 
+         * Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -4381,9 +4963,13 @@ export declare namespace Office {
         /**
          * Asynchronously loads custom properties for this add-in on the selected item.
          *
-         * Custom properties are stored as key/value pairs on a per-app, per-item basis. This method returns a CustomProperties object in the callback, which provides methods to access the custom properties specific to the current item and the current add-in. Custom properties are not encrypted on the item, so this should not be used as secure storage.
+         * Custom properties are stored as key/value pairs on a per-app, per-item basis. 
+         * This method returns a CustomProperties object in the callback, which provides methods to access the custom properties specific to the 
+         * current item and the current add-in. Custom properties are not encrypted on the item, so this should not be used as secure storage.
          *
-         * The custom properties are provided as a CustomProperties object in the asyncResult.value property. This object can be used to get, set, and remove custom properties from the item and save changes to the custom property set back to the server.
+         * The custom properties are provided as a CustomProperties object in the asyncResult.value property. 
+         * This object can be used to get, set, and remove custom properties from the item and save changes to the custom property set back to 
+         * the server.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -4393,10 +4979,12 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Message Read</td></tr></table>
          *
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
-         * @param userContext - Optional. Developers can provide any object they wish to access in the callback function. This object can be accessed by the asyncResult.asyncContext property in the callback function.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
+         * @param userContext - Optional. Developers can provide any object they wish to access in the callback function. 
+         *                    This object can be accessed by the asyncResult.asyncContext property in the callback function.
          */
-        loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;
+        loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any): void;
     }
 
     /**
@@ -4458,11 +5046,13 @@ export declare namespace Office {
         /**
          * Gets the location of an appointment.
          *
-         * The getAsync method starts an asynchronous call to the Exchange server to get the location of an appointment. The location of the appointment is provided as a string in the asyncResult.value property.
+         * The getAsync method starts an asynchronous call to the Exchange server to get the location of an appointment. 
+         * The location of the appointment is provided as a string in the asyncResult.value property.
          *
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -4473,16 +5063,18 @@ export declare namespace Office {
          * 
          * In addition to this signature, the method also has the following signature:
          * 
-         * `getAsync(callback: (result: AsyncResult) => void): void;`
+         * `getAsync(callback: (result: AsyncResult<string>) => void): void;`
          * 
          */
-        getAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        getAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;
         /**
          * Gets the location of an appointment.
          *
-         * The getAsync method starts an asynchronous call to the Exchange server to get the location of an appointment. The location of the appointment is provided as a string in the asyncResult.value property.
+         * The getAsync method starts an asynchronous call to the Exchange server to get the location of an appointment. 
+         * The location of the appointment is provided as a string in the asyncResult.value property.
          *
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -4491,16 +5083,18 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose</td></tr></table>
          */
-        getAsync(callback: (result: AsyncResult) => void): void;
+        getAsync(callback: (result: AsyncResult<string>) => void): void;
         /**
          * Sets the location of an appointment.
          *
-         * The setAsync method starts an asynchronous call to the Exchange server to set the location of an appointment. Setting the location of an appointment overwrites the current location.
+         * The setAsync method starts an asynchronous call to the Exchange server to set the location of an appointment. 
+         * Setting the location of an appointment overwrites the current location.
          *
          * @param location - The location of the appointment. The string is limited to 255 characters.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.  If setting the location fails, the asyncResult.error property will contain an error code.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. If setting the location fails, the asyncResult.error property will contain an error code.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -4517,13 +5111,14 @@ export declare namespace Office {
          * 
          * `setAsync(location: string, options: Office.AsyncContextOptions): void;`
          * 
-         * `setAsync(location: string, callback: (result: AsyncResult) => void): void;`
+         * `setAsync(location: string, callback: (result: AsyncResult<void>) => void): void;`
          */
-        setAsync(location: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        setAsync(location: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Sets the location of an appointment.
          *
-         * The setAsync method starts an asynchronous call to the Exchange server to set the location of an appointment. Setting the location of an appointment overwrites the current location.
+         * The setAsync method starts an asynchronous call to the Exchange server to set the location of an appointment. 
+         * Setting the location of an appointment overwrites the current location.
          *
          * @param location - The location of the appointment. The string is limited to 255 characters.
          *
@@ -4540,7 +5135,8 @@ export declare namespace Office {
         /**
          * Sets the location of an appointment.
          *
-         * The setAsync method starts an asynchronous call to the Exchange server to set the location of an appointment. Setting the location of an appointment overwrites the current location.
+         * The setAsync method starts an asynchronous call to the Exchange server to set the location of an appointment. 
+         * Setting the location of an appointment overwrites the current location.
          *
          * @param location - The location of the appointment. The string is limited to 255 characters.
          * @param options - Optional. An object literal that contains one or more of the following properties.
@@ -4559,10 +5155,12 @@ export declare namespace Office {
         /**
          * Sets the location of an appointment.
          *
-         * The setAsync method starts an asynchronous call to the Exchange server to set the location of an appointment. Setting the location of an appointment overwrites the current location.
+         * The setAsync method starts an asynchronous call to the Exchange server to set the location of an appointment. 
+         * Setting the location of an appointment overwrites the current location.
          *
          * @param location - The location of the appointment. The string is limited to 255 characters.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.  If setting the location fails, the asyncResult.error property will contain an error code.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. If setting the location fails, the asyncResult.error property will contain an error code.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -4573,10 +5171,10 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>DataExceedsMaximumSize - The location parameter is longer than 255 characters.</td></tr></table>
          */
-        setAsync(location: string, callback: (result: AsyncResult) => void): void;
+        setAsync(location: string, callback: (result: AsyncResult<void>) => void): void;
     }
     /**
-     * Provides access to the Outlook add-in object model for Microsoft Outlook and Microsoft Outlook on the web.
+     * Provides access to the Outlook Add-in object model for Microsoft Outlook and Microsoft Outlook on the web.
      *
      * Namespaces:
      *
@@ -4599,11 +5197,18 @@ export declare namespace Office {
          * 
          * Contains the following members:
          * 
-         *  - hostName (string): A string that represents the name of the host application. It be one of the following values: Outlook, Mac Outlook, OutlookIOS, or OutlookWebApp.
+         *  - hostName (string): A string that represents the name of the host application. 
+         * It be one of the following values: Outlook, Mac Outlook, OutlookIOS, or OutlookWebApp.
          * 
-         *  - hostVersion (string): A string that represents the version of either the host application or the Exchange Server. If the mail add-in is running on the Outlook desktop client or Outlook for iOS, the hostVersion property returns the version of the host application, Outlook. In Outlook Web App, the property returns the version of the Exchange Server. An example is the string 15.0.468.0.
+         *  - hostVersion (string): A string that represents the version of either the host application or the Exchange Server. 
+         * If the mail add-in is running on the Outlook desktop client or Outlook for iOS, the hostVersion property returns the version of the 
+         * host application, Outlook. In Outlook Web App, the property returns the version of the Exchange Server. An example is the string 15.0.468.0.
          * 
-         *  - OWAView (string): A string that represents the current view of Outlook Web App. If the host application is not Outlook Web App, then accessing this property results in undefined. Outlook Web App has three views (OneColumn - displayed when the screen is narrow, TwoColumns - displayed when the screen is wider, and ThreeColumns - displayed when the screen is wide.) that correspond to the width of the screen and the window, and the number of columns that can be displayed.
+         *  - OWAView (MailboxEnums.OWAView or string): An enum (or string literal) that represents the current view of Outlook Web App. 
+         * If the host application is not Outlook Web App, then accessing this property results in undefined. 
+         * Outlook Web App has three views (OneColumn - displayed when the screen is narrow, TwoColumns - displayed when the screen is wider, 
+         * and ThreeColumns - displayed when the screen is wide) that correspond to the width of the screen and the window, and the number of columns 
+         * that can be displayed.
          *
          *  More information is under {@link Office.Diagnostics}. 
          *
@@ -4620,7 +5225,8 @@ export declare namespace Office {
          *
          * Your app must have the ReadItem permission specified in its manifest to call the ewsUrl member in read mode.
          *
-         * In compose mode you must call the saveAsync method before you can use the ewsUrl member. Your app must have ReadWriteItem permissions to call the saveAsync method.
+         * In compose mode you must call the saveAsync method before you can use the ewsUrl member. 
+         * Your app must have ReadWriteItem permissions to call the saveAsync method.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -4642,7 +5248,7 @@ export declare namespace Office {
          */
         item: Item & ItemCompose & ItemRead & MessageRead & MessageCompose & AppointmentRead & AppointmentCompose;
         /**
-         * Information about the user associated with the mailbox. This includes their account type, display name, email adddress, and time zone.
+         * Information about the user associated with the mailbox. This includes their account type, display name, email address, and time zone.
          * 
          * More information is under {@link Office.UserProfile}
          */
@@ -4650,7 +5256,8 @@ export declare namespace Office {
         /**
          * Converts an item ID formatted for REST into EWS format.
          *
-         * Item IDs retrieved via a REST API (such as the Outlook Mail API or the Microsoft Graph) use a different format than the format used by Exchange Web Services (EWS). The convertToEwsId method converts a REST-formatted ID into the proper format for EWS.
+         * Item IDs retrieved via a REST API (such as the Outlook Mail API or the Microsoft Graph) use a different format than the format used by 
+         * Exchange Web Services (EWS). The convertToEwsId method converts a REST-formatted ID into the proper format for EWS.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -4669,9 +5276,15 @@ export declare namespace Office {
         /**
          * Gets a dictionary containing time information in local client time.
          *
-         * The dates and times used by a mail app for Outlook or Outlook Web App can use different time zones. Outlook uses the client computer time zone; Outlook Web App uses the time zone set on the Exchange Admin Center (EAC). You should handle date and time values so that the values you display on the user interface are always consistent with the time zone that the user expects.
+         * The dates and times used by a mail app for Outlook or Outlook Web App can use different time zones. 
+         * Outlook uses the client computer time zone; Outlook Web App uses the time zone set on the Exchange Admin Center (EAC). 
+         * You should handle date and time values so that the values you display on the user interface are always consistent with the time zone that 
+         * the user expects.
          *
-         * If the mail app is running in Outlook, the convertToLocalClientTime method will return a dictionary object with the values set to the client computer time zone. If the mail app is running in Outlook Web App, the convertToLocalClientTime method will return a dictionary object with the values set to the time zone specified in the EAC.
+         * If the mail app is running in Outlook, the convertToLocalClientTime method will return a dictionary object with the values set to the 
+         * client computer time zone. 
+         * If the mail app is running in Outlook Web App, the convertToLocalClientTime method will return a dictionary object with the values set to 
+         * the time zone specified in the EAC.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -4697,7 +5310,9 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          *
-         * Item IDs retrieved via EWS or via the itemId property use a different format than the format used by REST APIs (such as the {@link https://docs.microsoft.com/previous-versions/office/office-365-api/api/version-2.0/mail-rest-operations | Outlook Mail API} or the {@link http://graph.microsoft.io/ | Microsoft Graph}. The convertToRestId method converts an EWS-formatted ID into the proper format for REST.
+         * Item IDs retrieved via EWS or via the itemId property use a different format than the format used by REST APIs (such as the 
+         * {@link https://docs.microsoft.com/previous-versions/office/office-365-api/api/version-2.0/mail-rest-operations | Outlook Mail API} or the {@link http://graph.microsoft.io/ | Microsoft Graph}. 
+         * The convertToRestId method converts an EWS-formatted ID into the proper format for REST.
          *
          * @param itemId - An item ID formatted for Exchange Web Services (EWS)
          * @param restVersion - A value indicating the version of the Outlook REST API that the converted ID will be used with.
@@ -4706,7 +5321,8 @@ export declare namespace Office {
         /**
          * Gets a Date object from a dictionary containing time information.
          *
-         * The convertToUtcClientTime method converts a dictionary containing a local date and time to a Date object with the correct values for the local date and time.
+         * The convertToUtcClientTime method converts a dictionary containing a local date and time to a Date object with the correct values for the 
+         * local date and time.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -4723,13 +5339,17 @@ export declare namespace Office {
         /**
          * Displays an existing calendar appointment.
          *
-         * The displayAppointmentForm method opens an existing calendar appointment in a new window on the desktop or in a dialog box on mobile devices.
+         * The displayAppointmentForm method opens an existing calendar appointment in a new window on the desktop or in a dialog box on 
+         * mobile devices.
          *
-         * In Outlook for Mac, you can use this method to display a single appointment that is not part of a recurring series, or the master appointment of a recurring series, but you cannot display an instance of the series. This is because in Outlook for Mac, you cannot access the properties (including the item ID) of instances of a recurring series.
+         * In Outlook for Mac, you can use this method to display a single appointment that is not part of a recurring series, or the 
+         * master appointment of a recurring series, but you cannot display an instance of the series. 
+         * This is because in Outlook for Mac, you cannot access the properties (including the item ID) of instances of a recurring series.
          *
          * In Outlook Web App, this method opens the specified form only if the body of the form is less than or equal to 32KB number of characters.
          *
-         * If the specified item identifier does not identify an existing appointment, a blank pane opens on the client computer or device, and no error message will be returned.
+         * If the specified item identifier does not identify an existing appointment, a blank pane opens on the client computer or device, and 
+         * no error message will be returned.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -4751,9 +5371,11 @@ export declare namespace Office {
          *
          * In Outlook Web App, this method opens the specified form only if the body of the form is less than or equal to 32 KB number of characters.
          *
-         * If the specified item identifier does not identify an existing message, no message will be displayed on the client computer, and no error message will be returned.
+         * If the specified item identifier does not identify an existing message, no message will be displayed on the client computer, and 
+         * no error message will be returned.
          *
-         * Do not use the displayMessageForm with an itemId that represents an appointment. Use the displayAppointmentForm method to display an existing appointment, and displayNewAppointmentForm to display a form to create a new appointment.
+         * Do not use the displayMessageForm with an itemId that represents an appointment. Use the displayAppointmentForm method to display 
+         * an existing appointment, and displayNewAppointmentForm to display a form to create a new appointment.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -4771,11 +5393,16 @@ export declare namespace Office {
         /**
          * Displays a form for creating a new calendar appointment.
          *
-         * The displayNewAppointmentForm method opens a form that enables the user to create a new appointment or meeting. If parameters are specified, the appointment form fields are automatically populated with the contents of the parameters.
+         * The displayNewAppointmentForm method opens a form that enables the user to create a new appointment or meeting. 
+         * If parameters are specified, the appointment form fields are automatically populated with the contents of the parameters.
          *
-         * In Outlook Web App and OWA for Devices, this method always displays a form with an attendees field. If you do not specify any attendees as input arguments, the method displays a form with a Save button. If you have specified attendees, the form would include the attendees and a Send button.
+         * In Outlook Web App and OWA for Devices, this method always displays a form with an attendees field. 
+         * If you do not specify any attendees as input arguments, the method displays a form with a Save button. 
+         * If you have specified attendees, the form would include the attendees and a Send button.
          *
-         * In the Outlook rich client and Outlook RT, if you specify any attendees or resources in the requiredAttendees, optionalAttendees, or resources parameter, this method displays a meeting form with a Send button. If you don't specify any recipients, this method displays an appointment form with a Save & Close button.
+         * In the Outlook rich client and Outlook RT, if you specify any attendees or resources in the requiredAttendees, optionalAttendees, or 
+         * resources parameter, this method displays a meeting form with a Send button. 
+         * If you don't specify any recipients, this method displays an appointment form with a Save & Close button.
          *
          * If any of the parameters exceed the specified size limits, or if an unknown parameter name is specified, an exception is thrown.
          *
@@ -4795,13 +5422,17 @@ export declare namespace Office {
         /**
          * Gets a string that contains a token used to get an attachment or item from an Exchange Server.
          *
-         * The getCallbackTokenAsync method makes an asynchronous call to get an opaque token from the Exchange Server that hosts the user's mailbox. The lifetime of the callback token is 5 minutes.
+         * The getCallbackTokenAsync method makes an asynchronous call to get an opaque token from the Exchange Server that hosts the user's mailbox. 
+         * The lifetime of the callback token is 5 minutes.
          *
-         * You can pass the token and an attachment identifier or item identifier to a third-party system. The third-party system uses the token as a bearer authorization token to call the Exchange Web Services (EWS) GetAttachment or GetItem operation to return an attachment or item. For example, you can create a remote service to get attachments from the selected item.
+         * You can pass the token and an attachment identifier or item identifier to a third-party system. 
+         * The third-party system uses the token as a bearer authorization token to call the Exchange Web Services (EWS) GetAttachment or 
+         * GetItem operation to return an attachment or item. For example, you can create a remote service to get attachments from the selected item.
          *
          * Your app must have the ReadItem permission specified in its manifest to call the getCallbackTokenAsync method in read mode.
          *
-         * In compose mode you must call the saveAsync method to get an item identifier to pass to the getCallbackTokenAsync method. Your app must have ReadWriteItem permissions to call the saveAsync method.
+         * In compose mode you must call the saveAsync method to get an item identifier to pass to the getCallbackTokenAsync method. 
+         * Your app must have ReadWriteItem permissions to call the saveAsync method.
          *
          * [Api set: Mailbox 1.3]
          *
@@ -4811,10 +5442,11 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose and read</td></tr></table>
          *
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. The token is provided as a string in the asyncResult.value property.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. The token is provided as a string in the asyncResult.value property.
          * @param userContext - Optional. Any state data that is passed to the asynchronous method.
          */
-        getCallbackTokenAsync(callback: (result: AsyncResult) => void, userContext?: any): void;
+        getCallbackTokenAsync(callback: (result: AsyncResult<string>) => void, userContext?: any): void;
         /**
          * Gets a token identifying the user and the Office Add-in.
          *
@@ -4828,12 +5460,15 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose and read</td></tr></table>
          *
-         * The getUserIdentityTokenAsync method returns a token that you can use to identify and {@link https://docs.microsoft.com/outlook/add-ins/authentication | authenticate the add-in and user with a third-party system}.
+         * The getUserIdentityTokenAsync method returns a token that you can use to identify and 
+         * {@link https://docs.microsoft.com/outlook/add-ins/authentication | authenticate the add-in and user with a third-party system}.
          *
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
+         *                 The token is provided as a string in the asyncResult.value property.
          * @param userContext - Optional. Any state data that is passed to the asynchronous method.|
          */
-        getUserIdentityTokenAsync(callback: (result: AsyncResult) => void, userContext?: any): void;
+        getUserIdentityTokenAsync(callback: (result: AsyncResult<string>) => void, userContext?: any): void;
         /**
          * Makes an asynchronous request to an Exchange Web Services (EWS) service on the Exchange server that hosts the user's mailbox.
          *
@@ -4845,21 +5480,32 @@ export declare namespace Office {
          *
          * The XML request must specify UTF-8 encoding. \<?xml version="1.0" encoding="utf-8"?\>
          *
-         * Your add-in must have the ReadWriteMailbox permission to use the makeEwsRequestAsync method. For information about using the ReadWriteMailbox permission and the EWS operations that you can call with the makeEwsRequestAsync method, see Specify permissions for mail add-in access to the user's mailbox.
+         * Your add-in must have the ReadWriteMailbox permission to use the makeEwsRequestAsync method. 
+         * For information about using the ReadWriteMailbox permission and the EWS operations that you can call with the makeEwsRequestAsync method, 
+         * see {@link https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions | Specify permissions for mail add-in access to the user's mailbox}.
          *
-         * The XML result of the EWS call is provided as a string in the asyncResult.value property. If the result exceeds 1 MB in size, an error message is returned instead.
+         * The XML result of the EWS call is provided as a string in the asyncResult.value property. 
+         * If the result exceeds 1 MB in size, an error message is returned instead.
          *
-         * Note: This method is not supported in the following scenarios. - In Outlook for iOS or Outlook for Android - When the add-in is loaded in a Gmail mailbox
+         * Note: This method is not supported in the following scenarios:
+         * 
+         * - In Outlook for iOS or Outlook for Android.
+         * 
+         * - When the add-in is loaded in a Gmail mailbox.
          *
-         * Note: The server administrator must set OAuthAuthentication to true on the Client Access Server EWS directory to enable the makeEwsRequestAsync method to make EWS requests.
+         * Note: The server administrator must set OAuthAuthentication to true on the Client Access Server EWS directory to enable the 
+         * makeEwsRequestAsync method to make EWS requests.
          *
          * *Version differences*
          *
-         * When you use the makeEwsRequestAsync method in mail apps running in Outlook versions earlier than version 15.0.4535.1004, you should set the encoding value to ISO-8859-1.
+         * When you use the makeEwsRequestAsync method in mail apps running in Outlook versions earlier than version 15.0.4535.1004, you should set 
+         * the encoding value to ISO-8859-1.
          *
          * `<?xml version="1.0" encoding="iso-8859-1"?>`
          *
-         * You do not need to set the encoding value when your mail app is running in Outlook on the web. You can determine whether your mail app is running in Outlook or Outlook on the web by using the mailbox.diagnostics.hostName property. You can determine what version of Outlook is running by using the mailbox.diagnostics.hostVersion property.
+         * You do not need to set the encoding value when your mail app is running in Outlook on the web. 
+         * You can determine whether your mail app is running in Outlook or Outlook on the web by using the mailbox.diagnostics.hostName property. 
+         * You can determine what version of Outlook is running by using the mailbox.diagnostics.hostVersion property.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -4870,18 +5516,23 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose and read</td></tr></table>
          *
          * @param data - The EWS request.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult.
+         *                 The `value` property of the result is the XML of the EWS request provided as a string. 
+         *                 If the result exceeds 1 MB in size, an error message is returned instead.
          * @param userContext - Optional. Any state data that is passed to the asynchronous method.
          */
-        makeEwsRequestAsync(data: any, callback: (result: AsyncResult) => void, userContext?: any): void;
+        makeEwsRequestAsync(data: any, callback: (result: AsyncResult<string>) => void, userContext?: any): void;
     }
 
     /**
      * Represents a suggested meeting found in an item. Read mode only.
      *
-     * The list of meetings suggested in an email message is returned in the meetingSuggestions property of the Entities object that is returned when the getEntities or getEntitiesByType method is called on the active item.
+     * The list of meetings suggested in an email message is returned in the meetingSuggestions property of the Entities object that is returned when 
+     * the getEntities or getEntitiesByType method is called on the active item.
      *
-     * The start and end values are string representations of a Date object that contains the date and time at which the suggested meeting is to begin and end. The values are in the default time zone specified for the current user.
+     * The start and end values are string representations of a Date object that contains the date and time at which the suggested meeting is to 
+     * begin and end. 
+     * The values are in the default time zone specified for the current user.
      *
      * [Api set: Mailbox 1.0]
      *
@@ -4932,19 +5583,27 @@ export declare namespace Office {
          */
         key?: string;
         /**
-         * Specifies the ItemNotificationMessageType of message. If type is ProgressIndicator or ErrorMessage, an icon is automatically supplied and the message is not persistent. Therefore the icon and persistent properties are not valid for these types of messages. Including them will result in an ArgumentException. If type is ProgressIndicator, the developer should remove or replace the progress indicator when the action is complete.
+         * Specifies the ItemNotificationMessageType of message. If type is ProgressIndicator or ErrorMessage, an icon is automatically supplied and 
+         * the message is not persistent. Therefore the icon and persistent properties are not valid for these types of messages. 
+         * Including them will result in an ArgumentException. 
+         * If type is ProgressIndicator, the developer should remove or replace the progress indicator when the action is complete.
          */
         type: Office.MailboxEnums.ItemNotificationMessageType;
         /**
-         * A reference to an icon that is defined in the manifest in the Resources section. It appears in the infobar area. It is only applicable if the type is InformationalMessage. Specifying this parameter for an unsupported type results in an exception.
+         * A reference to an icon that is defined in the manifest in the Resources section. It appears in the infobar area. 
+         * It is only applicable if the type is InformationalMessage. Specifying this parameter for an unsupported type results in an exception.
          */
         icon?: string;
         /**
-         * The text of the notification message. Maximum length is 150 characters. If the developer passes in a longer string, an ArgumentOutOfRange exception is thrown.
+         * The text of the notification message. Maximum length is 150 characters. 
+         * If the developer passes in a longer string, an ArgumentOutOfRange exception is thrown.
          */
         message: string;
         /**
-         * Only applicable when type is InformationalMessage. If true, the message remains until removed by this add-in or dismissed by the user. If false, it is removed when the user navigates to a different item. For error notifications, the message persists until the user sees it once. Specifying this parameter for an unsupported type throws an exception.
+         * Only applicable when type is InformationalMessage. If true, the message remains until removed by this add-in or dismissed by the user. 
+         * If false, it is removed when the user navigates to a different item. 
+         * For error notifications, the message persists until the user sees it once. 
+         * Specifying this parameter for an unsupported type throws an exception.
          */
         persistent?: Boolean;
     }
@@ -4964,11 +5623,14 @@ export declare namespace Office {
          *
          * There are a maximum of 5 notifications per message. Setting more will return a NumberOfNotificationMessagesExceeded error.
          *
-         * @param key - A developer-specified key used to reference this notification message. Developers can use it to modify this message later. It can't be longer than 32 characters.
-         * @param JSONmessage - A JSON object that contains the notification message to be added to the item. It contains a NotificationMessageDetails object.
+         * @param key - A developer-specified key used to reference this notification message. 
+         *             Developers can use it to modify this message later. It can't be longer than 32 characters.
+         * @param JSONmessage - A JSON object that contains the notification message to be added to the item. 
+         *                    It contains a NotificationMessageDetails object.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          *
          * [Api set: Mailbox 1.3]
          *
@@ -4983,17 +5645,19 @@ export declare namespace Office {
          * 
          * `addAsync(key: string, JSONmessage: NotificationMessageDetails, options: Office.AsyncContextOptions): void;`
          * 
-         * `addAsync(key: string, JSONmessage: NotificationMessageDetails, callback: (result: AsyncResult) => void): void;`
+         * `addAsync(key: string, JSONmessage: NotificationMessageDetails, callback: (result: AsyncResult<void>) => void): void;`
          * 
          */
-        addAsync(key: string, JSONmessage: NotificationMessageDetails, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        addAsync(key: string, JSONmessage: NotificationMessageDetails, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Adds a notification to an item.
          *
          * There are a maximum of 5 notifications per message. Setting more will return a NumberOfNotificationMessagesExceeded error.
          *
-         * @param key - A developer-specified key used to reference this notification message. Developers can use it to modify this message later. It can't be longer than 32 characters.
-         * @param JSONmessage - A JSON object that contains the notification message to be added to the item. It contains a NotificationMessageDetails object.
+         * @param key - A developer-specified key used to reference this notification message. Developers can use it to modify this message later. 
+         *             It can't be longer than 32 characters.
+         * @param JSONmessage - A JSON object that contains the notification message to be added to the item. 
+         *                    It contains a NotificationMessageDetails object.
          *
          * [Api set: Mailbox 1.3]
          *
@@ -5008,8 +5672,10 @@ export declare namespace Office {
          *
          * There are a maximum of 5 notifications per message. Setting more will return a NumberOfNotificationMessagesExceeded error.
          *
-         * @param key - A developer-specified key used to reference this notification message. Developers can use it to modify this message later. It can't be longer than 32 characters.
-         * @param JSONmessage - A JSON object that contains the notification message to be added to the item. It contains a NotificationMessageDetails object.
+         * @param key - A developer-specified key used to reference this notification message. Developers can use it to modify this message later. 
+         *             It can't be longer than 32 characters.
+         * @param JSONmessage - A JSON object that contains the notification message to be added to the item. 
+         *                    It contains a NotificationMessageDetails object.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
          *
@@ -5026,9 +5692,12 @@ export declare namespace Office {
          *
          * There are a maximum of 5 notifications per message. Setting more will return a NumberOfNotificationMessagesExceeded error.
          *
-         * @param key - A developer-specified key used to reference this notification message. Developers can use it to modify this message later. It can't be longer than 32 characters.
-         * @param JSONmessage - A JSON object that contains the notification message to be added to the item. It contains a NotificationMessageDetails object.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param key - A developer-specified key used to reference this notification message. Developers can use it to modify this message later. 
+         *             It can't be longer than 32 characters.
+         * @param JSONmessage - A JSON object that contains the notification message to be added to the item. 
+         *                    It contains a NotificationMessageDetails object.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          *
          * [Api set: Mailbox 1.3]
          *
@@ -5037,7 +5706,7 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          */
-        addAsync(key: string, JSONmessage: NotificationMessageDetails, callback: (result: AsyncResult) => void): void;
+        addAsync(key: string, JSONmessage: NotificationMessageDetails, callback: (result: AsyncResult<void>) => void): void;
         /**
          * Returns all keys and messages for an item.
          *
@@ -5048,15 +5717,16 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          * 
-         * In addition to the main signature, this method also has this signature:
+         * In addition to this signature, this method also has the following signature:
          * 
-         * `getAllAsync(callback: (result: AsyncResult) => void): void;`
+         * `getAllAsync(callback: (result: AsyncResult<Office.NotificationMessageDetails[]>) => void): void;`
          *
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult.
+         *                 The `value` property of the result is an array of NotificationMessageDetails objects.
          */
-        getAllAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        getAllAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<Office.NotificationMessageDetails[]>) => void): void;
         /**
          * Returns all keys and messages for an item.
          *
@@ -5067,9 +5737,10 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          *
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult.
+         *                 The `value` property of the result is an array of NotificationMessageDetails objects.
          */
-        getAllAsync(callback: (result: AsyncResult) => void): void;
+        getAllAsync(callback: (result: AsyncResult<Office.NotificationMessageDetails[]>) => void): void;
         /**
          * Removes a notification message for an item.
          *
@@ -5080,20 +5751,21 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          * 
-         * In addition to the main signature, this method also has these signatures:
+         * In addition to this signature, this method also has the following signatures:
          * 
          * `removeAsync(key: string): void;`
          * 
          * `removeAsync(key: string, options: Office.AsyncContextOptions): void;`
          * 
-         * `removeAsync(key: string, callback: (result: AsyncResult) => void): void;`
+         * `removeAsync(key: string, callback: (result: AsyncResult<void>) => void): void;`
          *
          * @param key - The key for the notification message to remove.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          */
-        removeAsync(key: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        removeAsync(key: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Removes a notification message for an item.
          *
@@ -5133,9 +5805,10 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          *
          * @param key - The key for the notification message to remove.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          */
-        removeAsync(key: string, callback: (result: AsyncResult) => void): void;
+        removeAsync(key: string, callback: (result: AsyncResult<void>) => void): void;
         /**
          * Replaces a notification message that has a given key with another message.
          *
@@ -5148,21 +5821,23 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          * 
-         * In addition to the main signature, this method also has these signatures:
+         * In addition to this signature, this method also has the following signatures:
          * 
          * `replaceAsync(key: string, JSONmessage: NotificationMessageDetails): void;`
          * 
          * `replaceAsync(key: string, JSONmessage: NotificationMessageDetails, options: Office.AsyncContextOptions): void;`
          * 
-         * `replaceAsync(key: string, JSONmessage: NotificationMessageDetails, callback: (result: AsyncResult) => void): void;`
+         * `replaceAsync(key: string, JSONmessage: NotificationMessageDetails, callback: (result: AsyncResult<void>) => void): void;`
          *
          * @param key - The key for the notification message to replace. It can't be longer than 32 characters.
-         * @param JSONmessage - A JSON object that contains the new notification message to replace the existing message. It contains a NotificationMessageDetails object.
+         * @param JSONmessage - A JSON object that contains the new notification message to replace the existing message. 
+         *                    It contains a NotificationMessageDetails object.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          */
-        replaceAsync(key: string, JSONmessage: NotificationMessageDetails, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        replaceAsync(key: string, JSONmessage: NotificationMessageDetails, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Replaces a notification message that has a given key with another message.
          *
@@ -5176,7 +5851,8 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          *
          * @param key - The key for the notification message to replace. It can't be longer than 32 characters.
-         * @param JSONmessage - A JSON object that contains the new notification message to replace the existing message. It contains a NotificationMessageDetails object.
+         * @param JSONmessage - A JSON object that contains the new notification message to replace the existing message. 
+         *                    It contains a NotificationMessageDetails object.
          */
         replaceAsync(key: string, JSONmessage: NotificationMessageDetails): void;
         /**
@@ -5192,7 +5868,8 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          *
          * @param key - The key for the notification message to replace. It can't be longer than 32 characters.
-         * @param JSONmessage - A JSON object that contains the new notification message to replace the existing message. It contains a NotificationMessageDetails object.
+         * @param JSONmessage - A JSON object that contains the new notification message to replace the existing message. 
+         *                    It contains a NotificationMessageDetails object.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
          */
@@ -5210,15 +5887,18 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          *
          * @param key - The key for the notification message to replace. It can't be longer than 32 characters.
-         * @param JSONmessage - A JSON object that contains the new notification message to replace the existing message. It contains a NotificationMessageDetails object.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param JSONmessage - A JSON object that contains the new notification message to replace the existing message. 
+         *                    It contains a NotificationMessageDetails object.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          */
-        replaceAsync(key: string, JSONmessage: NotificationMessageDetails, callback: (result: AsyncResult) => void): void;
+        replaceAsync(key: string, JSONmessage: NotificationMessageDetails, callback: (result: AsyncResult<void>) => void): void;
     }
     /**
      * Represents a phone number identified in an item. Read mode only.
      *
-     * An array of PhoneNumber objects containing the phone numbers found in an email message is returned in the phoneNumbers property of the Entities object that is returned when you call the getEntities method on the selected item.
+     * An array of PhoneNumber objects containing the phone numbers found in an email message is returned in the phoneNumbers property of the 
+     * Entities object that is returned when you call the getEntities method on the selected item.
      *
      * [Api set: Mailbox 1.0]
      *
@@ -5270,20 +5950,21 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>NumberOfRecipientsExceeded - The number of recipients exceeded 100 entries.</td></tr></table>
          * 
-         * In addition to the main signature, this method also has these signatures:
+         * In addition to this signature, this method also has the following signatures:
          * 
          * `addAsync(recipients: (string | EmailUser | EmailAddressDetails)[]): void;`
          * 
          * `addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options: Office.AsyncContextOptions): void;`
          * 
-         * `addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult) => void): void;`
+         * `addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult<void>) => void): void;`
          *
          * @param recipients - The recipients to add to the recipients list.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If adding the recipients fails, the asyncResult.error property will contain an error code.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. If adding the recipients fails, the asyncResult.error property will contain an error code.
          */
-        addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Adds a recipient list to the existing recipients for an appointment or message.
          *
@@ -5353,13 +6034,14 @@ export declare namespace Office {
          * <tr><td>Errors</td><td>NumberOfRecipientsExceeded - The number of recipients exceeded 100 entries.</td></tr></table>
          *
          * @param recipients - The recipients to add to the recipients list.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If adding the recipients fails, the asyncResult.error property will contain an error code.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. If adding the recipients fails, the asyncResult.error property will contain an error code.
          */
-        addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult) => void): void;
+        addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult<void>) => void): void;
         /**
          * Gets a recipient list for an appointment or message.
          *
-         * When the call completes, the asyncResult.value property will contain an array of{@link Office.EmailAddressDetails} objects.
+         * When the call completes, the asyncResult.value property will contain an array of {@link Office.EmailAddressDetails} objects.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -5368,15 +6050,17 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose</td></tr></table>
          * 
-         * In addition to the main signature, this method also has this signature:
+         * In addition to this signature, this method also has the following signature:
          * 
-         * `getAsync(callback: (result: AsyncResult) => void): void;`
+         * `getAsync(callback: (result: AsyncResult<Office.EmailAddressDetails[]>) => void): void;`
          *
          * @param options - An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
+         *                 The `value` property of the result is an array of EmailAddressDetails objects.
          */
-        getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;
+        getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult<Office.EmailAddressDetails[]>) => void): void;
         /**
          * Gets a recipient list for an appointment or message.
          *
@@ -5389,9 +6073,11 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose</td></tr></table>
          *
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
+         *                 The `value` property of the result is an array of EmailAddressDetails objects.
          */
-        getAsync(callback: (result: AsyncResult) => void): void;
+        getAsync(callback: (result: AsyncResult<Office.EmailAddressDetails[]>) => void): void;
         /**
          * Sets a recipient list for an appointment or message.
          *
@@ -5414,20 +6100,23 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>NumberOfRecipientsExceeded - The number of recipients exceeded 100 entries.</td></tr></table>
          * 
-         * In addition to the main signature, this method also has these signatures:
+         * In addition to this signature, this method also has the following signatures:
          * 
          * `setAsync(recipients: (string | EmailUser | EmailAddressDetails)[]): void;`
          * 
          * `setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options: Office.AsyncContextOptions): void;`
          * 
-         * `setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult) => void): void;`
+         * `setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult<void>) => void): void;`
          *
          * @param recipients - The recipients to add to the recipients list.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.  If setting the recipients fails the asyncResult.error property will contain a code that indicates any error that occurred while adding the data.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
+         *                 If setting the recipients fails the asyncResult.error property will contain a code that indicates any error that occurred 
+         *                 while adding the data.
          */
-        setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Sets a recipient list for an appointment or message.
          *
@@ -5503,9 +6192,12 @@ export declare namespace Office {
          * <tr><td>Errors</td><td>NumberOfRecipientsExceeded - The number of recipients exceeded 100 entries.</td></tr></table>
          *
          * @param recipients - The recipients to add to the recipients list.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.  If setting the recipients fails the asyncResult.error property will contain a code that indicates any error that occurred while adding the data.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. 
+         *                 If setting the recipients fails the asyncResult.error property will contain a code that indicates any error that occurred 
+         *                 while adding the data.
          */
-        setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult) => void): void;
+        setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult<void>) => void): void;
 
     }
 
@@ -5526,7 +6218,8 @@ export declare namespace Office {
          */
         url?: string;
         /**
-         * Only used if type is set to file. If true, indicates that the attachment will be shown inline in the message body, and should not be displayed in the attachment list.
+         * Only used if type is set to file. If true, indicates that the attachment will be shown inline in the message body, and should not be 
+         * displayed in the attachment list.
          */
         inLine?: boolean;
         /**
@@ -5548,20 +6241,27 @@ export declare namespace Office {
          */
         attachments?: ReplyFormAttachment[];
         /**
-         * When the reply display call completes, the function passed in the callback parameter is called with a single parameter, asyncResult, which is an AsyncResult object.
+         * When the reply display call completes, the function passed in the callback parameter is called with a single parameter, 
+         * asyncResult, which is an Office.AsyncResult object.
          */
-        callback?: (result: AsyncResult) => void;
+        callback?: (result: AsyncResult<any>) => void;
     }
     /**
-     * The settings created by using the methods of the RoamingSettings object are saved per add-in and per user. That is, they are available only to the add-in that created them, and only from the user's mail box in which they are saved.
+     * The settings created by using the methods of the RoamingSettings object are saved per add-in and per user. 
+     * That is, they are available only to the add-in that created them, and only from the user's mail box in which they are saved.
      *
-     * While the Outlook add-in API limits access to these settings to only the add-in that created them, these settings should not be considered secure storage. They can be accessed by Exchange Web Services or Extended MAPI. They should not be used to store sensitive information such as user credentials or security tokens.
+     * While the Outlook Add-in API limits access to these settings to only the add-in that created them, these settings should not be considered 
+     * secure storage. They can be accessed by Exchange Web Services or Extended MAPI. 
+     * They should not be used to store sensitive information such as user credentials or security tokens.
      *
      * The name of a setting is a String, while the value can be a String, Number, Boolean, null, Object, or Array.
      *
      * The RoamingSettings object is accessible via the roamingSettings property in the Office.context namespace.
      *
-     * Important: The RoamingSettings object is initialized from the persisted storage only when the add-in is first loaded. For task panes, this means that it is only initialized when the task pane first opens. If the task pane navigates to another page or reloads the current page, the in-memory object is reset to its initial values, even if your add-in has persisted changes. The persisted changes will not be available until the task pane is closed and reopened.
+     * Important: The RoamingSettings object is initialized from the persisted storage only when the add-in is first loaded. 
+     * For task panes, this means that it is only initialized when the task pane first opens. 
+     * If the task pane navigates to another page or reloads the current page, the in-memory object is reset to its initial values, even if 
+     * your add-in has persisted changes. The persisted changes will not be available until the task pane is closed and reopened.
      *
      * [Api set: Mailbox 1.0]
      *
@@ -5601,7 +6301,9 @@ export declare namespace Office {
         /**
          * Saves the settings.
          *
-         * Any settings previously saved by an add-in are loaded when it is initialized, so during the lifetime of the session you can just use the set and get methods to work with the in-memory copy of the settings property bag. When you want to persist the settings so that they are available the next time the add-in is used, use the saveAsync method.
+         * Any settings previously saved by an add-in are loaded when it is initialized, so during the lifetime of the session you can just use 
+         * the set and get methods to work with the in-memory copy of the settings property bag. 
+         * When you want to persist the settings so that they are available the next time the add-in is used, use the saveAsync method.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -5610,13 +6312,15 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          *
-         * @param callback - Optional? When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          */
-        saveAsync(callback?: (result: AsyncResult) => void): void;
+        saveAsync(callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Sets or creates the specified setting.
          *
-         * The set method creates a new setting of the specified name if it does not already exist, or sets an existing setting of the specified name. The value is stored in the document as the serialized JSON representation of its data type.
+         * The set method creates a new setting of the specified name if it does not already exist, or sets an existing setting of the specified name. 
+         * The value is stored in the document as the serialized JSON representation of its data type.
          *
          * A maximum of 32KB is available for the settings of each add-in.
          *
@@ -5634,6 +6338,7 @@ export declare namespace Office {
          */
         set(name: string, value: any): void;
     }
+    
     /**
      * Provides methods to get and set the subject of an appointment or message in an Outlook add-in.
      *
@@ -5657,17 +6362,20 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose</td></tr></table>
          * 
-         * In addition to the main signature, this method also has this signature:
+         * In addition to this signature, this method also has the following signature:
          * 
-         * `getAsync(callback: (result: AsyncResult) => void): void;`
+         * `getAsync(callback: (result: AsyncResult<string>) => void): void;`
          *
          * @param options - An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
+         *                 The `value` property of the result is the subject of the item.
          */
-        getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;
+        getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult<string>) => void): void;
         /**
          * Gets the subject of an appointment or message.
+         * 
          * The getAsync method starts an asynchronous call to the Exchange server to get the subject of an appointment or message.
          *
          * [Api set: Mailbox 1.1]
@@ -5678,12 +6386,14 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose</td></tr></table>
          *
          * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         *                  The `value` property of the result is the subject of the item.
          */
-        getAsync(callback: (result: AsyncResult) => void): void;
+        getAsync(callback: (result: AsyncResult<string>) => void): void;
         /**
          * Sets the subject of an appointment or message.
          *
-         * The setAsync method starts an asynchronous call to the Exchange server to set the subject of an appointment or message. Setting the subject overwrites the current subject, but leaves any prefixes, such as "Fwd:" or "Re:" in place.
+         * The setAsync method starts an asynchronous call to the Exchange server to set the subject of an appointment or message. 
+         * Setting the subject overwrites the current subject, but leaves any prefixes, such as "Fwd:" or "Re:" in place.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -5694,24 +6404,26 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>DataExceedsMaximumSize - The subject parameter is longer than 255 characters.</td></tr></table>
          * 
-         * In addition to the main signature, this method also has these signatures:
+         * In addition to this signature, this method also has the following signatures:
          * 
          * `setAsync(subject: string): void;`
          * 
          * `setAsync(subject: string, options: Office.AsyncContextOptions): void;`
          * 
-         * `setAsync(subject: string, callback: (result: AsyncResult) => void): void;`
+         * `setAsync(subject: string, callback: (result: AsyncResult<void>) => void): void;`
          *
          * @param subject - The subject of the appointment or message. The string is limited to 255 characters.
          * @param options - An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If setting the subject fails, the asyncResult.error property will contain an error code.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. If setting the subject fails, the asyncResult.error property will contain an error code.
          */
-        setAsync(subject: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        setAsync(subject: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Sets the subject of an appointment or message.
          *
-         * The setAsync method starts an asynchronous call to the Exchange server to set the subject of an appointment or message. Setting the subject overwrites the current subject, but leaves any prefixes, such as "Fwd:" or "Re:" in place.
+         * The setAsync method starts an asynchronous call to the Exchange server to set the subject of an appointment or message. 
+         * Setting the subject overwrites the current subject, but leaves any prefixes, such as "Fwd:" or "Re:" in place.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -5728,7 +6440,8 @@ export declare namespace Office {
         /**
          * Sets the subject of an appointment or message.
          *
-         * The setAsync method starts an asynchronous call to the Exchange server to set the subject of an appointment or message. Setting the subject overwrites the current subject, but leaves any prefixes, such as "Fwd:" or "Re:" in place.
+         * The setAsync method starts an asynchronous call to the Exchange server to set the subject of an appointment or message. 
+         * Setting the subject overwrites the current subject, but leaves any prefixes, such as "Fwd:" or "Re:" in place.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -5747,7 +6460,8 @@ export declare namespace Office {
         /**
          * Sets the subject of an appointment or message.
          *
-         * The setAsync method starts an asynchronous call to the Exchange server to set the subject of an appointment or message. Setting the subject overwrites the current subject, but leaves any prefixes, such as "Fwd:" or "Re:" in place.
+         * The setAsync method starts an asynchronous call to the Exchange server to set the subject of an appointment or message. 
+         * Setting the subject overwrites the current subject, but leaves any prefixes, such as "Fwd:" or "Re:" in place.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -5759,15 +6473,17 @@ export declare namespace Office {
          * <tr><td>Errors</td><td>DataExceedsMaximumSize - The subject parameter is longer than 255 characters.</td></tr></table>
          *
          * @param subject - The subject of the appointment or message. The string is limited to 255 characters.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If setting the subject fails, the asyncResult.error property will contain an error code.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. If setting the subject fails, the asyncResult.error property will contain an error code.
          */
-        setAsync(data: string, callback: (result: AsyncResult) => void): void;
+        setAsync(data: string, callback: (result: AsyncResult<void>) => void): void;
 
     }
     /**
      * Represents a suggested task identified in an item. Read mode only.
      *
-     * The list of tasks suggested in an email message is returned in the taskSuggestions property of the [Entities]Entities object that is returned when the getEntities or getEntitiesByType method is called on the active item.
+     * The list of tasks suggested in an email message is returned in the taskSuggestions property of the {@link Office.Entities | Entities} object 
+     * that is returned when the getEntities or getEntitiesByType method is called on the active item.
      *
      * [Api set: Mailbox 1.0]
      *
@@ -5800,7 +6516,8 @@ export declare namespace Office {
         /**
          * Gets the start or end time of an appointment.
          *
-         * The date and time is provided as a Date object in the asyncResult.value property. The value is in Coordinated Universal Time (UTC). You can convert the UTC time to the local client time by using the convertToLocalClientTime method.
+         * The date and time is provided as a Date object in the asyncResult.value property. The value is in Coordinated Universal Time (UTC). 
+         * You can convert the UTC time to the local client time by using the convertToLocalClientTime method.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -5809,19 +6526,21 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose</td></tr></table>
          * 
-         * In addition to the main signature, this method also has this signature:
+         * In addition to this signature, this method also has the following signature:
          * 
-         * `getAsync(callback: (result: AsyncResult) => void): void;`
+         * `getAsync(callback: (result: AsyncResult<Date>) => void): void;`
          *
          * @param options - An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
          * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         *                  The `value` property of the result is a Date object.
          */
-        getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;
+        getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult<Date>) => void): void;
         /**
          * Gets the start or end time of an appointment.
          *
-         * The date and time is provided as a Date object in the asyncResult.value property. The value is in Coordinated Universal Time (UTC). You can convert the UTC time to the local client time by using the convertToLocalClientTime method.
+         * The date and time is provided as a Date object in the asyncResult.value property. The value is in Coordinated Universal Time (UTC). 
+         * You can convert the UTC time to the local client time by using the convertToLocalClientTime method.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -5831,12 +6550,14 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose</td></tr></table>
          *
          * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         *                  The `value` property of the result is a Date object.
          */
-        getAsync(callback: (result: AsyncResult) => void): void;
+        getAsync(callback: (result: AsyncResult<Date>) => void): void;
         /**
          * Sets the start or end time of an appointment.
          *
-         * If the setAsync method is called on the start property, the end property will be adjusted to maintain the duration of the appointment as previously set. If the setAsync method is called on the end property, the duration of the appointment will be extended to the new end time.
+         * If the setAsync method is called on the start property, the end property will be adjusted to maintain the duration of the appointment as 
+         * previously set. If the setAsync method is called on the end property, the duration of the appointment will be extended to the new end time.
          *
          * The time must be in UTC; you can get the correct UTC time by using the convertToUtcClientTime method.
          *
@@ -5849,24 +6570,27 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>InvalidEndTime - The appointment end time is before the appointment start time.</td></tr></table>
          * 
-         * In addition to the main signature, this method also has these signatures:
+         * In addition to this signature, this method also has the following signatures:
          * 
          * `setAsync(dateTime: Date): void;`
          * 
          * `setAsync(dateTime: Date, options: Office.AsyncContextOptions): void;`
          * 
-         * `setAsync(dateTime: Date, callback: (result: AsyncResult) => void): void;`
+         * `setAsync(dateTime: Date, callback: (result: AsyncResult<void>) => void): void;`
          *
          * @param dateTime - A date-time object in Coordinated Universal Time (UTC).
          * @param options - An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If setting the date and time fails, the asyncResult.error property will contain an error code.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. 
+         *                 If setting the date and time fails, the asyncResult.error property will contain an error code.
          */
-        setAsync(dateTime: Date, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        setAsync(dateTime: Date, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Sets the start or end time of an appointment.
          *
-         * If the setAsync method is called on the start property, the end property will be adjusted to maintain the duration of the appointment as previously set. If the setAsync method is called on the end property, the duration of the appointment will be extended to the new end time.
+         * If the setAsync method is called on the start property, the end property will be adjusted to maintain the duration of the appointment as 
+         * previously set. If the setAsync method is called on the end property, the duration of the appointment will be extended to the new end time.
          *
          * The time must be in UTC; you can get the correct UTC time by using the convertToUtcClientTime method.
          *
@@ -5885,7 +6609,8 @@ export declare namespace Office {
         /**
          * Sets the start or end time of an appointment.
          *
-         * If the setAsync method is called on the start property, the end property will be adjusted to maintain the duration of the appointment as previously set. If the setAsync method is called on the end property, the duration of the appointment will be extended to the new end time.
+         * If the setAsync method is called on the start property, the end property will be adjusted to maintain the duration of the appointment as 
+         * previously set. If the setAsync method is called on the end property, the duration of the appointment will be extended to the new end time.
          *
          * The time must be in UTC; you can get the correct UTC time by using the convertToUtcClientTime method.
          *
@@ -5906,7 +6631,8 @@ export declare namespace Office {
         /**
          * Sets the start or end time of an appointment.
          *
-         * If the setAsync method is called on the start property, the end property will be adjusted to maintain the duration of the appointment as previously set. If the setAsync method is called on the end property, the duration of the appointment will be extended to the new end time.
+         * If the setAsync method is called on the start property, the end property will be adjusted to maintain the duration of the appointment as 
+         * previously set. If the setAsync method is called on the end property, the duration of the appointment will be extended to the new end time.
          *
          * The time must be in UTC; you can get the correct UTC time by using the convertToUtcClientTime method.
          *
@@ -5920,9 +6646,11 @@ export declare namespace Office {
          * <tr><td>Errors</td><td>InvalidEndTime - The appointment end time is before the appointment start time.</td></tr></table>
          *
          * @param dateTime - A date-time object in Coordinated Universal Time (UTC).
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If setting the date and time fails, the asyncResult.error property will contain an error code.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. 
+         *                 If setting the date and time fails, the asyncResult.error property will contain an error code.
          */
-        setAsync(dateTime: Date, callback: (result: AsyncResult) => void): void;
+        setAsync(dateTime: Date, callback: (result: AsyncResult<void>) => void): void;
 
     }
     /**

--- a/generate-docs/api-extractor-inputs-outlook-legacy/Outlook_1_5/Outlook_1_5.d.ts
+++ b/generate-docs/api-extractor-inputs-outlook-legacy/Outlook_1_5/Outlook_1_5.d.ts
@@ -113,6 +113,24 @@ export declare namespace Office {
             Appointment = "appointment"
         }
         /**
+         * Represents the current view of Outlook Web App.
+         */
+        enum OWAView {
+            /**
+             * One column view. Displayed when the screen is narrow. Outlook Web App uses this single-column layout on the entire screen of a smartphone.
+             */
+            OneColumn = "OneColumn",
+            /**
+             * Two column view. Displayed when the screen is wider. Outlook Web App uses this view on most tablets.
+             */
+            TwoColumns = "TwoColumns",
+            /**
+             Three column view. Displayed when the screen is wide. For example, Outlook Web App uses this view in a full screen window on a desktop 
+             computer.
+             */
+            ThreeColumns = "ThreeColumns"
+        }
+        /**
          * Specifies the type of recipient for an appointment.
          *
          * [Api set: Mailbox 1.1]
@@ -140,7 +158,7 @@ export declare namespace Office {
              */
             Other = "other"
         }
-        /**  
+        /**
          * Specifies the type of response to a meeting invitation.
          *
          * [Api set: Mailbox 1.0]
@@ -236,7 +254,8 @@ export declare namespace Office {
         /**
          * Gets or sets the date and time that the appointment is to end.
          *
-         * The end property is expressed as a Coordinated Universal Time (UTC) date and time value. You can use the convertToLocalClientTime method to convert the end property value to the client's local date and time.
+         * The end property is expressed as a Coordinated Universal Time (UTC) date and time value. You can use the convertToLocalClientTime method to 
+         * convert the end property value to the client's local date and time.
          *
          * *Read mode*
          *
@@ -246,7 +265,8 @@ export declare namespace Office {
          *
          * The end property returns a Time object.
          *
-         * When you use the Time.setAsync method to set the end time, you should use the convertToUtcClientTime method to convert the local time on the client to UTC for the server.
+         * When you use the Time.setAsync method to set the end time, you should use the convertToUtcClientTime method to convert the local time on 
+         * the client to UTC for the server.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -320,7 +340,8 @@ export declare namespace Office {
         /**
          * Gets or sets the date and time that the appointment is to begin.
          *
-         * The start property is expressed as a Coordinated Universal Time (UTC) date and time value. You can use the convertToLocalClientTime method to convert the value to the client's local date and time.
+         * The start property is expressed as a Coordinated Universal Time (UTC) date and time value. You can use the convertToLocalClientTime method 
+         * to convert the value to the client's local date and time.
          *
          * *Read mode*
          *
@@ -330,7 +351,8 @@ export declare namespace Office {
          *
          * The start property returns a Time object.
          *
-         * When you use the Time.setAsync method to set the start time, you should use the convertToUtcClientTime method to convert the local time on the client to UTC for the server.
+         * When you use the Time.setAsync method to set the start time, you should use the convertToUtcClientTime method to convert the local time on 
+         * the client to UTC for the server.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -403,7 +425,8 @@ export declare namespace Office {
         size: number;
     }
     /**
-     * The body object provides methods for adding and updating the content of the message or appointment. It is returned in the body property of the selected item.
+     * The body object provides methods for adding and updating the content of the message or appointment. 
+     * It is returned in the body property of the selected item.
      *
      * [Api set: Mailbox 1.1]
      *
@@ -418,7 +441,9 @@ export declare namespace Office {
          *
          * This method returns the entire current body in the format specified by coercionType.
          *
-         * When working with HTML-formatted bodies, it is important to note that the Body.getAsync and Body.setAsync methods are not idempotent. The value returned from the getAsync method will not necessarily be exactly the same as the value that was passed in the setAsync method previously. The client may modify the value passed to setAsync in order to make it render efficiently with its rendering engine.
+         * When working with HTML-formatted bodies, it is important to note that the Body.getAsync and Body.setAsync methods are not idempotent. 
+         * The value returned from the getAsync method will not necessarily be exactly the same as the value that was passed in the setAsync method previously. 
+         * The client may modify the value passed to setAsync in order to make it render efficiently with its rendering engine.
          *
          * [Api set: Mailbox 1.3]
          *
@@ -427,22 +452,25 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          * 
-         * In addition to the main signature, this method also has this signature:
+         * In addition to this signature, this method also has the following signature:
          * 
-         * `getAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult) => void): void;`
+         * `getAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult<Office.Body>) => void): void;`
          * 
          * @param coercionType - The format for the returned body.
          * @param options - Optional. An object literal that contains one or more of the following properties:
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. The body is provided in the requested format in the asyncResult.value property.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. 
+         *                  The body is provided in the requested format in the asyncResult.value property.
          */
-        getAsync(coerciontype: Office.CoercionType, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        getAsync(coerciontype: Office.CoercionType, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<Office.Body>) => void): void;
         /**
          * Returns the current body in a specified format.
          *
          * This method returns the entire current body in the format specified by coercionType.
          *
-         * When working with HTML-formatted bodies, it is important to note that the Body.getAsync and Body.setAsync methods are not idempotent. The value returned from the getAsync method will not necessarily be exactly the same as the value that was passed in the setAsync method previously. The client may modify the value passed to setAsync in order to make it render efficiently with its rendering engine.
+         * When working with HTML-formatted bodies, it is important to note that the Body.getAsync and Body.setAsync methods are not idempotent. 
+         * The value returned from the getAsync method will not necessarily be exactly the same as the value that was passed in the setAsync method previously. 
+         * The client may modify the value passed to setAsync in order to make it render efficiently with its rendering engine.
          *
          * [Api set: Mailbox 1.3]
          *
@@ -452,9 +480,10 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          *
          * @param coercionType - The format for the returned body.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. The body is provided in the requested format in the asyncResult.value property.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult.
+         *                  The body is provided in the requested format in the asyncResult.value property.
          */
-        getAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult) => void): void;
+        getAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult<Office.Body>) => void): void;
 
         /**
          * Gets a value that indicates whether the content is in HTML or text format.
@@ -468,15 +497,18 @@ export declare namespace Office {
          *
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. The content type is returned as one of the CoercionType values in the asyncResult.value property.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult.
+         *                  The content type is returned as one of the CoercionType values in the asyncResult.value property.
          */
-        getTypeAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        getTypeAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<Office.CoercionType>) => void): void;
         /**
          * Adds the specified content to the beginning of the item body.
          *
-         * The prependAsync method inserts the specified string at the beginning of the item body. After insertion, the cursor is returned to its original place, relative to the inserted content.
+         * The prependAsync method inserts the specified string at the beginning of the item body. 
+         * After insertion, the cursor is returned to its original place, relative to the inserted content.
          *
-         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" (please see the Examples section for a sample).
+         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" 
+         * (please see the Examples section for a sample).
          *
          * [Api set: Mailbox 1.1]
          *
@@ -487,11 +519,11 @@ export declare namespace Office {
          * 
          * <tr><td>Errors</td><td>DataExceedsMaximumSize - The data parameter is longer than 1,000,000 characters.</td></tr></table>
          * 
-         * In addition to the main signature, this method also has these signatures:
+         * In addition to this signature, this method also has the following signatures:
          * 
          * `prependAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`
          * 
-         * `prependAsync(data: string, callback: (result: AsyncResult) => void): void;`
+         * `prependAsync(data: string, callback: (result: AsyncResult<void>) => void): void;`
          * 
          * `prependAsync(data: string): void;`
          *
@@ -499,15 +531,18 @@ export declare namespace Office {
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
          *        coercionType: The desired format for the body. The string in the data parameter will be converted to this format.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. Any errors encountered will be provided in the asyncResult.error property.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult.
+         *                  Any errors encountered will be provided in the asyncResult.error property.
          */
-        prependAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult) => void): void;
+        prependAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Adds the specified content to the beginning of the item body.
          *
-         * The prependAsync method inserts the specified string at the beginning of the item body. After insertion, the cursor is returned to its original place, relative to the inserted content.
+         * The prependAsync method inserts the specified string at the beginning of the item body. 
+         * After insertion, the cursor is returned to its original place, relative to the inserted content.
          *
-         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" (please see the Examples section for a sample).
+         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" 
+         * (please see the Examples section for a sample).
          *
          * [Api set: Mailbox 1.1]
          *
@@ -527,9 +562,11 @@ export declare namespace Office {
         /**
          * Adds the specified content to the beginning of the item body.
          *
-         * The prependAsync method inserts the specified string at the beginning of the item body. After insertion, the cursor is returned to its original place, relative to the inserted content.
+         * The prependAsync method inserts the specified string at the beginning of the item body. 
+         * After insertion, the cursor is returned to its original place, relative to the inserted content.
          *
-         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" (please see the Examples section for a sample).
+         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" 
+         * (please see the Examples section for a sample).
          *
          * [Api set: Mailbox 1.1]
          *
@@ -539,15 +576,18 @@ export declare namespace Office {
          * <tr><td>Errors</td><td>DataExceedsMaximumSize - The data parameter is longer than 1,000,000 characters.</td></tr></table>
          *
          * @param data - The string to be inserted at the beginning of the body. The string is limited to 1,000,000 characters.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. Any errors encountered will be provided in the asyncResult.error property.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult.
+         *                  Any errors encountered will be provided in the asyncResult.error property.
          */
-        prependAsync(data: string, callback: (result: AsyncResult) => void): void;
+        prependAsync(data: string, callback: (result: AsyncResult<void>) => void): void;
         /**
          * Adds the specified content to the beginning of the item body.
          *
-         * The prependAsync method inserts the specified string at the beginning of the item body. After insertion, the cursor is returned to its original place, relative to the inserted content.
+         * The prependAsync method inserts the specified string at the beginning of the item body. 
+         * After insertion, the cursor is returned to its original place, relative to the inserted content.
          *
-         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" (please see the Examples section for a sample).
+         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" 
+         * (please see the Examples section for a sample).
          *
          * [Api set: Mailbox 1.1]
          *
@@ -562,9 +602,12 @@ export declare namespace Office {
         /**
          * Replaces the entire body with the specified text.
          *
-         * When working with HTML-formatted bodies, it is important to note that the Body.getAsync and Body.setAsync methods are not idempotent. The value returned from the getAsync method will not necessarily be exactly the same as the value that was passed in the setAsync method previously. The client may modify the value passed to setAsync in order to make it render efficiently with its rendering engine.
+         * When working with HTML-formatted bodies, it is important to note that the Body.getAsync and Body.setAsync methods are not idempotent. 
+         * The value returned from the getAsync method will not necessarily be exactly the same as the value that was passed in the setAsync method 
+         * previously. The client may modify the value passed to setAsync in order to make it render efficiently with its rendering engine.
          *
-         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" (please see the Examples section for a sample).
+         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" 
+         * (please see the Examples section for a sample).
          *
          * [Api set: Mailbox 1.3]
          *
@@ -575,11 +618,11 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>DataExceedsMaximumSize - The data parameter is longer than 1,000,000 characters.</td></tr><tr><td></td><td>InvalidFormatError - The options.coercionType parameter is set to Office.CoercionType.Html and the message body is in plain text.</td></tr></table>
          * 
-         * In addition to the main signature, this method also has these signatures:
+         * In addition to this signature, this method also has the following signatures:
          * 
          * `setAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`
          * 
-         * `setAsync(data: string, callback: (result: AsyncResult) => void): void;`
+         * `setAsync(data: string, callback: (result: AsyncResult<void>) => void): void;`
          * 
          * `setAsync(data: string): void;`
          *
@@ -587,15 +630,19 @@ export declare namespace Office {
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
          *        coercionType: The desired format for the body. The string in the data parameter will be converted to this format.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.  Any errors encountered will be provided in the asyncResult.error property.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult.
+         *                  Any errors encountered will be provided in the asyncResult.error property.
          */
-        setAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult) => void): void;
+        setAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Replaces the entire body with the specified text.
          *
-         * When working with HTML-formatted bodies, it is important to note that the Body.getAsync and Body.setAsync methods are not idempotent. The value returned from the getAsync method will not necessarily be exactly the same as the value that was passed in the setAsync method previously. The client may modify the value passed to setAsync in order to make it render efficiently with its rendering engine.
+         * When working with HTML-formatted bodies, it is important to note that the Body.getAsync and Body.setAsync methods are not idempotent. 
+         * The value returned from the getAsync method will not necessarily be exactly the same as the value that was passed in the setAsync method 
+         * previously. The client may modify the value passed to setAsync in order to make it render efficiently with its rendering engine.
          *
-         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" (please see the Examples section for a sample).
+         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" 
+         * (please see the Examples section for a sample).
          *
          * [Api set: Mailbox 1.3]
          *
@@ -615,9 +662,12 @@ export declare namespace Office {
         /**
          * Replaces the entire body with the specified text.
          *
-         * When working with HTML-formatted bodies, it is important to note that the Body.getAsync and Body.setAsync methods are not idempotent. The value returned from the getAsync method will not necessarily be exactly the same as the value that was passed in the setAsync method previously. The client may modify the value passed to setAsync in order to make it render efficiently with its rendering engine.
+         * When working with HTML-formatted bodies, it is important to note that the Body.getAsync and Body.setAsync methods are not idempotent. 
+         * The value returned from the getAsync method will not necessarily be exactly the same as the value that was passed in the setAsync method 
+         * previously. The client may modify the value passed to setAsync in order to make it render efficiently with its rendering engine.
          *
-         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" (please see the Examples section for a sample).
+         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" 
+         * (please see the Examples section for a sample).
          *
          * [Api set: Mailbox 1.3]
          *
@@ -629,15 +679,19 @@ export declare namespace Office {
          * <tr><td>Errors</td><td>DataExceedsMaximumSize - The data parameter is longer than 1,000,000 characters.</td></tr><tr><td></td><td>InvalidFormatError - The options.coercionType parameter is set to Office.CoercionType.Html and the message body is in plain text.</td></tr></table>
          *
          * @param data - The string that will replace the existing body. The string is limited to 1,000,000 characters.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.  Any errors encountered will be provided in the asyncResult.error property.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult.
+         *                  Any errors encountered will be provided in the asyncResult.error property.
          */
-        setAsync(data: string, callback: (result: AsyncResult) => void): void;
+        setAsync(data: string, callback: (result: AsyncResult<void>) => void): void;
         /**
          * Replaces the entire body with the specified text.
          *
-         * When working with HTML-formatted bodies, it is important to note that the Body.getAsync and Body.setAsync methods are not idempotent. The value returned from the getAsync method will not necessarily be exactly the same as the value that was passed in the setAsync method previously. The client may modify the value passed to setAsync in order to make it render efficiently with its rendering engine.
+         * When working with HTML-formatted bodies, it is important to note that the Body.getAsync and Body.setAsync methods are not idempotent.
+         *  The value returned from the getAsync method will not necessarily be exactly the same as the value that was passed in the setAsync method 
+         * previously. The client may modify the value passed to setAsync in order to make it render efficiently with its rendering engine.
          *
-         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" (please see the Examples section for a sample).
+         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" 
+         * (please see the Examples section for a sample).
          *
          * [Api set: Mailbox 1.3]
          *
@@ -655,9 +709,12 @@ export declare namespace Office {
         /**
          * Replaces the selection in the body with the specified text.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor was never in the body of the item, or if the body of the item lost focus in the UI, the string will be inserted at the top of the body content. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the body of the item, or, if text is selected in 
+         * the editor, it replaces the selected text. If the cursor was never in the body of the item, or if the body of the item lost focus in the 
+         * UI, the string will be inserted at the top of the body content. After insertion, the cursor is placed at the end of the inserted content.
          *
-         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" (please see the Examples section for a sample).
+         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" 
+         * (please see the Examples section for a sample).
          *
          * [Api set: Mailbox 1.1]
          *
@@ -668,11 +725,11 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>DataExceedsMaximumSize - The data parameter is longer than 1,000,000 characters.</td></tr><tr><td></td><td>InvalidFormatError - The options.coercionType parameter is set to Office.CoercionType.Html and the message body is in plain text.</td></tr></table>
          * 
-         * In addition to the main signature, this method also has these signatures:
+         * In addition to this signature, this method also has the following signatures:
          * 
          * `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`
          * 
-         * `setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;`
+         * `setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;`
          * 
          * `setSelectedDataAsync(data: string): void;`
          *         
@@ -680,15 +737,19 @@ export declare namespace Office {
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
          *        coercionType: The desired format for the body. The string in the data parameter will be converted to this format.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.  Any errors encountered will be provided in the asyncResult.error property.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult.
+         *                  Any errors encountered will be provided in the asyncResult.error property.
          */
-        setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult) => void): void;
+        setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Replaces the selection in the body with the specified text.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor was never in the body of the item, or if the body of the item lost focus in the UI, the string will be inserted at the top of the body content. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the body of the item, or, if text is selected in 
+         * the editor, it replaces the selected text. If the cursor was never in the body of the item, or if the body of the item lost focus in the 
+         * UI, the string will be inserted at the top of the body content. After insertion, the cursor is placed at the end of the inserted content.
          *
-         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" (please see the Examples section for a sample).
+         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" 
+         * (please see the Examples section for a sample).
          *
          * [Api set: Mailbox 1.1]
          *
@@ -708,9 +769,12 @@ export declare namespace Office {
         /**
          * Replaces the selection in the body with the specified text.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor was never in the body of the item, or if the body of the item lost focus in the UI, the string will be inserted at the top of the body content. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the body of the item, or, if text is selected in 
+         * the editor, it replaces the selected text. If the cursor was never in the body of the item, or if the body of the item lost focus in the 
+         * UI, the string will be inserted at the top of the body content. After insertion, the cursor is placed at the end of the inserted content.
          *
-         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" (please see the Examples section for a sample).
+         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" 
+         * (please see the Examples section for a sample).
          *
          * [Api set: Mailbox 1.1]
          *
@@ -722,15 +786,19 @@ export declare namespace Office {
          * <tr><td>Errors</td><td>DataExceedsMaximumSize - The data parameter is longer than 1,000,000 characters.</td></tr><tr><td></td><td>InvalidFormatError - The options.coercionType parameter is set to Office.CoercionType.Html and the message body is in plain text.</td></tr></table>
          *
          * @param data - The string that will replace the existing body. The string is limited to 1,000,000 characters.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.  Any errors encountered will be provided in the asyncResult.error property.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult.
+         *                  Any errors encountered will be provided in the asyncResult.error property.
          */
-        setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;
+        setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;
         /**
          * Replaces the selection in the body with the specified text.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor was never in the body of the item, or if the body of the item lost focus in the UI, the string will be inserted at the top of the body content. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the body of the item, or, if text is selected in 
+         * the editor, it replaces the selected text. If the cursor was never in the body of the item, or if the body of the item lost focus in the 
+         * UI, the string will be inserted at the top of the body content. After insertion, the cursor is placed at the end of the inserted content.
          *
-         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" (please see the Examples section for a sample).
+         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" 
+         * (please see the Examples section for a sample).
          *
          * [Api set: Mailbox 1.1]
          *
@@ -748,7 +816,8 @@ export declare namespace Office {
     /**
      * Represents a contact stored on the server. Read mode only.
      *
-     * The list of contacts associated with an email message or appointment is returned in the contacts property of the {@link Office.Entities} object that is returned by the getEntities or getEntitiesByType method of the active item.
+     * The list of contacts associated with an email message or appointment is returned in the contacts property of the {@link Office.Entities} object 
+     * that is returned by the getEntities or getEntitiesByType method of the active item.
      *
      * [Api set: Mailbox 1.0]
      *
@@ -784,7 +853,10 @@ export declare namespace Office {
         urls: Array<string>;
     }
     /**
-     * The CustomProperties object represents custom properties that are specific to a particular item and specific to a mail add-in for Outlook. For example, there might be a need for a mail add-in to save some data that is specific to the current email message that activated the add-in. If the user revisits the same message in the future and activates the mail add-in again, the add-in will be able to retrieve the data that had been saved as custom properties.
+     * The CustomProperties object represents custom properties that are specific to a particular item and specific to a mail add-in for Outlook. 
+     * For example, there might be a need for a mail add-in to save some data that is specific to the current email message that activated the add-in. 
+     * If the user revisits the same message in the future and activates the mail add-in again, the add-in will be able to retrieve the data that had 
+     * been saved as custom properties.
      *
      * Because Outlook for Mac doesn't cache custom properties, if the user's network goes down, mail add-ins cannot access their custom properties.
      *
@@ -814,7 +886,9 @@ export declare namespace Office {
          *
          * The set method sets the specified property to the specified value. You must use the saveAsync method to save the property to the server.
          *
-         * The set method creates a new property if the specified property does not already exist; otherwise, the existing value is replaced with the new value. The value parameter can be of any type; however, it is always passed to the server as a string.
+         * The set method creates a new property if the specified property does not already exist; 
+         * otherwise, the existing value is replaced with the new value. 
+         * The value parameter can be of any type; however, it is always passed to the server as a string.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -844,11 +918,17 @@ export declare namespace Office {
         /**
          * Saves item-specific custom properties to the server.
          *
-         * You must call the saveAsync method to persist any changes made with the set method or the remove method of the CustomProperties object. The saving action is asynchronous.
+         * You must call the saveAsync method to persist any changes made with the set method or the remove method of the CustomProperties object. 
+         * The saving action is asynchronous.
          *
-         * It's a good practice to have your callback function check for and handle errors from saveAsync. In particular, a read add-in can be activated while the user is in a connected state in a read form, and subsequently the user becomes disconnected. If the add-in calls saveAsync while in the disconnected state, saveAsync would return an error. Your callback method should handle this error accordingly.
+         * It's a good practice to have your callback function check for and handle errors from saveAsync. 
+         * In particular, a read add-in can be activated while the user is in a connected state in a read form, and subsequently the user becomes 
+         * disconnected. 
+         * If the add-in calls saveAsync while in the disconnected state, saveAsync would return an error. 
+         * Your callback method should handle this error accordingly.
          *
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          * @param asyncContext - Optional. Any state data that is passed to the callback method.
          *
          * [Api set: Mailbox 1.0]
@@ -858,7 +938,7 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          */
-        saveAsync(callback?: (result: AsyncResult) => void, asyncContext?: any): void;
+        saveAsync(callback?: (result: AsyncResult<void>) => void, asyncContext?: any): void;
     }
     /**
      * Provides diagnostic information to an Outlook add-in.
@@ -887,7 +967,8 @@ export declare namespace Office {
         /**
          * Gets a string that represents the version of either the host application or the Exchange Server.
          *
-         * If the mail add-in is running on the Outlook desktop client or Outlook for iOS, the hostVersion property returns the version of the host application, Outlook. In Outlook Web App, the property returns the version of the Exchange Server. An example is the string 15.0.468.0.
+         * If the mail add-in is running on the Outlook desktop client or Outlook for iOS, the hostVersion property returns the version of the host 
+         * application, Outlook. In Outlook Web App, the property returns the version of the Exchange Server. An example is the string 15.0.468.0.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -906,11 +987,13 @@ export declare namespace Office {
          *
          * Outlook Web App has three views that correspond to the width of the screen and the window, and the number of columns that can be displayed:
          *
-         * - OneColumn, which is displayed when the screen is narrow. Outlook Web App uses this single-column layout on the entire screen of a smartphone.
+         * - OneColumn, which is displayed when the screen is narrow. Outlook Web App uses this single-column layout on the entire screen of a 
+         * smartphone.
          *
          * - TwoColumns, which is displayed when the screen is wider. Outlook Web App uses this view on most tablets.
          *
-         * - ThreeColumns, which is displayed when the screen is wide. For example, Outlook Web App uses this view in a full screen window on a desktop computer.
+         * - ThreeColumns, which is displayed when the screen is wide. For example, Outlook Web App uses this view in a full screen window on a 
+         * desktop computer.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -919,7 +1002,7 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          */
-        OWAView: "string";
+        OWAView: MailboxEnums.OWAView | "OneColumn" | "TwoColumns" | "ThreeColumns";
     }
     /**
      * Provides the email properties of the sender or specified recipients of an email message or appointment.
@@ -941,7 +1024,9 @@ export declare namespace Office {
          */
         displayName: string;
         /**
-         * Gets the response that an attendee returned for an appointment. This property applies to only an attendee of an appointment, as represented by the optionalAttendees or requiredAttendees property. This property returns undefined in other scenarios.
+         * Gets the response that an attendee returned for an appointment. 
+         * This property applies to only an attendee of an appointment, as represented by the optionalAttendees or requiredAttendees property. 
+         * This property returns undefined in other scenarios.
          */
         appointmentResponse: Office.MailboxEnums.ResponseType;
         /**
@@ -972,17 +1057,25 @@ export declare namespace Office {
     /**
      * Represents a collection of entities found in an email message or appointment. Read mode only.
      *
-     * The Entities object is a container for the entity arrays returned by the getEntities and getEntitiesByType methods when the item (either an email message or an appointment) contains one or more entities that have been found by the server. You can use these entities in your code to provide additional context information to the viewer, such as a map to an address found in the item, or to open a dialer for a phone number found in the item.
+     * The Entities object is a container for the entity arrays returned by the getEntities and getEntitiesByType methods when the item 
+     * (either an email message or an appointment) contains one or more entities that have been found by the server. 
+     * You can use these entities in your code to provide additional context information to the viewer, such as a map to an address found in the item, 
+     * or to open a dialer for a phone number found in the item.
      *
-     * If no entities of the type specified in the property are present in the item, the property associated with that entity is null. For example, if a message contains a street address and a phone number, the addresses property and phoneNumbers property would contain information, and the other properties would be null.
+     * If no entities of the type specified in the property are present in the item, the property associated with that entity is null. 
+     * For example, if a message contains a street address and a phone number, the addresses property and phoneNumbers property would contain 
+     * information, and the other properties would be null.
      *
-     * To be recognized as an address, the string must contain a United States postal address that has at least a subset of the elements of a street number, street name, city, state, and zip code.
+     * To be recognized as an address, the string must contain a United States postal address that has at least a subset of the elements of a street 
+     * number, street name, city, state, and zip code.
      *
      * To be recognized as a phone number, the string must contain a North American phone number format.
      *
-     * Entity recognition relies on natural language recognition that is based on machine learning of large amounts of data. The recognition of an entity is non-deterministic and success sometimes relies on the particular context in the item.
+     * Entity recognition relies on natural language recognition that is based on machine learning of large amounts of data. 
+     * The recognition of an entity is non-deterministic and success sometimes relies on the particular context in the item.
      *
-     * When the property arrays are returned by the getEntitiesByType method, only the property for the specified entity contains data; all other properties are null.
+     * When the property arrays are returned by the getEntitiesByType method, only the property for the specified entity contains data; 
+     * all other properties are null.
      *
      * [Api set: Mailbox 1.0]
      *
@@ -1024,14 +1117,16 @@ export declare namespace Office {
     /**
      * The subclass of {@link Office.Item} dealing with appointments.
      * 
-     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of Office.context.mailbox.item. Refer to the Object Model pages for more information.
+     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. 
+     * You should treat this as a mode of Office.context.mailbox.item. Refer to the Object Model pages for more information.
      */
     export interface Appointment extends Item {
     }
     /**
      * The appointment organizer mode of {@link Office.Item | Office.context.mailbox.item}.
      * 
-     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
+     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. 
+     * You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
      */
     export interface AppointmentCompose extends Appointment, ItemCompose {
          /**
@@ -1075,9 +1170,11 @@ export declare namespace Office {
         /**
          * Gets or sets the date and time that the appointment is to end.
          *
-         * The end property is an {@link Office.Time} object expressed as a Coordinated Universal Time (UTC) date and time value. You can use the convertToLocalClientTime method to convert the end property value to the client's local date and time.
+         * The end property is an {@link Office.Time} object expressed as a Coordinated Universal Time (UTC) date and time value. 
+         * You can use the convertToLocalClientTime method to convert the end property value to the client's local date and time.
          *
-         * When you use the Time.setAsync method to set the end time, you should use the convertToUtcClientTime method to convert the local time on the client to UTC for the server.
+         * When you use the Time.setAsync method to set the end time, you should use the convertToUtcClientTime method to convert the local time on 
+         * the client to UTC for the server.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1103,7 +1200,8 @@ export declare namespace Office {
          */
         itemType: Office.MailboxEnums.ItemType;
         /**
-         * Gets or sets the {@link Office.Location} of an appointment. The location property returns a Location object that provides methods that are used to get and set the location of the appointment.
+         * Gets or sets the {@link Office.Location} of an appointment. The location property returns a Location object that provides methods that are 
+         * used to get and set the location of the appointment.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1127,7 +1225,9 @@ export declare namespace Office {
          */
         notificationMessages: Office.NotificationMessages;
         /**
-         * Provides access to the optional attendees of an event. The type of object and level of access depends on the mode of the current item. The optionalAttendees property returns an {@link Office.Recipients} object that provides methods to get or update the optional attendees for a meeting.
+         * Provides access to the optional attendees of an event. The type of object and level of access depends on the mode of the current item. 
+         * The optionalAttendees property returns an {@link Office.Recipients} object that provides methods to get or update the optional attendees 
+         * for a meeting.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1139,7 +1239,9 @@ export declare namespace Office {
          */
         optionalAttendees: Recipients;
         /**
-         * Provides access to the required attendees of an event. The type of object and level of access depends on the mode of the current item. The requiredAttendees property returns an {@link Office.Recipients} object that provides methods to get or update the required attendees for a meeting.
+         * Provides access to the required attendees of an event. The type of object and level of access depends on the mode of the current item. 
+         * The requiredAttendees property returns an {@link Office.Recipients} object that provides methods to get or update the required attendees 
+         * for a meeting.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1153,9 +1255,11 @@ export declare namespace Office {
         /**
          * Gets or sets the date and time that the appointment is to begin.
          *
-         * The start property is an {@link Office.Time} object expressed as a Coordinated Universal Time (UTC) date and time value. You can use the convertToLocalClientTime method to convert the value to the client's local date and time.
+         * The start property is an {@link Office.Time} object expressed as a Coordinated Universal Time (UTC) date and time value. 
+         * You can use the convertToLocalClientTime method to convert the value to the client's local date and time.
          *
-         * When you use the Time.setAsync method to set the start time, you should use the convertToUtcClientTime method to convert the local time on the client to UTC for the server.
+         * When you use the Time.setAsync method to set the start time, you should use the convertToUtcClientTime method to convert the local time on 
+         * the client to UTC for the server.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1204,16 +1308,18 @@ export declare namespace Office {
          * 
          * `addFileAttachmentAsync(uri: string, attachmentName: string, options: Office.AsyncContextOptions): void;`
          * 
-         * `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+         * `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;`
          *
          * @param uri - The URI that provides the location of the file to attach to the message or appointment. The maximum length is 2048 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
          *        isInline: If true, indicates that the attachment will be shown inline in the message body, and should not be displayed in the attachment list.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type asyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type asyncResult. 
+         *                 On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
          */
-        addFileAttachmentAsync(uri: string, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        addFileAttachmentAsync(uri: string, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;
         /**
          * Adds a file to a message or appointment as an attachment.
          *
@@ -1254,7 +1360,7 @@ export declare namespace Office {
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         *        isInline: If true, indicates that the attachment will be shown inline in the message body, and should not be displayed in the attachment list.
+         *        isInline: If true, indicates that the attachment will be shown inline in the message body and should not be displayed in the attachment list.
          */
         addFileAttachmentAsync(uri: string, attachmentName: string, options: Office.AsyncContextOptions): void;
         /**
@@ -1275,17 +1381,23 @@ export declare namespace Office {
          *
          * @param uri - The URI that provides the location of the file to attach to the message or appointment. The maximum length is 2048 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type asyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type asyncResult. 
+         *                 On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
          */
-        addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;
+        addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. 
+         * You can use the options parameter to pass state information to the callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -1296,29 +1408,35 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>NumberOfAttachmentsExceeded - The message or appointment has too many attachments.</td></tr></table>
          * 
-         * In addition to the main signature, this method also has these signatures:
+         * In addition to this signature, this method also has the following signatures:
          * 
          * `addItemAttachmentAsync(itemId: any, attachmentName: string): void;`
          * 
          * `addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;`
          * 
-         * `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+         * `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;`
          *
          * @param itemId - The Exchange identifier of the item to attach. The maximum length is 100 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
          * @param options - An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. 
+         *                 On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
          */
-        addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. 
+         * You can use the options parameter to pass state information to the callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -1336,11 +1454,15 @@ export declare namespace Office {
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. 
+         * You can use the options parameter to pass state information to the callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -1360,11 +1482,15 @@ export declare namespace Office {
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. 
+         * You can use the options parameter to pass state information to the callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -1377,17 +1503,21 @@ export declare namespace Office {
          *
          * @param itemId - The Exchange identifier of the item to attach. The maximum length is 100 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. 
+         *                 On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
          */
-        addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;
+        addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;
         /**
          * Closes the current item that is being composed
          *
-         * The behaviors of the close method depends on the current state of the item being composed. If the item has unsaved changes, the client prompts the user to save, discard, or close the action.
+         * The behaviors of the close method depends on the current state of the item being composed. 
+         * If the item has unsaved changes, the client prompts the user to save, discard, or close the action.
          *
          * In the Outlook desktop client, if the message is an inline reply, the close method has no effect.
          *
-         * Note: In Outlook on the web, if the item is an appointment and it has previously been saved using saveAsync, the user is prompted to save, discard, or cancel even if no changes have occurred since the item was last saved.
+         * Note: In Outlook on the web, if the item is an appointment and it has previously been saved using saveAsync, the user is prompted to save, 
+         * discard, or cancel even if no changes have occurred since the item was last saved.
          *
          * [Api set: Mailbox 1.3]
          *
@@ -1401,9 +1531,11 @@ export declare namespace Office {
         /**
          * Asynchronously returns selected data from the subject or body of a message.
          *
-         * If there is no selection but the cursor is in the body or subject, the method returns null for the selected data. If a field other than the body or subject is selected, the method returns the InvalidSelection error.
+         * If there is no selection but the cursor is in the body or subject, the method returns null for the selected data. 
+         * If a field other than the body or subject is selected, the method returns the InvalidSelection error.
          *
-         * To access the selected data from the callback method, call asyncResult.value.data. To access the source property that the selection comes from, call asyncResult.value.sourceProperty, which will be either body or subject.
+         * To access the selected data from the callback method, call asyncResult.value.data. 
+         * To access the source property that the selection comes from, call asyncResult.value.sourceProperty, which will be either body or subject.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -1416,18 +1548,21 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Appointment Organizer</td></tr></table>
          *
-         * @param coercionType - Requests a format for the data. If Text, the method returns the plain text as a string , removing any HTML tags present. If HTML, the method returns the selected text, whether it is plaintext or HTML.
+         * @param coercionType - Requests a format for the data. If Text, the method returns the plain text as a string , removing any HTML tags present. 
+         *                     If HTML, the method returns the selected text, whether it is plaintext or HTML.
          * @param options - An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
          * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
          */
-        getSelectedDataAsync(coerciontype: Office.CoercionType, options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;
+        getSelectedDataAsync(coerciontype: Office.CoercionType, options: Office.AsyncContextOptions, callback: (result: AsyncResult<any>) => void): void;
          /**
          * Asynchronously returns selected data from the subject or body of a message.
          *
-         * If there is no selection but the cursor is in the body or subject, the method returns null for the selected data. If a field other than the body or subject is selected, the method returns the InvalidSelection error.
+         * If there is no selection but the cursor is in the body or subject, the method returns null for the selected data. 
+         * If a field other than the body or subject is selected, the method returns the InvalidSelection error.
          *
-         * To access the selected data from the callback method, call asyncResult.value.data. To access the source property that the selection comes from, call asyncResult.value.sourceProperty, which will be either body or subject.
+         * To access the selected data from the callback method, call asyncResult.value.data. 
+         * To access the source property that the selection comes from, call asyncResult.value.sourceProperty, which will be either body or subject.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -1440,16 +1575,22 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Appointment Organizer</td></tr></table>
          *
-         * @param coercionType - Requests a format for the data. If Text, the method returns the plain text as a string , removing any HTML tags present. If HTML, the method returns the selected text, whether it is plaintext or HTML.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param coercionType - Requests a format for the data. If Text, the method returns the plain text as a string , removing any HTML tags present. 
+         *                     If HTML, the method returns the selected text, whether it is plaintext or HTML.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          */
-        getSelectedDataAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult) => void): void;
+        getSelectedDataAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult<string>) => void): void;
         /**
          * Asynchronously loads custom properties for this add-in on the selected item.
          *
-         * Custom properties are stored as key/value pairs on a per-app, per-item basis. This method returns a CustomProperties object in the callback, which provides methods to access the custom properties specific to the current item and the current add-in. Custom properties are not encrypted on the item, so this should not be used as secure storage.
+         * Custom properties are stored as key/value pairs on a per-app, per-item basis. 
+         * This method returns a CustomProperties object in the callback, which provides methods to access the custom properties specific to the 
+         * current item and the current add-in. Custom properties are not encrypted on the item, so this should not be used as secure storage.
          *
-         * The custom properties are provided as a CustomProperties object in the asyncResult.value property. This object can be used to get, set, and remove custom properties from the item and save changes to the custom property set back to the server.
+         * The custom properties are provided as a CustomProperties object in the asyncResult.value property. 
+         * This object can be used to get, set, and remove custom properties from the item and save changes to the custom property set back to 
+         * the server.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1459,14 +1600,20 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Appointment Organizer</td></tr></table>
          *
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
-         * @param userContext - Optional. Developers can provide any object they wish to access in the callback function. This object can be accessed by the asyncResult.asyncContext property in the callback function.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
+         * @param userContext - Optional. Developers can provide any object they wish to access in the callback function. 
+         *                    This object can be accessed by the asyncResult.asyncContext property in the callback function.
          */
-        loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;
+        loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any): void;
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -1484,18 +1631,23 @@ export declare namespace Office {
          * 
          * `removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;`
          * 
-         * `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;`
+         * `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;`
          *
          * @param attachmentIndex - The identifier of the attachment to remove. The maximum length of the string is 100 characters.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. 
+         *                 If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
          */
-        removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -1513,7 +1665,11 @@ export declare namespace Office {
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -1533,7 +1689,12 @@ export declare namespace Office {
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. 
+         * In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -1546,17 +1707,25 @@ export declare namespace Office {
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
          * @param attachmentIndex - The identifier of the attachment to remove. The maximum length of the string is 100 characters.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. 
+         *                 If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
          */
-        removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;
+        removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;
         /**
          * Asynchronously saves an item.
          *
-         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. In Outlook Web App or Outlook in online mode, the item is saved to the server. In Outlook in cached mode, the item is saved to the local cache.
+         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. 
+         * In Outlook Web App or Outlook in online mode, the item is saved to the server. 
+         * In Outlook in cached mode, the item is saved to the local cache.
          *
-         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. Saving an existing appointment will send an update to added or removed attendees.
+         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal 
+         * appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. 
+         * Saving an existing appointment will send an update to added or removed attendees.
          *
-         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that when Outlook is in cached mode, it may take some time before the item is actually synced to the server. Until the item is synced, using the itemId will return an error.
+         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that 
+         * when Outlook is in cached mode, it may take some time before the item is actually synced to the server. 
+         * Until the item is synced, using the itemId will return an error.
          *
          * Note: The following clients have different behavior for saveAsync on appointments in compose mode:
          *
@@ -1580,21 +1749,27 @@ export declare namespace Office {
          * 
          * `saveAsync(options: Office.AsyncContextOptions): void;`
          * 
-         * `saveAsync(callback: (result: AsyncResult) => void): void;`
+         * `saveAsync(callback: (result: AsyncResult<void>) => void): void;`
          *
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. 
          */
-        saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Asynchronously saves an item.
          *
-         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. In Outlook Web App or Outlook in online mode, the item is saved to the server. In Outlook in cached mode, the item is saved to the local cache.
+         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. 
+         * In Outlook Web App or Outlook in online mode, the item is saved to the server. 
+         * In Outlook in cached mode, the item is saved to the local cache.
          *
-         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. Saving an existing appointment will send an update to added or removed attendees.
+         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal 
+         * appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. 
+         * Saving an existing appointment will send an update to added or removed attendees.
          *
-         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that when Outlook is in cached mode, it may take some time before the item is actually synced to the server. Until the item is synced, using the itemId will return an error.
+         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that 
+         * when Outlook is in cached mode, it may take some time before the item is actually synced to the server. 
+         * Until the item is synced, using the itemId will return an error.
          *
          * Note: The following clients have different behavior for saveAsync on appointments in compose mode:
          *
@@ -1617,11 +1792,17 @@ export declare namespace Office {
         /**
          * Asynchronously saves an item.
          *
-         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. In Outlook Web App or Outlook in online mode, the item is saved to the server. In Outlook in cached mode, the item is saved to the local cache.
+         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. 
+         * In Outlook Web App or Outlook in online mode, the item is saved to the server. 
+         * In Outlook in cached mode, the item is saved to the local cache.
          *
-         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. Saving an existing appointment will send an update to added or removed attendees.
+         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal 
+         * appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. 
+         * Saving an existing appointment will send an update to added or removed attendees.
          *
-         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that when Outlook is in cached mode, it may take some time before the item is actually synced to the server. Until the item is synced, using the itemId will return an error.
+         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that 
+         * when Outlook is in cached mode, it may take some time before the item is actually synced to the server. 
+         * Until the item is synced, using the itemId will return an error.
          *
          * Note: The following clients have different behavior for saveAsync on appointments in compose mode:
          *
@@ -1646,11 +1827,16 @@ export declare namespace Office {
         /**
          * Asynchronously saves an item.
          *
-         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. In Outlook Web App or Outlook in online mode, the item is saved to the server. In Outlook in cached mode, the item is saved to the local cache.
+         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. 
+         * In Outlook Web App or Outlook in online mode, the item is saved to the server. In Outlook in cached mode, the item is saved to the local cache.
          *
-         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. Saving an existing appointment will send an update to added or removed attendees.
+         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal 
+         * appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. 
+         * Saving an existing appointment will send an update to added or removed attendees.
          *
-         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that when Outlook is in cached mode, it may take some time before the item is actually synced to the server. Until the item is synced, using the itemId will return an error.
+         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that 
+         * when Outlook is in cached mode, it may take some time before the item is actually synced to the server. 
+         * Until the item is synced, using the itemId will return an error.
          *
          * Note: The following clients have different behavior for saveAsync on appointments in compose mode:
          *
@@ -1668,13 +1854,15 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult.
          */
-        saveAsync(callback: (result: AsyncResult) => void): void;
+        saveAsync(callback: (result: AsyncResult<void>) => void): void;
         /**
          * Asynchronously inserts data into the body or subject of a message.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is 
+         * selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. 
+         * After insertion, the cursor is placed at the end of the inserted content.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -1692,19 +1880,29 @@ export declare namespace Office {
          * 
          * `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`
          * 
-         * `setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;`
+         * `setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;`
          *
-         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
+         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. 
+         *             If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         *        coercionType: If text, the current style is applied in Outlook Web App and Outlook. If the field is an HTML editor, only the text data is inserted, even if the data is HTML. If html and the field supports HTML (the subject doesn't), the current style is applied in Outlook Web App and the default style is applied in Outlook. If the field is a text field, an InvalidDataFormat error is returned. If coercionType is not set, the result depends on the field: if the field is HTML then HTML is used; if the field is text, then plain text is used.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         *        coercionType: If text, the current style is applied in Outlook Web App and Outlook. 
+         *                      If the field is an HTML editor, only the text data is inserted, even if the data is HTML. 
+         *                      If html and the field supports HTML (the subject doesn't), the current style is applied in Outlook Web App and the 
+         *                      default style is applied in Outlook. 
+         *                      If the field is a text field, an InvalidDataFormat error is returned. 
+         *                      If coercionType is not set, the result depends on the field: if the field is HTML then HTML is used; 
+         *                      if the field is text, then plain text is used.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          */
-        setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult) => void): void;
+        setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Asynchronously inserts data into the body or subject of a message.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is 
+         * selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. 
+         * After insertion, the cursor is placed at the end of the inserted content.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -1716,13 +1914,16 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
-         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
+         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. 
+         *             If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
          */
         setSelectedDataAsync(data: string): void;
         /**
          * Asynchronously inserts data into the body or subject of a message.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is 
+         * selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. 
+         * After insertion, the cursor is placed at the end of the inserted content.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -1734,16 +1935,24 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
-         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
+         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. 
+         *             If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         *        coercionType: If text, the current style is applied in Outlook Web App and Outlook. If the field is an HTML editor, only the text data is inserted, even if the data is HTML. If html and the field supports HTML (the subject doesn't), the current style is applied in Outlook Web App and the default style is applied in Outlook. If the field is a text field, an InvalidDataFormat error is returned. If coercionType is not set, the result depends on the field: if the field is HTML then HTML is used; if the field is text, then plain text is used.
+         *        coercionType: If text, the current style is applied in Outlook Web App and Outlook. 
+         *                      If the field is an HTML editor, only the text data is inserted, even if the data is HTML. 
+         *                      If html and the field supports HTML (the subject doesn't), the current style is applied in Outlook Web App and the 
+         *                      default style is applied in Outlook. If the field is a text field, an InvalidDataFormat error is returned. 
+         *                      If coercionType is not set, the result depends on the field: if the field is HTML then HTML is used; 
+         *                      if the field is text, then plain text is used.
          */
         setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;
         /**
          * Asynchronously inserts data into the body or subject of a message.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is 
+         * selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. 
+         * After insertion, the cursor is placed at the end of the inserted content.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -1755,20 +1964,23 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
-         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. 
+         *             If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          */
-        setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;
+        setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;
     }
 
     /**
      * The appointment attendee mode of {@link Office.Item | Office.context.mailbox.item}.
      * 
-     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of 'Office.context.mailbox.item'. Refer to the Object Model pages for more information.
+     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. 
+     * You should treat this as a mode of 'Office.context.mailbox.item'. Refer to the Object Model pages for more information.
      */
     export interface AppointmentRead extends Appointment, ItemRead {
         /**
-         * Gets an array of attachments for the item.
+         * Gets the item's attachments as an array.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1778,7 +1990,8 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Appointment Attendee</td></tr></table>
          *
-         * Note: Certain types of files are blocked by Outlook due to potential security issues and are therefore not returned. For more information, see {@link https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519 | Blocked attachments in Outlook}.
+         * Note: Certain types of files are blocked by Outlook due to potential security issues and are therefore not returned. For more information, see 
+         * {@link https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519 | Blocked attachments in Outlook}.
          *
          */
         attachments: Office.AttachmentDetails[];
@@ -1823,9 +2036,11 @@ export declare namespace Office {
         /**
          * Gets the date and time that the appointment is to end.
          *
-         * The end property is a Date object expressed as a Coordinated Universal Time (UTC) date and time value. You can use the convertToLocalClientTime method to convert the end property value to the client's local date and time.
+         * The end property is a Date object expressed as a Coordinated Universal Time (UTC) date and time value. 
+         * You can use the convertToLocalClientTime method to convert the end property value to the client's local date and time.
          *
-         * When you use the Time.setAsync method to set the end time, you should use the convertToUtcClientTime method to convert the local time on the client to UTC for the server.
+         * When you use the Time.setAsync method to set the end time, you should use the convertToUtcClientTime method to convert the local time on 
+         * the client to UTC for the server.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1875,9 +2090,14 @@ export declare namespace Office {
         /**
          * Gets the Exchange Web Services item identifier for the current item.
          *
-         * The itemId property is not available in compose mode. If an item identifier is required, the saveAsync method can be used to save the item to the store, which will return the item identifier in the AsyncResult.value parameter in the callback function.
+         * The itemId property is not available in compose mode. 
+         * If an item identifier is required, the saveAsync method can be used to save the item to the store, which will return the item identifier 
+         * in the AsyncResult.value parameter in the callback function.
          *
-         * Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more details, see Use the Outlook REST APIs from an Outlook add-in.
+         * Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. 
+         * The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. 
+         * Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. 
+         * For more details, see {@link https://docs.microsoft.com/outlook/add-ins/use-rest-api#get-the-item-id | Use the Outlook REST APIs from an Outlook add-in}.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1919,7 +2139,8 @@ export declare namespace Office {
         /**
          * Gets the subject of an item, with all prefixes removed (including RE: and FWD:).
          *
-         * The normalizedSubject property gets the subject of the item, with any standard prefixes (such as RE: and FW:) that are added by email programs. To get the subject of the item with the prefixes intact, use the subject property.
+         * The normalizedSubject property gets the subject of the item, with any standard prefixes (such as RE: and FW:) that are added by email programs. 
+         * To get the subject of the item with the prefixes intact, use the subject property.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1945,7 +2166,8 @@ export declare namespace Office {
         /**
          * Provides access to the optional attendees of an event. The type of object and level of access depends on the mode of the current item.
          *
-         * The optionalAttendees property returns an array that contains an {@link Office.EmailAddressDetails} object for each optional attendee to the meeting.
+         * The optionalAttendees property returns an array that contains an {@link Office.EmailAddressDetails} object for each optional attendee to 
+         * the meeting.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1957,7 +2179,7 @@ export declare namespace Office {
          */
         optionalAttendees: EmailAddressDetails[];
         /**
-         * Gets the email address of the meeting organizer for a specified meeting. Read mode only.
+         * Gets the email address of the meeting organizer for a specified meeting.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1971,7 +2193,8 @@ export declare namespace Office {
         /**
          * Provides access to the required attendees of an event. The type of object and level of access depends on the mode of the current item.
          *
-         * The requiredAttendees property returns an array that contains an {@link Office.EmailAddressDetails} object for each required attendee to the meeting.
+         * The requiredAttendees property returns an array that contains an {@link Office.EmailAddressDetails} object for each required attendee to 
+         * the meeting.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1985,7 +2208,8 @@ export declare namespace Office {
         /**
          * Gets the date and time that the appointment is to begin.
          *
-         * The start property is a Date object expressed as a Coordinated Universal Time (UTC) date and time value. You can use the convertToLocalClientTime method to convert the value to the client's local date and time.
+         * The start property is a Date object expressed as a Coordinated Universal Time (UTC) date and time value. 
+         * You can use the convertToLocalClientTime method to convert the value to the client's local date and time.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -2012,14 +2236,18 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Appointment Attendee</td></tr></table>
          */
         subject: string;
+
         /**
-         * Displays a reply form that includes the sender and all recipients of the selected message or the organizer and all attendees of the selected appointment.
+         * Displays a reply form that includes the sender and all recipients of the selected message or the organizer and all attendees of the 
+         * selected appointment.
          *
          * In Outlook Web App, the reply form is displayed as a pop-out form in the 3-column view and a pop-up form in the 2- or 1-column view.
          *
          * If any of the string parameters exceed their limits, displayReplyAllForm throws an exception.
          *
-         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. If this isn't possible, then no error message is thrown.
+         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and 
+         * attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. 
+         * If this isn't possible, then no error message is thrown.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -2042,7 +2270,9 @@ export declare namespace Office {
          *
          * If any of the string parameters exceed their limits, displayReplyForm throws an exception.
          *
-         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. If this isn't possible, then no error message is thrown.
+         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and 
+         * attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. 
+         * If this isn't possible, then no error message is thrown.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -2060,7 +2290,7 @@ export declare namespace Office {
          */
         displayReplyForm(formData: string | ReplyFormData): void;
         /**
-         * Gets the entities found in the selected item.
+         * Gets the entities found in the selected item's body.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -2074,7 +2304,7 @@ export declare namespace Office {
          */
         getEntities(): Entities;
         /**
-         * Gets an array of all the entities of the specified entity type found in the selected item.
+         * Gets an array of all the entities of the specified entity type found in the selected item's body.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -2083,7 +2313,9 @@ export declare namespace Office {
          * @param entityType - One of the EntityType enumeration values.
          *
          * @returns
-         * If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. If no entities of the specified type are present on the item, the method returns an empty array. Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter.
+         * If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. 
+         * If no entities of the specified type are present in the item's body, the method returns an empty array. 
+         * Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter.
          *
          * @remarks
          * <table><tr><td>{@link https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions | Minimum permission level}</td><td>Restricted</td></tr>
@@ -2139,7 +2371,8 @@ export declare namespace Office {
         /**
          * Returns well-known entities in the selected item that pass the named filter defined in the manifest XML file.
          *
-         * The getFilteredEntitiesByName method returns the entities that match the regular expression defined in the ItemHasKnownEntity rule element in the manifest XML file with the specified FilterName element value.
+         * The getFilteredEntitiesByName method returns the entities that match the regular expression defined in the ItemHasKnownEntity rule element 
+         * in the manifest XML file with the specified FilterName element value.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -2152,22 +2385,33 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Appointment Attendee</td></tr></table>
          *
          * @param name - The name of the ItemHasKnownEntity rule element that defines the filter to match.
-         * @returns If there is no ItemHasKnownEntity element in the manifest with a FilterName element value that matches the name parameter, the method returns null. If the name parameter does match an ItemHasKnownEntity element in the manifest, but there are no entities in the current item that match, the method return an empty array.
+         * @returns If there is no ItemHasKnownEntity element in the manifest with a FilterName element value that matches the name parameter, 
+         * the method returns null. 
+         * If the name parameter does match an ItemHasKnownEntity element in the manifest, but there are no entities in the current item that match, 
+         * the method return an empty array.
          */
         getFilteredEntitiesByName(name: string): (string | Contact | MeetingSuggestion | PhoneNumber | TaskSuggestion)[];
         /**
          * Returns string values in the selected item that match the regular expressions defined in the manifest XML file.
          *
-         * The getRegExMatches method returns the strings that match the regular expression defined in each ItemHasRegularExpressionMatch or ItemHasKnownEntity rule element in the manifest XML file. For an ItemHasRegularExpressionMatch rule, a matching string has to occur in the property of the item that is specified by that rule. The PropertyName simple type defines the supported properties.
+         * The getRegExMatches method returns the strings that match the regular expression defined in each ItemHasRegularExpressionMatch or 
+         * ItemHasKnownEntity rule element in the manifest XML file. 
+         * For an ItemHasRegularExpressionMatch rule, a matching string has to occur in the property of the item that is specified by that rule. 
+         * The PropertyName simple type defines the supported properties.
          *
-         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body and should not attempt to return the entire body of the item. Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results. Instead, use the Body.getAsync method to retrieve the entire body.
+         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body 
+         * and should not attempt to return the entire body of the item. 
+         * Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results. 
+         * Instead, use the Body.getAsync method to retrieve the entire body.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
          * [Api set: Mailbox 1.0]
          *
          * @returns
-         * An object that contains arrays of strings that match the regular expressions defined in the manifest XML file. The name of each array is equal to the corresponding value of the RegExName attribute of the matching ItemHasRegularExpressionMatch rule or the FilterName attribute of the matching ItemHasKnownEntity rule.
+         * An object that contains arrays of strings that match the regular expressions defined in the manifest XML file. 
+         * The name of each array is equal to the corresponding value of the RegExName attribute of the matching ItemHasRegularExpressionMatch rule 
+         * or the FilterName attribute of the matching ItemHasKnownEntity rule.
          *
          * @remarks
          *
@@ -2179,9 +2423,12 @@ export declare namespace Office {
         /**
          * Returns string values in the selected item that match the named regular expression defined in the manifest XML file.
          *
-         * The getRegExMatchesByName method returns the strings that match the regular expression defined in the ItemHasRegularExpressionMatch rule element in the manifest XML file with the specified RegExName element value.
+         * The getRegExMatchesByName method returns the strings that match the regular expression defined in the ItemHasRegularExpressionMatch rule 
+         * element in the manifest XML file with the specified RegExName element value.
          *
-         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body and should not attempt to return the entire body of the item. Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results.
+         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body 
+         * and should not attempt to return the entire body of the item. 
+         * Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -2199,12 +2446,16 @@ export declare namespace Office {
          * @param name - The name of the ItemHasRegularExpressionMatch rule element that defines the filter to match.
          */
         getRegExMatchesByName(name: string): string[];
-       /**
+        /**
         * Asynchronously loads custom properties for this add-in on the selected item.
         *
-        * Custom properties are stored as key/value pairs on a per-app, per-item basis. This method returns a CustomProperties object in the callback, which provides methods to access the custom properties specific to the current item and the current add-in. Custom properties are not encrypted on the item, so this should not be used as secure storage.
+        * Custom properties are stored as key/value pairs on a per-app, per-item basis. 
+        * This method returns a CustomProperties object in the callback, which provides methods to access the custom properties specific to the 
+        * current item and the current add-in. Custom properties are not encrypted on the item, so this should not be used as secure storage.
         *
-        * The custom properties are provided as a CustomProperties object in the asyncResult.value property. This object can be used to get, set, and remove custom properties from the item and save changes to the custom property set back to the server.
+        * The custom properties are provided as a CustomProperties object in the asyncResult.value property. 
+        * This object can be used to get, set, and remove custom properties from the item and save changes to the custom property set back to 
+        * the server.
         *
         * [Api set: Mailbox 1.0]
         *
@@ -2214,14 +2465,17 @@ export declare namespace Office {
         *
         * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Appointment Attendee</td></tr></table>
         *
-        * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
-        * @param userContext - Optional. Developers can provide any object they wish to access in the callback function. This object can be accessed by the asyncResult.asyncContext property in the callback function.
+        * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+        *                 type Office.AsyncResult.
+        * @param userContext - Optional. Developers can provide any object they wish to access in the callback function. 
+        *                    This object can be accessed by the asyncResult.asyncContext property in the callback function.
         */
-       loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;
+       loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any): void;
     }
 
     /**
-     * The item namespace is used to access the currently selected message, meeting request, or appointment. You can determine the type of the item by using the `itemType` property.
+     * The item namespace is used to access the currently selected message, meeting request, or appointment. 
+     * You can determine the type of the item by using the `itemType` property.
      *
      * [Api set: Mailbox 1.0]
      *
@@ -2272,7 +2526,8 @@ export declare namespace Office {
         /**
          * Gets the type of item that an instance represents.
          *
-         * The itemType property returns one of the ItemType enumeration values, indicating whether the item object instance is a message or an appointment.
+         * The itemType property returns one of the ItemType enumeration values, indicating whether the item object instance is a message or 
+         * an appointment.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -2299,9 +2554,13 @@ export declare namespace Office {
        /**
         * Asynchronously loads custom properties for this add-in on the selected item.
         *
-        * Custom properties are stored as key/value pairs on a per-app, per-item basis. This method returns a CustomProperties object in the callback, which provides methods to access the custom properties specific to the current item and the current add-in. Custom properties are not encrypted on the item, so this should not be used as secure storage.
+        * Custom properties are stored as key/value pairs on a per-app, per-item basis. 
+        * This method returns a CustomProperties object in the callback, which provides methods to access the custom properties specific to the 
+        * current item and the current add-in. Custom properties are not encrypted on the item, so this should not be used as secure storage.
         *
-        * The custom properties are provided as a CustomProperties object in the asyncResult.value property. This object can be used to get, set, and remove custom properties from the item and save changes to the custom property set back to the server.
+        * The custom properties are provided as a CustomProperties object in the asyncResult.value property. 
+        * This object can be used to get, set, and remove custom properties from the item and save changes to the custom property set back to 
+        * the server.
         *
         * [Api set: Mailbox 1.0]
         *
@@ -2311,15 +2570,18 @@ export declare namespace Office {
         *
         * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
         *
-        * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
-        * @param userContext - Optional. Developers can provide any object they wish to access in the callback function. This object can be accessed by the asyncResult.asyncContext property in the callback function.
+        * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+        *                 type Office.AsyncResult.
+        * @param userContext - Optional. Developers can provide any object they wish to access in the callback function. 
+        *                    This object can be accessed by the asyncResult.asyncContext property in the callback function.
         */
-       loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;
+       loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any): void;
     }
     /**
      * The compose mode of {@link Office.Item | Office.context.mailbox.item}.
      * 
-     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
+     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. 
+     * You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
      */
     export interface ItemCompose extends Item {
         /**
@@ -2360,16 +2622,20 @@ export declare namespace Office {
          * 
          * `addFileAttachmentAsync(uri: string, attachmentName: string, options: Office.AsyncContextOptions): void;`
          * 
-         * `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+         * `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;`
          *
          * @param uri - The URI that provides the location of the file to attach to the message or appointment. The maximum length is 2048 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         *        isInline: If true, indicates that the attachment will be shown inline in the message body, and should not be displayed in the attachment list.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type asyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         *        isInline: If true, indicates that the attachment will be shown inline in the message body, and should not be displayed in the 
+         *        attachment list.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type asyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of 
+         *                 the error.
          */
-        addFileAttachmentAsync(uri: string, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        addFileAttachmentAsync(uri: string, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;
         /**
          * Adds a file to a message or appointment as an attachment.
          *
@@ -2410,7 +2676,8 @@ export declare namespace Office {
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         *        isInline: If true, indicates that the attachment will be shown inline in the message body, and should not be displayed in the attachment list.
+         *        isInline: If true, indicates that the attachment will be shown inline in the message body, and should not be displayed in the 
+         *        attachment list.
          */
         addFileAttachmentAsync(uri: string, attachmentName: string, options: Office.AsyncContextOptions): void;
         /**
@@ -2431,18 +2698,25 @@ export declare namespace Office {
          *
          * @param uri - The URI that provides the location of the file to attach to the message or appointment. The maximum length is 2048 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type asyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of 
+         *                 the error.
          */
-        addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;
+        addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;
 
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the 
+         * callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -2453,29 +2727,36 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>NumberOfAttachmentsExceeded - The message or appointment has too many attachments.</td></tr></table>
          * 
-         * In addition to the main signature, this method also has these signatures:
+         * In addition to this signature, this method also has the following signatures:
          * 
          * `addItemAttachmentAsync(itemId: any, attachmentName: string): void;`
          * 
          * `addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;`
          * 
-         * `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+         * `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;`
          *
          * @param itemId - The Exchange identifier of the item to attach. The maximum length is 100 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
          * @param options - An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of 
+         *                 the error.
          */
-        addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the 
+         * callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -2493,11 +2774,15 @@ export declare namespace Office {
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the 
+         * callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -2517,11 +2802,15 @@ export declare namespace Office {
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the 
+         * callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -2534,18 +2823,23 @@ export declare namespace Office {
          *
          * @param itemId - The Exchange identifier of the item to attach. The maximum length is 100 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of 
+         *                 the error.
          */
-        addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;
+        addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;
 
         /**
          * Closes the current item that is being composed
          *
-         * The behaviors of the close method depends on the current state of the item being composed. If the item has unsaved changes, the client prompts the user to save, discard, or close the action.
+         * The behaviors of the close method depends on the current state of the item being composed. 
+         * If the item has unsaved changes, the client prompts the user to save, discard, or close the action.
          *
          * In the Outlook desktop client, if the message is an inline reply, the close method has no effect.
          *
-         * Note: In Outlook on the web, if the item is an appointment and it has previously been saved using saveAsync, the user is prompted to save, discard, or cancel even if no changes have occurred since the item was last saved.
+         * Note: In Outlook on the web, if the item is an appointment and it has previously been saved using saveAsync, the user is prompted to save, 
+         * discard, or cancel even if no changes have occurred since the item was last saved.
          *
          * [Api set: Mailbox 1.3]
          *
@@ -2559,9 +2853,11 @@ export declare namespace Office {
         /**
          * Asynchronously returns selected data from the subject or body of a message.
          *
-         * If there is no selection but the cursor is in the body or subject, the method returns null for the selected data. If a field other than the body or subject is selected, the method returns the InvalidSelection error.
+         * If there is no selection but the cursor is in the body or subject, the method returns null for the selected data. 
+         * If a field other than the body or subject is selected, the method returns the InvalidSelection error.
          *
-         * To access the selected data from the callback method, call asyncResult.value.data. To access the source property that the selection comes from, call asyncResult.value.sourceProperty, which will be either body or subject.
+         * To access the selected data from the callback method, call asyncResult.value.data. To access the source property that the selection comes 
+         * from, call asyncResult.value.sourceProperty, which will be either body or subject.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -2574,16 +2870,20 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose</td></tr></table>
          *
-         * @param coercionType - Requests a format for the data. If Text, the method returns the plain text as a string , removing any HTML tags present. If HTML, the method returns the selected text, whether it is plaintext or HTML.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param coercionType - Requests a format for the data. If Text, the method returns the plain text as a string , removing any HTML tags present. 
+         *                     If HTML, the method returns the selected text, whether it is plaintext or HTML.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          */
-        getSelectedDataAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult) => void): void;
+        getSelectedDataAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult<any>) => void): void;
         /**
          * Asynchronously returns selected data from the subject or body of a message.
          *
-         * If there is no selection but the cursor is in the body or subject, the method returns null for the selected data. If a field other than the body or subject is selected, the method returns the InvalidSelection error.
+         * If there is no selection but the cursor is in the body or subject, the method returns null for the selected data. 
+         * If a field other than the body or subject is selected, the method returns the InvalidSelection error.
          *
-         * To access the selected data from the callback method, call asyncResult.value.data. To access the source property that the selection comes from, call asyncResult.value.sourceProperty, which will be either body or subject.
+         * To access the selected data from the callback method, call asyncResult.value.data. 
+         * To access the source property that the selection comes from, call asyncResult.value.sourceProperty, which will be either body or subject.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -2596,16 +2896,22 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose</td></tr></table>
          *
-         * @param coercionType - Requests a format for the data. If Text, the method returns the plain text as a string , removing any HTML tags present. If HTML, the method returns the selected text, whether it is plaintext or HTML.
+         * @param coercionType - Requests a format for the data. If Text, the method returns the plain text as a string, removing any HTML tags present. 
+         *                     If HTML, the method returns the selected text, whether it is plaintext or HTML.
          * @param options - An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          */
-        getSelectedDataAsync(coerciontype: Office.CoercionType, options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;
+        getSelectedDataAsync(coerciontype: Office.CoercionType, options: Office.AsyncContextOptions, callback: (result: AsyncResult<any>) => void): void;
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -2623,18 +2929,24 @@ export declare namespace Office {
          * 
          * `removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;`
          * 
-         * `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;`
+         * `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;`
          *
          * @param attachmentIndex - The identifier of the attachment to remove. The maximum length of the string is 100 characters.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. 
+         *                 If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
          */
-        removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -2652,7 +2964,11 @@ export declare namespace Office {
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -2672,7 +2988,11 @@ export declare namespace Office {
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -2685,18 +3005,26 @@ export declare namespace Office {
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
          * @param attachmentIndex - The identifier of the attachment to remove. The maximum length of the string is 100 characters.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type {@link Offfice.AsyncResult}. 
+         *                 If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
          */
-        removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;
+        removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;
 
         /**
          * Asynchronously saves an item.
          *
-         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. In Outlook Web App or Outlook in online mode, the item is saved to the server. In Outlook in cached mode, the item is saved to the local cache.
+         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. 
+         * In Outlook Web App or Outlook in online mode, the item is saved to the server. 
+         * In Outlook in cached mode, the item is saved to the local cache.
          *
-         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. Saving an existing appointment will send an update to added or removed attendees.
+         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal 
+         * appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. 
+         * Saving an existing appointment will send an update to added or removed attendees.
          *
-         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that when Outlook is in cached mode, it may take some time before the item is actually synced to the server. Until the item is synced, using the itemId will return an error.
+         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that 
+         * when Outlook is in cached mode, it may take some time before the item is actually synced to the server. 
+         * Until the item is synced, using the itemId will return an error.
          *
          * Note: The following clients have different behavior for saveAsync on appointments in compose mode:
          *
@@ -2720,21 +3048,29 @@ export declare namespace Office {
          * 
          * `saveAsync(options: Office.AsyncContextOptions): void;`
          * 
-         * `saveAsync(callback: (result: AsyncResult) => void): void;`
+         * `saveAsync(callback: (result: AsyncResult<void>) => void): void;`
          *
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. 
+         *                 If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
          */
-        saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Asynchronously saves an item.
          *
-         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. In Outlook Web App or Outlook in online mode, the item is saved to the server. In Outlook in cached mode, the item is saved to the local cache.
+         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. 
+         * In Outlook Web App or Outlook in online mode, the item is saved to the server. 
+         * In Outlook in cached mode, the item is saved to the local cache.
          *
-         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. Saving an existing appointment will send an update to added or removed attendees.
+         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal 
+         * appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. 
+         * Saving an existing appointment will send an update to added or removed attendees.
          *
-         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that when Outlook is in cached mode, it may take some time before the item is actually synced to the server. Until the item is synced, using the itemId will return an error.
+         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that 
+         * when Outlook is in cached mode, it may take some time before the item is actually synced to the server. 
+         * Until the item is synced, using the itemId will return an error.
          *
          * Note: The following clients have different behavior for saveAsync on appointments in compose mode:
          *
@@ -2757,11 +3093,17 @@ export declare namespace Office {
         /**
          * Asynchronously saves an item.
          *
-         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. In Outlook Web App or Outlook in online mode, the item is saved to the server. In Outlook in cached mode, the item is saved to the local cache.
+         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. 
+         * In Outlook Web App or Outlook in online mode, the item is saved to the server. 
+         * In Outlook in cached mode, the item is saved to the local cache.
          *
-         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. Saving an existing appointment will send an update to added or removed attendees.
+         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal 
+         * appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. 
+         * Saving an existing appointment will send an update to added or removed attendees.
          *
-         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that when Outlook is in cached mode, it may take some time before the item is actually synced to the server. Until the item is synced, using the itemId will return an error.
+         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that 
+         * when Outlook is in cached mode, it may take some time before the item is actually synced to the server. 
+         * Until the item is synced, using the itemId will return an error.
          *
          * Note: The following clients have different behavior for saveAsync on appointments in compose mode:
          *
@@ -2786,11 +3128,17 @@ export declare namespace Office {
         /**
          * Asynchronously saves an item.
          *
-         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. In Outlook Web App or Outlook in online mode, the item is saved to the server. In Outlook in cached mode, the item is saved to the local cache.
+         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. 
+         * In Outlook Web App or Outlook in online mode, the item is saved to the server. 
+         * In Outlook in cached mode, the item is saved to the local cache.
          *
-         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. Saving an existing appointment will send an update to added or removed attendees.
+         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal 
+         * appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. 
+         * Saving an existing appointment will send an update to added or removed attendees.
          *
-         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that when Outlook is in cached mode, it may take some time before the item is actually synced to the server. Until the item is synced, using the itemId will return an error.
+         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that 
+         * when Outlook is in cached mode, it may take some time before the item is actually synced to the server. 
+         * Until the item is synced, using the itemId will return an error.
          *
          * Note: The following clients have different behavior for saveAsync on appointments in compose mode:
          *
@@ -2808,13 +3156,17 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. 
+         *                 If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
          */
-        saveAsync(callback: (result: AsyncResult) => void): void;
+        saveAsync(callback: (result: AsyncResult<void>) => void): void;
         /**
          * Asynchronously inserts data into the body or subject of a message.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is 
+         * selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. 
+         * After insertion, the cursor is placed at the end of the inserted content.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -2832,19 +3184,29 @@ export declare namespace Office {
          * 
          * `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`
          * 
-         * `setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;`
+         * `setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;`
          *
-         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
+         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. 
+         *             If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         *        coercionType: If text, the current style is applied in Outlook Web App and Outlook. If the field is an HTML editor, only the text data is inserted, even if the data is HTML. If html and the field supports HTML (the subject doesn't), the current style is applied in Outlook Web App and the default style is applied in Outlook. If the field is a text field, an InvalidDataFormat error is returned. If coercionType is not set, the result depends on the field: if the field is HTML then HTML is used; if the field is text, then plain text is used.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         *        coercionType: If text, the current style is applied in Outlook Web App and Outlook. 
+         *        If the field is an HTML editor, only the text data is inserted, even if the data is HTML. 
+         *        If html and the field supports HTML (the subject doesn't), the current style is applied in Outlook Web App and the default style is 
+         *        applied in Outlook. 
+         *        If the field is a text field, an InvalidDataFormat error is returned. 
+         *        If coercionType is not set, the result depends on the field: if the field is HTML then HTML is used; 
+         *        if the field is text, then plain text is used.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. 
          */
-        setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult) => void): void;
+        setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Asynchronously inserts data into the body or subject of a message.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is 
+         * selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. 
+         * After insertion, the cursor is placed at the end of the inserted content.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -2856,13 +3218,16 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
-         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
+         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. 
+         *             If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
          */
         setSelectedDataAsync(data: string): void;
         /**
          * Asynchronously inserts data into the body or subject of a message.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is 
+         * selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. 
+         * After insertion, the cursor is placed at the end of the inserted content.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -2874,16 +3239,25 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
-         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
+         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. 
+         *             If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         *        coercionType: If text, the current style is applied in Outlook Web App and Outlook. If the field is an HTML editor, only the text data is inserted, even if the data is HTML. If html and the field supports HTML (the subject doesn't), the current style is applied in Outlook Web App and the default style is applied in Outlook. If the field is a text field, an InvalidDataFormat error is returned. If coercionType is not set, the result depends on the field: if the field is HTML then HTML is used; if the field is text, then plain text is used.
+         *        coercionType: If text, the current style is applied in Outlook Web App and Outlook. 
+         *        If the field is an HTML editor, only the text data is inserted, even if the data is HTML. 
+         *        If html and the field supports HTML (the subject doesn't), the current style is applied in Outlook Web App and the default style is 
+         *        applied in Outlook. 
+         *        If the field is a text field, an InvalidDataFormat error is returned. 
+         *        If coercionType is not set, the result depends on the field: if the field is HTML then HTML is used; 
+         *        if the field is text, then plain text is used.
          */
         setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;
         /**
          * Asynchronously inserts data into the body or subject of a message.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is 
+         * selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. 
+         * After insertion, the cursor is placed at the end of the inserted content.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -2895,19 +3269,22 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
-         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. 
+         *             If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. 
          */
-        setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;
+        setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;
     }
     /**
      * The read mode of {@link Office.Item | Office.context.mailbox.item}.
      * 
-     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
+     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. 
+     * You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
      */
     export interface ItemRead extends Item {
         /**
-         * Gets an array of attachments for the item.
+         * Gets the item's attachments as an array.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -2916,7 +3293,9 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Read</td></tr></table>
          *
-         * Note: Certain types of files are blocked by Outlook due to potential security issues and are therefore not returned. For more information, see {@link https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519 | Blocked attachments in Outlook}.
+         * Note: Certain types of files are blocked by Outlook due to potential security issues and are therefore not returned. 
+         * For more information, see 
+         * {@link https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519 | Blocked attachments in Outlook}.
          *
          */
         attachments: Office.AttachmentDetails[];
@@ -2924,7 +3303,8 @@ export declare namespace Office {
          * Gets the Exchange Web Services item class of the selected item.
          *
          *
-         * You can create custom message classes that extends a default message class, for example, a custom appointment message class IPM.Appointment.Contoso.
+         * You can create custom message classes that extends a default message class, for example, a custom appointment message class 
+         * IPM.Appointment.Contoso.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -2934,7 +3314,8 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Read</td></tr></table>
          * 
-         * The itemClass property specifies the message class of the selected item. The following are the default message classes for the message or appointment item.
+         * The itemClass property specifies the message class of the selected item. The following are the default message classes for the message or 
+         * appointment item.
          * 
          * <table>
          *   <tr>
@@ -2958,9 +3339,14 @@ export declare namespace Office {
         /**
          * Gets the Exchange Web Services item identifier for the current item.
          *
-         * The itemId property is not available in compose mode. If an item identifier is required, the saveAsync method can be used to save the item to the store, which will return the item identifier in the AsyncResult.value parameter in the callback function.
+         * The itemId property is not available in compose mode. 
+         * If an item identifier is required, the saveAsync method can be used to save the item to the store, which will return the item identifier 
+         * in the AsyncResult.value parameter in the callback function.
          *
-         * Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more details, see Use the Outlook REST APIs from an Outlook add-in.
+         * Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. 
+         * The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. 
+         * Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. 
+         * For more details, see {@link https://docs.microsoft.com/outlook/add-ins/use-rest-api#get-the-item-id | Use the Outlook REST APIs from an Outlook add-in}.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -2974,7 +3360,8 @@ export declare namespace Office {
         /**
          * Gets the subject of an item, with all prefixes removed (including RE: and FWD:).
          *
-         * The normalizedSubject property gets the subject of the item, with any standard prefixes (such as RE: and FW:) that are added by email programs. To get the subject of the item with the prefixes intact, use the subject property.
+         * The normalizedSubject property gets the subject of the item, with any standard prefixes (such as RE: and FW:) that are added by 
+         * email programs. To get the subject of the item with the prefixes intact, use the subject property.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -3002,13 +3389,16 @@ export declare namespace Office {
          */
         subject: string;
         /**
-         * Displays a reply form that includes the sender and all recipients of the selected message or the organizer and all attendees of the selected appointment.
+         * Displays a reply form that includes the sender and all recipients of the selected message or the organizer and all attendees of the 
+         * selected appointment.
          *
          * In Outlook Web App, the reply form is displayed as a pop-out form in the 3-column view and a pop-up form in the 2- or 1-column view.
          *
          * If any of the string parameters exceed their limits, displayReplyAllForm throws an exception.
          *
-         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. If this isn't possible, then no error message is thrown.
+         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and 
+         * attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. 
+         * If this isn't possible, then no error message is thrown.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -3031,7 +3421,9 @@ export declare namespace Office {
          *
          * If any of the string parameters exceed their limits, displayReplyForm throws an exception.
          *
-         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. If this isn't possible, then no error message is thrown.
+         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and 
+         * attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. 
+         * If this isn't possible, then no error message is thrown.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -3049,7 +3441,7 @@ export declare namespace Office {
          */
         displayReplyForm(formData: string | ReplyFormData): void;
         /**
-         * Gets the entities found in the selected item.
+         * Gets the entities found in the selected item's body.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -3063,7 +3455,7 @@ export declare namespace Office {
          */
         getEntities(): Entities;
         /**
-         * Gets an array of all the entities of the specified entity type found in the selected item.
+         * Gets an array of all the entities of the specified entity type found in the selected item's body.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -3072,14 +3464,17 @@ export declare namespace Office {
          * @param entityType - One of the EntityType enumeration values.
          *
          * @returns
-         * If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. If no entities of the specified type are present on the item, the method returns an empty array. Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter.
+         * If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. 
+         * If no entities of the specified type are present in the item's body, the method returns an empty array. 
+         * Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter.
          *
          * @remarks
          * <table><tr><td>{@link https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions | Minimum permission level}</td><td>Restricted</td></tr>
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Read</td></tr></table>
          * 
-         * While the minimum permission level to use this method is Restricted, some entity types require ReadItem to access, as specified in the following table.
+         * While the minimum permission level to use this method is Restricted, some entity types require ReadItem to access, as specified in the 
+         * following table.
          * 
          * <table>
          *   <tr>
@@ -3128,7 +3523,8 @@ export declare namespace Office {
         /**
          * Returns well-known entities in the selected item that pass the named filter defined in the manifest XML file.
          *
-         * The getFilteredEntitiesByName method returns the entities that match the regular expression defined in the ItemHasKnownEntity rule element in the manifest XML file with the specified FilterName element value.
+         * The getFilteredEntitiesByName method returns the entities that match the regular expression defined in the ItemHasKnownEntity rule element 
+         * in the manifest XML file with the specified FilterName element value.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -3141,22 +3537,33 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Read</td></tr></table>
          *
          * @param name - The name of the ItemHasKnownEntity rule element that defines the filter to match.
-         * @returns If there is no ItemHasKnownEntity element in the manifest with a FilterName element value that matches the name parameter, the method returns null. If the name parameter does match an ItemHasKnownEntity element in the manifest, but there are no entities in the current item that match, the method return an empty array.
+         * @returns If there is no ItemHasKnownEntity element in the manifest with a FilterName element value that matches the name parameter, 
+         * the method returns null. 
+         * If the name parameter does match an ItemHasKnownEntity element in the manifest, but there are no entities in the current item that match, 
+         * the method return an empty array.
          */
         getFilteredEntitiesByName(name: string): (string | Contact | MeetingSuggestion | PhoneNumber | TaskSuggestion)[];
         /**
          * Returns string values in the selected item that match the regular expressions defined in the manifest XML file.
          *
-         * The getRegExMatches method returns the strings that match the regular expression defined in each ItemHasRegularExpressionMatch or ItemHasKnownEntity rule element in the manifest XML file. For an ItemHasRegularExpressionMatch rule, a matching string has to occur in the property of the item that is specified by that rule. The PropertyName simple type defines the supported properties.
+         * The getRegExMatches method returns the strings that match the regular expression defined in each ItemHasRegularExpressionMatch or 
+         * ItemHasKnownEntity rule element in the manifest XML file. 
+         * For an ItemHasRegularExpressionMatch rule, a matching string has to occur in the property of the item that is specified by that rule. 
+         * The PropertyName simple type defines the supported properties.
          *
-         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body and should not attempt to return the entire body of the item. Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results. Instead, use the Body.getAsync method to retrieve the entire body.
+         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body 
+         * and should not attempt to return the entire body of the item. 
+         * Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results. 
+         * Instead, use the Body.getAsync method to retrieve the entire body.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
          * [Api set: Mailbox 1.0]
          *
          * @returns
-         * An object that contains arrays of strings that match the regular expressions defined in the manifest XML file. The name of each array is equal to the corresponding value of the RegExName attribute of the matching ItemHasRegularExpressionMatch rule or the FilterName attribute of the matching ItemHasKnownEntity rule.
+         * An object that contains arrays of strings that match the regular expressions defined in the manifest XML file. 
+         * The name of each array is equal to the corresponding value of the RegExName attribute of the matching ItemHasRegularExpressionMatch rule 
+         * or the FilterName attribute of the matching ItemHasKnownEntity rule.
          *
          * @remarks
          *
@@ -3168,9 +3575,12 @@ export declare namespace Office {
         /**
          * Returns string values in the selected item that match the named regular expression defined in the manifest XML file.
          *
-         * The getRegExMatchesByName method returns the strings that match the regular expression defined in the ItemHasRegularExpressionMatch rule element in the manifest XML file with the specified RegExName element value.
+         * The getRegExMatchesByName method returns the strings that match the regular expression defined in the ItemHasRegularExpressionMatch rule 
+         * element in the manifest XML file with the specified RegExName element value.
          *
-         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body and should not attempt to return the entire body of the item. Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results.
+         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body 
+         * and should not attempt to return the entire body of the item. 
+         * Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -3192,15 +3602,19 @@ export declare namespace Office {
     /**
      * A subclass of {@link Office.Item} for messages.
      * 
-     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
+     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. 
+     * You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
      */
     export interface Message extends Item {
         /**
          * Gets an identifier for the email conversation that contains a particular message.
          *
-         * You can get an integer for this property if your mail app is activated in read forms or responses in compose forms. If subsequently the user changes the subject of the reply message, upon sending the reply, the conversation ID for that message will change and that value you obtained earlier will no longer apply.
+         * You can get an integer for this property if your mail app is activated in read forms or responses in compose forms. 
+         * If subsequently the user changes the subject of the reply message, upon sending the reply, the conversation ID for that message will 
+         * change and that value you obtained earlier will no longer apply.
          *
-         * You get null for this property for a new item in a compose form. If the user sets a subject and saves the item, the conversationId property will return a value.
+         * You get null for this property for a new item in a compose form. 
+         * If the user sets a subject and saves the item, the conversationId property will return a value.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -3216,7 +3630,8 @@ export declare namespace Office {
      /**
      * The message compose mode of {@link Office.Item | Office.context.mailbox.item}.
      * 
-     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
+     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. 
+     * You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
      */
     export interface MessageCompose extends Message, ItemCompose {
         /**
@@ -3244,9 +3659,11 @@ export declare namespace Office {
          */
         body: Office.Body;
         /**
-         * Provides access to the Cc (carbon copy) recipients of a message. The type of object and level of access depends on the mode of the current item.
+         * Provides access to the Cc (carbon copy) recipients of a message. The type of object and level of access depends on the mode of the 
+         * current item.
          *
-         * The cc property returns a {@link Office.Recipients} object that provides methods to get or update the recipients on the Cc line of the message.
+         * The cc property returns a {@link Office.Recipients} object that provides methods to get or update the recipients on the Cc line of 
+         * the message.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -3260,9 +3677,12 @@ export declare namespace Office {
         /**
          * Gets an identifier for the email conversation that contains a particular message.
          *
-         * You can get an integer for this property if your mail app is activated in read forms or responses in compose forms. If subsequently the user changes the subject of the reply message, upon sending the reply, the conversation ID for that message will change and that value you obtained earlier will no longer apply.
+         * You can get an integer for this property if your mail app is activated in read forms or responses in compose forms. 
+         * If subsequently the user changes the subject of the reply message, upon sending the reply, the conversation ID for that message will change 
+         * and that value you obtained earlier will no longer apply.
          *
-         * You get null for this property for a new item in a compose form. If the user sets a subject and saves the item, the conversationId property will return a value.
+         * You get null for this property for a new item in a compose form. 
+         * If the user sets a subject and saves the item, the conversationId property will return a value.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -3302,7 +3722,8 @@ export declare namespace Office {
         /**
          * Gets the type of item that an instance represents.
          *
-         * The itemType property returns one of the ItemType enumeration values, indicating whether the item object instance is a message or an appointment.
+         * The itemType property returns one of the ItemType enumeration values, indicating whether the item object instance is a message or 
+         * an appointment.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -3342,7 +3763,8 @@ export declare namespace Office {
          */
         subject: Subject;
         /**
-         * Provides access to the recipients on the To line of a message. The type of object and level of access depends on the mode of the current item.
+         * Provides access to the recipients on the To line of a message. The type of object and level of access depends on the mode of the 
+         * current item.
          *
          * The to property returns a Recipients object that provides methods to get or update the recipients on the To line of the message.
          *
@@ -3378,16 +3800,20 @@ export declare namespace Office {
          * 
          * `addFileAttachmentAsync(uri: string, attachmentName: string, options: AsyncContextOptions): void;`
          * 
-         * `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+         * `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;`
          *
          * @param uri - The URI that provides the location of the file to attach to the message or appointment. The maximum length is 2048 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         *        isInline: If true, indicates that the attachment will be shown inline in the message body, and should not be displayed in the attachment list.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type asyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         *        isInline: If true, indicates that the attachment will be shown inline in the message body, and should not be displayed in the 
+         *        attachment list.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of 
+         *                 the error.
          */
-        addFileAttachmentAsync(uri: string, attachmentName: string, options?: AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        addFileAttachmentAsync(uri: string, attachmentName: string, options?: AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;
         /**
          * Adds a file to a message or appointment as an attachment.
          *
@@ -3428,7 +3854,7 @@ export declare namespace Office {
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         *        isInline: If true, indicates that the attachment will be shown inline in the message body, and should not be displayed in the attachment list.
+         *        isInline: If true, indicates that the attachment will be shown inline in the message body and should not be displayed in the attachment list.
          */
         addFileAttachmentAsync(uri: string, attachmentName: string, options: AsyncContextOptions): void;
         /**
@@ -3449,17 +3875,24 @@ export declare namespace Office {
          *
          * @param uri - The URI that provides the location of the file to attach to the message or appointment. The maximum length is 2048 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type asyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of 
+         *                 the error.
          */
-        addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;
+        addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the 
+         * callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -3470,29 +3903,36 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>NumberOfAttachmentsExceeded - The message or appointment has too many attachments.</td></tr></table>
          * 
-         * In addition to the main signature, this method also has these signatures:
+         * In addition to this signature, this method also has the following signatures:
          * 
          * `addItemAttachmentAsync(itemId: any, attachmentName: string): void;`
          * 
          * `addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;`
          * 
-         * `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+         * `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;`
          *
          * @param itemId - The Exchange identifier of the item to attach. The maximum length is 100 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
          * @param options - An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of 
+         *                 the error.
          */
-        addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. 
+         * You can use the options parameter to pass state information to the callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -3510,11 +3950,15 @@ export declare namespace Office {
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. 
+         * You can use the options parameter to pass state information to the callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -3534,11 +3978,15 @@ export declare namespace Office {
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. 
+         * You can use the options parameter to pass state information to the callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -3551,17 +3999,22 @@ export declare namespace Office {
          *
          * @param itemId - The Exchange identifier of the item to attach. The maximum length is 100 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of 
+         *                 the error.
          */
-        addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;
+        addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;
         /**
          * Closes the current item that is being composed
          *
-         * The behaviors of the close method depends on the current state of the item being composed. If the item has unsaved changes, the client prompts the user to save, discard, or close the action.
+         * The behaviors of the close method depends on the current state of the item being composed. 
+         * If the item has unsaved changes, the client prompts the user to save, discard, or close the action.
          *
          * In the Outlook desktop client, if the message is an inline reply, the close method has no effect.
          *
-         * Note: In Outlook on the web, if the item is an appointment and it has previously been saved using saveAsync, the user is prompted to save, discard, or cancel even if no changes have occurred since the item was last saved.
+         * Note: In Outlook on the web, if the item is an appointment and it has previously been saved using saveAsync, the user is prompted to save, 
+         * discard, or cancel even if no changes have occurred since the item was last saved.
          *
          * [Api set: Mailbox 1.3]
          *
@@ -3575,9 +4028,11 @@ export declare namespace Office {
         /**
          * Asynchronously returns selected data from the subject or body of a message.
          *
-         * If there is no selection but the cursor is in the body or subject, the method returns null for the selected data. If a field other than the body or subject is selected, the method returns the InvalidSelection error.
+         * If there is no selection but the cursor is in the body or subject, the method returns null for the selected data. 
+         * If a field other than the body or subject is selected, the method returns the InvalidSelection error.
          *
-         * To access the selected data from the callback method, call asyncResult.value.data. To access the source property that the selection comes from, call asyncResult.value.sourceProperty, which will be either body or subject.
+         * To access the selected data from the callback method, call asyncResult.value.data. 
+         * To access the source property that the selection comes from, call asyncResult.value.sourceProperty, which will be either body or subject.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -3590,16 +4045,20 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Message Compose</td></tr></table>
          *
-         * @param coercionType - Requests a format for the data. If Text, the method returns the plain text as a string , removing any HTML tags present. If HTML, the method returns the selected text, whether it is plaintext or HTML.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param coercionType - Requests a format for the data. If Text, the method returns the plain text as a string, removing any HTML tags present. 
+         *                     If HTML, the method returns the selected text, whether it is plaintext or HTML.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          */
-        getSelectedDataAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult) => void): void;
+        getSelectedDataAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult<any>) => void): void;
         /**
          * Asynchronously returns selected data from the subject or body of a message.
          *
-         * If there is no selection but the cursor is in the body or subject, the method returns null for the selected data. If a field other than the body or subject is selected, the method returns the InvalidSelection error.
+         * If there is no selection but the cursor is in the body or subject, the method returns null for the selected data. 
+         * If a field other than the body or subject is selected, the method returns the InvalidSelection error.
          *
-         * To access the selected data from the callback method, call asyncResult.value.data. To access the source property that the selection comes from, call asyncResult.value.sourceProperty, which will be either body or subject.
+         * To access the selected data from the callback method, call asyncResult.value.data. 
+         * To access the source property that the selection comes from, call asyncResult.value.sourceProperty, which will be either body or subject.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -3612,18 +4071,24 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Message Compose</td></tr></table>
          *
-         * @param coercionType - Requests a format for the data. If Text, the method returns the plain text as a string , removing any HTML tags present. If HTML, the method returns the selected text, whether it is plaintext or HTML.
+         * @param coercionType - Requests a format for the data. If Text, the method returns the plain text as a string, removing any HTML tags present. 
+         *                     If HTML, the method returns the selected text, whether it is plaintext or HTML.
          * @param options - An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          */
-        getSelectedDataAsync(coerciontype: Office.CoercionType, options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;
+        getSelectedDataAsync(coerciontype: Office.CoercionType, options: Office.AsyncContextOptions, callback: (result: AsyncResult<any>) => void): void;
         /**
          * Asynchronously loads custom properties for this add-in on the selected item.
          *
-         * Custom properties are stored as key/value pairs on a per-app, per-item basis. This method returns a CustomProperties object in the callback, which provides methods to access the custom properties specific to the current item and the current add-in. Custom properties are not encrypted on the item, so this should not be used as secure storage.
+         * Custom properties are stored as key/value pairs on a per-app, per-item basis. 
+         * This method returns a CustomProperties object in the callback, which provides methods to access the custom properties specific to the 
+         * current item and the current add-in. Custom properties are not encrypted on the item, so this should not be used as secure storage.
          *
-         * The custom properties are provided as a CustomProperties object in the asyncResult.value property. This object can be used to get, set, and remove custom properties from the item and save changes to the custom property set back to the server.
+         * The custom properties are provided as a CustomProperties object in the asyncResult.value property. 
+         * This object can be used to get, set, and remove custom properties from the item and save changes to the custom property set back to 
+         * the server.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -3633,14 +4098,20 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Message Compose</td></tr></table>
          *
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
-         * @param userContext - Optional. Developers can provide any object they wish to access in the callback function. This object can be accessed by the asyncResult.asyncContext property in the callback function.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
+         * @param userContext - Optional. Developers can provide any object they wish to access in the callback function. 
+         *                    This object can be accessed by the asyncResult.asyncContext property in the callback function.
          */
-        loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;
+        loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any): void;
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -3658,18 +4129,24 @@ export declare namespace Office {
          * 
          * `removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;`
          * 
-         * `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;`
+         * `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;`
          *
          * @param attachmentIndex - The identifier of the attachment to remove. The maximum length of the string is 100 characters.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. 
+         *                 If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
          */
-        removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -3687,7 +4164,11 @@ export declare namespace Office {
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -3707,7 +4188,11 @@ export declare namespace Office {
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -3720,17 +4205,25 @@ export declare namespace Office {
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
          * @param attachmentIndex - The identifier of the attachment to remove. The maximum length of the string is 100 characters.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. 
+         *                 If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
          */
-        removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;
+        removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;
         /**
          * Asynchronously saves an item.
          *
-         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. In Outlook Web App or Outlook in online mode, the item is saved to the server. In Outlook in cached mode, the item is saved to the local cache.
+         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. 
+         * In Outlook Web App or Outlook in online mode, the item is saved to the server. 
+         * In Outlook in cached mode, the item is saved to the local cache.
          *
-         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. Saving an existing appointment will send an update to added or removed attendees.
+         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal 
+         * appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. 
+         * Saving an existing appointment will send an update to added or removed attendees.
          *
-         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that when Outlook is in cached mode, it may take some time before the item is actually synced to the server. Until the item is synced, using the itemId will return an error.
+         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that 
+         * when Outlook is in cached mode, it may take some time before the item is actually synced to the server. 
+         * Until the item is synced, using the itemId will return an error.
          *
          * Note: The following clients have different behavior for saveAsync on appointments in compose mode:
          *
@@ -3754,21 +4247,28 @@ export declare namespace Office {
          * 
          * `saveAsync(options: Office.AsyncContextOptions): void;`
          * 
-         * `saveAsync(callback: (result: AsyncResult) => void): void;`
+         * `saveAsync(callback: (result: AsyncResult<void>) => void): void;`
          *
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. 
          */
-        saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Asynchronously saves an item.
          *
-         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. In Outlook Web App or Outlook in online mode, the item is saved to the server. In Outlook in cached mode, the item is saved to the local cache.
+         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. 
+         * In Outlook Web App or Outlook in online mode, the item is saved to the server. 
+         * In Outlook in cached mode, the item is saved to the local cache.
          *
-         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. Saving an existing appointment will send an update to added or removed attendees.
+         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal 
+         * appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. 
+         * Saving an existing appointment will send an update to added or removed attendees.
          *
-         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that when Outlook is in cached mode, it may take some time before the item is actually synced to the server. Until the item is synced, using the itemId will return an error.
+         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that 
+         * when Outlook is in cached mode, it may take some time before the item is actually synced to the server. 
+         * Until the item is synced, using the itemId will return an error.
          *
          * Note: The following clients have different behavior for saveAsync on appointments in compose mode:
          *
@@ -3791,11 +4291,16 @@ export declare namespace Office {
         /**
          * Asynchronously saves an item.
          *
-         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. In Outlook Web App or Outlook in online mode, the item is saved to the server. In Outlook in cached mode, the item is saved to the local cache.
+         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. 
+         * In Outlook Web App or Outlook in online mode, the item is saved to the server. 
+         * In Outlook in cached mode, the item is saved to the local cache.
          *
-         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. Saving an existing appointment will send an update to added or removed attendees.
+         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal 
+         * appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. Saving an existing appointment will send an update to added or removed attendees.
          *
-         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that when Outlook is in cached mode, it may take some time before the item is actually synced to the server. Until the item is synced, using the itemId will return an error.
+         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that 
+         * when Outlook is in cached mode, it may take some time before the item is actually synced to the server. 
+         * Until the item is synced, using the itemId will return an error.
          *
          * Note: The following clients have different behavior for saveAsync on appointments in compose mode:
          *
@@ -3820,11 +4325,17 @@ export declare namespace Office {
         /**
          * Asynchronously saves an item.
          *
-         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. In Outlook Web App or Outlook in online mode, the item is saved to the server. In Outlook in cached mode, the item is saved to the local cache.
+         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. 
+         * In Outlook Web App or Outlook in online mode, the item is saved to the server. 
+         * In Outlook in cached mode, the item is saved to the local cache.
          *
-         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. Saving an existing appointment will send an update to added or removed attendees.
+         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal 
+         * appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. 
+         * Saving an existing appointment will send an update to added or removed attendees.
          *
-         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that when Outlook is in cached mode, it may take some time before the item is actually synced to the server. Until the item is synced, using the itemId will return an error.
+         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that 
+         * when Outlook is in cached mode, it may take some time before the item is actually synced to the server. 
+         * Until the item is synced, using the itemId will return an error.
          *
          * Note: The following clients have different behavior for saveAsync on appointments in compose mode:
          *
@@ -3842,13 +4353,16 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. 
          */
-        saveAsync(callback: (result: AsyncResult) => void): void;
+        saveAsync(callback: (result: AsyncResult<void>) => void): void;
         /**
          * Asynchronously inserts data into the body or subject of a message.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is 
+         * selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. 
+         * After insertion, the cursor is placed at the end of the inserted content.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -3866,19 +4380,28 @@ export declare namespace Office {
          * 
          * `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`
          * 
-         * `setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;`
+         * `setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;`
          *
-         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
+         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. 
+         *             If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         *        coercionType: If text, the current style is applied in Outlook Web App and Outlook. If the field is an HTML editor, only the text data is inserted, even if the data is HTML. If html and the field supports HTML (the subject doesn't), the current style is applied in Outlook Web App and the default style is applied in Outlook. If the field is a text field, an InvalidDataFormat error is returned. If coercionType is not set, the result depends on the field: if the field is HTML then HTML is used; if the field is text, then plain text is used.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         *        coercionType: If text, the current style is applied in Outlook Web App and Outlook. 
+         *        If the field is an HTML editor, only the text data is inserted, even if the data is HTML. 
+         *        If html and the field supports HTML (the subject doesn't), the current style is applied in Outlook Web App and the default style is 
+         *        applied in Outlook. If the field is a text field, an InvalidDataFormat error is returned. 
+         *        If coercionType is not set, the result depends on the field: if the field is HTML then HTML is used; 
+         *        if the field is text, then plain text is used.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          */
-        setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult) => void): void;
+        setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Asynchronously inserts data into the body or subject of a message.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is 
+         * selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. 
+         * After insertion, the cursor is placed at the end of the inserted content.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -3890,13 +4413,16 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
-         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
+         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. 
+         *             If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
          */
         setSelectedDataAsync(data: string): void;
         /**
          * Asynchronously inserts data into the body or subject of a message.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is 
+         * selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. 
+         * After insertion, the cursor is placed at the end of the inserted content.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -3908,16 +4434,24 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
-         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
+         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. 
+         *             If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         *        coercionType: If text, the current style is applied in Outlook Web App and Outlook. If the field is an HTML editor, only the text data is inserted, even if the data is HTML. If html and the field supports HTML (the subject doesn't), the current style is applied in Outlook Web App and the default style is applied in Outlook. If the field is a text field, an InvalidDataFormat error is returned. If coercionType is not set, the result depends on the field: if the field is HTML then HTML is used; if the field is text, then plain text is used.
+         *        coercionType: If text, the current style is applied in Outlook Web App and Outlook. 
+         *        If the field is an HTML editor, only the text data is inserted, even if the data is HTML. 
+         *        If html and the field supports HTML (the subject doesn't), the current style is applied in Outlook Web App and the default style is 
+         *        applied in Outlook. If the field is a text field, an InvalidDataFormat error is returned. 
+         *        If coercionType is not set, the result depends on the field: if the field is HTML then HTML is used; 
+         *        if the field is text, then plain text is used.
          */
         setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;
         /**
          * Asynchronously inserts data into the body or subject of a message.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is 
+         * selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. 
+         * After insertion, the cursor is placed at the end of the inserted content.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -3929,19 +4463,22 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
-         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. 
+         *             If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 typeOffice.AsyncResult.
          */
-        setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;
+        setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;
     }
     /**
      * The message read mode of {@link Office.Item | Office.context.mailbox.item}.
      * 
-     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of Office.context.mailbox.item. Refer to the Object Model pages for more information.
+     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. 
+     * You should treat this as a mode of Office.context.mailbox.item. Refer to the Object Model pages for more information.
      */
     export interface MessageRead extends Message, ItemRead {
         /**
-         * Gets an array of attachments for the item.
+         * Gets the item's attachments as an array.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -3951,7 +4488,9 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Message Read</td></tr></table>
          * 
-         * Note: Certain types of files are blocked by Outlook due to potential security issues and are therefore not returned. For more information, see {@link https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519 | Blocked attachments in Outlook}.
+         * Note: Certain types of files are blocked by Outlook due to potential security issues and are therefore not returned. 
+         * For more information, see 
+         * {@link https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519 | Blocked attachments in Outlook}.
          *
          */
         attachments: Office.AttachmentDetails[];
@@ -3968,9 +4507,11 @@ export declare namespace Office {
          */
         body: Office.Body;
         /**
-         * Provides access to the Cc (carbon copy) recipients of a message. The type of object and level of access depends on the mode of the current item.
+         * Provides access to the Cc (carbon copy) recipients of a message. The type of object and level of access depends on the mode of the 
+         * current item.
          *
-         * The cc property returns an array that contains an EmailAddressDetails object for each recipient listed on the Cc line of the message. The collection is limited to a maximum of 100 members.
+         * The cc property returns an array that contains an EmailAddressDetails object for each recipient listed on the Cc line of the message. 
+         * The collection is limited to a maximum of 100 members.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -3984,9 +4525,12 @@ export declare namespace Office {
         /**
          * Gets an identifier for the email conversation that contains a particular message.
          *
-         * You can get an integer for this property if your mail app is activated in read forms or responses in compose forms. If subsequently the user changes the subject of the reply message, upon sending the reply, the conversation ID for that message will change and that value you obtained earlier will no longer apply.
+         * You can get an integer for this property if your mail app is activated in read forms or responses in compose forms. 
+         * If subsequently the user changes the subject of the reply message, upon sending the reply, the conversation ID for that message will change 
+         * and that value you obtained earlier will no longer apply.
          *
-         * You get null for this property for a new item in a compose form. If the user sets a subject and saves the item, the conversationId property will return a value.
+         * You get null for this property for a new item in a compose form. 
+         * If the user sets a subject and saves the item, the conversationId property will return a value.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -4026,7 +4570,8 @@ export declare namespace Office {
         /**
          * Gets the email address of the sender of a message.
          *
-         * The from and sender properties represent the same person unless the message is sent by a delegate. In that case, the from property represents the delegator, and the sender property represents the delegate.
+         * The from and sender properties represent the same person unless the message is sent by a delegate. 
+         * In that case, the from property represents the delegator, and the sender property represents the delegate.
          *
          * Note: The recipientType property of the EmailAddressDetails object in the from property is undefined.
          * 
@@ -4056,7 +4601,8 @@ export declare namespace Office {
         /**
          * Gets the Exchange Web Services item class of the selected item.
          * 
-         * You can create custom message classes that extends a default message class, for example, a custom appointment message class IPM.Appointment.Contoso.
+         * You can create custom message classes that extends a default message class, for example, a custom appointment message class 
+         * IPM.Appointment.Contoso.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -4066,7 +4612,8 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Message Read</td></tr></table>
 		 
-         * The itemClass property specifies the message class of the selected item. The following are the default message classes for the message or appointment item.
+         * The itemClass property specifies the message class of the selected item. 
+         * The following are the default message classes for the message or appointment item.
          * 
          * <table>
          *   <tr>
@@ -4091,9 +4638,14 @@ export declare namespace Office {
         /**
          * Gets the Exchange Web Services item identifier for the current item.
          *
-         * The itemId property is not available in compose mode. If an item identifier is required, the saveAsync method can be used to save the item to the store, which will return the item identifier in the AsyncResult.value parameter in the callback function.
+         * The itemId property is not available in compose mode. 
+         * If an item identifier is required, the saveAsync method can be used to save the item to the store, which will return the item identifier 
+         * in the AsyncResult.value parameter in the callback function.
          *
-         * Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more details, see Use the Outlook REST APIs from an Outlook add-in.
+         * Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. 
+         * The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. 
+         * Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. 
+         * For more details, see {@link https://docs.microsoft.com/outlook/add-ins/use-rest-api#get-the-item-id | Use the Outlook REST APIs from an Outlook add-in}.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -4107,7 +4659,8 @@ export declare namespace Office {
         /**
          * Gets the type of item that an instance represents.
          *
-         * The itemType property returns one of the ItemType enumeration values, indicating whether the item object instance is a message or an appointment.
+         * The itemType property returns one of the ItemType enumeration values, indicating whether the item object instance is a message or 
+         * an appointment.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -4121,7 +4674,9 @@ export declare namespace Office {
         /**
          * Gets the subject of an item, with all prefixes removed (including RE: and FWD:).
          *
-         * The normalizedSubject property gets the subject of the item, with any standard prefixes (such as RE: and FW:) that are added by email programs. To get the subject of the item with the prefixes intact, use the subject property.
+         * The normalizedSubject property gets the subject of the item, with any standard prefixes (such as RE: and FW:) that are added by 
+         * email programs. 
+         * To get the subject of the item with the prefixes intact, use the subject property.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -4147,7 +4702,8 @@ export declare namespace Office {
         /**
          * Gets the email address of the sender of an email message.
          *
-         * The from and sender properties represent the same person unless the message is sent by a delegate. In that case, the from property represents the delegator, and the sender property represents the delegate.
+         * The from and sender properties represent the same person unless the message is sent by a delegate. 
+         * In that case, the from property represents the delegator, and the sender property represents the delegate.
          *
          * Note: The recipientType property of the EmailAddressDetails object in the sender property is undefined.
          *
@@ -4177,9 +4733,11 @@ export declare namespace Office {
          */
         subject: string;
         /**
-         * Provides access to the recipients on the To line of a message. The type of object and level of access depends on the mode of the current item.
+         * Provides access to the recipients on the To line of a message. The type of object and level of access depends on the mode of the 
+         * current item.
          *
-         * The to property returns an array that contains an EmailAddressDetails object for each recipient listed on the To line of the message. The collection is limited to a maximum of 100 members.
+         * The to property returns an array that contains an EmailAddressDetails object for each recipient listed on the To line of the message. 
+         * The collection is limited to a maximum of 100 members.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -4190,14 +4748,18 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Message Read</td></tr></table>
          */
         to: EmailAddressDetails[];
+
         /**
-         * Displays a reply form that includes the sender and all recipients of the selected message or the organizer and all attendees of the selected appointment.
+         * Displays a reply form that includes the sender and all recipients of the selected message or the organizer and all attendees of the 
+         * selected appointment.
          *
          * In Outlook Web App, the reply form is displayed as a pop-out form in the 3-column view and a pop-up form in the 2- or 1-column view.
          *
          * If any of the string parameters exceed their limits, displayReplyAllForm throws an exception.
          *
-         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. If this isn't possible, then no error message is thrown.
+         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and 
+         * attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. 
+         * If this isn't possible, then no error message is thrown.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -4220,7 +4782,9 @@ export declare namespace Office {
          *
          * If any of the string parameters exceed their limits, displayReplyForm throws an exception.
          *
-         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. If this isn't possible, then no error message is thrown.
+         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and 
+         * attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. 
+         * If this isn't possible, then no error message is thrown.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -4238,7 +4802,7 @@ export declare namespace Office {
          */
         displayReplyForm(formData: string | ReplyFormData): void;
         /**
-         * Gets the entities found in the selected item.
+         * Gets the entities found in the selected item's body.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -4252,7 +4816,7 @@ export declare namespace Office {
          */
         getEntities(): Entities;
         /**
-         * Gets an array of all the entities of the specified entity type found in the selected item.
+         * Gets an array of all the entities of the specified entity type found in the selected item's body.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -4261,7 +4825,9 @@ export declare namespace Office {
          * @param entityType - One of the EntityType enumeration values.
          * 
          * @returns
-         * If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. If no entities of the specified type are present on the item, the method returns an empty array. Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter.
+         * If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. 
+         * If no entities of the specified type are present in the item's body, the method returns an empty array. 
+         * Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter.
          *
          * @remarks
          * 
@@ -4269,7 +4835,8 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Read</td></tr></table>
          * 
-         * While the minimum permission level to use this method is Restricted, some entity types require ReadItem to access, as specified in the following table.
+         * While the minimum permission level to use this method is Restricted, some entity types require ReadItem to access, as specified in the 
+         * following table.
          * 
          * <table>
          *   <tr>
@@ -4318,7 +4885,8 @@ export declare namespace Office {
         /**
          * Returns well-known entities in the selected item that pass the named filter defined in the manifest XML file.
          *
-         * The getFilteredEntitiesByName method returns the entities that match the regular expression defined in the ItemHasKnownEntity rule element in the manifest XML file with the specified FilterName element value.
+         * The getFilteredEntitiesByName method returns the entities that match the regular expression defined in the ItemHasKnownEntity rule element 
+         * in the manifest XML file with the specified FilterName element value.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -4331,22 +4899,33 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Message Read</td></tr></table>
          *
          * @param name - The name of the ItemHasKnownEntity rule element that defines the filter to match.
-         * @returns If there is no ItemHasKnownEntity element in the manifest with a FilterName element value that matches the name parameter, the method returns null. If the name parameter does match an ItemHasKnownEntity element in the manifest, but there are no entities in the current item that match, the method return an empty array.
+         * @returns If there is no ItemHasKnownEntity element in the manifest with a FilterName element value that matches the name parameter, 
+         * the method returns null. 
+         * If the name parameter does match an ItemHasKnownEntity element in the manifest, but there are no entities in the current item that match, 
+         * the method return an empty array.
          */
         getFilteredEntitiesByName(name: string): (string | Contact | MeetingSuggestion | PhoneNumber | TaskSuggestion)[];
         /**
          * Returns string values in the selected item that match the regular expressions defined in the manifest XML file.
          *
-         * The getRegExMatches method returns the strings that match the regular expression defined in each ItemHasRegularExpressionMatch or ItemHasKnownEntity rule element in the manifest XML file. For an ItemHasRegularExpressionMatch rule, a matching string has to occur in the property of the item that is specified by that rule. The PropertyName simple type defines the supported properties.
+         * The getRegExMatches method returns the strings that match the regular expression defined in each ItemHasRegularExpressionMatch or 
+         * ItemHasKnownEntity rule element in the manifest XML file. 
+         * For an ItemHasRegularExpressionMatch rule, a matching string has to occur in the property of the item that is specified by that rule. 
+         * The PropertyName simple type defines the supported properties.
          *
-         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body and should not attempt to return the entire body of the item. Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results. Instead, use the Body.getAsync method to retrieve the entire body.
+         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body 
+         * and should not attempt to return the entire body of the item. 
+         * Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results. 
+         * Instead, use the Body.getAsync method to retrieve the entire body.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
          * [Api set: Mailbox 1.0]
          *
          * @returns
-         * An object that contains arrays of strings that match the regular expressions defined in the manifest XML file. The name of each array is equal to the corresponding value of the RegExName attribute of the matching ItemHasRegularExpressionMatch rule or the FilterName attribute of the matching ItemHasKnownEntity rule.
+         * An object that contains arrays of strings that match the regular expressions defined in the manifest XML file. 
+         * The name of each array is equal to the corresponding value of the RegExName attribute of the matching ItemHasRegularExpressionMatch rule 
+         * or the FilterName attribute of the matching ItemHasKnownEntity rule.
          *
          * @remarks
          *
@@ -4358,9 +4937,12 @@ export declare namespace Office {
         /**
          * Returns string values in the selected item that match the named regular expression defined in the manifest XML file.
          *
-         * The getRegExMatchesByName method returns the strings that match the regular expression defined in the ItemHasRegularExpressionMatch rule element in the manifest XML file with the specified RegExName element value.
+         * The getRegExMatchesByName method returns the strings that match the regular expression defined in the ItemHasRegularExpressionMatch rule 
+         * element in the manifest XML file with the specified RegExName element value.
          *
-         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body and should not attempt to return the entire body of the item. Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results.
+         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body 
+         * and should not attempt to return the entire body of the item. 
+         * Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -4381,9 +4963,13 @@ export declare namespace Office {
         /**
          * Asynchronously loads custom properties for this add-in on the selected item.
          *
-         * Custom properties are stored as key/value pairs on a per-app, per-item basis. This method returns a CustomProperties object in the callback, which provides methods to access the custom properties specific to the current item and the current add-in. Custom properties are not encrypted on the item, so this should not be used as secure storage.
+         * Custom properties are stored as key/value pairs on a per-app, per-item basis. 
+         * This method returns a CustomProperties object in the callback, which provides methods to access the custom properties specific to the 
+         * current item and the current add-in. Custom properties are not encrypted on the item, so this should not be used as secure storage.
          *
-         * The custom properties are provided as a CustomProperties object in the asyncResult.value property. This object can be used to get, set, and remove custom properties from the item and save changes to the custom property set back to the server.
+         * The custom properties are provided as a CustomProperties object in the asyncResult.value property. 
+         * This object can be used to get, set, and remove custom properties from the item and save changes to the custom property set back to 
+         * the server.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -4393,10 +4979,12 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Message Read</td></tr></table>
          *
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
-         * @param userContext - Optional. Developers can provide any object they wish to access in the callback function. This object can be accessed by the asyncResult.asyncContext property in the callback function.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
+         * @param userContext - Optional. Developers can provide any object they wish to access in the callback function. 
+         *                    This object can be accessed by the asyncResult.asyncContext property in the callback function.
          */
-        loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;
+        loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any): void;
     }
 
     /**
@@ -4458,11 +5046,13 @@ export declare namespace Office {
         /**
          * Gets the location of an appointment.
          *
-         * The getAsync method starts an asynchronous call to the Exchange server to get the location of an appointment. The location of the appointment is provided as a string in the asyncResult.value property.
+         * The getAsync method starts an asynchronous call to the Exchange server to get the location of an appointment. 
+         * The location of the appointment is provided as a string in the asyncResult.value property.
          *
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -4473,16 +5063,18 @@ export declare namespace Office {
          * 
          * In addition to this signature, the method also has the following signature:
          * 
-         * `getAsync(callback: (result: AsyncResult) => void): void;`
+         * `getAsync(callback: (result: AsyncResult<string>) => void): void;`
          * 
          */
-        getAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        getAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;
         /**
          * Gets the location of an appointment.
          *
-         * The getAsync method starts an asynchronous call to the Exchange server to get the location of an appointment. The location of the appointment is provided as a string in the asyncResult.value property.
+         * The getAsync method starts an asynchronous call to the Exchange server to get the location of an appointment. 
+         * The location of the appointment is provided as a string in the asyncResult.value property.
          *
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -4491,16 +5083,18 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose</td></tr></table>
          */
-        getAsync(callback: (result: AsyncResult) => void): void;
+        getAsync(callback: (result: AsyncResult<string>) => void): void;
         /**
          * Sets the location of an appointment.
          *
-         * The setAsync method starts an asynchronous call to the Exchange server to set the location of an appointment. Setting the location of an appointment overwrites the current location.
+         * The setAsync method starts an asynchronous call to the Exchange server to set the location of an appointment. 
+         * Setting the location of an appointment overwrites the current location.
          *
          * @param location - The location of the appointment. The string is limited to 255 characters.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.  If setting the location fails, the asyncResult.error property will contain an error code.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. If setting the location fails, the asyncResult.error property will contain an error code.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -4517,13 +5111,14 @@ export declare namespace Office {
          * 
          * `setAsync(location: string, options: Office.AsyncContextOptions): void;`
          * 
-         * `setAsync(location: string, callback: (result: AsyncResult) => void): void;`
+         * `setAsync(location: string, callback: (result: AsyncResult<void>) => void): void;`
          */
-        setAsync(location: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        setAsync(location: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Sets the location of an appointment.
          *
-         * The setAsync method starts an asynchronous call to the Exchange server to set the location of an appointment. Setting the location of an appointment overwrites the current location.
+         * The setAsync method starts an asynchronous call to the Exchange server to set the location of an appointment. 
+         * Setting the location of an appointment overwrites the current location.
          *
          * @param location - The location of the appointment. The string is limited to 255 characters.
          *
@@ -4540,7 +5135,8 @@ export declare namespace Office {
         /**
          * Sets the location of an appointment.
          *
-         * The setAsync method starts an asynchronous call to the Exchange server to set the location of an appointment. Setting the location of an appointment overwrites the current location.
+         * The setAsync method starts an asynchronous call to the Exchange server to set the location of an appointment. 
+         * Setting the location of an appointment overwrites the current location.
          *
          * @param location - The location of the appointment. The string is limited to 255 characters.
          * @param options - Optional. An object literal that contains one or more of the following properties.
@@ -4559,10 +5155,12 @@ export declare namespace Office {
         /**
          * Sets the location of an appointment.
          *
-         * The setAsync method starts an asynchronous call to the Exchange server to set the location of an appointment. Setting the location of an appointment overwrites the current location.
+         * The setAsync method starts an asynchronous call to the Exchange server to set the location of an appointment. 
+         * Setting the location of an appointment overwrites the current location.
          *
          * @param location - The location of the appointment. The string is limited to 255 characters.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.  If setting the location fails, the asyncResult.error property will contain an error code.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. If setting the location fails, the asyncResult.error property will contain an error code.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -4573,10 +5171,10 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>DataExceedsMaximumSize - The location parameter is longer than 255 characters.</td></tr></table>
          */
-        setAsync(location: string, callback: (result: AsyncResult) => void): void;
+        setAsync(location: string, callback: (result: AsyncResult<void>) => void): void;
     }
     /**
-     * Provides access to the Outlook add-in object model for Microsoft Outlook and Microsoft Outlook on the web.
+     * Provides access to the Outlook Add-in object model for Microsoft Outlook and Microsoft Outlook on the web.
      *
      * Namespaces:
      *
@@ -4599,11 +5197,18 @@ export declare namespace Office {
          * 
          * Contains the following members:
          * 
-         *  - hostName (string): A string that represents the name of the host application. It be one of the following values: Outlook, Mac Outlook, OutlookIOS, or OutlookWebApp.
+         *  - hostName (string): A string that represents the name of the host application. 
+         * It be one of the following values: Outlook, Mac Outlook, OutlookIOS, or OutlookWebApp.
          * 
-         *  - hostVersion (string): A string that represents the version of either the host application or the Exchange Server. If the mail add-in is running on the Outlook desktop client or Outlook for iOS, the hostVersion property returns the version of the host application, Outlook. In Outlook Web App, the property returns the version of the Exchange Server. An example is the string 15.0.468.0.
+         *  - hostVersion (string): A string that represents the version of either the host application or the Exchange Server. 
+         * If the mail add-in is running on the Outlook desktop client or Outlook for iOS, the hostVersion property returns the version of the 
+         * host application, Outlook. In Outlook Web App, the property returns the version of the Exchange Server. An example is the string 15.0.468.0.
          * 
-         *  - OWAView (string): A string that represents the current view of Outlook Web App. If the host application is not Outlook Web App, then accessing this property results in undefined. Outlook Web App has three views (OneColumn - displayed when the screen is narrow, TwoColumns - displayed when the screen is wider, and ThreeColumns - displayed when the screen is wide.) that correspond to the width of the screen and the window, and the number of columns that can be displayed.
+         *  - OWAView (MailboxEnums.OWAView or string): An enum (or string literal) that represents the current view of Outlook Web App. 
+         * If the host application is not Outlook Web App, then accessing this property results in undefined. 
+         * Outlook Web App has three views (OneColumn - displayed when the screen is narrow, TwoColumns - displayed when the screen is wider, 
+         * and ThreeColumns - displayed when the screen is wide) that correspond to the width of the screen and the window, and the number of columns 
+         * that can be displayed.
          *
          *  More information is under {@link Office.Diagnostics}. 
          *
@@ -4620,7 +5225,8 @@ export declare namespace Office {
          *
          * Your app must have the ReadItem permission specified in its manifest to call the ewsUrl member in read mode.
          *
-         * In compose mode you must call the saveAsync method before you can use the ewsUrl member. Your app must have ReadWriteItem permissions to call the saveAsync method.
+         * In compose mode you must call the saveAsync method before you can use the ewsUrl member. 
+         * Your app must have ReadWriteItem permissions to call the saveAsync method.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -4646,7 +5252,8 @@ export declare namespace Office {
          *
          * Your app must have the ReadItem permission specified in its manifest to call the restUrl member in read mode.
          *
-         * In compose mode you must call the saveAsync method before you can use the restUrl member. Your app must have ReadWriteItem permissions to call the saveAsync method.
+         * In compose mode you must call the saveAsync method before you can use the restUrl member. 
+         * Your app must have ReadWriteItem permissions to call the saveAsync method.
          *
          * [Api set: Mailbox 1.5]
          *
@@ -4660,7 +5267,7 @@ export declare namespace Office {
          */
         restUrl: string;
         /**
-         * Information about the user associated with the mailbox. This includes their account type, display name, email adddress, and time zone.
+         * Information about the user associated with the mailbox. This includes their account type, display name, email address, and time zone.
          * 
          * More information is under {@link Office.UserProfile}
          */
@@ -4668,7 +5275,7 @@ export declare namespace Office {
         /**
          * Adds an event handler for a supported event.
          *
-         * Currently the only supported event type is Office.EventType.ItemChanged, which is invoked when the user selects a new item. This event is used by add-ins that implement a pinnable taskpane, and allows the add-in to refresh the taskpane UI based on the currently selected item.
+         * Currently, the only supported event type is `Office.EventType.ItemChanged`.
          *
          * [Api set: Mailbox 1.5]
          *
@@ -4679,15 +5286,18 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          *
          * @param eventType - The event that should invoke the handler.
-         * @param handler - The function to handle the event. The function must accept a single parameter, which is an object literal. The type property on the parameter will match the eventType parameter passed to addHandlerAsync.
+         * @param handler - The function to handle the event. The function must accept a single parameter, which is an object literal. 
+         *                The type property on the parameter will match the eventType parameter passed to addHandlerAsync.
          * @param options - Optional. Provides an option for preserving context data of any type, unchanged, for use in a callback.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          */
-        addHandlerAsync(eventType: Office.EventType, handler: (type: EventType) => void, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        addHandlerAsync(eventType: Office.EventType, handler: (type: EventType) => void, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Converts an item ID formatted for REST into EWS format.
          *
-         * Item IDs retrieved via a REST API (such as the Outlook Mail API or the Microsoft Graph) use a different format than the format used by Exchange Web Services (EWS). The convertToEwsId method converts a REST-formatted ID into the proper format for EWS.
+         * Item IDs retrieved via a REST API (such as the Outlook Mail API or the Microsoft Graph) use a different format than the format used by 
+         * Exchange Web Services (EWS). The convertToEwsId method converts a REST-formatted ID into the proper format for EWS.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -4706,9 +5316,15 @@ export declare namespace Office {
         /**
          * Gets a dictionary containing time information in local client time.
          *
-         * The dates and times used by a mail app for Outlook or Outlook Web App can use different time zones. Outlook uses the client computer time zone; Outlook Web App uses the time zone set on the Exchange Admin Center (EAC). You should handle date and time values so that the values you display on the user interface are always consistent with the time zone that the user expects.
+         * The dates and times used by a mail app for Outlook or Outlook Web App can use different time zones. 
+         * Outlook uses the client computer time zone; Outlook Web App uses the time zone set on the Exchange Admin Center (EAC). 
+         * You should handle date and time values so that the values you display on the user interface are always consistent with the time zone that 
+         * the user expects.
          *
-         * If the mail app is running in Outlook, the convertToLocalClientTime method will return a dictionary object with the values set to the client computer time zone. If the mail app is running in Outlook Web App, the convertToLocalClientTime method will return a dictionary object with the values set to the time zone specified in the EAC.
+         * If the mail app is running in Outlook, the convertToLocalClientTime method will return a dictionary object with the values set to the 
+         * client computer time zone. 
+         * If the mail app is running in Outlook Web App, the convertToLocalClientTime method will return a dictionary object with the values set to 
+         * the time zone specified in the EAC.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -4734,7 +5350,9 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          *
-         * Item IDs retrieved via EWS or via the itemId property use a different format than the format used by REST APIs (such as the {@link https://docs.microsoft.com/previous-versions/office/office-365-api/api/version-2.0/mail-rest-operations | Outlook Mail API} or the {@link http://graph.microsoft.io/ | Microsoft Graph}. The convertToRestId method converts an EWS-formatted ID into the proper format for REST.
+         * Item IDs retrieved via EWS or via the itemId property use a different format than the format used by REST APIs (such as the 
+         * {@link https://docs.microsoft.com/previous-versions/office/office-365-api/api/version-2.0/mail-rest-operations | Outlook Mail API} or the {@link http://graph.microsoft.io/ | Microsoft Graph}. 
+         * The convertToRestId method converts an EWS-formatted ID into the proper format for REST.
          *
          * @param itemId - An item ID formatted for Exchange Web Services (EWS)
          * @param restVersion - A value indicating the version of the Outlook REST API that the converted ID will be used with.
@@ -4743,7 +5361,8 @@ export declare namespace Office {
         /**
          * Gets a Date object from a dictionary containing time information.
          *
-         * The convertToUtcClientTime method converts a dictionary containing a local date and time to a Date object with the correct values for the local date and time.
+         * The convertToUtcClientTime method converts a dictionary containing a local date and time to a Date object with the correct values for the 
+         * local date and time.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -4760,13 +5379,17 @@ export declare namespace Office {
         /**
          * Displays an existing calendar appointment.
          *
-         * The displayAppointmentForm method opens an existing calendar appointment in a new window on the desktop or in a dialog box on mobile devices.
+         * The displayAppointmentForm method opens an existing calendar appointment in a new window on the desktop or in a dialog box on 
+         * mobile devices.
          *
-         * In Outlook for Mac, you can use this method to display a single appointment that is not part of a recurring series, or the master appointment of a recurring series, but you cannot display an instance of the series. This is because in Outlook for Mac, you cannot access the properties (including the item ID) of instances of a recurring series.
+         * In Outlook for Mac, you can use this method to display a single appointment that is not part of a recurring series, or the 
+         * master appointment of a recurring series, but you cannot display an instance of the series. 
+         * This is because in Outlook for Mac, you cannot access the properties (including the item ID) of instances of a recurring series.
          *
          * In Outlook Web App, this method opens the specified form only if the body of the form is less than or equal to 32KB number of characters.
          *
-         * If the specified item identifier does not identify an existing appointment, a blank pane opens on the client computer or device, and no error message will be returned.
+         * If the specified item identifier does not identify an existing appointment, a blank pane opens on the client computer or device, and 
+         * no error message will be returned.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -4788,9 +5411,11 @@ export declare namespace Office {
          *
          * In Outlook Web App, this method opens the specified form only if the body of the form is less than or equal to 32 KB number of characters.
          *
-         * If the specified item identifier does not identify an existing message, no message will be displayed on the client computer, and no error message will be returned.
+         * If the specified item identifier does not identify an existing message, no message will be displayed on the client computer, and 
+         * no error message will be returned.
          *
-         * Do not use the displayMessageForm with an itemId that represents an appointment. Use the displayAppointmentForm method to display an existing appointment, and displayNewAppointmentForm to display a form to create a new appointment.
+         * Do not use the displayMessageForm with an itemId that represents an appointment. Use the displayAppointmentForm method to display 
+         * an existing appointment, and displayNewAppointmentForm to display a form to create a new appointment.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -4808,11 +5433,16 @@ export declare namespace Office {
         /**
          * Displays a form for creating a new calendar appointment.
          *
-         * The displayNewAppointmentForm method opens a form that enables the user to create a new appointment or meeting. If parameters are specified, the appointment form fields are automatically populated with the contents of the parameters.
+         * The displayNewAppointmentForm method opens a form that enables the user to create a new appointment or meeting. 
+         * If parameters are specified, the appointment form fields are automatically populated with the contents of the parameters.
          *
-         * In Outlook Web App and OWA for Devices, this method always displays a form with an attendees field. If you do not specify any attendees as input arguments, the method displays a form with a Save button. If you have specified attendees, the form would include the attendees and a Send button.
+         * In Outlook Web App and OWA for Devices, this method always displays a form with an attendees field. 
+         * If you do not specify any attendees as input arguments, the method displays a form with a Save button. 
+         * If you have specified attendees, the form would include the attendees and a Send button.
          *
-         * In the Outlook rich client and Outlook RT, if you specify any attendees or resources in the requiredAttendees, optionalAttendees, or resources parameter, this method displays a meeting form with a Send button. If you don't specify any recipients, this method displays an appointment form with a Save & Close button.
+         * In the Outlook rich client and Outlook RT, if you specify any attendees or resources in the requiredAttendees, optionalAttendees, or 
+         * resources parameter, this method displays a meeting form with a Send button. 
+         * If you don't specify any recipients, this method displays an appointment form with a Save & Close button.
          *
          * If any of the parameters exceed the specified size limits, or if an unknown parameter name is specified, an exception is thrown.
          *
@@ -4832,17 +5462,23 @@ export declare namespace Office {
         /**
          * Gets a string that contains a token used to call REST APIs or Exchange Web Services.
          *
-         * The getCallbackTokenAsync method makes an asynchronous call to get an opaque token from the Exchange Server that hosts the user's mailbox. The lifetime of the callback token is 5 minutes.
+         * The getCallbackTokenAsync method makes an asynchronous call to get an opaque token from the Exchange Server that hosts the user's mailbox. 
+         * The lifetime of the callback token is 5 minutes.
          *
          * *REST Tokens*
          *
-         * When a REST token is requested (options.isRest = true), the resulting token will not work to authenticate Exchange Web Services calls. The token will be limited in scope to read-only access to the current item and its attachments, unless the add-in has specified the ReadWriteMailbox permission in its manifest. If the ReadWriteMailbox permission is specified, the resulting token will grant read/write access to mail, calendar, and contacts, including the ability to send mail.
+         * When a REST token is requested (options.isRest = true), the resulting token will not work to authenticate Exchange Web Services calls. 
+         * The token will be limited in scope to read-only access to the current item and its attachments, unless the add-in has specified the 
+         * ReadWriteMailbox permission in its manifest. 
+         * If the ReadWriteMailbox permission is specified, the resulting token will grant read/write access to mail, calendar, and contacts, 
+         * including the ability to send mail.
          *
          * The add-in should use the restUrl property to determine the correct URL to use when making REST API calls.
          *
          * *EWS Tokens*
          *
-         * When an EWS token is requested (options.isRest = false), the resulting token will not work to authenticate REST API calls. The token will be limited in scope to accessing the current item.
+         * When an EWS token is requested (options.isRest = false), the resulting token will not work to authenticate REST API calls. 
+         * The token will be limited in scope to accessing the current item.
          *
          * The add-in should use the ewsUrl property to determine the correct URL to use when making EWS calls.
          *
@@ -4858,26 +5494,31 @@ export declare namespace Office {
          * 
          * In addition to this signature, the method has the following signatures:
          * 
-         * `getCallbackTokenAsync(callback: (result: AsyncResult) => void): void;`
+         * `getCallbackTokenAsync(callback: (result: AsyncResult<string>) => void): void;`
          * 
-         * `getCallbackTokenAsync(callback: (result: AsyncResult) => void, userContext?: any): void;`
+         * `getCallbackTokenAsync(callback: (result: AsyncResult<string>) => void, userContext?: any): void;`
          *
          * @param options - An object literal that contains one or more of the following properties.
          *        isRest: Determines if the token provided will be used for the Outlook REST APIs or Exchange Web Services. Default value is false.
          *        asyncContext: Any state data that is passed to the asynchronous method.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. The token is provided as a string in the asyncResult.value property.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. The token is provided as a string in the asyncResult.value property.
          */
-        getCallbackTokenAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;
+        getCallbackTokenAsync(options: Office.AsyncContextOptions & { isRest?: boolean }, callback: (result: AsyncResult<string>) => void): void;
         /**
          * Gets a string that contains a token used to get an attachment or item from an Exchange Server.
          *
-         * The getCallbackTokenAsync method makes an asynchronous call to get an opaque token from the Exchange Server that hosts the user's mailbox. The lifetime of the callback token is 5 minutes.
+         * The getCallbackTokenAsync method makes an asynchronous call to get an opaque token from the Exchange Server that hosts the user's mailbox. 
+         * The lifetime of the callback token is 5 minutes.
          *
-         * You can pass the token and an attachment identifier or item identifier to a third-party system. The third-party system uses the token as a bearer authorization token to call the Exchange Web Services (EWS) GetAttachment or GetItem operation to return an attachment or item. For example, you can create a remote service to get attachments from the selected item.
+         * You can pass the token and an attachment identifier or item identifier to a third-party system. 
+         * The third-party system uses the token as a bearer authorization token to call the Exchange Web Services (EWS) GetAttachment or 
+         * GetItem operation to return an attachment or item. For example, you can create a remote service to get attachments from the selected item.
          *
          * Your app must have the ReadItem permission specified in its manifest to call the getCallbackTokenAsync method in read mode.
          *
-         * In compose mode you must call the saveAsync method to get an item identifier to pass to the getCallbackTokenAsync method. Your app must have ReadWriteItem permissions to call the saveAsync method.
+         * In compose mode you must call the saveAsync method to get an item identifier to pass to the getCallbackTokenAsync method. 
+         * Your app must have ReadWriteItem permissions to call the saveAsync method.
          *
          * [Api set: Mailbox 1.5]
          *
@@ -4887,19 +5528,24 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose and read</td></tr></table>
          *
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. The token is provided as a string in the asyncResult.value property.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. 
+         *                 The token is provided as a string in the asyncResult.value property.
          */
-        getCallbackTokenAsync(callback: (result: AsyncResult) => void): void;
+        getCallbackTokenAsync(callback: (result: AsyncResult<string>) => void): void;
         /**
          * Gets a string that contains a token used to get an attachment or item from an Exchange Server.
          *
-         * The getCallbackTokenAsync method makes an asynchronous call to get an opaque token from the Exchange Server that hosts the user's mailbox. The lifetime of the callback token is 5 minutes.
+         * The getCallbackTokenAsync method makes an asynchronous call to get an opaque token from the Exchange Server that hosts the user's mailbox. 
+         * The lifetime of the callback token is 5 minutes.
          *
-         * You can pass the token and an attachment identifier or item identifier to a third-party system. The third-party system uses the token as a bearer authorization token to call the Exchange Web Services (EWS) GetAttachment or GetItem operation to return an attachment or item. For example, you can create a remote service to get attachments from the selected item.
+         * You can pass the token and an attachment identifier or item identifier to a third-party system. 
+         * The third-party system uses the token as a bearer authorization token to call the Exchange Web Services (EWS) GetAttachment or 
+         * GetItem operation to return an attachment or item. For example, you can create a remote service to get attachments from the selected item.
          *
          * Your app must have the ReadItem permission specified in its manifest to call the getCallbackTokenAsync method in read mode.
          *
-         * In compose mode you must call the saveAsync method to get an item identifier to pass to the getCallbackTokenAsync method. Your app must have ReadWriteItem permissions to call the saveAsync method.
+         * In compose mode you must call the saveAsync method to get an item identifier to pass to the getCallbackTokenAsync method. 
+         * Your app must have ReadWriteItem permissions to call the saveAsync method.
          *
          * [Api set: Mailbox 1.3]
          *
@@ -4909,10 +5555,11 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose and read</td></tr></table>
          *
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. The token is provided as a string in the asyncResult.value property.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. The token is provided as a string in the asyncResult.value property.
          * @param userContext - Optional. Any state data that is passed to the asynchronous method.
          */
-        getCallbackTokenAsync(callback: (result: AsyncResult) => void, userContext?: any): void;
+        getCallbackTokenAsync(callback: (result: AsyncResult<string>) => void, userContext?: any): void;
         /**
          * Gets a token identifying the user and the Office Add-in.
          *
@@ -4926,12 +5573,15 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose and read</td></tr></table>
          *
-         * The getUserIdentityTokenAsync method returns a token that you can use to identify and {@link https://docs.microsoft.com/outlook/add-ins/authentication | authenticate the add-in and user with a third-party system}.
+         * The getUserIdentityTokenAsync method returns a token that you can use to identify and 
+         * {@link https://docs.microsoft.com/outlook/add-ins/authentication | authenticate the add-in and user with a third-party system}.
          *
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
+         *                 The token is provided as a string in the asyncResult.value property.
          * @param userContext - Optional. Any state data that is passed to the asynchronous method.|
          */
-        getUserIdentityTokenAsync(callback: (result: AsyncResult) => void, userContext?: any): void;
+        getUserIdentityTokenAsync(callback: (result: AsyncResult<string>) => void, userContext?: any): void;
         /**
          * Makes an asynchronous request to an Exchange Web Services (EWS) service on the Exchange server that hosts the user's mailbox.
          *
@@ -4943,21 +5593,32 @@ export declare namespace Office {
          *
          * The XML request must specify UTF-8 encoding. \<?xml version="1.0" encoding="utf-8"?\>
          *
-         * Your add-in must have the ReadWriteMailbox permission to use the makeEwsRequestAsync method. For information about using the ReadWriteMailbox permission and the EWS operations that you can call with the makeEwsRequestAsync method, see Specify permissions for mail add-in access to the user's mailbox.
+         * Your add-in must have the ReadWriteMailbox permission to use the makeEwsRequestAsync method. 
+         * For information about using the ReadWriteMailbox permission and the EWS operations that you can call with the makeEwsRequestAsync method, 
+         * see {@link https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions | Specify permissions for mail add-in access to the user's mailbox}.
          *
-         * The XML result of the EWS call is provided as a string in the asyncResult.value property. If the result exceeds 1 MB in size, an error message is returned instead.
+         * The XML result of the EWS call is provided as a string in the asyncResult.value property. 
+         * If the result exceeds 1 MB in size, an error message is returned instead.
          *
-         * Note: This method is not supported in the following scenarios. - In Outlook for iOS or Outlook for Android - When the add-in is loaded in a Gmail mailbox
+         * Note: This method is not supported in the following scenarios:
+         * 
+         * - In Outlook for iOS or Outlook for Android.
+         * 
+         * - When the add-in is loaded in a Gmail mailbox.
          *
-         * Note: The server administrator must set OAuthAuthentication to true on the Client Access Server EWS directory to enable the makeEwsRequestAsync method to make EWS requests.
+         * Note: The server administrator must set OAuthAuthentication to true on the Client Access Server EWS directory to enable the 
+         * makeEwsRequestAsync method to make EWS requests.
          *
          * *Version differences*
          *
-         * When you use the makeEwsRequestAsync method in mail apps running in Outlook versions earlier than version 15.0.4535.1004, you should set the encoding value to ISO-8859-1.
+         * When you use the makeEwsRequestAsync method in mail apps running in Outlook versions earlier than version 15.0.4535.1004, you should set 
+         * the encoding value to ISO-8859-1.
          *
          * `<?xml version="1.0" encoding="iso-8859-1"?>`
          *
-         * You do not need to set the encoding value when your mail app is running in Outlook on the web. You can determine whether your mail app is running in Outlook or Outlook on the web by using the mailbox.diagnostics.hostName property. You can determine what version of Outlook is running by using the mailbox.diagnostics.hostVersion property.
+         * You do not need to set the encoding value when your mail app is running in Outlook on the web. 
+         * You can determine whether your mail app is running in Outlook or Outlook on the web by using the mailbox.diagnostics.hostName property. 
+         * You can determine what version of Outlook is running by using the mailbox.diagnostics.hostVersion property.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -4968,18 +5629,44 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose and read</td></tr></table>
          *
          * @param data - The EWS request.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult.
+         *                 The `value` property of the result is the XML of the EWS request provided as a string. 
+         *                 If the result exceeds 1 MB in size, an error message is returned instead.
          * @param userContext - Optional. Any state data that is passed to the asynchronous method.
          */
-        makeEwsRequestAsync(data: any, callback: (result: AsyncResult) => void, userContext?: any): void;
+        makeEwsRequestAsync(data: any, callback: (result: AsyncResult<string>) => void, userContext?: any): void;
+        /**
+         * Removes an event handler for a supported event.
+         *
+         * Currently, the only supported event type is `Office.EventType.ItemChanged`.
+         *
+         * [Api set: Mailbox 1.5]
+         *
+         * @remarks
+         *
+         * <table><tr><td>{@link https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions | Minimum permission level}</td><td>ReadItem</td></tr>
+         *
+         * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
+         *
+         * @param eventType - The event that should revoke the handler.
+         * @param handler - The function to handle the event. The function must accept a single parameter, which is an object literal. 
+         *                The type property on the parameter will match the eventType parameter passed to addHandlerAsync.
+         * @param options - Optional. Provides an option for preserving context data of any type, unchanged, for use in a callback.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
+         */
+        removeHandlerAsync(eventType: Office.EventType, handler: (type: EventType) => void, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
     }
 
     /**
      * Represents a suggested meeting found in an item. Read mode only.
      *
-     * The list of meetings suggested in an email message is returned in the meetingSuggestions property of the Entities object that is returned when the getEntities or getEntitiesByType method is called on the active item.
+     * The list of meetings suggested in an email message is returned in the meetingSuggestions property of the Entities object that is returned when 
+     * the getEntities or getEntitiesByType method is called on the active item.
      *
-     * The start and end values are string representations of a Date object that contains the date and time at which the suggested meeting is to begin and end. The values are in the default time zone specified for the current user.
+     * The start and end values are string representations of a Date object that contains the date and time at which the suggested meeting is to 
+     * begin and end. 
+     * The values are in the default time zone specified for the current user.
      *
      * [Api set: Mailbox 1.0]
      *
@@ -5030,19 +5717,27 @@ export declare namespace Office {
          */
         key?: string;
         /**
-         * Specifies the ItemNotificationMessageType of message. If type is ProgressIndicator or ErrorMessage, an icon is automatically supplied and the message is not persistent. Therefore the icon and persistent properties are not valid for these types of messages. Including them will result in an ArgumentException. If type is ProgressIndicator, the developer should remove or replace the progress indicator when the action is complete.
+         * Specifies the ItemNotificationMessageType of message. If type is ProgressIndicator or ErrorMessage, an icon is automatically supplied and 
+         * the message is not persistent. Therefore the icon and persistent properties are not valid for these types of messages. 
+         * Including them will result in an ArgumentException. 
+         * If type is ProgressIndicator, the developer should remove or replace the progress indicator when the action is complete.
          */
         type: Office.MailboxEnums.ItemNotificationMessageType;
         /**
-         * A reference to an icon that is defined in the manifest in the Resources section. It appears in the infobar area. It is only applicable if the type is InformationalMessage. Specifying this parameter for an unsupported type results in an exception.
+         * A reference to an icon that is defined in the manifest in the Resources section. It appears in the infobar area. 
+         * It is only applicable if the type is InformationalMessage. Specifying this parameter for an unsupported type results in an exception.
          */
         icon?: string;
         /**
-         * The text of the notification message. Maximum length is 150 characters. If the developer passes in a longer string, an ArgumentOutOfRange exception is thrown.
+         * The text of the notification message. Maximum length is 150 characters. 
+         * If the developer passes in a longer string, an ArgumentOutOfRange exception is thrown.
          */
         message: string;
         /**
-         * Only applicable when type is InformationalMessage. If true, the message remains until removed by this add-in or dismissed by the user. If false, it is removed when the user navigates to a different item. For error notifications, the message persists until the user sees it once. Specifying this parameter for an unsupported type throws an exception.
+         * Only applicable when type is InformationalMessage. If true, the message remains until removed by this add-in or dismissed by the user. 
+         * If false, it is removed when the user navigates to a different item. 
+         * For error notifications, the message persists until the user sees it once. 
+         * Specifying this parameter for an unsupported type throws an exception.
          */
         persistent?: Boolean;
     }
@@ -5062,11 +5757,14 @@ export declare namespace Office {
          *
          * There are a maximum of 5 notifications per message. Setting more will return a NumberOfNotificationMessagesExceeded error.
          *
-         * @param key - A developer-specified key used to reference this notification message. Developers can use it to modify this message later. It can't be longer than 32 characters.
-         * @param JSONmessage - A JSON object that contains the notification message to be added to the item. It contains a NotificationMessageDetails object.
+         * @param key - A developer-specified key used to reference this notification message. 
+         *             Developers can use it to modify this message later. It can't be longer than 32 characters.
+         * @param JSONmessage - A JSON object that contains the notification message to be added to the item. 
+         *                    It contains a NotificationMessageDetails object.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          *
          * [Api set: Mailbox 1.3]
          *
@@ -5081,17 +5779,19 @@ export declare namespace Office {
          * 
          * `addAsync(key: string, JSONmessage: NotificationMessageDetails, options: Office.AsyncContextOptions): void;`
          * 
-         * `addAsync(key: string, JSONmessage: NotificationMessageDetails, callback: (result: AsyncResult) => void): void;`
+         * `addAsync(key: string, JSONmessage: NotificationMessageDetails, callback: (result: AsyncResult<void>) => void): void;`
          * 
          */
-        addAsync(key: string, JSONmessage: NotificationMessageDetails, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        addAsync(key: string, JSONmessage: NotificationMessageDetails, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Adds a notification to an item.
          *
          * There are a maximum of 5 notifications per message. Setting more will return a NumberOfNotificationMessagesExceeded error.
          *
-         * @param key - A developer-specified key used to reference this notification message. Developers can use it to modify this message later. It can't be longer than 32 characters.
-         * @param JSONmessage - A JSON object that contains the notification message to be added to the item. It contains a NotificationMessageDetails object.
+         * @param key - A developer-specified key used to reference this notification message. Developers can use it to modify this message later. 
+         *             It can't be longer than 32 characters.
+         * @param JSONmessage - A JSON object that contains the notification message to be added to the item. 
+         *                    It contains a NotificationMessageDetails object.
          *
          * [Api set: Mailbox 1.3]
          *
@@ -5106,8 +5806,10 @@ export declare namespace Office {
          *
          * There are a maximum of 5 notifications per message. Setting more will return a NumberOfNotificationMessagesExceeded error.
          *
-         * @param key - A developer-specified key used to reference this notification message. Developers can use it to modify this message later. It can't be longer than 32 characters.
-         * @param JSONmessage - A JSON object that contains the notification message to be added to the item. It contains a NotificationMessageDetails object.
+         * @param key - A developer-specified key used to reference this notification message. Developers can use it to modify this message later. 
+         *             It can't be longer than 32 characters.
+         * @param JSONmessage - A JSON object that contains the notification message to be added to the item. 
+         *                    It contains a NotificationMessageDetails object.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
          *
@@ -5124,9 +5826,12 @@ export declare namespace Office {
          *
          * There are a maximum of 5 notifications per message. Setting more will return a NumberOfNotificationMessagesExceeded error.
          *
-         * @param key - A developer-specified key used to reference this notification message. Developers can use it to modify this message later. It can't be longer than 32 characters.
-         * @param JSONmessage - A JSON object that contains the notification message to be added to the item. It contains a NotificationMessageDetails object.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param key - A developer-specified key used to reference this notification message. Developers can use it to modify this message later. 
+         *             It can't be longer than 32 characters.
+         * @param JSONmessage - A JSON object that contains the notification message to be added to the item. 
+         *                    It contains a NotificationMessageDetails object.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          *
          * [Api set: Mailbox 1.3]
          *
@@ -5135,7 +5840,7 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          */
-        addAsync(key: string, JSONmessage: NotificationMessageDetails, callback: (result: AsyncResult) => void): void;
+        addAsync(key: string, JSONmessage: NotificationMessageDetails, callback: (result: AsyncResult<void>) => void): void;
         /**
          * Returns all keys and messages for an item.
          *
@@ -5146,15 +5851,16 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          * 
-         * In addition to the main signature, this method also has this signature:
+         * In addition to this signature, this method also has the following signature:
          * 
-         * `getAllAsync(callback: (result: AsyncResult) => void): void;`
+         * `getAllAsync(callback: (result: AsyncResult<Office.NotificationMessageDetails[]>) => void): void;`
          *
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult.
+         *                 The `value` property of the result is an array of NotificationMessageDetails objects.
          */
-        getAllAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        getAllAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<Office.NotificationMessageDetails[]>) => void): void;
         /**
          * Returns all keys and messages for an item.
          *
@@ -5165,9 +5871,10 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          *
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult.
+         *                 The `value` property of the result is an array of NotificationMessageDetails objects.
          */
-        getAllAsync(callback: (result: AsyncResult) => void): void;
+        getAllAsync(callback: (result: AsyncResult<Office.NotificationMessageDetails[]>) => void): void;
         /**
          * Removes a notification message for an item.
          *
@@ -5178,20 +5885,21 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          * 
-         * In addition to the main signature, this method also has these signatures:
+         * In addition to this signature, this method also has the following signatures:
          * 
          * `removeAsync(key: string): void;`
          * 
          * `removeAsync(key: string, options: Office.AsyncContextOptions): void;`
          * 
-         * `removeAsync(key: string, callback: (result: AsyncResult) => void): void;`
+         * `removeAsync(key: string, callback: (result: AsyncResult<void>) => void): void;`
          *
          * @param key - The key for the notification message to remove.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          */
-        removeAsync(key: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        removeAsync(key: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Removes a notification message for an item.
          *
@@ -5231,9 +5939,10 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          *
          * @param key - The key for the notification message to remove.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          */
-        removeAsync(key: string, callback: (result: AsyncResult) => void): void;
+        removeAsync(key: string, callback: (result: AsyncResult<void>) => void): void;
         /**
          * Replaces a notification message that has a given key with another message.
          *
@@ -5246,21 +5955,23 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          * 
-         * In addition to the main signature, this method also has these signatures:
+         * In addition to this signature, this method also has the following signatures:
          * 
          * `replaceAsync(key: string, JSONmessage: NotificationMessageDetails): void;`
          * 
          * `replaceAsync(key: string, JSONmessage: NotificationMessageDetails, options: Office.AsyncContextOptions): void;`
          * 
-         * `replaceAsync(key: string, JSONmessage: NotificationMessageDetails, callback: (result: AsyncResult) => void): void;`
+         * `replaceAsync(key: string, JSONmessage: NotificationMessageDetails, callback: (result: AsyncResult<void>) => void): void;`
          *
          * @param key - The key for the notification message to replace. It can't be longer than 32 characters.
-         * @param JSONmessage - A JSON object that contains the new notification message to replace the existing message. It contains a NotificationMessageDetails object.
+         * @param JSONmessage - A JSON object that contains the new notification message to replace the existing message. 
+         *                    It contains a NotificationMessageDetails object.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          */
-        replaceAsync(key: string, JSONmessage: NotificationMessageDetails, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        replaceAsync(key: string, JSONmessage: NotificationMessageDetails, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Replaces a notification message that has a given key with another message.
          *
@@ -5274,7 +5985,8 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          *
          * @param key - The key for the notification message to replace. It can't be longer than 32 characters.
-         * @param JSONmessage - A JSON object that contains the new notification message to replace the existing message. It contains a NotificationMessageDetails object.
+         * @param JSONmessage - A JSON object that contains the new notification message to replace the existing message. 
+         *                    It contains a NotificationMessageDetails object.
          */
         replaceAsync(key: string, JSONmessage: NotificationMessageDetails): void;
         /**
@@ -5290,7 +6002,8 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          *
          * @param key - The key for the notification message to replace. It can't be longer than 32 characters.
-         * @param JSONmessage - A JSON object that contains the new notification message to replace the existing message. It contains a NotificationMessageDetails object.
+         * @param JSONmessage - A JSON object that contains the new notification message to replace the existing message. 
+         *                    It contains a NotificationMessageDetails object.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
          */
@@ -5308,15 +6021,18 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          *
          * @param key - The key for the notification message to replace. It can't be longer than 32 characters.
-         * @param JSONmessage - A JSON object that contains the new notification message to replace the existing message. It contains a NotificationMessageDetails object.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param JSONmessage - A JSON object that contains the new notification message to replace the existing message. 
+         *                    It contains a NotificationMessageDetails object.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          */
-        replaceAsync(key: string, JSONmessage: NotificationMessageDetails, callback: (result: AsyncResult) => void): void;
+        replaceAsync(key: string, JSONmessage: NotificationMessageDetails, callback: (result: AsyncResult<void>) => void): void;
     }
     /**
      * Represents a phone number identified in an item. Read mode only.
      *
-     * An array of PhoneNumber objects containing the phone numbers found in an email message is returned in the phoneNumbers property of the Entities object that is returned when you call the getEntities method on the selected item.
+     * An array of PhoneNumber objects containing the phone numbers found in an email message is returned in the phoneNumbers property of the 
+     * Entities object that is returned when you call the getEntities method on the selected item.
      *
      * [Api set: Mailbox 1.0]
      *
@@ -5368,20 +6084,21 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>NumberOfRecipientsExceeded - The number of recipients exceeded 100 entries.</td></tr></table>
          * 
-         * In addition to the main signature, this method also has these signatures:
+         * In addition to this signature, this method also has the following signatures:
          * 
          * `addAsync(recipients: (string | EmailUser | EmailAddressDetails)[]): void;`
          * 
          * `addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options: Office.AsyncContextOptions): void;`
          * 
-         * `addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult) => void): void;`
+         * `addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult<void>) => void): void;`
          *
          * @param recipients - The recipients to add to the recipients list.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If adding the recipients fails, the asyncResult.error property will contain an error code.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. If adding the recipients fails, the asyncResult.error property will contain an error code.
          */
-        addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Adds a recipient list to the existing recipients for an appointment or message.
          *
@@ -5451,13 +6168,14 @@ export declare namespace Office {
          * <tr><td>Errors</td><td>NumberOfRecipientsExceeded - The number of recipients exceeded 100 entries.</td></tr></table>
          *
          * @param recipients - The recipients to add to the recipients list.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If adding the recipients fails, the asyncResult.error property will contain an error code.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. If adding the recipients fails, the asyncResult.error property will contain an error code.
          */
-        addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult) => void): void;
+        addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult<void>) => void): void;
         /**
          * Gets a recipient list for an appointment or message.
          *
-         * When the call completes, the asyncResult.value property will contain an array of{@link Office.EmailAddressDetails} objects.
+         * When the call completes, the asyncResult.value property will contain an array of {@link Office.EmailAddressDetails} objects.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -5466,15 +6184,17 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose</td></tr></table>
          * 
-         * In addition to the main signature, this method also has this signature:
+         * In addition to this signature, this method also has the following signature:
          * 
-         * `getAsync(callback: (result: AsyncResult) => void): void;`
+         * `getAsync(callback: (result: AsyncResult<Office.EmailAddressDetails[]>) => void): void;`
          *
          * @param options - An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
+         *                 The `value` property of the result is an array of EmailAddressDetails objects.
          */
-        getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;
+        getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult<Office.EmailAddressDetails[]>) => void): void;
         /**
          * Gets a recipient list for an appointment or message.
          *
@@ -5487,9 +6207,11 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose</td></tr></table>
          *
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
+         *                 The `value` property of the result is an array of EmailAddressDetails objects.
          */
-        getAsync(callback: (result: AsyncResult) => void): void;
+        getAsync(callback: (result: AsyncResult<Office.EmailAddressDetails[]>) => void): void;
         /**
          * Sets a recipient list for an appointment or message.
          *
@@ -5512,20 +6234,23 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>NumberOfRecipientsExceeded - The number of recipients exceeded 100 entries.</td></tr></table>
          * 
-         * In addition to the main signature, this method also has these signatures:
+         * In addition to this signature, this method also has the following signatures:
          * 
          * `setAsync(recipients: (string | EmailUser | EmailAddressDetails)[]): void;`
          * 
          * `setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options: Office.AsyncContextOptions): void;`
          * 
-         * `setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult) => void): void;`
+         * `setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult<void>) => void): void;`
          *
          * @param recipients - The recipients to add to the recipients list.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.  If setting the recipients fails the asyncResult.error property will contain a code that indicates any error that occurred while adding the data.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
+         *                 If setting the recipients fails the asyncResult.error property will contain a code that indicates any error that occurred 
+         *                 while adding the data.
          */
-        setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Sets a recipient list for an appointment or message.
          *
@@ -5601,9 +6326,12 @@ export declare namespace Office {
          * <tr><td>Errors</td><td>NumberOfRecipientsExceeded - The number of recipients exceeded 100 entries.</td></tr></table>
          *
          * @param recipients - The recipients to add to the recipients list.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.  If setting the recipients fails the asyncResult.error property will contain a code that indicates any error that occurred while adding the data.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. 
+         *                 If setting the recipients fails the asyncResult.error property will contain a code that indicates any error that occurred 
+         *                 while adding the data.
          */
-        setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult) => void): void;
+        setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult<void>) => void): void;
 
     }
 
@@ -5624,7 +6352,8 @@ export declare namespace Office {
          */
         url?: string;
         /**
-         * Only used if type is set to file. If true, indicates that the attachment will be shown inline in the message body, and should not be displayed in the attachment list.
+         * Only used if type is set to file. If true, indicates that the attachment will be shown inline in the message body, and should not be 
+         * displayed in the attachment list.
          */
         inLine?: boolean;
         /**
@@ -5646,20 +6375,27 @@ export declare namespace Office {
          */
         attachments?: ReplyFormAttachment[];
         /**
-         * When the reply display call completes, the function passed in the callback parameter is called with a single parameter, asyncResult, which is an AsyncResult object.
+         * When the reply display call completes, the function passed in the callback parameter is called with a single parameter, 
+         * asyncResult, which is an Office.AsyncResult object.
          */
-        callback?: (result: AsyncResult) => void;
+        callback?: (result: AsyncResult<any>) => void;
     }
     /**
-     * The settings created by using the methods of the RoamingSettings object are saved per add-in and per user. That is, they are available only to the add-in that created them, and only from the user's mail box in which they are saved.
+     * The settings created by using the methods of the RoamingSettings object are saved per add-in and per user. 
+     * That is, they are available only to the add-in that created them, and only from the user's mail box in which they are saved.
      *
-     * While the Outlook add-in API limits access to these settings to only the add-in that created them, these settings should not be considered secure storage. They can be accessed by Exchange Web Services or Extended MAPI. They should not be used to store sensitive information such as user credentials or security tokens.
+     * While the Outlook Add-in API limits access to these settings to only the add-in that created them, these settings should not be considered 
+     * secure storage. They can be accessed by Exchange Web Services or Extended MAPI. 
+     * They should not be used to store sensitive information such as user credentials or security tokens.
      *
      * The name of a setting is a String, while the value can be a String, Number, Boolean, null, Object, or Array.
      *
      * The RoamingSettings object is accessible via the roamingSettings property in the Office.context namespace.
      *
-     * Important: The RoamingSettings object is initialized from the persisted storage only when the add-in is first loaded. For task panes, this means that it is only initialized when the task pane first opens. If the task pane navigates to another page or reloads the current page, the in-memory object is reset to its initial values, even if your add-in has persisted changes. The persisted changes will not be available until the task pane is closed and reopened.
+     * Important: The RoamingSettings object is initialized from the persisted storage only when the add-in is first loaded. 
+     * For task panes, this means that it is only initialized when the task pane first opens. 
+     * If the task pane navigates to another page or reloads the current page, the in-memory object is reset to its initial values, even if 
+     * your add-in has persisted changes. The persisted changes will not be available until the task pane is closed and reopened.
      *
      * [Api set: Mailbox 1.0]
      *
@@ -5699,7 +6435,9 @@ export declare namespace Office {
         /**
          * Saves the settings.
          *
-         * Any settings previously saved by an add-in are loaded when it is initialized, so during the lifetime of the session you can just use the set and get methods to work with the in-memory copy of the settings property bag. When you want to persist the settings so that they are available the next time the add-in is used, use the saveAsync method.
+         * Any settings previously saved by an add-in are loaded when it is initialized, so during the lifetime of the session you can just use 
+         * the set and get methods to work with the in-memory copy of the settings property bag. 
+         * When you want to persist the settings so that they are available the next time the add-in is used, use the saveAsync method.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -5708,13 +6446,15 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          *
-         * @param callback - Optional? When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          */
-        saveAsync(callback?: (result: AsyncResult) => void): void;
+        saveAsync(callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Sets or creates the specified setting.
          *
-         * The set method creates a new setting of the specified name if it does not already exist, or sets an existing setting of the specified name. The value is stored in the document as the serialized JSON representation of its data type.
+         * The set method creates a new setting of the specified name if it does not already exist, or sets an existing setting of the specified name. 
+         * The value is stored in the document as the serialized JSON representation of its data type.
          *
          * A maximum of 32KB is available for the settings of each add-in.
          *
@@ -5732,6 +6472,7 @@ export declare namespace Office {
          */
         set(name: string, value: any): void;
     }
+    
     /**
      * Provides methods to get and set the subject of an appointment or message in an Outlook add-in.
      *
@@ -5755,17 +6496,20 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose</td></tr></table>
          * 
-         * In addition to the main signature, this method also has this signature:
+         * In addition to this signature, this method also has the following signature:
          * 
-         * `getAsync(callback: (result: AsyncResult) => void): void;`
+         * `getAsync(callback: (result: AsyncResult<string>) => void): void;`
          *
          * @param options - An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
+         *                 The `value` property of the result is the subject of the item.
          */
-        getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;
+        getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult<string>) => void): void;
         /**
          * Gets the subject of an appointment or message.
+         * 
          * The getAsync method starts an asynchronous call to the Exchange server to get the subject of an appointment or message.
          *
          * [Api set: Mailbox 1.1]
@@ -5776,12 +6520,14 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose</td></tr></table>
          *
          * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         *                  The `value` property of the result is the subject of the item.
          */
-        getAsync(callback: (result: AsyncResult) => void): void;
+        getAsync(callback: (result: AsyncResult<string>) => void): void;
         /**
          * Sets the subject of an appointment or message.
          *
-         * The setAsync method starts an asynchronous call to the Exchange server to set the subject of an appointment or message. Setting the subject overwrites the current subject, but leaves any prefixes, such as "Fwd:" or "Re:" in place.
+         * The setAsync method starts an asynchronous call to the Exchange server to set the subject of an appointment or message. 
+         * Setting the subject overwrites the current subject, but leaves any prefixes, such as "Fwd:" or "Re:" in place.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -5792,24 +6538,26 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>DataExceedsMaximumSize - The subject parameter is longer than 255 characters.</td></tr></table>
          * 
-         * In addition to the main signature, this method also has these signatures:
+         * In addition to this signature, this method also has the following signatures:
          * 
          * `setAsync(subject: string): void;`
          * 
          * `setAsync(subject: string, options: Office.AsyncContextOptions): void;`
          * 
-         * `setAsync(subject: string, callback: (result: AsyncResult) => void): void;`
+         * `setAsync(subject: string, callback: (result: AsyncResult<void>) => void): void;`
          *
          * @param subject - The subject of the appointment or message. The string is limited to 255 characters.
          * @param options - An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If setting the subject fails, the asyncResult.error property will contain an error code.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. If setting the subject fails, the asyncResult.error property will contain an error code.
          */
-        setAsync(subject: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        setAsync(subject: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Sets the subject of an appointment or message.
          *
-         * The setAsync method starts an asynchronous call to the Exchange server to set the subject of an appointment or message. Setting the subject overwrites the current subject, but leaves any prefixes, such as "Fwd:" or "Re:" in place.
+         * The setAsync method starts an asynchronous call to the Exchange server to set the subject of an appointment or message. 
+         * Setting the subject overwrites the current subject, but leaves any prefixes, such as "Fwd:" or "Re:" in place.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -5826,7 +6574,8 @@ export declare namespace Office {
         /**
          * Sets the subject of an appointment or message.
          *
-         * The setAsync method starts an asynchronous call to the Exchange server to set the subject of an appointment or message. Setting the subject overwrites the current subject, but leaves any prefixes, such as "Fwd:" or "Re:" in place.
+         * The setAsync method starts an asynchronous call to the Exchange server to set the subject of an appointment or message. 
+         * Setting the subject overwrites the current subject, but leaves any prefixes, such as "Fwd:" or "Re:" in place.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -5845,7 +6594,8 @@ export declare namespace Office {
         /**
          * Sets the subject of an appointment or message.
          *
-         * The setAsync method starts an asynchronous call to the Exchange server to set the subject of an appointment or message. Setting the subject overwrites the current subject, but leaves any prefixes, such as "Fwd:" or "Re:" in place.
+         * The setAsync method starts an asynchronous call to the Exchange server to set the subject of an appointment or message. 
+         * Setting the subject overwrites the current subject, but leaves any prefixes, such as "Fwd:" or "Re:" in place.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -5857,15 +6607,17 @@ export declare namespace Office {
          * <tr><td>Errors</td><td>DataExceedsMaximumSize - The subject parameter is longer than 255 characters.</td></tr></table>
          *
          * @param subject - The subject of the appointment or message. The string is limited to 255 characters.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If setting the subject fails, the asyncResult.error property will contain an error code.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. If setting the subject fails, the asyncResult.error property will contain an error code.
          */
-        setAsync(data: string, callback: (result: AsyncResult) => void): void;
+        setAsync(data: string, callback: (result: AsyncResult<void>) => void): void;
 
     }
     /**
      * Represents a suggested task identified in an item. Read mode only.
      *
-     * The list of tasks suggested in an email message is returned in the taskSuggestions property of the [Entities]Entities object that is returned when the getEntities or getEntitiesByType method is called on the active item.
+     * The list of tasks suggested in an email message is returned in the taskSuggestions property of the {@link Office.Entities | Entities} object 
+     * that is returned when the getEntities or getEntitiesByType method is called on the active item.
      *
      * [Api set: Mailbox 1.0]
      *
@@ -5898,7 +6650,8 @@ export declare namespace Office {
         /**
          * Gets the start or end time of an appointment.
          *
-         * The date and time is provided as a Date object in the asyncResult.value property. The value is in Coordinated Universal Time (UTC). You can convert the UTC time to the local client time by using the convertToLocalClientTime method.
+         * The date and time is provided as a Date object in the asyncResult.value property. The value is in Coordinated Universal Time (UTC). 
+         * You can convert the UTC time to the local client time by using the convertToLocalClientTime method.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -5907,19 +6660,21 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose</td></tr></table>
          * 
-         * In addition to the main signature, this method also has this signature:
+         * In addition to this signature, this method also has the following signature:
          * 
-         * `getAsync(callback: (result: AsyncResult) => void): void;`
+         * `getAsync(callback: (result: AsyncResult<Date>) => void): void;`
          *
          * @param options - An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
          * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         *                  The `value` property of the result is a Date object.
          */
-        getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;
+        getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult<Date>) => void): void;
         /**
          * Gets the start or end time of an appointment.
          *
-         * The date and time is provided as a Date object in the asyncResult.value property. The value is in Coordinated Universal Time (UTC). You can convert the UTC time to the local client time by using the convertToLocalClientTime method.
+         * The date and time is provided as a Date object in the asyncResult.value property. The value is in Coordinated Universal Time (UTC). 
+         * You can convert the UTC time to the local client time by using the convertToLocalClientTime method.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -5929,12 +6684,14 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose</td></tr></table>
          *
          * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         *                  The `value` property of the result is a Date object.
          */
-        getAsync(callback: (result: AsyncResult) => void): void;
+        getAsync(callback: (result: AsyncResult<Date>) => void): void;
         /**
          * Sets the start or end time of an appointment.
          *
-         * If the setAsync method is called on the start property, the end property will be adjusted to maintain the duration of the appointment as previously set. If the setAsync method is called on the end property, the duration of the appointment will be extended to the new end time.
+         * If the setAsync method is called on the start property, the end property will be adjusted to maintain the duration of the appointment as 
+         * previously set. If the setAsync method is called on the end property, the duration of the appointment will be extended to the new end time.
          *
          * The time must be in UTC; you can get the correct UTC time by using the convertToUtcClientTime method.
          *
@@ -5947,24 +6704,27 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>InvalidEndTime - The appointment end time is before the appointment start time.</td></tr></table>
          * 
-         * In addition to the main signature, this method also has these signatures:
+         * In addition to this signature, this method also has the following signatures:
          * 
          * `setAsync(dateTime: Date): void;`
          * 
          * `setAsync(dateTime: Date, options: Office.AsyncContextOptions): void;`
          * 
-         * `setAsync(dateTime: Date, callback: (result: AsyncResult) => void): void;`
+         * `setAsync(dateTime: Date, callback: (result: AsyncResult<void>) => void): void;`
          *
          * @param dateTime - A date-time object in Coordinated Universal Time (UTC).
          * @param options - An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If setting the date and time fails, the asyncResult.error property will contain an error code.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. 
+         *                 If setting the date and time fails, the asyncResult.error property will contain an error code.
          */
-        setAsync(dateTime: Date, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        setAsync(dateTime: Date, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Sets the start or end time of an appointment.
          *
-         * If the setAsync method is called on the start property, the end property will be adjusted to maintain the duration of the appointment as previously set. If the setAsync method is called on the end property, the duration of the appointment will be extended to the new end time.
+         * If the setAsync method is called on the start property, the end property will be adjusted to maintain the duration of the appointment as 
+         * previously set. If the setAsync method is called on the end property, the duration of the appointment will be extended to the new end time.
          *
          * The time must be in UTC; you can get the correct UTC time by using the convertToUtcClientTime method.
          *
@@ -5983,7 +6743,8 @@ export declare namespace Office {
         /**
          * Sets the start or end time of an appointment.
          *
-         * If the setAsync method is called on the start property, the end property will be adjusted to maintain the duration of the appointment as previously set. If the setAsync method is called on the end property, the duration of the appointment will be extended to the new end time.
+         * If the setAsync method is called on the start property, the end property will be adjusted to maintain the duration of the appointment as 
+         * previously set. If the setAsync method is called on the end property, the duration of the appointment will be extended to the new end time.
          *
          * The time must be in UTC; you can get the correct UTC time by using the convertToUtcClientTime method.
          *
@@ -6004,7 +6765,8 @@ export declare namespace Office {
         /**
          * Sets the start or end time of an appointment.
          *
-         * If the setAsync method is called on the start property, the end property will be adjusted to maintain the duration of the appointment as previously set. If the setAsync method is called on the end property, the duration of the appointment will be extended to the new end time.
+         * If the setAsync method is called on the start property, the end property will be adjusted to maintain the duration of the appointment as 
+         * previously set. If the setAsync method is called on the end property, the duration of the appointment will be extended to the new end time.
          *
          * The time must be in UTC; you can get the correct UTC time by using the convertToUtcClientTime method.
          *
@@ -6018,9 +6780,11 @@ export declare namespace Office {
          * <tr><td>Errors</td><td>InvalidEndTime - The appointment end time is before the appointment start time.</td></tr></table>
          *
          * @param dateTime - A date-time object in Coordinated Universal Time (UTC).
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If setting the date and time fails, the asyncResult.error property will contain an error code.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. 
+         *                 If setting the date and time fails, the asyncResult.error property will contain an error code.
          */
-        setAsync(dateTime: Date, callback: (result: AsyncResult) => void): void;
+        setAsync(dateTime: Date, callback: (result: AsyncResult<void>) => void): void;
 
     }
     /**

--- a/generate-docs/api-extractor-inputs-outlook-legacy/Outlook_1_6/Outlook_1_6.d.ts
+++ b/generate-docs/api-extractor-inputs-outlook-legacy/Outlook_1_6/Outlook_1_6.d.ts
@@ -113,6 +113,24 @@ export declare namespace Office {
             Appointment = "appointment"
         }
         /**
+         * Represents the current view of Outlook Web App.
+         */
+        enum OWAView {
+            /**
+             * One column view. Displayed when the screen is narrow. Outlook Web App uses this single-column layout on the entire screen of a smartphone.
+             */
+            OneColumn = "OneColumn",
+            /**
+             * Two column view. Displayed when the screen is wider. Outlook Web App uses this view on most tablets.
+             */
+            TwoColumns = "TwoColumns",
+            /**
+             Three column view. Displayed when the screen is wide. For example, Outlook Web App uses this view in a full screen window on a desktop 
+             computer.
+             */
+            ThreeColumns = "ThreeColumns"
+        }
+        /**
          * Specifies the type of recipient for an appointment.
          *
          * [Api set: Mailbox 1.1]
@@ -140,7 +158,7 @@ export declare namespace Office {
              */
             Other = "other"
         }
-        /**  
+        /**
          * Specifies the type of response to a meeting invitation.
          *
          * [Api set: Mailbox 1.0]
@@ -236,7 +254,8 @@ export declare namespace Office {
         /**
          * Gets or sets the date and time that the appointment is to end.
          *
-         * The end property is expressed as a Coordinated Universal Time (UTC) date and time value. You can use the convertToLocalClientTime method to convert the end property value to the client's local date and time.
+         * The end property is expressed as a Coordinated Universal Time (UTC) date and time value. You can use the convertToLocalClientTime method to 
+         * convert the end property value to the client's local date and time.
          *
          * *Read mode*
          *
@@ -246,7 +265,8 @@ export declare namespace Office {
          *
          * The end property returns a Time object.
          *
-         * When you use the Time.setAsync method to set the end time, you should use the convertToUtcClientTime method to convert the local time on the client to UTC for the server.
+         * When you use the Time.setAsync method to set the end time, you should use the convertToUtcClientTime method to convert the local time on 
+         * the client to UTC for the server.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -320,7 +340,8 @@ export declare namespace Office {
         /**
          * Gets or sets the date and time that the appointment is to begin.
          *
-         * The start property is expressed as a Coordinated Universal Time (UTC) date and time value. You can use the convertToLocalClientTime method to convert the value to the client's local date and time.
+         * The start property is expressed as a Coordinated Universal Time (UTC) date and time value. You can use the convertToLocalClientTime method 
+         * to convert the value to the client's local date and time.
          *
          * *Read mode*
          *
@@ -330,7 +351,8 @@ export declare namespace Office {
          *
          * The start property returns a Time object.
          *
-         * When you use the Time.setAsync method to set the start time, you should use the convertToUtcClientTime method to convert the local time on the client to UTC for the server.
+         * When you use the Time.setAsync method to set the start time, you should use the convertToUtcClientTime method to convert the local time on 
+         * the client to UTC for the server.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -403,7 +425,8 @@ export declare namespace Office {
         size: number;
     }
     /**
-     * The body object provides methods for adding and updating the content of the message or appointment. It is returned in the body property of the selected item.
+     * The body object provides methods for adding and updating the content of the message or appointment. 
+     * It is returned in the body property of the selected item.
      *
      * [Api set: Mailbox 1.1]
      *
@@ -418,7 +441,9 @@ export declare namespace Office {
          *
          * This method returns the entire current body in the format specified by coercionType.
          *
-         * When working with HTML-formatted bodies, it is important to note that the Body.getAsync and Body.setAsync methods are not idempotent. The value returned from the getAsync method will not necessarily be exactly the same as the value that was passed in the setAsync method previously. The client may modify the value passed to setAsync in order to make it render efficiently with its rendering engine.
+         * When working with HTML-formatted bodies, it is important to note that the Body.getAsync and Body.setAsync methods are not idempotent. 
+         * The value returned from the getAsync method will not necessarily be exactly the same as the value that was passed in the setAsync method previously. 
+         * The client may modify the value passed to setAsync in order to make it render efficiently with its rendering engine.
          *
          * [Api set: Mailbox 1.3]
          *
@@ -427,22 +452,25 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          * 
-         * In addition to the main signature, this method also has this signature:
+         * In addition to this signature, this method also has the following signature:
          * 
-         * `getAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult) => void): void;`
+         * `getAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult<Office.Body>) => void): void;`
          * 
          * @param coercionType - The format for the returned body.
          * @param options - Optional. An object literal that contains one or more of the following properties:
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. The body is provided in the requested format in the asyncResult.value property.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. 
+         *                  The body is provided in the requested format in the asyncResult.value property.
          */
-        getAsync(coerciontype: Office.CoercionType, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        getAsync(coerciontype: Office.CoercionType, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<Office.Body>) => void): void;
         /**
          * Returns the current body in a specified format.
          *
          * This method returns the entire current body in the format specified by coercionType.
          *
-         * When working with HTML-formatted bodies, it is important to note that the Body.getAsync and Body.setAsync methods are not idempotent. The value returned from the getAsync method will not necessarily be exactly the same as the value that was passed in the setAsync method previously. The client may modify the value passed to setAsync in order to make it render efficiently with its rendering engine.
+         * When working with HTML-formatted bodies, it is important to note that the Body.getAsync and Body.setAsync methods are not idempotent. 
+         * The value returned from the getAsync method will not necessarily be exactly the same as the value that was passed in the setAsync method previously. 
+         * The client may modify the value passed to setAsync in order to make it render efficiently with its rendering engine.
          *
          * [Api set: Mailbox 1.3]
          *
@@ -452,9 +480,10 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          *
          * @param coercionType - The format for the returned body.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. The body is provided in the requested format in the asyncResult.value property.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult.
+         *                  The body is provided in the requested format in the asyncResult.value property.
          */
-        getAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult) => void): void;
+        getAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult<Office.Body>) => void): void;
 
         /**
          * Gets a value that indicates whether the content is in HTML or text format.
@@ -468,15 +497,18 @@ export declare namespace Office {
          *
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. The content type is returned as one of the CoercionType values in the asyncResult.value property.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult.
+         *                  The content type is returned as one of the CoercionType values in the asyncResult.value property.
          */
-        getTypeAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        getTypeAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<Office.CoercionType>) => void): void;
         /**
          * Adds the specified content to the beginning of the item body.
          *
-         * The prependAsync method inserts the specified string at the beginning of the item body. After insertion, the cursor is returned to its original place, relative to the inserted content.
+         * The prependAsync method inserts the specified string at the beginning of the item body. 
+         * After insertion, the cursor is returned to its original place, relative to the inserted content.
          *
-         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" (please see the Examples section for a sample).
+         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" 
+         * (please see the Examples section for a sample).
          *
          * [Api set: Mailbox 1.1]
          *
@@ -487,11 +519,11 @@ export declare namespace Office {
          * 
          * <tr><td>Errors</td><td>DataExceedsMaximumSize - The data parameter is longer than 1,000,000 characters.</td></tr></table>
          * 
-         * In addition to the main signature, this method also has these signatures:
+         * In addition to this signature, this method also has the following signatures:
          * 
          * `prependAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`
          * 
-         * `prependAsync(data: string, callback: (result: AsyncResult) => void): void;`
+         * `prependAsync(data: string, callback: (result: AsyncResult<void>) => void): void;`
          * 
          * `prependAsync(data: string): void;`
          *
@@ -499,15 +531,18 @@ export declare namespace Office {
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
          *        coercionType: The desired format for the body. The string in the data parameter will be converted to this format.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. Any errors encountered will be provided in the asyncResult.error property.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult.
+         *                  Any errors encountered will be provided in the asyncResult.error property.
          */
-        prependAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult) => void): void;
+        prependAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Adds the specified content to the beginning of the item body.
          *
-         * The prependAsync method inserts the specified string at the beginning of the item body. After insertion, the cursor is returned to its original place, relative to the inserted content.
+         * The prependAsync method inserts the specified string at the beginning of the item body. 
+         * After insertion, the cursor is returned to its original place, relative to the inserted content.
          *
-         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" (please see the Examples section for a sample).
+         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" 
+         * (please see the Examples section for a sample).
          *
          * [Api set: Mailbox 1.1]
          *
@@ -527,9 +562,11 @@ export declare namespace Office {
         /**
          * Adds the specified content to the beginning of the item body.
          *
-         * The prependAsync method inserts the specified string at the beginning of the item body. After insertion, the cursor is returned to its original place, relative to the inserted content.
+         * The prependAsync method inserts the specified string at the beginning of the item body. 
+         * After insertion, the cursor is returned to its original place, relative to the inserted content.
          *
-         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" (please see the Examples section for a sample).
+         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" 
+         * (please see the Examples section for a sample).
          *
          * [Api set: Mailbox 1.1]
          *
@@ -539,15 +576,18 @@ export declare namespace Office {
          * <tr><td>Errors</td><td>DataExceedsMaximumSize - The data parameter is longer than 1,000,000 characters.</td></tr></table>
          *
          * @param data - The string to be inserted at the beginning of the body. The string is limited to 1,000,000 characters.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. Any errors encountered will be provided in the asyncResult.error property.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult.
+         *                  Any errors encountered will be provided in the asyncResult.error property.
          */
-        prependAsync(data: string, callback: (result: AsyncResult) => void): void;
+        prependAsync(data: string, callback: (result: AsyncResult<void>) => void): void;
         /**
          * Adds the specified content to the beginning of the item body.
          *
-         * The prependAsync method inserts the specified string at the beginning of the item body. After insertion, the cursor is returned to its original place, relative to the inserted content.
+         * The prependAsync method inserts the specified string at the beginning of the item body. 
+         * After insertion, the cursor is returned to its original place, relative to the inserted content.
          *
-         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" (please see the Examples section for a sample).
+         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" 
+         * (please see the Examples section for a sample).
          *
          * [Api set: Mailbox 1.1]
          *
@@ -562,9 +602,12 @@ export declare namespace Office {
         /**
          * Replaces the entire body with the specified text.
          *
-         * When working with HTML-formatted bodies, it is important to note that the Body.getAsync and Body.setAsync methods are not idempotent. The value returned from the getAsync method will not necessarily be exactly the same as the value that was passed in the setAsync method previously. The client may modify the value passed to setAsync in order to make it render efficiently with its rendering engine.
+         * When working with HTML-formatted bodies, it is important to note that the Body.getAsync and Body.setAsync methods are not idempotent. 
+         * The value returned from the getAsync method will not necessarily be exactly the same as the value that was passed in the setAsync method 
+         * previously. The client may modify the value passed to setAsync in order to make it render efficiently with its rendering engine.
          *
-         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" (please see the Examples section for a sample).
+         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" 
+         * (please see the Examples section for a sample).
          *
          * [Api set: Mailbox 1.3]
          *
@@ -575,11 +618,11 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>DataExceedsMaximumSize - The data parameter is longer than 1,000,000 characters.</td></tr><tr><td></td><td>InvalidFormatError - The options.coercionType parameter is set to Office.CoercionType.Html and the message body is in plain text.</td></tr></table>
          * 
-         * In addition to the main signature, this method also has these signatures:
+         * In addition to this signature, this method also has the following signatures:
          * 
          * `setAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`
          * 
-         * `setAsync(data: string, callback: (result: AsyncResult) => void): void;`
+         * `setAsync(data: string, callback: (result: AsyncResult<void>) => void): void;`
          * 
          * `setAsync(data: string): void;`
          *
@@ -587,15 +630,19 @@ export declare namespace Office {
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
          *        coercionType: The desired format for the body. The string in the data parameter will be converted to this format.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.  Any errors encountered will be provided in the asyncResult.error property.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult.
+         *                  Any errors encountered will be provided in the asyncResult.error property.
          */
-        setAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult) => void): void;
+        setAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Replaces the entire body with the specified text.
          *
-         * When working with HTML-formatted bodies, it is important to note that the Body.getAsync and Body.setAsync methods are not idempotent. The value returned from the getAsync method will not necessarily be exactly the same as the value that was passed in the setAsync method previously. The client may modify the value passed to setAsync in order to make it render efficiently with its rendering engine.
+         * When working with HTML-formatted bodies, it is important to note that the Body.getAsync and Body.setAsync methods are not idempotent. 
+         * The value returned from the getAsync method will not necessarily be exactly the same as the value that was passed in the setAsync method 
+         * previously. The client may modify the value passed to setAsync in order to make it render efficiently with its rendering engine.
          *
-         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" (please see the Examples section for a sample).
+         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" 
+         * (please see the Examples section for a sample).
          *
          * [Api set: Mailbox 1.3]
          *
@@ -615,9 +662,12 @@ export declare namespace Office {
         /**
          * Replaces the entire body with the specified text.
          *
-         * When working with HTML-formatted bodies, it is important to note that the Body.getAsync and Body.setAsync methods are not idempotent. The value returned from the getAsync method will not necessarily be exactly the same as the value that was passed in the setAsync method previously. The client may modify the value passed to setAsync in order to make it render efficiently with its rendering engine.
+         * When working with HTML-formatted bodies, it is important to note that the Body.getAsync and Body.setAsync methods are not idempotent. 
+         * The value returned from the getAsync method will not necessarily be exactly the same as the value that was passed in the setAsync method 
+         * previously. The client may modify the value passed to setAsync in order to make it render efficiently with its rendering engine.
          *
-         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" (please see the Examples section for a sample).
+         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" 
+         * (please see the Examples section for a sample).
          *
          * [Api set: Mailbox 1.3]
          *
@@ -629,15 +679,19 @@ export declare namespace Office {
          * <tr><td>Errors</td><td>DataExceedsMaximumSize - The data parameter is longer than 1,000,000 characters.</td></tr><tr><td></td><td>InvalidFormatError - The options.coercionType parameter is set to Office.CoercionType.Html and the message body is in plain text.</td></tr></table>
          *
          * @param data - The string that will replace the existing body. The string is limited to 1,000,000 characters.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.  Any errors encountered will be provided in the asyncResult.error property.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult.
+         *                  Any errors encountered will be provided in the asyncResult.error property.
          */
-        setAsync(data: string, callback: (result: AsyncResult) => void): void;
+        setAsync(data: string, callback: (result: AsyncResult<void>) => void): void;
         /**
          * Replaces the entire body with the specified text.
          *
-         * When working with HTML-formatted bodies, it is important to note that the Body.getAsync and Body.setAsync methods are not idempotent. The value returned from the getAsync method will not necessarily be exactly the same as the value that was passed in the setAsync method previously. The client may modify the value passed to setAsync in order to make it render efficiently with its rendering engine.
+         * When working with HTML-formatted bodies, it is important to note that the Body.getAsync and Body.setAsync methods are not idempotent.
+         *  The value returned from the getAsync method will not necessarily be exactly the same as the value that was passed in the setAsync method 
+         * previously. The client may modify the value passed to setAsync in order to make it render efficiently with its rendering engine.
          *
-         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" (please see the Examples section for a sample).
+         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" 
+         * (please see the Examples section for a sample).
          *
          * [Api set: Mailbox 1.3]
          *
@@ -655,9 +709,12 @@ export declare namespace Office {
         /**
          * Replaces the selection in the body with the specified text.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor was never in the body of the item, or if the body of the item lost focus in the UI, the string will be inserted at the top of the body content. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the body of the item, or, if text is selected in 
+         * the editor, it replaces the selected text. If the cursor was never in the body of the item, or if the body of the item lost focus in the 
+         * UI, the string will be inserted at the top of the body content. After insertion, the cursor is placed at the end of the inserted content.
          *
-         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" (please see the Examples section for a sample).
+         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" 
+         * (please see the Examples section for a sample).
          *
          * [Api set: Mailbox 1.1]
          *
@@ -668,11 +725,11 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>DataExceedsMaximumSize - The data parameter is longer than 1,000,000 characters.</td></tr><tr><td></td><td>InvalidFormatError - The options.coercionType parameter is set to Office.CoercionType.Html and the message body is in plain text.</td></tr></table>
          * 
-         * In addition to the main signature, this method also has these signatures:
+         * In addition to this signature, this method also has the following signatures:
          * 
          * `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`
          * 
-         * `setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;`
+         * `setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;`
          * 
          * `setSelectedDataAsync(data: string): void;`
          *         
@@ -680,15 +737,19 @@ export declare namespace Office {
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
          *        coercionType: The desired format for the body. The string in the data parameter will be converted to this format.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.  Any errors encountered will be provided in the asyncResult.error property.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult.
+         *                  Any errors encountered will be provided in the asyncResult.error property.
          */
-        setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult) => void): void;
+        setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Replaces the selection in the body with the specified text.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor was never in the body of the item, or if the body of the item lost focus in the UI, the string will be inserted at the top of the body content. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the body of the item, or, if text is selected in 
+         * the editor, it replaces the selected text. If the cursor was never in the body of the item, or if the body of the item lost focus in the 
+         * UI, the string will be inserted at the top of the body content. After insertion, the cursor is placed at the end of the inserted content.
          *
-         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" (please see the Examples section for a sample).
+         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" 
+         * (please see the Examples section for a sample).
          *
          * [Api set: Mailbox 1.1]
          *
@@ -708,9 +769,12 @@ export declare namespace Office {
         /**
          * Replaces the selection in the body with the specified text.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor was never in the body of the item, or if the body of the item lost focus in the UI, the string will be inserted at the top of the body content. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the body of the item, or, if text is selected in 
+         * the editor, it replaces the selected text. If the cursor was never in the body of the item, or if the body of the item lost focus in the 
+         * UI, the string will be inserted at the top of the body content. After insertion, the cursor is placed at the end of the inserted content.
          *
-         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" (please see the Examples section for a sample).
+         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" 
+         * (please see the Examples section for a sample).
          *
          * [Api set: Mailbox 1.1]
          *
@@ -722,15 +786,19 @@ export declare namespace Office {
          * <tr><td>Errors</td><td>DataExceedsMaximumSize - The data parameter is longer than 1,000,000 characters.</td></tr><tr><td></td><td>InvalidFormatError - The options.coercionType parameter is set to Office.CoercionType.Html and the message body is in plain text.</td></tr></table>
          *
          * @param data - The string that will replace the existing body. The string is limited to 1,000,000 characters.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.  Any errors encountered will be provided in the asyncResult.error property.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult.
+         *                  Any errors encountered will be provided in the asyncResult.error property.
          */
-        setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;
+        setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;
         /**
          * Replaces the selection in the body with the specified text.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor was never in the body of the item, or if the body of the item lost focus in the UI, the string will be inserted at the top of the body content. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the body of the item, or, if text is selected in 
+         * the editor, it replaces the selected text. If the cursor was never in the body of the item, or if the body of the item lost focus in the 
+         * UI, the string will be inserted at the top of the body content. After insertion, the cursor is placed at the end of the inserted content.
          *
-         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" (please see the Examples section for a sample).
+         * When including links in HTML markup, you can disable online link preview by setting the id attribute on the anchor (<a>) to "LPNoLP" 
+         * (please see the Examples section for a sample).
          *
          * [Api set: Mailbox 1.1]
          *
@@ -748,7 +816,8 @@ export declare namespace Office {
     /**
      * Represents a contact stored on the server. Read mode only.
      *
-     * The list of contacts associated with an email message or appointment is returned in the contacts property of the {@link Office.Entities} object that is returned by the getEntities or getEntitiesByType method of the active item.
+     * The list of contacts associated with an email message or appointment is returned in the contacts property of the {@link Office.Entities} object 
+     * that is returned by the getEntities or getEntitiesByType method of the active item.
      *
      * [Api set: Mailbox 1.0]
      *
@@ -784,7 +853,10 @@ export declare namespace Office {
         urls: Array<string>;
     }
     /**
-     * The CustomProperties object represents custom properties that are specific to a particular item and specific to a mail add-in for Outlook. For example, there might be a need for a mail add-in to save some data that is specific to the current email message that activated the add-in. If the user revisits the same message in the future and activates the mail add-in again, the add-in will be able to retrieve the data that had been saved as custom properties.
+     * The CustomProperties object represents custom properties that are specific to a particular item and specific to a mail add-in for Outlook. 
+     * For example, there might be a need for a mail add-in to save some data that is specific to the current email message that activated the add-in. 
+     * If the user revisits the same message in the future and activates the mail add-in again, the add-in will be able to retrieve the data that had 
+     * been saved as custom properties.
      *
      * Because Outlook for Mac doesn't cache custom properties, if the user's network goes down, mail add-ins cannot access their custom properties.
      *
@@ -814,7 +886,9 @@ export declare namespace Office {
          *
          * The set method sets the specified property to the specified value. You must use the saveAsync method to save the property to the server.
          *
-         * The set method creates a new property if the specified property does not already exist; otherwise, the existing value is replaced with the new value. The value parameter can be of any type; however, it is always passed to the server as a string.
+         * The set method creates a new property if the specified property does not already exist; 
+         * otherwise, the existing value is replaced with the new value. 
+         * The value parameter can be of any type; however, it is always passed to the server as a string.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -844,11 +918,17 @@ export declare namespace Office {
         /**
          * Saves item-specific custom properties to the server.
          *
-         * You must call the saveAsync method to persist any changes made with the set method or the remove method of the CustomProperties object. The saving action is asynchronous.
+         * You must call the saveAsync method to persist any changes made with the set method or the remove method of the CustomProperties object. 
+         * The saving action is asynchronous.
          *
-         * It's a good practice to have your callback function check for and handle errors from saveAsync. In particular, a read add-in can be activated while the user is in a connected state in a read form, and subsequently the user becomes disconnected. If the add-in calls saveAsync while in the disconnected state, saveAsync would return an error. Your callback method should handle this error accordingly.
+         * It's a good practice to have your callback function check for and handle errors from saveAsync. 
+         * In particular, a read add-in can be activated while the user is in a connected state in a read form, and subsequently the user becomes 
+         * disconnected. 
+         * If the add-in calls saveAsync while in the disconnected state, saveAsync would return an error. 
+         * Your callback method should handle this error accordingly.
          *
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          * @param asyncContext - Optional. Any state data that is passed to the callback method.
          *
          * [Api set: Mailbox 1.0]
@@ -858,7 +938,7 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          */
-        saveAsync(callback?: (result: AsyncResult) => void, asyncContext?: any): void;
+        saveAsync(callback?: (result: AsyncResult<void>) => void, asyncContext?: any): void;
     }
     /**
      * Provides diagnostic information to an Outlook add-in.
@@ -887,7 +967,8 @@ export declare namespace Office {
         /**
          * Gets a string that represents the version of either the host application or the Exchange Server.
          *
-         * If the mail add-in is running on the Outlook desktop client or Outlook for iOS, the hostVersion property returns the version of the host application, Outlook. In Outlook Web App, the property returns the version of the Exchange Server. An example is the string 15.0.468.0.
+         * If the mail add-in is running on the Outlook desktop client or Outlook for iOS, the hostVersion property returns the version of the host 
+         * application, Outlook. In Outlook Web App, the property returns the version of the Exchange Server. An example is the string 15.0.468.0.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -906,11 +987,13 @@ export declare namespace Office {
          *
          * Outlook Web App has three views that correspond to the width of the screen and the window, and the number of columns that can be displayed:
          *
-         * - OneColumn, which is displayed when the screen is narrow. Outlook Web App uses this single-column layout on the entire screen of a smartphone.
+         * - OneColumn, which is displayed when the screen is narrow. Outlook Web App uses this single-column layout on the entire screen of a 
+         * smartphone.
          *
          * - TwoColumns, which is displayed when the screen is wider. Outlook Web App uses this view on most tablets.
          *
-         * - ThreeColumns, which is displayed when the screen is wide. For example, Outlook Web App uses this view in a full screen window on a desktop computer.
+         * - ThreeColumns, which is displayed when the screen is wide. For example, Outlook Web App uses this view in a full screen window on a 
+         * desktop computer.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -919,7 +1002,7 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          */
-        OWAView: "string";
+        OWAView: MailboxEnums.OWAView | "OneColumn" | "TwoColumns" | "ThreeColumns";
     }
     /**
      * Provides the email properties of the sender or specified recipients of an email message or appointment.
@@ -941,7 +1024,9 @@ export declare namespace Office {
          */
         displayName: string;
         /**
-         * Gets the response that an attendee returned for an appointment. This property applies to only an attendee of an appointment, as represented by the optionalAttendees or requiredAttendees property. This property returns undefined in other scenarios.
+         * Gets the response that an attendee returned for an appointment. 
+         * This property applies to only an attendee of an appointment, as represented by the optionalAttendees or requiredAttendees property. 
+         * This property returns undefined in other scenarios.
          */
         appointmentResponse: Office.MailboxEnums.ResponseType;
         /**
@@ -972,17 +1057,25 @@ export declare namespace Office {
     /**
      * Represents a collection of entities found in an email message or appointment. Read mode only.
      *
-     * The Entities object is a container for the entity arrays returned by the getEntities and getEntitiesByType methods when the item (either an email message or an appointment) contains one or more entities that have been found by the server. You can use these entities in your code to provide additional context information to the viewer, such as a map to an address found in the item, or to open a dialer for a phone number found in the item.
+     * The Entities object is a container for the entity arrays returned by the getEntities and getEntitiesByType methods when the item 
+     * (either an email message or an appointment) contains one or more entities that have been found by the server. 
+     * You can use these entities in your code to provide additional context information to the viewer, such as a map to an address found in the item, 
+     * or to open a dialer for a phone number found in the item.
      *
-     * If no entities of the type specified in the property are present in the item, the property associated with that entity is null. For example, if a message contains a street address and a phone number, the addresses property and phoneNumbers property would contain information, and the other properties would be null.
+     * If no entities of the type specified in the property are present in the item, the property associated with that entity is null. 
+     * For example, if a message contains a street address and a phone number, the addresses property and phoneNumbers property would contain 
+     * information, and the other properties would be null.
      *
-     * To be recognized as an address, the string must contain a United States postal address that has at least a subset of the elements of a street number, street name, city, state, and zip code.
+     * To be recognized as an address, the string must contain a United States postal address that has at least a subset of the elements of a street 
+     * number, street name, city, state, and zip code.
      *
      * To be recognized as a phone number, the string must contain a North American phone number format.
      *
-     * Entity recognition relies on natural language recognition that is based on machine learning of large amounts of data. The recognition of an entity is non-deterministic and success sometimes relies on the particular context in the item.
+     * Entity recognition relies on natural language recognition that is based on machine learning of large amounts of data. 
+     * The recognition of an entity is non-deterministic and success sometimes relies on the particular context in the item.
      *
-     * When the property arrays are returned by the getEntitiesByType method, only the property for the specified entity contains data; all other properties are null.
+     * When the property arrays are returned by the getEntitiesByType method, only the property for the specified entity contains data; 
+     * all other properties are null.
      *
      * [Api set: Mailbox 1.0]
      *
@@ -1024,14 +1117,16 @@ export declare namespace Office {
     /**
      * The subclass of {@link Office.Item} dealing with appointments.
      * 
-     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of Office.context.mailbox.item. Refer to the Object Model pages for more information.
+     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. 
+     * You should treat this as a mode of Office.context.mailbox.item. Refer to the Object Model pages for more information.
      */
     export interface Appointment extends Item {
     }
     /**
      * The appointment organizer mode of {@link Office.Item | Office.context.mailbox.item}.
      * 
-     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
+     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. 
+     * You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
      */
     export interface AppointmentCompose extends Appointment, ItemCompose {
          /**
@@ -1075,9 +1170,11 @@ export declare namespace Office {
         /**
          * Gets or sets the date and time that the appointment is to end.
          *
-         * The end property is an {@link Office.Time} object expressed as a Coordinated Universal Time (UTC) date and time value. You can use the convertToLocalClientTime method to convert the end property value to the client's local date and time.
+         * The end property is an {@link Office.Time} object expressed as a Coordinated Universal Time (UTC) date and time value. 
+         * You can use the convertToLocalClientTime method to convert the end property value to the client's local date and time.
          *
-         * When you use the Time.setAsync method to set the end time, you should use the convertToUtcClientTime method to convert the local time on the client to UTC for the server.
+         * When you use the Time.setAsync method to set the end time, you should use the convertToUtcClientTime method to convert the local time on 
+         * the client to UTC for the server.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1103,7 +1200,8 @@ export declare namespace Office {
          */
         itemType: Office.MailboxEnums.ItemType;
         /**
-         * Gets or sets the {@link Office.Location} of an appointment. The location property returns a Location object that provides methods that are used to get and set the location of the appointment.
+         * Gets or sets the {@link Office.Location} of an appointment. The location property returns a Location object that provides methods that are 
+         * used to get and set the location of the appointment.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1127,7 +1225,9 @@ export declare namespace Office {
          */
         notificationMessages: Office.NotificationMessages;
         /**
-         * Provides access to the optional attendees of an event. The type of object and level of access depends on the mode of the current item. The optionalAttendees property returns an {@link Office.Recipients} object that provides methods to get or update the optional attendees for a meeting.
+         * Provides access to the optional attendees of an event. The type of object and level of access depends on the mode of the current item. 
+         * The optionalAttendees property returns an {@link Office.Recipients} object that provides methods to get or update the optional attendees 
+         * for a meeting.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1139,7 +1239,9 @@ export declare namespace Office {
          */
         optionalAttendees: Recipients;
         /**
-         * Provides access to the required attendees of an event. The type of object and level of access depends on the mode of the current item. The requiredAttendees property returns an {@link Office.Recipients} object that provides methods to get or update the required attendees for a meeting.
+         * Provides access to the required attendees of an event. The type of object and level of access depends on the mode of the current item. 
+         * The requiredAttendees property returns an {@link Office.Recipients} object that provides methods to get or update the required attendees 
+         * for a meeting.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1153,9 +1255,11 @@ export declare namespace Office {
         /**
          * Gets or sets the date and time that the appointment is to begin.
          *
-         * The start property is an {@link Office.Time} object expressed as a Coordinated Universal Time (UTC) date and time value. You can use the convertToLocalClientTime method to convert the value to the client's local date and time.
+         * The start property is an {@link Office.Time} object expressed as a Coordinated Universal Time (UTC) date and time value. 
+         * You can use the convertToLocalClientTime method to convert the value to the client's local date and time.
          *
-         * When you use the Time.setAsync method to set the start time, you should use the convertToUtcClientTime method to convert the local time on the client to UTC for the server.
+         * When you use the Time.setAsync method to set the start time, you should use the convertToUtcClientTime method to convert the local time on 
+         * the client to UTC for the server.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1204,16 +1308,18 @@ export declare namespace Office {
          * 
          * `addFileAttachmentAsync(uri: string, attachmentName: string, options: Office.AsyncContextOptions): void;`
          * 
-         * `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+         * `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;`
          *
          * @param uri - The URI that provides the location of the file to attach to the message or appointment. The maximum length is 2048 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
          *        isInline: If true, indicates that the attachment will be shown inline in the message body, and should not be displayed in the attachment list.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type asyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type asyncResult. 
+         *                 On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
          */
-        addFileAttachmentAsync(uri: string, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        addFileAttachmentAsync(uri: string, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;
         /**
          * Adds a file to a message or appointment as an attachment.
          *
@@ -1254,7 +1360,7 @@ export declare namespace Office {
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         *        isInline: If true, indicates that the attachment will be shown inline in the message body, and should not be displayed in the attachment list.
+         *        isInline: If true, indicates that the attachment will be shown inline in the message body and should not be displayed in the attachment list.
          */
         addFileAttachmentAsync(uri: string, attachmentName: string, options: Office.AsyncContextOptions): void;
         /**
@@ -1275,17 +1381,23 @@ export declare namespace Office {
          *
          * @param uri - The URI that provides the location of the file to attach to the message or appointment. The maximum length is 2048 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type asyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type asyncResult. 
+         *                 On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
          */
-        addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;
+        addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. 
+         * You can use the options parameter to pass state information to the callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -1296,29 +1408,35 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>NumberOfAttachmentsExceeded - The message or appointment has too many attachments.</td></tr></table>
          * 
-         * In addition to the main signature, this method also has these signatures:
+         * In addition to this signature, this method also has the following signatures:
          * 
          * `addItemAttachmentAsync(itemId: any, attachmentName: string): void;`
          * 
          * `addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;`
          * 
-         * `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+         * `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;`
          *
          * @param itemId - The Exchange identifier of the item to attach. The maximum length is 100 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
          * @param options - An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. 
+         *                 On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
          */
-        addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. 
+         * You can use the options parameter to pass state information to the callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -1336,11 +1454,15 @@ export declare namespace Office {
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. 
+         * You can use the options parameter to pass state information to the callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -1360,11 +1482,15 @@ export declare namespace Office {
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. 
+         * You can use the options parameter to pass state information to the callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -1377,17 +1503,21 @@ export declare namespace Office {
          *
          * @param itemId - The Exchange identifier of the item to attach. The maximum length is 100 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. 
+         *                 On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
          */
-        addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;
+        addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;
         /**
          * Closes the current item that is being composed
          *
-         * The behaviors of the close method depends on the current state of the item being composed. If the item has unsaved changes, the client prompts the user to save, discard, or close the action.
+         * The behaviors of the close method depends on the current state of the item being composed. 
+         * If the item has unsaved changes, the client prompts the user to save, discard, or close the action.
          *
          * In the Outlook desktop client, if the message is an inline reply, the close method has no effect.
          *
-         * Note: In Outlook on the web, if the item is an appointment and it has previously been saved using saveAsync, the user is prompted to save, discard, or cancel even if no changes have occurred since the item was last saved.
+         * Note: In Outlook on the web, if the item is an appointment and it has previously been saved using saveAsync, the user is prompted to save, 
+         * discard, or cancel even if no changes have occurred since the item was last saved.
          *
          * [Api set: Mailbox 1.3]
          *
@@ -1401,9 +1531,11 @@ export declare namespace Office {
         /**
          * Asynchronously returns selected data from the subject or body of a message.
          *
-         * If there is no selection but the cursor is in the body or subject, the method returns null for the selected data. If a field other than the body or subject is selected, the method returns the InvalidSelection error.
+         * If there is no selection but the cursor is in the body or subject, the method returns null for the selected data. 
+         * If a field other than the body or subject is selected, the method returns the InvalidSelection error.
          *
-         * To access the selected data from the callback method, call asyncResult.value.data. To access the source property that the selection comes from, call asyncResult.value.sourceProperty, which will be either body or subject.
+         * To access the selected data from the callback method, call asyncResult.value.data. 
+         * To access the source property that the selection comes from, call asyncResult.value.sourceProperty, which will be either body or subject.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -1416,18 +1548,21 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Appointment Organizer</td></tr></table>
          *
-         * @param coercionType - Requests a format for the data. If Text, the method returns the plain text as a string , removing any HTML tags present. If HTML, the method returns the selected text, whether it is plaintext or HTML.
+         * @param coercionType - Requests a format for the data. If Text, the method returns the plain text as a string , removing any HTML tags present. 
+         *                     If HTML, the method returns the selected text, whether it is plaintext or HTML.
          * @param options - An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
          * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
          */
-        getSelectedDataAsync(coerciontype: Office.CoercionType, options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;
+        getSelectedDataAsync(coerciontype: Office.CoercionType, options: Office.AsyncContextOptions, callback: (result: AsyncResult<any>) => void): void;
          /**
          * Asynchronously returns selected data from the subject or body of a message.
          *
-         * If there is no selection but the cursor is in the body or subject, the method returns null for the selected data. If a field other than the body or subject is selected, the method returns the InvalidSelection error.
+         * If there is no selection but the cursor is in the body or subject, the method returns null for the selected data. 
+         * If a field other than the body or subject is selected, the method returns the InvalidSelection error.
          *
-         * To access the selected data from the callback method, call asyncResult.value.data. To access the source property that the selection comes from, call asyncResult.value.sourceProperty, which will be either body or subject.
+         * To access the selected data from the callback method, call asyncResult.value.data. 
+         * To access the source property that the selection comes from, call asyncResult.value.sourceProperty, which will be either body or subject.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -1440,16 +1575,22 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Appointment Organizer</td></tr></table>
          *
-         * @param coercionType - Requests a format for the data. If Text, the method returns the plain text as a string , removing any HTML tags present. If HTML, the method returns the selected text, whether it is plaintext or HTML.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param coercionType - Requests a format for the data. If Text, the method returns the plain text as a string , removing any HTML tags present. 
+         *                     If HTML, the method returns the selected text, whether it is plaintext or HTML.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          */
-        getSelectedDataAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult) => void): void;
+        getSelectedDataAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult<string>) => void): void;
         /**
          * Asynchronously loads custom properties for this add-in on the selected item.
          *
-         * Custom properties are stored as key/value pairs on a per-app, per-item basis. This method returns a CustomProperties object in the callback, which provides methods to access the custom properties specific to the current item and the current add-in. Custom properties are not encrypted on the item, so this should not be used as secure storage.
+         * Custom properties are stored as key/value pairs on a per-app, per-item basis. 
+         * This method returns a CustomProperties object in the callback, which provides methods to access the custom properties specific to the 
+         * current item and the current add-in. Custom properties are not encrypted on the item, so this should not be used as secure storage.
          *
-         * The custom properties are provided as a CustomProperties object in the asyncResult.value property. This object can be used to get, set, and remove custom properties from the item and save changes to the custom property set back to the server.
+         * The custom properties are provided as a CustomProperties object in the asyncResult.value property. 
+         * This object can be used to get, set, and remove custom properties from the item and save changes to the custom property set back to 
+         * the server.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1459,14 +1600,20 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Appointment Organizer</td></tr></table>
          *
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
-         * @param userContext - Optional. Developers can provide any object they wish to access in the callback function. This object can be accessed by the asyncResult.asyncContext property in the callback function.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
+         * @param userContext - Optional. Developers can provide any object they wish to access in the callback function. 
+         *                    This object can be accessed by the asyncResult.asyncContext property in the callback function.
          */
-        loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;
+        loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any): void;
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -1484,18 +1631,23 @@ export declare namespace Office {
          * 
          * `removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;`
          * 
-         * `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;`
+         * `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;`
          *
          * @param attachmentIndex - The identifier of the attachment to remove. The maximum length of the string is 100 characters.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. 
+         *                 If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
          */
-        removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -1513,7 +1665,11 @@ export declare namespace Office {
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -1533,7 +1689,12 @@ export declare namespace Office {
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. 
+         * In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -1546,17 +1707,25 @@ export declare namespace Office {
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
          * @param attachmentIndex - The identifier of the attachment to remove. The maximum length of the string is 100 characters.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. 
+         *                 If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
          */
-        removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;
+        removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;
         /**
          * Asynchronously saves an item.
          *
-         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. In Outlook Web App or Outlook in online mode, the item is saved to the server. In Outlook in cached mode, the item is saved to the local cache.
+         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. 
+         * In Outlook Web App or Outlook in online mode, the item is saved to the server. 
+         * In Outlook in cached mode, the item is saved to the local cache.
          *
-         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. Saving an existing appointment will send an update to added or removed attendees.
+         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal 
+         * appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. 
+         * Saving an existing appointment will send an update to added or removed attendees.
          *
-         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that when Outlook is in cached mode, it may take some time before the item is actually synced to the server. Until the item is synced, using the itemId will return an error.
+         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that 
+         * when Outlook is in cached mode, it may take some time before the item is actually synced to the server. 
+         * Until the item is synced, using the itemId will return an error.
          *
          * Note: The following clients have different behavior for saveAsync on appointments in compose mode:
          *
@@ -1580,21 +1749,27 @@ export declare namespace Office {
          * 
          * `saveAsync(options: Office.AsyncContextOptions): void;`
          * 
-         * `saveAsync(callback: (result: AsyncResult) => void): void;`
+         * `saveAsync(callback: (result: AsyncResult<void>) => void): void;`
          *
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. 
          */
-        saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Asynchronously saves an item.
          *
-         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. In Outlook Web App or Outlook in online mode, the item is saved to the server. In Outlook in cached mode, the item is saved to the local cache.
+         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. 
+         * In Outlook Web App or Outlook in online mode, the item is saved to the server. 
+         * In Outlook in cached mode, the item is saved to the local cache.
          *
-         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. Saving an existing appointment will send an update to added or removed attendees.
+         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal 
+         * appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. 
+         * Saving an existing appointment will send an update to added or removed attendees.
          *
-         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that when Outlook is in cached mode, it may take some time before the item is actually synced to the server. Until the item is synced, using the itemId will return an error.
+         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that 
+         * when Outlook is in cached mode, it may take some time before the item is actually synced to the server. 
+         * Until the item is synced, using the itemId will return an error.
          *
          * Note: The following clients have different behavior for saveAsync on appointments in compose mode:
          *
@@ -1617,11 +1792,17 @@ export declare namespace Office {
         /**
          * Asynchronously saves an item.
          *
-         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. In Outlook Web App or Outlook in online mode, the item is saved to the server. In Outlook in cached mode, the item is saved to the local cache.
+         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. 
+         * In Outlook Web App or Outlook in online mode, the item is saved to the server. 
+         * In Outlook in cached mode, the item is saved to the local cache.
          *
-         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. Saving an existing appointment will send an update to added or removed attendees.
+         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal 
+         * appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. 
+         * Saving an existing appointment will send an update to added or removed attendees.
          *
-         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that when Outlook is in cached mode, it may take some time before the item is actually synced to the server. Until the item is synced, using the itemId will return an error.
+         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that 
+         * when Outlook is in cached mode, it may take some time before the item is actually synced to the server. 
+         * Until the item is synced, using the itemId will return an error.
          *
          * Note: The following clients have different behavior for saveAsync on appointments in compose mode:
          *
@@ -1646,11 +1827,16 @@ export declare namespace Office {
         /**
          * Asynchronously saves an item.
          *
-         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. In Outlook Web App or Outlook in online mode, the item is saved to the server. In Outlook in cached mode, the item is saved to the local cache.
+         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. 
+         * In Outlook Web App or Outlook in online mode, the item is saved to the server. In Outlook in cached mode, the item is saved to the local cache.
          *
-         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. Saving an existing appointment will send an update to added or removed attendees.
+         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal 
+         * appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. 
+         * Saving an existing appointment will send an update to added or removed attendees.
          *
-         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that when Outlook is in cached mode, it may take some time before the item is actually synced to the server. Until the item is synced, using the itemId will return an error.
+         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that 
+         * when Outlook is in cached mode, it may take some time before the item is actually synced to the server. 
+         * Until the item is synced, using the itemId will return an error.
          *
          * Note: The following clients have different behavior for saveAsync on appointments in compose mode:
          *
@@ -1668,13 +1854,15 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult.
          */
-        saveAsync(callback: (result: AsyncResult) => void): void;
+        saveAsync(callback: (result: AsyncResult<void>) => void): void;
         /**
          * Asynchronously inserts data into the body or subject of a message.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is 
+         * selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. 
+         * After insertion, the cursor is placed at the end of the inserted content.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -1692,19 +1880,29 @@ export declare namespace Office {
          * 
          * `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`
          * 
-         * `setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;`
+         * `setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;`
          *
-         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
+         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. 
+         *             If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         *        coercionType: If text, the current style is applied in Outlook Web App and Outlook. If the field is an HTML editor, only the text data is inserted, even if the data is HTML. If html and the field supports HTML (the subject doesn't), the current style is applied in Outlook Web App and the default style is applied in Outlook. If the field is a text field, an InvalidDataFormat error is returned. If coercionType is not set, the result depends on the field: if the field is HTML then HTML is used; if the field is text, then plain text is used.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         *        coercionType: If text, the current style is applied in Outlook Web App and Outlook. 
+         *                      If the field is an HTML editor, only the text data is inserted, even if the data is HTML. 
+         *                      If html and the field supports HTML (the subject doesn't), the current style is applied in Outlook Web App and the 
+         *                      default style is applied in Outlook. 
+         *                      If the field is a text field, an InvalidDataFormat error is returned. 
+         *                      If coercionType is not set, the result depends on the field: if the field is HTML then HTML is used; 
+         *                      if the field is text, then plain text is used.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          */
-        setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult) => void): void;
+        setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Asynchronously inserts data into the body or subject of a message.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is 
+         * selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. 
+         * After insertion, the cursor is placed at the end of the inserted content.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -1716,13 +1914,16 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
-         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
+         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. 
+         *             If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
          */
         setSelectedDataAsync(data: string): void;
         /**
          * Asynchronously inserts data into the body or subject of a message.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is 
+         * selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. 
+         * After insertion, the cursor is placed at the end of the inserted content.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -1734,16 +1935,24 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
-         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
+         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. 
+         *             If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         *        coercionType: If text, the current style is applied in Outlook Web App and Outlook. If the field is an HTML editor, only the text data is inserted, even if the data is HTML. If html and the field supports HTML (the subject doesn't), the current style is applied in Outlook Web App and the default style is applied in Outlook. If the field is a text field, an InvalidDataFormat error is returned. If coercionType is not set, the result depends on the field: if the field is HTML then HTML is used; if the field is text, then plain text is used.
+         *        coercionType: If text, the current style is applied in Outlook Web App and Outlook. 
+         *                      If the field is an HTML editor, only the text data is inserted, even if the data is HTML. 
+         *                      If html and the field supports HTML (the subject doesn't), the current style is applied in Outlook Web App and the 
+         *                      default style is applied in Outlook. If the field is a text field, an InvalidDataFormat error is returned. 
+         *                      If coercionType is not set, the result depends on the field: if the field is HTML then HTML is used; 
+         *                      if the field is text, then plain text is used.
          */
         setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;
         /**
          * Asynchronously inserts data into the body or subject of a message.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is 
+         * selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. 
+         * After insertion, the cursor is placed at the end of the inserted content.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -1755,20 +1964,23 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
-         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. 
+         *             If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          */
-        setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;
+        setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;
     }
 
     /**
      * The appointment attendee mode of {@link Office.Item | Office.context.mailbox.item}.
      * 
-     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of 'Office.context.mailbox.item'. Refer to the Object Model pages for more information.
+     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. 
+     * You should treat this as a mode of 'Office.context.mailbox.item'. Refer to the Object Model pages for more information.
      */
     export interface AppointmentRead extends Appointment, ItemRead {
         /**
-         * Gets an array of attachments for the item.
+         * Gets the item's attachments as an array.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1778,7 +1990,8 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Appointment Attendee</td></tr></table>
          *
-         * Note: Certain types of files are blocked by Outlook due to potential security issues and are therefore not returned. For more information, see {@link https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519 | Blocked attachments in Outlook}.
+         * Note: Certain types of files are blocked by Outlook due to potential security issues and are therefore not returned. For more information, see 
+         * {@link https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519 | Blocked attachments in Outlook}.
          *
          */
         attachments: Office.AttachmentDetails[];
@@ -1823,9 +2036,11 @@ export declare namespace Office {
         /**
          * Gets the date and time that the appointment is to end.
          *
-         * The end property is a Date object expressed as a Coordinated Universal Time (UTC) date and time value. You can use the convertToLocalClientTime method to convert the end property value to the client's local date and time.
+         * The end property is a Date object expressed as a Coordinated Universal Time (UTC) date and time value. 
+         * You can use the convertToLocalClientTime method to convert the end property value to the client's local date and time.
          *
-         * When you use the Time.setAsync method to set the end time, you should use the convertToUtcClientTime method to convert the local time on the client to UTC for the server.
+         * When you use the Time.setAsync method to set the end time, you should use the convertToUtcClientTime method to convert the local time on 
+         * the client to UTC for the server.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1875,9 +2090,14 @@ export declare namespace Office {
         /**
          * Gets the Exchange Web Services item identifier for the current item.
          *
-         * The itemId property is not available in compose mode. If an item identifier is required, the saveAsync method can be used to save the item to the store, which will return the item identifier in the AsyncResult.value parameter in the callback function.
+         * The itemId property is not available in compose mode. 
+         * If an item identifier is required, the saveAsync method can be used to save the item to the store, which will return the item identifier 
+         * in the AsyncResult.value parameter in the callback function.
          *
-         * Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more details, see Use the Outlook REST APIs from an Outlook add-in.
+         * Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. 
+         * The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. 
+         * Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. 
+         * For more details, see {@link https://docs.microsoft.com/outlook/add-ins/use-rest-api#get-the-item-id | Use the Outlook REST APIs from an Outlook add-in}.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1919,7 +2139,8 @@ export declare namespace Office {
         /**
          * Gets the subject of an item, with all prefixes removed (including RE: and FWD:).
          *
-         * The normalizedSubject property gets the subject of the item, with any standard prefixes (such as RE: and FW:) that are added by email programs. To get the subject of the item with the prefixes intact, use the subject property.
+         * The normalizedSubject property gets the subject of the item, with any standard prefixes (such as RE: and FW:) that are added by email programs. 
+         * To get the subject of the item with the prefixes intact, use the subject property.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1945,7 +2166,8 @@ export declare namespace Office {
         /**
          * Provides access to the optional attendees of an event. The type of object and level of access depends on the mode of the current item.
          *
-         * The optionalAttendees property returns an array that contains an {@link Office.EmailAddressDetails} object for each optional attendee to the meeting.
+         * The optionalAttendees property returns an array that contains an {@link Office.EmailAddressDetails} object for each optional attendee to 
+         * the meeting.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1957,7 +2179,7 @@ export declare namespace Office {
          */
         optionalAttendees: EmailAddressDetails[];
         /**
-         * Gets the email address of the meeting organizer for a specified meeting. Read mode only.
+         * Gets the email address of the meeting organizer for a specified meeting.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1971,7 +2193,8 @@ export declare namespace Office {
         /**
          * Provides access to the required attendees of an event. The type of object and level of access depends on the mode of the current item.
          *
-         * The requiredAttendees property returns an array that contains an {@link Office.EmailAddressDetails} object for each required attendee to the meeting.
+         * The requiredAttendees property returns an array that contains an {@link Office.EmailAddressDetails} object for each required attendee to 
+         * the meeting.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -1985,7 +2208,8 @@ export declare namespace Office {
         /**
          * Gets the date and time that the appointment is to begin.
          *
-         * The start property is a Date object expressed as a Coordinated Universal Time (UTC) date and time value. You can use the convertToLocalClientTime method to convert the value to the client's local date and time.
+         * The start property is a Date object expressed as a Coordinated Universal Time (UTC) date and time value. 
+         * You can use the convertToLocalClientTime method to convert the value to the client's local date and time.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -2012,14 +2236,18 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Appointment Attendee</td></tr></table>
          */
         subject: string;
+
         /**
-         * Displays a reply form that includes the sender and all recipients of the selected message or the organizer and all attendees of the selected appointment.
+         * Displays a reply form that includes the sender and all recipients of the selected message or the organizer and all attendees of the 
+         * selected appointment.
          *
          * In Outlook Web App, the reply form is displayed as a pop-out form in the 3-column view and a pop-up form in the 2- or 1-column view.
          *
          * If any of the string parameters exceed their limits, displayReplyAllForm throws an exception.
          *
-         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. If this isn't possible, then no error message is thrown.
+         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and 
+         * attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. 
+         * If this isn't possible, then no error message is thrown.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -2042,7 +2270,9 @@ export declare namespace Office {
          *
          * If any of the string parameters exceed their limits, displayReplyForm throws an exception.
          *
-         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. If this isn't possible, then no error message is thrown.
+         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and 
+         * attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. 
+         * If this isn't possible, then no error message is thrown.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -2060,7 +2290,7 @@ export declare namespace Office {
          */
         displayReplyForm(formData: string | ReplyFormData): void;
         /**
-         * Gets the entities found in the selected item.
+         * Gets the entities found in the selected item's body.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -2074,7 +2304,7 @@ export declare namespace Office {
          */
         getEntities(): Entities;
         /**
-         * Gets an array of all the entities of the specified entity type found in the selected item.
+         * Gets an array of all the entities of the specified entity type found in the selected item's body.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -2083,7 +2313,9 @@ export declare namespace Office {
          * @param entityType - One of the EntityType enumeration values.
          *
          * @returns
-         * If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. If no entities of the specified type are present on the item, the method returns an empty array. Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter.
+         * If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. 
+         * If no entities of the specified type are present in the item's body, the method returns an empty array. 
+         * Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter.
          *
          * @remarks
          * <table><tr><td>{@link https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions | Minimum permission level}</td><td>Restricted</td></tr>
@@ -2139,7 +2371,8 @@ export declare namespace Office {
         /**
          * Returns well-known entities in the selected item that pass the named filter defined in the manifest XML file.
          *
-         * The getFilteredEntitiesByName method returns the entities that match the regular expression defined in the ItemHasKnownEntity rule element in the manifest XML file with the specified FilterName element value.
+         * The getFilteredEntitiesByName method returns the entities that match the regular expression defined in the ItemHasKnownEntity rule element 
+         * in the manifest XML file with the specified FilterName element value.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -2152,22 +2385,33 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Appointment Attendee</td></tr></table>
          *
          * @param name - The name of the ItemHasKnownEntity rule element that defines the filter to match.
-         * @returns If there is no ItemHasKnownEntity element in the manifest with a FilterName element value that matches the name parameter, the method returns null. If the name parameter does match an ItemHasKnownEntity element in the manifest, but there are no entities in the current item that match, the method return an empty array.
+         * @returns If there is no ItemHasKnownEntity element in the manifest with a FilterName element value that matches the name parameter, 
+         * the method returns null. 
+         * If the name parameter does match an ItemHasKnownEntity element in the manifest, but there are no entities in the current item that match, 
+         * the method return an empty array.
          */
         getFilteredEntitiesByName(name: string): (string | Contact | MeetingSuggestion | PhoneNumber | TaskSuggestion)[];
         /**
          * Returns string values in the selected item that match the regular expressions defined in the manifest XML file.
          *
-         * The getRegExMatches method returns the strings that match the regular expression defined in each ItemHasRegularExpressionMatch or ItemHasKnownEntity rule element in the manifest XML file. For an ItemHasRegularExpressionMatch rule, a matching string has to occur in the property of the item that is specified by that rule. The PropertyName simple type defines the supported properties.
+         * The getRegExMatches method returns the strings that match the regular expression defined in each ItemHasRegularExpressionMatch or 
+         * ItemHasKnownEntity rule element in the manifest XML file. 
+         * For an ItemHasRegularExpressionMatch rule, a matching string has to occur in the property of the item that is specified by that rule. 
+         * The PropertyName simple type defines the supported properties.
          *
-         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body and should not attempt to return the entire body of the item. Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results. Instead, use the Body.getAsync method to retrieve the entire body.
+         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body 
+         * and should not attempt to return the entire body of the item. 
+         * Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results. 
+         * Instead, use the Body.getAsync method to retrieve the entire body.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
          * [Api set: Mailbox 1.0]
          *
          * @returns
-         * An object that contains arrays of strings that match the regular expressions defined in the manifest XML file. The name of each array is equal to the corresponding value of the RegExName attribute of the matching ItemHasRegularExpressionMatch rule or the FilterName attribute of the matching ItemHasKnownEntity rule.
+         * An object that contains arrays of strings that match the regular expressions defined in the manifest XML file. 
+         * The name of each array is equal to the corresponding value of the RegExName attribute of the matching ItemHasRegularExpressionMatch rule 
+         * or the FilterName attribute of the matching ItemHasKnownEntity rule.
          *
          * @remarks
          *
@@ -2179,9 +2423,12 @@ export declare namespace Office {
         /**
          * Returns string values in the selected item that match the named regular expression defined in the manifest XML file.
          *
-         * The getRegExMatchesByName method returns the strings that match the regular expression defined in the ItemHasRegularExpressionMatch rule element in the manifest XML file with the specified RegExName element value.
+         * The getRegExMatchesByName method returns the strings that match the regular expression defined in the ItemHasRegularExpressionMatch rule 
+         * element in the manifest XML file with the specified RegExName element value.
          *
-         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body and should not attempt to return the entire body of the item. Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results.
+         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body 
+         * and should not attempt to return the entire body of the item. 
+         * Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -2216,18 +2463,27 @@ export declare namespace Office {
          */
         getSelectedEntities(): Entities;
         /**
-         * Returns string values in a highlighted match that match the regular expressions defined in the manifest XML file. Highlighted matches apply to contextual add-ins.
+         * Returns string values in a highlighted match that match the regular expressions defined in the manifest XML file. 
+         * Highlighted matches apply to contextual add-ins.
          *
-         * The getSelectedRegExMatches method returns the strings that match the regular expression defined in each ItemHasRegularExpressionMatch or ItemHasKnownEntity rule element in the manifest XML file. For an ItemHasRegularExpressionMatch rule, a matching string has to occur in the property of the item that is specified by that rule. The PropertyName simple type defines the supported properties.
+         * The getSelectedRegExMatches method returns the strings that match the regular expression defined in each ItemHasRegularExpressionMatch or 
+         * ItemHasKnownEntity rule element in the manifest XML file. 
+         * For an ItemHasRegularExpressionMatch rule, a matching string has to occur in the property of the item that is specified by that rule. 
+         * The PropertyName simple type defines the supported properties.
          *
-         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body and should not attempt to return the entire body of the item. Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results. Instead, use the Body.getAsync method to retrieve the entire body.
+         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body 
+         * and should not attempt to return the entire body of the item. 
+         * Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results. 
+         * Instead, use the Body.getAsync method to retrieve the entire body.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
          * [Api set: Mailbox 1.6]
          *
          * @returns
-         * An object that contains arrays of strings that match the regular expressions defined in the manifest XML file. The name of each array is equal to the corresponding value of the RegExName attribute of the matching ItemHasRegularExpressionMatch rule or the FilterName attribute of the matching ItemHasKnownEntity rule.
+         * An object that contains arrays of strings that match the regular expressions defined in the manifest XML file. 
+         * The name of each array is equal to the corresponding value of the RegExName attribute of the matching ItemHasRegularExpressionMatch rule 
+         * or the FilterName attribute of the matching ItemHasKnownEntity rule.
          *
          * @remarks
          *
@@ -2239,9 +2495,13 @@ export declare namespace Office {
        /**
         * Asynchronously loads custom properties for this add-in on the selected item.
         *
-        * Custom properties are stored as key/value pairs on a per-app, per-item basis. This method returns a CustomProperties object in the callback, which provides methods to access the custom properties specific to the current item and the current add-in. Custom properties are not encrypted on the item, so this should not be used as secure storage.
+        * Custom properties are stored as key/value pairs on a per-app, per-item basis. 
+        * This method returns a CustomProperties object in the callback, which provides methods to access the custom properties specific to the 
+        * current item and the current add-in. Custom properties are not encrypted on the item, so this should not be used as secure storage.
         *
-        * The custom properties are provided as a CustomProperties object in the asyncResult.value property. This object can be used to get, set, and remove custom properties from the item and save changes to the custom property set back to the server.
+        * The custom properties are provided as a CustomProperties object in the asyncResult.value property. 
+        * This object can be used to get, set, and remove custom properties from the item and save changes to the custom property set back to 
+        * the server.
         *
         * [Api set: Mailbox 1.0]
         *
@@ -2251,14 +2511,17 @@ export declare namespace Office {
         *
         * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Appointment Attendee</td></tr></table>
         *
-        * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
-        * @param userContext - Optional. Developers can provide any object they wish to access in the callback function. This object can be accessed by the asyncResult.asyncContext property in the callback function.
+        * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+        *                 type Office.AsyncResult.
+        * @param userContext - Optional. Developers can provide any object they wish to access in the callback function. 
+        *                    This object can be accessed by the asyncResult.asyncContext property in the callback function.
         */
-       loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;
+       loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any): void;
     }
 
     /**
-     * The item namespace is used to access the currently selected message, meeting request, or appointment. You can determine the type of the item by using the `itemType` property.
+     * The item namespace is used to access the currently selected message, meeting request, or appointment. 
+     * You can determine the type of the item by using the `itemType` property.
      *
      * [Api set: Mailbox 1.0]
      *
@@ -2309,7 +2572,8 @@ export declare namespace Office {
         /**
          * Gets the type of item that an instance represents.
          *
-         * The itemType property returns one of the ItemType enumeration values, indicating whether the item object instance is a message or an appointment.
+         * The itemType property returns one of the ItemType enumeration values, indicating whether the item object instance is a message or 
+         * an appointment.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -2336,9 +2600,13 @@ export declare namespace Office {
        /**
         * Asynchronously loads custom properties for this add-in on the selected item.
         *
-        * Custom properties are stored as key/value pairs on a per-app, per-item basis. This method returns a CustomProperties object in the callback, which provides methods to access the custom properties specific to the current item and the current add-in. Custom properties are not encrypted on the item, so this should not be used as secure storage.
+        * Custom properties are stored as key/value pairs on a per-app, per-item basis. 
+        * This method returns a CustomProperties object in the callback, which provides methods to access the custom properties specific to the 
+        * current item and the current add-in. Custom properties are not encrypted on the item, so this should not be used as secure storage.
         *
-        * The custom properties are provided as a CustomProperties object in the asyncResult.value property. This object can be used to get, set, and remove custom properties from the item and save changes to the custom property set back to the server.
+        * The custom properties are provided as a CustomProperties object in the asyncResult.value property. 
+        * This object can be used to get, set, and remove custom properties from the item and save changes to the custom property set back to 
+        * the server.
         *
         * [Api set: Mailbox 1.0]
         *
@@ -2348,15 +2616,18 @@ export declare namespace Office {
         *
         * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
         *
-        * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
-        * @param userContext - Optional. Developers can provide any object they wish to access in the callback function. This object can be accessed by the asyncResult.asyncContext property in the callback function.
+        * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+        *                 type Office.AsyncResult.
+        * @param userContext - Optional. Developers can provide any object they wish to access in the callback function. 
+        *                    This object can be accessed by the asyncResult.asyncContext property in the callback function.
         */
-       loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;
+       loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any): void;
     }
     /**
      * The compose mode of {@link Office.Item | Office.context.mailbox.item}.
      * 
-     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
+     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. 
+     * You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
      */
     export interface ItemCompose extends Item {
         /**
@@ -2397,16 +2668,20 @@ export declare namespace Office {
          * 
          * `addFileAttachmentAsync(uri: string, attachmentName: string, options: Office.AsyncContextOptions): void;`
          * 
-         * `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+         * `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;`
          *
          * @param uri - The URI that provides the location of the file to attach to the message or appointment. The maximum length is 2048 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         *        isInline: If true, indicates that the attachment will be shown inline in the message body, and should not be displayed in the attachment list.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type asyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         *        isInline: If true, indicates that the attachment will be shown inline in the message body, and should not be displayed in the 
+         *        attachment list.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type asyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of 
+         *                 the error.
          */
-        addFileAttachmentAsync(uri: string, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        addFileAttachmentAsync(uri: string, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;
         /**
          * Adds a file to a message or appointment as an attachment.
          *
@@ -2447,7 +2722,8 @@ export declare namespace Office {
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         *        isInline: If true, indicates that the attachment will be shown inline in the message body, and should not be displayed in the attachment list.
+         *        isInline: If true, indicates that the attachment will be shown inline in the message body, and should not be displayed in the 
+         *        attachment list.
          */
         addFileAttachmentAsync(uri: string, attachmentName: string, options: Office.AsyncContextOptions): void;
         /**
@@ -2468,18 +2744,25 @@ export declare namespace Office {
          *
          * @param uri - The URI that provides the location of the file to attach to the message or appointment. The maximum length is 2048 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type asyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of 
+         *                 the error.
          */
-        addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;
+        addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;
 
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the 
+         * callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -2490,29 +2773,36 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>NumberOfAttachmentsExceeded - The message or appointment has too many attachments.</td></tr></table>
          * 
-         * In addition to the main signature, this method also has these signatures:
+         * In addition to this signature, this method also has the following signatures:
          * 
          * `addItemAttachmentAsync(itemId: any, attachmentName: string): void;`
          * 
          * `addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;`
          * 
-         * `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+         * `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;`
          *
          * @param itemId - The Exchange identifier of the item to attach. The maximum length is 100 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
          * @param options - An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of 
+         *                 the error.
          */
-        addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the 
+         * callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -2530,11 +2820,15 @@ export declare namespace Office {
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the 
+         * callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -2554,11 +2848,15 @@ export declare namespace Office {
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the 
+         * callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -2571,18 +2869,23 @@ export declare namespace Office {
          *
          * @param itemId - The Exchange identifier of the item to attach. The maximum length is 100 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of 
+         *                 the error.
          */
-        addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;
+        addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;
 
         /**
          * Closes the current item that is being composed
          *
-         * The behaviors of the close method depends on the current state of the item being composed. If the item has unsaved changes, the client prompts the user to save, discard, or close the action.
+         * The behaviors of the close method depends on the current state of the item being composed. 
+         * If the item has unsaved changes, the client prompts the user to save, discard, or close the action.
          *
          * In the Outlook desktop client, if the message is an inline reply, the close method has no effect.
          *
-         * Note: In Outlook on the web, if the item is an appointment and it has previously been saved using saveAsync, the user is prompted to save, discard, or cancel even if no changes have occurred since the item was last saved.
+         * Note: In Outlook on the web, if the item is an appointment and it has previously been saved using saveAsync, the user is prompted to save, 
+         * discard, or cancel even if no changes have occurred since the item was last saved.
          *
          * [Api set: Mailbox 1.3]
          *
@@ -2596,9 +2899,11 @@ export declare namespace Office {
         /**
          * Asynchronously returns selected data from the subject or body of a message.
          *
-         * If there is no selection but the cursor is in the body or subject, the method returns null for the selected data. If a field other than the body or subject is selected, the method returns the InvalidSelection error.
+         * If there is no selection but the cursor is in the body or subject, the method returns null for the selected data. 
+         * If a field other than the body or subject is selected, the method returns the InvalidSelection error.
          *
-         * To access the selected data from the callback method, call asyncResult.value.data. To access the source property that the selection comes from, call asyncResult.value.sourceProperty, which will be either body or subject.
+         * To access the selected data from the callback method, call asyncResult.value.data. To access the source property that the selection comes 
+         * from, call asyncResult.value.sourceProperty, which will be either body or subject.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -2611,16 +2916,20 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose</td></tr></table>
          *
-         * @param coercionType - Requests a format for the data. If Text, the method returns the plain text as a string , removing any HTML tags present. If HTML, the method returns the selected text, whether it is plaintext or HTML.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param coercionType - Requests a format for the data. If Text, the method returns the plain text as a string , removing any HTML tags present. 
+         *                     If HTML, the method returns the selected text, whether it is plaintext or HTML.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          */
-        getSelectedDataAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult) => void): void;
+        getSelectedDataAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult<any>) => void): void;
         /**
          * Asynchronously returns selected data from the subject or body of a message.
          *
-         * If there is no selection but the cursor is in the body or subject, the method returns null for the selected data. If a field other than the body or subject is selected, the method returns the InvalidSelection error.
+         * If there is no selection but the cursor is in the body or subject, the method returns null for the selected data. 
+         * If a field other than the body or subject is selected, the method returns the InvalidSelection error.
          *
-         * To access the selected data from the callback method, call asyncResult.value.data. To access the source property that the selection comes from, call asyncResult.value.sourceProperty, which will be either body or subject.
+         * To access the selected data from the callback method, call asyncResult.value.data. 
+         * To access the source property that the selection comes from, call asyncResult.value.sourceProperty, which will be either body or subject.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -2633,16 +2942,22 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose</td></tr></table>
          *
-         * @param coercionType - Requests a format for the data. If Text, the method returns the plain text as a string , removing any HTML tags present. If HTML, the method returns the selected text, whether it is plaintext or HTML.
+         * @param coercionType - Requests a format for the data. If Text, the method returns the plain text as a string, removing any HTML tags present. 
+         *                     If HTML, the method returns the selected text, whether it is plaintext or HTML.
          * @param options - An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          */
-        getSelectedDataAsync(coerciontype: Office.CoercionType, options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;
+        getSelectedDataAsync(coerciontype: Office.CoercionType, options: Office.AsyncContextOptions, callback: (result: AsyncResult<any>) => void): void;
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -2660,18 +2975,24 @@ export declare namespace Office {
          * 
          * `removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;`
          * 
-         * `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;`
+         * `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;`
          *
          * @param attachmentIndex - The identifier of the attachment to remove. The maximum length of the string is 100 characters.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. 
+         *                 If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
          */
-        removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -2689,7 +3010,11 @@ export declare namespace Office {
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -2709,7 +3034,11 @@ export declare namespace Office {
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -2722,18 +3051,26 @@ export declare namespace Office {
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
          * @param attachmentIndex - The identifier of the attachment to remove. The maximum length of the string is 100 characters.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type {@link Offfice.AsyncResult}. 
+         *                 If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
          */
-        removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;
+        removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;
 
         /**
          * Asynchronously saves an item.
          *
-         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. In Outlook Web App or Outlook in online mode, the item is saved to the server. In Outlook in cached mode, the item is saved to the local cache.
+         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. 
+         * In Outlook Web App or Outlook in online mode, the item is saved to the server. 
+         * In Outlook in cached mode, the item is saved to the local cache.
          *
-         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. Saving an existing appointment will send an update to added or removed attendees.
+         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal 
+         * appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. 
+         * Saving an existing appointment will send an update to added or removed attendees.
          *
-         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that when Outlook is in cached mode, it may take some time before the item is actually synced to the server. Until the item is synced, using the itemId will return an error.
+         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that 
+         * when Outlook is in cached mode, it may take some time before the item is actually synced to the server. 
+         * Until the item is synced, using the itemId will return an error.
          *
          * Note: The following clients have different behavior for saveAsync on appointments in compose mode:
          *
@@ -2757,21 +3094,29 @@ export declare namespace Office {
          * 
          * `saveAsync(options: Office.AsyncContextOptions): void;`
          * 
-         * `saveAsync(callback: (result: AsyncResult) => void): void;`
+         * `saveAsync(callback: (result: AsyncResult<void>) => void): void;`
          *
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. 
+         *                 If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
          */
-        saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Asynchronously saves an item.
          *
-         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. In Outlook Web App or Outlook in online mode, the item is saved to the server. In Outlook in cached mode, the item is saved to the local cache.
+         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. 
+         * In Outlook Web App or Outlook in online mode, the item is saved to the server. 
+         * In Outlook in cached mode, the item is saved to the local cache.
          *
-         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. Saving an existing appointment will send an update to added or removed attendees.
+         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal 
+         * appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. 
+         * Saving an existing appointment will send an update to added or removed attendees.
          *
-         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that when Outlook is in cached mode, it may take some time before the item is actually synced to the server. Until the item is synced, using the itemId will return an error.
+         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that 
+         * when Outlook is in cached mode, it may take some time before the item is actually synced to the server. 
+         * Until the item is synced, using the itemId will return an error.
          *
          * Note: The following clients have different behavior for saveAsync on appointments in compose mode:
          *
@@ -2794,11 +3139,17 @@ export declare namespace Office {
         /**
          * Asynchronously saves an item.
          *
-         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. In Outlook Web App or Outlook in online mode, the item is saved to the server. In Outlook in cached mode, the item is saved to the local cache.
+         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. 
+         * In Outlook Web App or Outlook in online mode, the item is saved to the server. 
+         * In Outlook in cached mode, the item is saved to the local cache.
          *
-         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. Saving an existing appointment will send an update to added or removed attendees.
+         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal 
+         * appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. 
+         * Saving an existing appointment will send an update to added or removed attendees.
          *
-         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that when Outlook is in cached mode, it may take some time before the item is actually synced to the server. Until the item is synced, using the itemId will return an error.
+         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that 
+         * when Outlook is in cached mode, it may take some time before the item is actually synced to the server. 
+         * Until the item is synced, using the itemId will return an error.
          *
          * Note: The following clients have different behavior for saveAsync on appointments in compose mode:
          *
@@ -2823,11 +3174,17 @@ export declare namespace Office {
         /**
          * Asynchronously saves an item.
          *
-         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. In Outlook Web App or Outlook in online mode, the item is saved to the server. In Outlook in cached mode, the item is saved to the local cache.
+         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. 
+         * In Outlook Web App or Outlook in online mode, the item is saved to the server. 
+         * In Outlook in cached mode, the item is saved to the local cache.
          *
-         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. Saving an existing appointment will send an update to added or removed attendees.
+         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal 
+         * appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. 
+         * Saving an existing appointment will send an update to added or removed attendees.
          *
-         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that when Outlook is in cached mode, it may take some time before the item is actually synced to the server. Until the item is synced, using the itemId will return an error.
+         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that 
+         * when Outlook is in cached mode, it may take some time before the item is actually synced to the server. 
+         * Until the item is synced, using the itemId will return an error.
          *
          * Note: The following clients have different behavior for saveAsync on appointments in compose mode:
          *
@@ -2845,13 +3202,17 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. 
+         *                 If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
          */
-        saveAsync(callback: (result: AsyncResult) => void): void;
+        saveAsync(callback: (result: AsyncResult<void>) => void): void;
         /**
          * Asynchronously inserts data into the body or subject of a message.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is 
+         * selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. 
+         * After insertion, the cursor is placed at the end of the inserted content.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -2869,19 +3230,29 @@ export declare namespace Office {
          * 
          * `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`
          * 
-         * `setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;`
+         * `setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;`
          *
-         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
+         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. 
+         *             If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         *        coercionType: If text, the current style is applied in Outlook Web App and Outlook. If the field is an HTML editor, only the text data is inserted, even if the data is HTML. If html and the field supports HTML (the subject doesn't), the current style is applied in Outlook Web App and the default style is applied in Outlook. If the field is a text field, an InvalidDataFormat error is returned. If coercionType is not set, the result depends on the field: if the field is HTML then HTML is used; if the field is text, then plain text is used.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         *        coercionType: If text, the current style is applied in Outlook Web App and Outlook. 
+         *        If the field is an HTML editor, only the text data is inserted, even if the data is HTML. 
+         *        If html and the field supports HTML (the subject doesn't), the current style is applied in Outlook Web App and the default style is 
+         *        applied in Outlook. 
+         *        If the field is a text field, an InvalidDataFormat error is returned. 
+         *        If coercionType is not set, the result depends on the field: if the field is HTML then HTML is used; 
+         *        if the field is text, then plain text is used.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. 
          */
-        setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult) => void): void;
+        setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Asynchronously inserts data into the body or subject of a message.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is 
+         * selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. 
+         * After insertion, the cursor is placed at the end of the inserted content.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -2893,13 +3264,16 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
-         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
+         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. 
+         *             If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
          */
         setSelectedDataAsync(data: string): void;
         /**
          * Asynchronously inserts data into the body or subject of a message.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is 
+         * selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. 
+         * After insertion, the cursor is placed at the end of the inserted content.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -2911,16 +3285,25 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
-         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
+         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. 
+         *             If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         *        coercionType: If text, the current style is applied in Outlook Web App and Outlook. If the field is an HTML editor, only the text data is inserted, even if the data is HTML. If html and the field supports HTML (the subject doesn't), the current style is applied in Outlook Web App and the default style is applied in Outlook. If the field is a text field, an InvalidDataFormat error is returned. If coercionType is not set, the result depends on the field: if the field is HTML then HTML is used; if the field is text, then plain text is used.
+         *        coercionType: If text, the current style is applied in Outlook Web App and Outlook. 
+         *        If the field is an HTML editor, only the text data is inserted, even if the data is HTML. 
+         *        If html and the field supports HTML (the subject doesn't), the current style is applied in Outlook Web App and the default style is 
+         *        applied in Outlook. 
+         *        If the field is a text field, an InvalidDataFormat error is returned. 
+         *        If coercionType is not set, the result depends on the field: if the field is HTML then HTML is used; 
+         *        if the field is text, then plain text is used.
          */
         setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;
         /**
          * Asynchronously inserts data into the body or subject of a message.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is 
+         * selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. 
+         * After insertion, the cursor is placed at the end of the inserted content.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -2932,19 +3315,22 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
-         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. 
+         *             If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. 
          */
-        setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;
+        setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;
     }
     /**
      * The read mode of {@link Office.Item | Office.context.mailbox.item}.
      * 
-     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
+     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. 
+     * You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
      */
     export interface ItemRead extends Item {
         /**
-         * Gets an array of attachments for the item.
+         * Gets the item's attachments as an array.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -2953,7 +3339,9 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Read</td></tr></table>
          *
-         * Note: Certain types of files are blocked by Outlook due to potential security issues and are therefore not returned. For more information, see {@link https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519 | Blocked attachments in Outlook}.
+         * Note: Certain types of files are blocked by Outlook due to potential security issues and are therefore not returned. 
+         * For more information, see 
+         * {@link https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519 | Blocked attachments in Outlook}.
          *
          */
         attachments: Office.AttachmentDetails[];
@@ -2961,7 +3349,8 @@ export declare namespace Office {
          * Gets the Exchange Web Services item class of the selected item.
          *
          *
-         * You can create custom message classes that extends a default message class, for example, a custom appointment message class IPM.Appointment.Contoso.
+         * You can create custom message classes that extends a default message class, for example, a custom appointment message class 
+         * IPM.Appointment.Contoso.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -2971,7 +3360,8 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Read</td></tr></table>
          * 
-         * The itemClass property specifies the message class of the selected item. The following are the default message classes for the message or appointment item.
+         * The itemClass property specifies the message class of the selected item. The following are the default message classes for the message or 
+         * appointment item.
          * 
          * <table>
          *   <tr>
@@ -2995,9 +3385,14 @@ export declare namespace Office {
         /**
          * Gets the Exchange Web Services item identifier for the current item.
          *
-         * The itemId property is not available in compose mode. If an item identifier is required, the saveAsync method can be used to save the item to the store, which will return the item identifier in the AsyncResult.value parameter in the callback function.
+         * The itemId property is not available in compose mode. 
+         * If an item identifier is required, the saveAsync method can be used to save the item to the store, which will return the item identifier 
+         * in the AsyncResult.value parameter in the callback function.
          *
-         * Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more details, see Use the Outlook REST APIs from an Outlook add-in.
+         * Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. 
+         * The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. 
+         * Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. 
+         * For more details, see {@link https://docs.microsoft.com/outlook/add-ins/use-rest-api#get-the-item-id | Use the Outlook REST APIs from an Outlook add-in}.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -3011,7 +3406,8 @@ export declare namespace Office {
         /**
          * Gets the subject of an item, with all prefixes removed (including RE: and FWD:).
          *
-         * The normalizedSubject property gets the subject of the item, with any standard prefixes (such as RE: and FW:) that are added by email programs. To get the subject of the item with the prefixes intact, use the subject property.
+         * The normalizedSubject property gets the subject of the item, with any standard prefixes (such as RE: and FW:) that are added by 
+         * email programs. To get the subject of the item with the prefixes intact, use the subject property.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -3039,13 +3435,16 @@ export declare namespace Office {
          */
         subject: string;
         /**
-         * Displays a reply form that includes the sender and all recipients of the selected message or the organizer and all attendees of the selected appointment.
+         * Displays a reply form that includes the sender and all recipients of the selected message or the organizer and all attendees of the 
+         * selected appointment.
          *
          * In Outlook Web App, the reply form is displayed as a pop-out form in the 3-column view and a pop-up form in the 2- or 1-column view.
          *
          * If any of the string parameters exceed their limits, displayReplyAllForm throws an exception.
          *
-         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. If this isn't possible, then no error message is thrown.
+         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and 
+         * attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. 
+         * If this isn't possible, then no error message is thrown.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -3068,7 +3467,9 @@ export declare namespace Office {
          *
          * If any of the string parameters exceed their limits, displayReplyForm throws an exception.
          *
-         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. If this isn't possible, then no error message is thrown.
+         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and 
+         * attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. 
+         * If this isn't possible, then no error message is thrown.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -3086,7 +3487,7 @@ export declare namespace Office {
          */
         displayReplyForm(formData: string | ReplyFormData): void;
         /**
-         * Gets the entities found in the selected item.
+         * Gets the entities found in the selected item's body.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -3100,7 +3501,7 @@ export declare namespace Office {
          */
         getEntities(): Entities;
         /**
-         * Gets an array of all the entities of the specified entity type found in the selected item.
+         * Gets an array of all the entities of the specified entity type found in the selected item's body.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -3109,14 +3510,17 @@ export declare namespace Office {
          * @param entityType - One of the EntityType enumeration values.
          *
          * @returns
-         * If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. If no entities of the specified type are present on the item, the method returns an empty array. Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter.
+         * If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. 
+         * If no entities of the specified type are present in the item's body, the method returns an empty array. 
+         * Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter.
          *
          * @remarks
          * <table><tr><td>{@link https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions | Minimum permission level}</td><td>Restricted</td></tr>
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Read</td></tr></table>
          * 
-         * While the minimum permission level to use this method is Restricted, some entity types require ReadItem to access, as specified in the following table.
+         * While the minimum permission level to use this method is Restricted, some entity types require ReadItem to access, as specified in the 
+         * following table.
          * 
          * <table>
          *   <tr>
@@ -3165,7 +3569,8 @@ export declare namespace Office {
         /**
          * Returns well-known entities in the selected item that pass the named filter defined in the manifest XML file.
          *
-         * The getFilteredEntitiesByName method returns the entities that match the regular expression defined in the ItemHasKnownEntity rule element in the manifest XML file with the specified FilterName element value.
+         * The getFilteredEntitiesByName method returns the entities that match the regular expression defined in the ItemHasKnownEntity rule element 
+         * in the manifest XML file with the specified FilterName element value.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -3178,22 +3583,33 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Read</td></tr></table>
          *
          * @param name - The name of the ItemHasKnownEntity rule element that defines the filter to match.
-         * @returns If there is no ItemHasKnownEntity element in the manifest with a FilterName element value that matches the name parameter, the method returns null. If the name parameter does match an ItemHasKnownEntity element in the manifest, but there are no entities in the current item that match, the method return an empty array.
+         * @returns If there is no ItemHasKnownEntity element in the manifest with a FilterName element value that matches the name parameter, 
+         * the method returns null. 
+         * If the name parameter does match an ItemHasKnownEntity element in the manifest, but there are no entities in the current item that match, 
+         * the method return an empty array.
          */
         getFilteredEntitiesByName(name: string): (string | Contact | MeetingSuggestion | PhoneNumber | TaskSuggestion)[];
         /**
          * Returns string values in the selected item that match the regular expressions defined in the manifest XML file.
          *
-         * The getRegExMatches method returns the strings that match the regular expression defined in each ItemHasRegularExpressionMatch or ItemHasKnownEntity rule element in the manifest XML file. For an ItemHasRegularExpressionMatch rule, a matching string has to occur in the property of the item that is specified by that rule. The PropertyName simple type defines the supported properties.
+         * The getRegExMatches method returns the strings that match the regular expression defined in each ItemHasRegularExpressionMatch or 
+         * ItemHasKnownEntity rule element in the manifest XML file. 
+         * For an ItemHasRegularExpressionMatch rule, a matching string has to occur in the property of the item that is specified by that rule. 
+         * The PropertyName simple type defines the supported properties.
          *
-         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body and should not attempt to return the entire body of the item. Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results. Instead, use the Body.getAsync method to retrieve the entire body.
+         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body 
+         * and should not attempt to return the entire body of the item. 
+         * Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results. 
+         * Instead, use the Body.getAsync method to retrieve the entire body.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
          * [Api set: Mailbox 1.0]
          *
          * @returns
-         * An object that contains arrays of strings that match the regular expressions defined in the manifest XML file. The name of each array is equal to the corresponding value of the RegExName attribute of the matching ItemHasRegularExpressionMatch rule or the FilterName attribute of the matching ItemHasKnownEntity rule.
+         * An object that contains arrays of strings that match the regular expressions defined in the manifest XML file. 
+         * The name of each array is equal to the corresponding value of the RegExName attribute of the matching ItemHasRegularExpressionMatch rule 
+         * or the FilterName attribute of the matching ItemHasKnownEntity rule.
          *
          * @remarks
          *
@@ -3205,9 +3621,12 @@ export declare namespace Office {
         /**
          * Returns string values in the selected item that match the named regular expression defined in the manifest XML file.
          *
-         * The getRegExMatchesByName method returns the strings that match the regular expression defined in the ItemHasRegularExpressionMatch rule element in the manifest XML file with the specified RegExName element value.
+         * The getRegExMatchesByName method returns the strings that match the regular expression defined in the ItemHasRegularExpressionMatch rule 
+         * element in the manifest XML file with the specified RegExName element value.
          *
-         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body and should not attempt to return the entire body of the item. Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results.
+         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body 
+         * and should not attempt to return the entire body of the item. 
+         * Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -3242,18 +3661,25 @@ export declare namespace Office {
          */
         getSelectedEntities(): Entities;
         /**
-         * Returns string values in a highlighted match that match the regular expressions defined in the manifest XML file. Highlighted matches apply to contextual add-ins.
+         * Returns string values in a highlighted match that match the regular expressions defined in the manifest XML file. 
+         * Highlighted matches apply to contextual add-ins.
          *
-         * The getSelectedRegExMatches method returns the strings that match the regular expression defined in each ItemHasRegularExpressionMatch or ItemHasKnownEntity rule element in the manifest XML file. For an ItemHasRegularExpressionMatch rule, a matching string has to occur in the property of the item that is specified by that rule. The PropertyName simple type defines the supported properties.
+         * The getSelectedRegExMatches method returns the strings that match the regular expression defined in each ItemHasRegularExpressionMatch or 
+         * ItemHasKnownEntity rule element in the manifest XML file. For an ItemHasRegularExpressionMatch rule, a matching string has to occur in the property of the item that is specified by that rule. The PropertyName simple type defines the supported properties.
          *
-         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body and should not attempt to return the entire body of the item. Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results. Instead, use the Body.getAsync method to retrieve the entire body.
+         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body 
+         * and should not attempt to return the entire body of the item. 
+         * Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results. 
+         * Instead, use the Body.getAsync method to retrieve the entire body.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
          * [Api set: Mailbox 1.6]
          *
          * @returns
-         * An object that contains arrays of strings that match the regular expressions defined in the manifest XML file. The name of each array is equal to the corresponding value of the RegExName attribute of the matching ItemHasRegularExpressionMatch rule or the FilterName attribute of the matching ItemHasKnownEntity rule.
+         * An object that contains arrays of strings that match the regular expressions defined in the manifest XML file. 
+         * The name of each array is equal to the corresponding value of the RegExName attribute of the matching ItemHasRegularExpressionMatch rule 
+         * or the FilterName attribute of the matching ItemHasKnownEntity rule.
          *
          * @remarks
          *
@@ -3266,15 +3692,19 @@ export declare namespace Office {
     /**
      * A subclass of {@link Office.Item} for messages.
      * 
-     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
+     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. 
+     * You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
      */
     export interface Message extends Item {
         /**
          * Gets an identifier for the email conversation that contains a particular message.
          *
-         * You can get an integer for this property if your mail app is activated in read forms or responses in compose forms. If subsequently the user changes the subject of the reply message, upon sending the reply, the conversation ID for that message will change and that value you obtained earlier will no longer apply.
+         * You can get an integer for this property if your mail app is activated in read forms or responses in compose forms. 
+         * If subsequently the user changes the subject of the reply message, upon sending the reply, the conversation ID for that message will 
+         * change and that value you obtained earlier will no longer apply.
          *
-         * You get null for this property for a new item in a compose form. If the user sets a subject and saves the item, the conversationId property will return a value.
+         * You get null for this property for a new item in a compose form. 
+         * If the user sets a subject and saves the item, the conversationId property will return a value.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -3290,7 +3720,8 @@ export declare namespace Office {
      /**
      * The message compose mode of {@link Office.Item | Office.context.mailbox.item}.
      * 
-     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
+     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. 
+     * You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information.
      */
     export interface MessageCompose extends Message, ItemCompose {
         /**
@@ -3318,9 +3749,11 @@ export declare namespace Office {
          */
         body: Office.Body;
         /**
-         * Provides access to the Cc (carbon copy) recipients of a message. The type of object and level of access depends on the mode of the current item.
+         * Provides access to the Cc (carbon copy) recipients of a message. The type of object and level of access depends on the mode of the 
+         * current item.
          *
-         * The cc property returns a {@link Office.Recipients} object that provides methods to get or update the recipients on the Cc line of the message.
+         * The cc property returns a {@link Office.Recipients} object that provides methods to get or update the recipients on the Cc line of 
+         * the message.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -3334,9 +3767,12 @@ export declare namespace Office {
         /**
          * Gets an identifier for the email conversation that contains a particular message.
          *
-         * You can get an integer for this property if your mail app is activated in read forms or responses in compose forms. If subsequently the user changes the subject of the reply message, upon sending the reply, the conversation ID for that message will change and that value you obtained earlier will no longer apply.
+         * You can get an integer for this property if your mail app is activated in read forms or responses in compose forms. 
+         * If subsequently the user changes the subject of the reply message, upon sending the reply, the conversation ID for that message will change 
+         * and that value you obtained earlier will no longer apply.
          *
-         * You get null for this property for a new item in a compose form. If the user sets a subject and saves the item, the conversationId property will return a value.
+         * You get null for this property for a new item in a compose form. 
+         * If the user sets a subject and saves the item, the conversationId property will return a value.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -3376,7 +3812,8 @@ export declare namespace Office {
         /**
          * Gets the type of item that an instance represents.
          *
-         * The itemType property returns one of the ItemType enumeration values, indicating whether the item object instance is a message or an appointment.
+         * The itemType property returns one of the ItemType enumeration values, indicating whether the item object instance is a message or 
+         * an appointment.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -3416,7 +3853,8 @@ export declare namespace Office {
          */
         subject: Subject;
         /**
-         * Provides access to the recipients on the To line of a message. The type of object and level of access depends on the mode of the current item.
+         * Provides access to the recipients on the To line of a message. The type of object and level of access depends on the mode of the 
+         * current item.
          *
          * The to property returns a Recipients object that provides methods to get or update the recipients on the To line of the message.
          *
@@ -3452,16 +3890,20 @@ export declare namespace Office {
          * 
          * `addFileAttachmentAsync(uri: string, attachmentName: string, options: AsyncContextOptions): void;`
          * 
-         * `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+         * `addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;`
          *
          * @param uri - The URI that provides the location of the file to attach to the message or appointment. The maximum length is 2048 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         *        isInline: If true, indicates that the attachment will be shown inline in the message body, and should not be displayed in the attachment list.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type asyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         *        isInline: If true, indicates that the attachment will be shown inline in the message body, and should not be displayed in the 
+         *        attachment list.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of 
+         *                 the error.
          */
-        addFileAttachmentAsync(uri: string, attachmentName: string, options?: AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        addFileAttachmentAsync(uri: string, attachmentName: string, options?: AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;
         /**
          * Adds a file to a message or appointment as an attachment.
          *
@@ -3502,7 +3944,7 @@ export declare namespace Office {
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         *        isInline: If true, indicates that the attachment will be shown inline in the message body, and should not be displayed in the attachment list.
+         *        isInline: If true, indicates that the attachment will be shown inline in the message body and should not be displayed in the attachment list.
          */
         addFileAttachmentAsync(uri: string, attachmentName: string, options: AsyncContextOptions): void;
         /**
@@ -3523,17 +3965,24 @@ export declare namespace Office {
          *
          * @param uri - The URI that provides the location of the file to attach to the message or appointment. The maximum length is 2048 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type asyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of 
+         *                 the error.
          */
-        addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;
+        addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the 
+         * callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -3544,29 +3993,36 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>NumberOfAttachmentsExceeded - The message or appointment has too many attachments.</td></tr></table>
          * 
-         * In addition to the main signature, this method also has these signatures:
+         * In addition to this signature, this method also has the following signatures:
          * 
          * `addItemAttachmentAsync(itemId: any, attachmentName: string): void;`
          * 
          * `addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;`
          * 
-         * `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;`
+         * `addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;`
          *
          * @param itemId - The Exchange identifier of the item to attach. The maximum length is 100 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
          * @param options - An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of 
+         *                 the error.
          */
-        addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. 
+         * You can use the options parameter to pass state information to the callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -3584,11 +4040,15 @@ export declare namespace Office {
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. 
+         * You can use the options parameter to pass state information to the callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -3608,11 +4068,15 @@ export declare namespace Office {
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
-         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or a code that indicates any error that occurred while attaching the item. You can use the options parameter to pass state information to the callback method, if needed.
+         * The addItemAttachmentAsync method attaches the item with the specified Exchange identifier to the item in the compose form. 
+         * If you specify a callback method, the method is called with one parameter, asyncResult, which contains either the attachment identifier or 
+         * a code that indicates any error that occurred while attaching the item. 
+         * You can use the options parameter to pass state information to the callback method, if needed.
          *
          * You can subsequently use the identifier with the removeAttachmentAsync method to remove the attachment in the same session.
          *
-         * If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended.
+         * If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that 
+         * you are editing; however, this is not supported and is not recommended.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -3625,17 +4089,22 @@ export declare namespace Office {
          *
          * @param itemId - The Exchange identifier of the item to attach. The maximum length is 100 characters.
          * @param attachmentName - The name of the attachment that is shown while the attachment is uploading. The maximum length is 255 characters.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. 
+         *                 If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of 
+         *                 the error.
          */
-        addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;
+        addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;
         /**
          * Closes the current item that is being composed
          *
-         * The behaviors of the close method depends on the current state of the item being composed. If the item has unsaved changes, the client prompts the user to save, discard, or close the action.
+         * The behaviors of the close method depends on the current state of the item being composed. 
+         * If the item has unsaved changes, the client prompts the user to save, discard, or close the action.
          *
          * In the Outlook desktop client, if the message is an inline reply, the close method has no effect.
          *
-         * Note: In Outlook on the web, if the item is an appointment and it has previously been saved using saveAsync, the user is prompted to save, discard, or cancel even if no changes have occurred since the item was last saved.
+         * Note: In Outlook on the web, if the item is an appointment and it has previously been saved using saveAsync, the user is prompted to save, 
+         * discard, or cancel even if no changes have occurred since the item was last saved.
          *
          * [Api set: Mailbox 1.3]
          *
@@ -3649,9 +4118,11 @@ export declare namespace Office {
         /**
          * Asynchronously returns selected data from the subject or body of a message.
          *
-         * If there is no selection but the cursor is in the body or subject, the method returns null for the selected data. If a field other than the body or subject is selected, the method returns the InvalidSelection error.
+         * If there is no selection but the cursor is in the body or subject, the method returns null for the selected data. 
+         * If a field other than the body or subject is selected, the method returns the InvalidSelection error.
          *
-         * To access the selected data from the callback method, call asyncResult.value.data. To access the source property that the selection comes from, call asyncResult.value.sourceProperty, which will be either body or subject.
+         * To access the selected data from the callback method, call asyncResult.value.data. 
+         * To access the source property that the selection comes from, call asyncResult.value.sourceProperty, which will be either body or subject.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -3664,16 +4135,20 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Message Compose</td></tr></table>
          *
-         * @param coercionType - Requests a format for the data. If Text, the method returns the plain text as a string , removing any HTML tags present. If HTML, the method returns the selected text, whether it is plaintext or HTML.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param coercionType - Requests a format for the data. If Text, the method returns the plain text as a string, removing any HTML tags present. 
+         *                     If HTML, the method returns the selected text, whether it is plaintext or HTML.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          */
-        getSelectedDataAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult) => void): void;
+        getSelectedDataAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult<any>) => void): void;
         /**
          * Asynchronously returns selected data from the subject or body of a message.
          *
-         * If there is no selection but the cursor is in the body or subject, the method returns null for the selected data. If a field other than the body or subject is selected, the method returns the InvalidSelection error.
+         * If there is no selection but the cursor is in the body or subject, the method returns null for the selected data. 
+         * If a field other than the body or subject is selected, the method returns the InvalidSelection error.
          *
-         * To access the selected data from the callback method, call asyncResult.value.data. To access the source property that the selection comes from, call asyncResult.value.sourceProperty, which will be either body or subject.
+         * To access the selected data from the callback method, call asyncResult.value.data. 
+         * To access the source property that the selection comes from, call asyncResult.value.sourceProperty, which will be either body or subject.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -3686,18 +4161,24 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Message Compose</td></tr></table>
          *
-         * @param coercionType - Requests a format for the data. If Text, the method returns the plain text as a string , removing any HTML tags present. If HTML, the method returns the selected text, whether it is plaintext or HTML.
+         * @param coercionType - Requests a format for the data. If Text, the method returns the plain text as a string, removing any HTML tags present. 
+         *                     If HTML, the method returns the selected text, whether it is plaintext or HTML.
          * @param options - An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          */
-        getSelectedDataAsync(coerciontype: Office.CoercionType, options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;
+        getSelectedDataAsync(coerciontype: Office.CoercionType, options: Office.AsyncContextOptions, callback: (result: AsyncResult<any>) => void): void;
         /**
          * Asynchronously loads custom properties for this add-in on the selected item.
          *
-         * Custom properties are stored as key/value pairs on a per-app, per-item basis. This method returns a CustomProperties object in the callback, which provides methods to access the custom properties specific to the current item and the current add-in. Custom properties are not encrypted on the item, so this should not be used as secure storage.
+         * Custom properties are stored as key/value pairs on a per-app, per-item basis. 
+         * This method returns a CustomProperties object in the callback, which provides methods to access the custom properties specific to the 
+         * current item and the current add-in. Custom properties are not encrypted on the item, so this should not be used as secure storage.
          *
-         * The custom properties are provided as a CustomProperties object in the asyncResult.value property. This object can be used to get, set, and remove custom properties from the item and save changes to the custom property set back to the server.
+         * The custom properties are provided as a CustomProperties object in the asyncResult.value property. 
+         * This object can be used to get, set, and remove custom properties from the item and save changes to the custom property set back to 
+         * the server.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -3707,14 +4188,20 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Message Compose</td></tr></table>
          *
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
-         * @param userContext - Optional. Developers can provide any object they wish to access in the callback function. This object can be accessed by the asyncResult.asyncContext property in the callback function.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
+         * @param userContext - Optional. Developers can provide any object they wish to access in the callback function. 
+         *                    This object can be accessed by the asyncResult.asyncContext property in the callback function.
          */
-        loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;
+        loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any): void;
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -3732,18 +4219,24 @@ export declare namespace Office {
          * 
          * `removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;`
          * 
-         * `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;`
+         * `removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;`
          *
          * @param attachmentIndex - The identifier of the attachment to remove. The maximum length of the string is 100 characters.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. 
+         *                 If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
          */
-        removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -3761,7 +4254,11 @@ export declare namespace Office {
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -3781,7 +4278,11 @@ export declare namespace Office {
         /**
          * Removes an attachment from a message or appointment.
          *
-         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window.
+         * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
+         * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
+         * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -3794,17 +4295,25 @@ export declare namespace Office {
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
          * @param attachmentIndex - The identifier of the attachment to remove. The maximum length of the string is 100 characters.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. 
+         *                 If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
          */
-        removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;
+        removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;
         /**
          * Asynchronously saves an item.
          *
-         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. In Outlook Web App or Outlook in online mode, the item is saved to the server. In Outlook in cached mode, the item is saved to the local cache.
+         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. 
+         * In Outlook Web App or Outlook in online mode, the item is saved to the server. 
+         * In Outlook in cached mode, the item is saved to the local cache.
          *
-         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. Saving an existing appointment will send an update to added or removed attendees.
+         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal 
+         * appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. 
+         * Saving an existing appointment will send an update to added or removed attendees.
          *
-         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that when Outlook is in cached mode, it may take some time before the item is actually synced to the server. Until the item is synced, using the itemId will return an error.
+         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that 
+         * when Outlook is in cached mode, it may take some time before the item is actually synced to the server. 
+         * Until the item is synced, using the itemId will return an error.
          *
          * Note: The following clients have different behavior for saveAsync on appointments in compose mode:
          *
@@ -3828,21 +4337,28 @@ export declare namespace Office {
          * 
          * `saveAsync(options: Office.AsyncContextOptions): void;`
          * 
-         * `saveAsync(callback: (result: AsyncResult) => void): void;`
+         * `saveAsync(callback: (result: AsyncResult<void>) => void): void;`
          *
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. 
          */
-        saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Asynchronously saves an item.
          *
-         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. In Outlook Web App or Outlook in online mode, the item is saved to the server. In Outlook in cached mode, the item is saved to the local cache.
+         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. 
+         * In Outlook Web App or Outlook in online mode, the item is saved to the server. 
+         * In Outlook in cached mode, the item is saved to the local cache.
          *
-         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. Saving an existing appointment will send an update to added or removed attendees.
+         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal 
+         * appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. 
+         * Saving an existing appointment will send an update to added or removed attendees.
          *
-         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that when Outlook is in cached mode, it may take some time before the item is actually synced to the server. Until the item is synced, using the itemId will return an error.
+         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that 
+         * when Outlook is in cached mode, it may take some time before the item is actually synced to the server. 
+         * Until the item is synced, using the itemId will return an error.
          *
          * Note: The following clients have different behavior for saveAsync on appointments in compose mode:
          *
@@ -3865,11 +4381,16 @@ export declare namespace Office {
         /**
          * Asynchronously saves an item.
          *
-         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. In Outlook Web App or Outlook in online mode, the item is saved to the server. In Outlook in cached mode, the item is saved to the local cache.
+         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. 
+         * In Outlook Web App or Outlook in online mode, the item is saved to the server. 
+         * In Outlook in cached mode, the item is saved to the local cache.
          *
-         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. Saving an existing appointment will send an update to added or removed attendees.
+         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal 
+         * appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. Saving an existing appointment will send an update to added or removed attendees.
          *
-         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that when Outlook is in cached mode, it may take some time before the item is actually synced to the server. Until the item is synced, using the itemId will return an error.
+         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that 
+         * when Outlook is in cached mode, it may take some time before the item is actually synced to the server. 
+         * Until the item is synced, using the itemId will return an error.
          *
          * Note: The following clients have different behavior for saveAsync on appointments in compose mode:
          *
@@ -3894,11 +4415,17 @@ export declare namespace Office {
         /**
          * Asynchronously saves an item.
          *
-         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. In Outlook Web App or Outlook in online mode, the item is saved to the server. In Outlook in cached mode, the item is saved to the local cache.
+         * When invoked, this method saves the current message as a draft and returns the item id via the callback method. 
+         * In Outlook Web App or Outlook in online mode, the item is saved to the server. 
+         * In Outlook in cached mode, the item is saved to the local cache.
          *
-         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. Saving an existing appointment will send an update to added or removed attendees.
+         * Since appointments have no draft state, if saveAsync is called on an appointment in compose mode, the item will be saved as a normal 
+         * appointment on the user's calendar. For new appointments that have not been saved before, no invitation will be sent. 
+         * Saving an existing appointment will send an update to added or removed attendees.
          *
-         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that when Outlook is in cached mode, it may take some time before the item is actually synced to the server. Until the item is synced, using the itemId will return an error.
+         * Note: If your add-in calls saveAsync on an item in compose mode in order to get an itemId to use with EWS or the REST API, be aware that 
+         * when Outlook is in cached mode, it may take some time before the item is actually synced to the server. 
+         * Until the item is synced, using the itemId will return an error.
          *
          * Note: The following clients have different behavior for saveAsync on appointments in compose mode:
          *
@@ -3916,13 +4443,16 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. 
          */
-        saveAsync(callback: (result: AsyncResult) => void): void;
+        saveAsync(callback: (result: AsyncResult<void>) => void): void;
         /**
          * Asynchronously inserts data into the body or subject of a message.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is 
+         * selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. 
+         * After insertion, the cursor is placed at the end of the inserted content.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -3940,19 +4470,28 @@ export declare namespace Office {
          * 
          * `setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`
          * 
-         * `setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;`
+         * `setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;`
          *
-         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
+         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. 
+         *             If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         *        coercionType: If text, the current style is applied in Outlook Web App and Outlook. If the field is an HTML editor, only the text data is inserted, even if the data is HTML. If html and the field supports HTML (the subject doesn't), the current style is applied in Outlook Web App and the default style is applied in Outlook. If the field is a text field, an InvalidDataFormat error is returned. If coercionType is not set, the result depends on the field: if the field is HTML then HTML is used; if the field is text, then plain text is used.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         *        coercionType: If text, the current style is applied in Outlook Web App and Outlook. 
+         *        If the field is an HTML editor, only the text data is inserted, even if the data is HTML. 
+         *        If html and the field supports HTML (the subject doesn't), the current style is applied in Outlook Web App and the default style is 
+         *        applied in Outlook. If the field is a text field, an InvalidDataFormat error is returned. 
+         *        If coercionType is not set, the result depends on the field: if the field is HTML then HTML is used; 
+         *        if the field is text, then plain text is used.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          */
-        setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult) => void): void;
+        setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Asynchronously inserts data into the body or subject of a message.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is 
+         * selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. 
+         * After insertion, the cursor is placed at the end of the inserted content.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -3964,13 +4503,16 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
-         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
+         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. 
+         *             If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
          */
         setSelectedDataAsync(data: string): void;
         /**
          * Asynchronously inserts data into the body or subject of a message.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is 
+         * selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. 
+         * After insertion, the cursor is placed at the end of the inserted content.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -3982,16 +4524,24 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
-         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
+         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. 
+         *             If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         *        coercionType: If text, the current style is applied in Outlook Web App and Outlook. If the field is an HTML editor, only the text data is inserted, even if the data is HTML. If html and the field supports HTML (the subject doesn't), the current style is applied in Outlook Web App and the default style is applied in Outlook. If the field is a text field, an InvalidDataFormat error is returned. If coercionType is not set, the result depends on the field: if the field is HTML then HTML is used; if the field is text, then plain text is used.
+         *        coercionType: If text, the current style is applied in Outlook Web App and Outlook. 
+         *        If the field is an HTML editor, only the text data is inserted, even if the data is HTML. 
+         *        If html and the field supports HTML (the subject doesn't), the current style is applied in Outlook Web App and the default style is 
+         *        applied in Outlook. If the field is a text field, an InvalidDataFormat error is returned. 
+         *        If coercionType is not set, the result depends on the field: if the field is HTML then HTML is used; 
+         *        if the field is text, then plain text is used.
          */
         setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;
         /**
          * Asynchronously inserts data into the body or subject of a message.
          *
-         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. After insertion, the cursor is placed at the end of the inserted content.
+         * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is 
+         * selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. 
+         * After insertion, the cursor is placed at the end of the inserted content.
          *
          * [Api set: Mailbox 1.2]
          *
@@ -4003,19 +4553,22 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>InvalidAttachmentId - The attachment identifier does not exist.</td></tr></table>
          *
-         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
+         * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. 
+         *             If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 typeOffice.AsyncResult.
          */
-        setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;
+        setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;
     }
     /**
      * The message read mode of {@link Office.Item | Office.context.mailbox.item}.
      * 
-     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of Office.context.mailbox.item. Refer to the Object Model pages for more information.
+     * Important: This is an internal Outlook object, not directly exposed through existing interfaces. 
+     * You should treat this as a mode of Office.context.mailbox.item. Refer to the Object Model pages for more information.
      */
     export interface MessageRead extends Message, ItemRead {
         /**
-         * Gets an array of attachments for the item.
+         * Gets the item's attachments as an array.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -4025,7 +4578,9 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Message Read</td></tr></table>
          * 
-         * Note: Certain types of files are blocked by Outlook due to potential security issues and are therefore not returned. For more information, see {@link https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519 | Blocked attachments in Outlook}.
+         * Note: Certain types of files are blocked by Outlook due to potential security issues and are therefore not returned. 
+         * For more information, see 
+         * {@link https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519 | Blocked attachments in Outlook}.
          *
          */
         attachments: Office.AttachmentDetails[];
@@ -4042,9 +4597,11 @@ export declare namespace Office {
          */
         body: Office.Body;
         /**
-         * Provides access to the Cc (carbon copy) recipients of a message. The type of object and level of access depends on the mode of the current item.
+         * Provides access to the Cc (carbon copy) recipients of a message. The type of object and level of access depends on the mode of the 
+         * current item.
          *
-         * The cc property returns an array that contains an EmailAddressDetails object for each recipient listed on the Cc line of the message. The collection is limited to a maximum of 100 members.
+         * The cc property returns an array that contains an EmailAddressDetails object for each recipient listed on the Cc line of the message. 
+         * The collection is limited to a maximum of 100 members.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -4058,9 +4615,12 @@ export declare namespace Office {
         /**
          * Gets an identifier for the email conversation that contains a particular message.
          *
-         * You can get an integer for this property if your mail app is activated in read forms or responses in compose forms. If subsequently the user changes the subject of the reply message, upon sending the reply, the conversation ID for that message will change and that value you obtained earlier will no longer apply.
+         * You can get an integer for this property if your mail app is activated in read forms or responses in compose forms. 
+         * If subsequently the user changes the subject of the reply message, upon sending the reply, the conversation ID for that message will change 
+         * and that value you obtained earlier will no longer apply.
          *
-         * You get null for this property for a new item in a compose form. If the user sets a subject and saves the item, the conversationId property will return a value.
+         * You get null for this property for a new item in a compose form. 
+         * If the user sets a subject and saves the item, the conversationId property will return a value.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -4100,7 +4660,8 @@ export declare namespace Office {
         /**
          * Gets the email address of the sender of a message.
          *
-         * The from and sender properties represent the same person unless the message is sent by a delegate. In that case, the from property represents the delegator, and the sender property represents the delegate.
+         * The from and sender properties represent the same person unless the message is sent by a delegate. 
+         * In that case, the from property represents the delegator, and the sender property represents the delegate.
          *
          * Note: The recipientType property of the EmailAddressDetails object in the from property is undefined.
          * 
@@ -4130,7 +4691,8 @@ export declare namespace Office {
         /**
          * Gets the Exchange Web Services item class of the selected item.
          * 
-         * You can create custom message classes that extends a default message class, for example, a custom appointment message class IPM.Appointment.Contoso.
+         * You can create custom message classes that extends a default message class, for example, a custom appointment message class 
+         * IPM.Appointment.Contoso.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -4140,7 +4702,8 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Message Read</td></tr></table>
 		 
-         * The itemClass property specifies the message class of the selected item. The following are the default message classes for the message or appointment item.
+         * The itemClass property specifies the message class of the selected item. 
+         * The following are the default message classes for the message or appointment item.
          * 
          * <table>
          *   <tr>
@@ -4165,9 +4728,14 @@ export declare namespace Office {
         /**
          * Gets the Exchange Web Services item identifier for the current item.
          *
-         * The itemId property is not available in compose mode. If an item identifier is required, the saveAsync method can be used to save the item to the store, which will return the item identifier in the AsyncResult.value parameter in the callback function.
+         * The itemId property is not available in compose mode. 
+         * If an item identifier is required, the saveAsync method can be used to save the item to the store, which will return the item identifier 
+         * in the AsyncResult.value parameter in the callback function.
          *
-         * Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more details, see Use the Outlook REST APIs from an Outlook add-in.
+         * Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. 
+         * The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. 
+         * Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. 
+         * For more details, see {@link https://docs.microsoft.com/outlook/add-ins/use-rest-api#get-the-item-id | Use the Outlook REST APIs from an Outlook add-in}.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -4181,7 +4749,8 @@ export declare namespace Office {
         /**
          * Gets the type of item that an instance represents.
          *
-         * The itemType property returns one of the ItemType enumeration values, indicating whether the item object instance is a message or an appointment.
+         * The itemType property returns one of the ItemType enumeration values, indicating whether the item object instance is a message or 
+         * an appointment.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -4195,7 +4764,9 @@ export declare namespace Office {
         /**
          * Gets the subject of an item, with all prefixes removed (including RE: and FWD:).
          *
-         * The normalizedSubject property gets the subject of the item, with any standard prefixes (such as RE: and FW:) that are added by email programs. To get the subject of the item with the prefixes intact, use the subject property.
+         * The normalizedSubject property gets the subject of the item, with any standard prefixes (such as RE: and FW:) that are added by 
+         * email programs. 
+         * To get the subject of the item with the prefixes intact, use the subject property.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -4221,7 +4792,8 @@ export declare namespace Office {
         /**
          * Gets the email address of the sender of an email message.
          *
-         * The from and sender properties represent the same person unless the message is sent by a delegate. In that case, the from property represents the delegator, and the sender property represents the delegate.
+         * The from and sender properties represent the same person unless the message is sent by a delegate. 
+         * In that case, the from property represents the delegator, and the sender property represents the delegate.
          *
          * Note: The recipientType property of the EmailAddressDetails object in the sender property is undefined.
          *
@@ -4251,9 +4823,11 @@ export declare namespace Office {
          */
         subject: string;
         /**
-         * Provides access to the recipients on the To line of a message. The type of object and level of access depends on the mode of the current item.
+         * Provides access to the recipients on the To line of a message. The type of object and level of access depends on the mode of the 
+         * current item.
          *
-         * The to property returns an array that contains an EmailAddressDetails object for each recipient listed on the To line of the message. The collection is limited to a maximum of 100 members.
+         * The to property returns an array that contains an EmailAddressDetails object for each recipient listed on the To line of the message. 
+         * The collection is limited to a maximum of 100 members.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -4264,14 +4838,18 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Message Read</td></tr></table>
          */
         to: EmailAddressDetails[];
+
         /**
-         * Displays a reply form that includes the sender and all recipients of the selected message or the organizer and all attendees of the selected appointment.
+         * Displays a reply form that includes the sender and all recipients of the selected message or the organizer and all attendees of the 
+         * selected appointment.
          *
          * In Outlook Web App, the reply form is displayed as a pop-out form in the 3-column view and a pop-up form in the 2- or 1-column view.
          *
          * If any of the string parameters exceed their limits, displayReplyAllForm throws an exception.
          *
-         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. If this isn't possible, then no error message is thrown.
+         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and 
+         * attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. 
+         * If this isn't possible, then no error message is thrown.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -4294,7 +4872,9 @@ export declare namespace Office {
          *
          * If any of the string parameters exceed their limits, displayReplyForm throws an exception.
          *
-         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. If this isn't possible, then no error message is thrown.
+         * When attachments are specified in the formData.attachments parameter, Outlook and Outlook Web App attempt to download all attachments and 
+         * attach them to the reply form. If any attachments fail to be added, an error is shown in the form UI. 
+         * If this isn't possible, then no error message is thrown.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -4312,7 +4892,7 @@ export declare namespace Office {
          */
         displayReplyForm(formData: string | ReplyFormData): void;
         /**
-         * Gets the entities found in the selected item.
+         * Gets the entities found in the selected item's body.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -4326,7 +4906,7 @@ export declare namespace Office {
          */
         getEntities(): Entities;
         /**
-         * Gets an array of all the entities of the specified entity type found in the selected item.
+         * Gets an array of all the entities of the specified entity type found in the selected item's body.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -4335,7 +4915,9 @@ export declare namespace Office {
          * @param entityType - One of the EntityType enumeration values.
          * 
          * @returns
-         * If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. If no entities of the specified type are present on the item, the method returns an empty array. Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter.
+         * If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. 
+         * If no entities of the specified type are present in the item's body, the method returns an empty array. 
+         * Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter.
          *
          * @remarks
          * 
@@ -4343,7 +4925,8 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Read</td></tr></table>
          * 
-         * While the minimum permission level to use this method is Restricted, some entity types require ReadItem to access, as specified in the following table.
+         * While the minimum permission level to use this method is Restricted, some entity types require ReadItem to access, as specified in the 
+         * following table.
          * 
          * <table>
          *   <tr>
@@ -4392,7 +4975,8 @@ export declare namespace Office {
         /**
          * Returns well-known entities in the selected item that pass the named filter defined in the manifest XML file.
          *
-         * The getFilteredEntitiesByName method returns the entities that match the regular expression defined in the ItemHasKnownEntity rule element in the manifest XML file with the specified FilterName element value.
+         * The getFilteredEntitiesByName method returns the entities that match the regular expression defined in the ItemHasKnownEntity rule element 
+         * in the manifest XML file with the specified FilterName element value.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -4405,22 +4989,33 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Message Read</td></tr></table>
          *
          * @param name - The name of the ItemHasKnownEntity rule element that defines the filter to match.
-         * @returns If there is no ItemHasKnownEntity element in the manifest with a FilterName element value that matches the name parameter, the method returns null. If the name parameter does match an ItemHasKnownEntity element in the manifest, but there are no entities in the current item that match, the method return an empty array.
+         * @returns If there is no ItemHasKnownEntity element in the manifest with a FilterName element value that matches the name parameter, 
+         * the method returns null. 
+         * If the name parameter does match an ItemHasKnownEntity element in the manifest, but there are no entities in the current item that match, 
+         * the method return an empty array.
          */
         getFilteredEntitiesByName(name: string): (string | Contact | MeetingSuggestion | PhoneNumber | TaskSuggestion)[];
         /**
          * Returns string values in the selected item that match the regular expressions defined in the manifest XML file.
          *
-         * The getRegExMatches method returns the strings that match the regular expression defined in each ItemHasRegularExpressionMatch or ItemHasKnownEntity rule element in the manifest XML file. For an ItemHasRegularExpressionMatch rule, a matching string has to occur in the property of the item that is specified by that rule. The PropertyName simple type defines the supported properties.
+         * The getRegExMatches method returns the strings that match the regular expression defined in each ItemHasRegularExpressionMatch or 
+         * ItemHasKnownEntity rule element in the manifest XML file. 
+         * For an ItemHasRegularExpressionMatch rule, a matching string has to occur in the property of the item that is specified by that rule. 
+         * The PropertyName simple type defines the supported properties.
          *
-         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body and should not attempt to return the entire body of the item. Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results. Instead, use the Body.getAsync method to retrieve the entire body.
+         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body 
+         * and should not attempt to return the entire body of the item. 
+         * Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results. 
+         * Instead, use the Body.getAsync method to retrieve the entire body.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
          * [Api set: Mailbox 1.0]
          *
          * @returns
-         * An object that contains arrays of strings that match the regular expressions defined in the manifest XML file. The name of each array is equal to the corresponding value of the RegExName attribute of the matching ItemHasRegularExpressionMatch rule or the FilterName attribute of the matching ItemHasKnownEntity rule.
+         * An object that contains arrays of strings that match the regular expressions defined in the manifest XML file. 
+         * The name of each array is equal to the corresponding value of the RegExName attribute of the matching ItemHasRegularExpressionMatch rule 
+         * or the FilterName attribute of the matching ItemHasKnownEntity rule.
          *
          * @remarks
          *
@@ -4432,9 +5027,12 @@ export declare namespace Office {
         /**
          * Returns string values in the selected item that match the named regular expression defined in the manifest XML file.
          *
-         * The getRegExMatchesByName method returns the strings that match the regular expression defined in the ItemHasRegularExpressionMatch rule element in the manifest XML file with the specified RegExName element value.
+         * The getRegExMatchesByName method returns the strings that match the regular expression defined in the ItemHasRegularExpressionMatch rule 
+         * element in the manifest XML file with the specified RegExName element value.
          *
-         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body and should not attempt to return the entire body of the item. Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results.
+         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body 
+         * and should not attempt to return the entire body of the item. 
+         * Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -4469,18 +5067,27 @@ export declare namespace Office {
          */
         getSelectedEntities(): Entities;
         /**
-         * Returns string values in a highlighted match that match the regular expressions defined in the manifest XML file. Highlighted matches apply to contextual add-ins.
+         * Returns string values in a highlighted match that match the regular expressions defined in the manifest XML file. 
+         * Highlighted matches apply to contextual add-ins.
          *
-         * The getSelectedRegExMatches method returns the strings that match the regular expression defined in each ItemHasRegularExpressionMatch or ItemHasKnownEntity rule element in the manifest XML file. For an ItemHasRegularExpressionMatch rule, a matching string has to occur in the property of the item that is specified by that rule. The PropertyName simple type defines the supported properties.
+         * The getSelectedRegExMatches method returns the strings that match the regular expression defined in each ItemHasRegularExpressionMatch or 
+         * ItemHasKnownEntity rule element in the manifest XML file. 
+         * For an ItemHasRegularExpressionMatch rule, a matching string has to occur in the property of the item that is specified by that rule. 
+         * The PropertyName simple type defines the supported properties.
          *
-         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body and should not attempt to return the entire body of the item. Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results. Instead, use the Body.getAsync method to retrieve the entire body.
+         * If you specify an ItemHasRegularExpressionMatch rule on the body property of an item, the regular expression should further filter the body 
+         * and should not attempt to return the entire body of the item. 
+         * Using a regular expression such as .* to obtain the entire body of an item does not always return the expected results. 
+         * Instead, use the Body.getAsync method to retrieve the entire body.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
          * [Api set: Mailbox 1.6]
          *
          * @returns
-         * An object that contains arrays of strings that match the regular expressions defined in the manifest XML file. The name of each array is equal to the corresponding value of the RegExName attribute of the matching ItemHasRegularExpressionMatch rule or the FilterName attribute of the matching ItemHasKnownEntity rule.
+         * An object that contains arrays of strings that match the regular expressions defined in the manifest XML file. 
+         * The name of each array is equal to the corresponding value of the RegExName attribute of the matching ItemHasRegularExpressionMatch rule or 
+         * the FilterName attribute of the matching ItemHasKnownEntity rule.
          *
          * @remarks
          *
@@ -4492,9 +5099,13 @@ export declare namespace Office {
         /**
          * Asynchronously loads custom properties for this add-in on the selected item.
          *
-         * Custom properties are stored as key/value pairs on a per-app, per-item basis. This method returns a CustomProperties object in the callback, which provides methods to access the custom properties specific to the current item and the current add-in. Custom properties are not encrypted on the item, so this should not be used as secure storage.
+         * Custom properties are stored as key/value pairs on a per-app, per-item basis. 
+         * This method returns a CustomProperties object in the callback, which provides methods to access the custom properties specific to the 
+         * current item and the current add-in. Custom properties are not encrypted on the item, so this should not be used as secure storage.
          *
-         * The custom properties are provided as a CustomProperties object in the asyncResult.value property. This object can be used to get, set, and remove custom properties from the item and save changes to the custom property set back to the server.
+         * The custom properties are provided as a CustomProperties object in the asyncResult.value property. 
+         * This object can be used to get, set, and remove custom properties from the item and save changes to the custom property set back to 
+         * the server.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -4504,10 +5115,12 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Message Read</td></tr></table>
          *
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
-         * @param userContext - Optional. Developers can provide any object they wish to access in the callback function. This object can be accessed by the asyncResult.asyncContext property in the callback function.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
+         * @param userContext - Optional. Developers can provide any object they wish to access in the callback function. 
+         *                    This object can be accessed by the asyncResult.asyncContext property in the callback function.
          */
-        loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;
+        loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any): void;
     }
 
     /**
@@ -4569,11 +5182,13 @@ export declare namespace Office {
         /**
          * Gets the location of an appointment.
          *
-         * The getAsync method starts an asynchronous call to the Exchange server to get the location of an appointment. The location of the appointment is provided as a string in the asyncResult.value property.
+         * The getAsync method starts an asynchronous call to the Exchange server to get the location of an appointment. 
+         * The location of the appointment is provided as a string in the asyncResult.value property.
          *
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -4584,16 +5199,18 @@ export declare namespace Office {
          * 
          * In addition to this signature, the method also has the following signature:
          * 
-         * `getAsync(callback: (result: AsyncResult) => void): void;`
+         * `getAsync(callback: (result: AsyncResult<string>) => void): void;`
          * 
          */
-        getAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        getAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;
         /**
          * Gets the location of an appointment.
          *
-         * The getAsync method starts an asynchronous call to the Exchange server to get the location of an appointment. The location of the appointment is provided as a string in the asyncResult.value property.
+         * The getAsync method starts an asynchronous call to the Exchange server to get the location of an appointment. 
+         * The location of the appointment is provided as a string in the asyncResult.value property.
          *
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -4602,16 +5219,18 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose</td></tr></table>
          */
-        getAsync(callback: (result: AsyncResult) => void): void;
+        getAsync(callback: (result: AsyncResult<string>) => void): void;
         /**
          * Sets the location of an appointment.
          *
-         * The setAsync method starts an asynchronous call to the Exchange server to set the location of an appointment. Setting the location of an appointment overwrites the current location.
+         * The setAsync method starts an asynchronous call to the Exchange server to set the location of an appointment. 
+         * Setting the location of an appointment overwrites the current location.
          *
          * @param location - The location of the appointment. The string is limited to 255 characters.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.  If setting the location fails, the asyncResult.error property will contain an error code.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. If setting the location fails, the asyncResult.error property will contain an error code.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -4628,13 +5247,14 @@ export declare namespace Office {
          * 
          * `setAsync(location: string, options: Office.AsyncContextOptions): void;`
          * 
-         * `setAsync(location: string, callback: (result: AsyncResult) => void): void;`
+         * `setAsync(location: string, callback: (result: AsyncResult<void>) => void): void;`
          */
-        setAsync(location: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        setAsync(location: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Sets the location of an appointment.
          *
-         * The setAsync method starts an asynchronous call to the Exchange server to set the location of an appointment. Setting the location of an appointment overwrites the current location.
+         * The setAsync method starts an asynchronous call to the Exchange server to set the location of an appointment. 
+         * Setting the location of an appointment overwrites the current location.
          *
          * @param location - The location of the appointment. The string is limited to 255 characters.
          *
@@ -4651,7 +5271,8 @@ export declare namespace Office {
         /**
          * Sets the location of an appointment.
          *
-         * The setAsync method starts an asynchronous call to the Exchange server to set the location of an appointment. Setting the location of an appointment overwrites the current location.
+         * The setAsync method starts an asynchronous call to the Exchange server to set the location of an appointment. 
+         * Setting the location of an appointment overwrites the current location.
          *
          * @param location - The location of the appointment. The string is limited to 255 characters.
          * @param options - Optional. An object literal that contains one or more of the following properties.
@@ -4670,10 +5291,12 @@ export declare namespace Office {
         /**
          * Sets the location of an appointment.
          *
-         * The setAsync method starts an asynchronous call to the Exchange server to set the location of an appointment. Setting the location of an appointment overwrites the current location.
+         * The setAsync method starts an asynchronous call to the Exchange server to set the location of an appointment. 
+         * Setting the location of an appointment overwrites the current location.
          *
          * @param location - The location of the appointment. The string is limited to 255 characters.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.  If setting the location fails, the asyncResult.error property will contain an error code.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. If setting the location fails, the asyncResult.error property will contain an error code.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -4684,10 +5307,10 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>DataExceedsMaximumSize - The location parameter is longer than 255 characters.</td></tr></table>
          */
-        setAsync(location: string, callback: (result: AsyncResult) => void): void;
+        setAsync(location: string, callback: (result: AsyncResult<void>) => void): void;
     }
     /**
-     * Provides access to the Outlook add-in object model for Microsoft Outlook and Microsoft Outlook on the web.
+     * Provides access to the Outlook Add-in object model for Microsoft Outlook and Microsoft Outlook on the web.
      *
      * Namespaces:
      *
@@ -4710,11 +5333,18 @@ export declare namespace Office {
          * 
          * Contains the following members:
          * 
-         *  - hostName (string): A string that represents the name of the host application. It be one of the following values: Outlook, Mac Outlook, OutlookIOS, or OutlookWebApp.
+         *  - hostName (string): A string that represents the name of the host application. 
+         * It be one of the following values: Outlook, Mac Outlook, OutlookIOS, or OutlookWebApp.
          * 
-         *  - hostVersion (string): A string that represents the version of either the host application or the Exchange Server. If the mail add-in is running on the Outlook desktop client or Outlook for iOS, the hostVersion property returns the version of the host application, Outlook. In Outlook Web App, the property returns the version of the Exchange Server. An example is the string 15.0.468.0.
+         *  - hostVersion (string): A string that represents the version of either the host application or the Exchange Server. 
+         * If the mail add-in is running on the Outlook desktop client or Outlook for iOS, the hostVersion property returns the version of the 
+         * host application, Outlook. In Outlook Web App, the property returns the version of the Exchange Server. An example is the string 15.0.468.0.
          * 
-         *  - OWAView (string): A string that represents the current view of Outlook Web App. If the host application is not Outlook Web App, then accessing this property results in undefined. Outlook Web App has three views (OneColumn - displayed when the screen is narrow, TwoColumns - displayed when the screen is wider, and ThreeColumns - displayed when the screen is wide.) that correspond to the width of the screen and the window, and the number of columns that can be displayed.
+         *  - OWAView (MailboxEnums.OWAView or string): An enum (or string literal) that represents the current view of Outlook Web App. 
+         * If the host application is not Outlook Web App, then accessing this property results in undefined. 
+         * Outlook Web App has three views (OneColumn - displayed when the screen is narrow, TwoColumns - displayed when the screen is wider, 
+         * and ThreeColumns - displayed when the screen is wide) that correspond to the width of the screen and the window, and the number of columns 
+         * that can be displayed.
          *
          *  More information is under {@link Office.Diagnostics}. 
          *
@@ -4731,7 +5361,8 @@ export declare namespace Office {
          *
          * Your app must have the ReadItem permission specified in its manifest to call the ewsUrl member in read mode.
          *
-         * In compose mode you must call the saveAsync method before you can use the ewsUrl member. Your app must have ReadWriteItem permissions to call the saveAsync method.
+         * In compose mode you must call the saveAsync method before you can use the ewsUrl member. 
+         * Your app must have ReadWriteItem permissions to call the saveAsync method.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -4757,7 +5388,8 @@ export declare namespace Office {
          *
          * Your app must have the ReadItem permission specified in its manifest to call the restUrl member in read mode.
          *
-         * In compose mode you must call the saveAsync method before you can use the restUrl member. Your app must have ReadWriteItem permissions to call the saveAsync method.
+         * In compose mode you must call the saveAsync method before you can use the restUrl member. 
+         * Your app must have ReadWriteItem permissions to call the saveAsync method.
          *
          * [Api set: Mailbox 1.5]
          *
@@ -4771,7 +5403,7 @@ export declare namespace Office {
          */
         restUrl: string;
         /**
-         * Information about the user associated with the mailbox. This includes their account type, display name, email adddress, and time zone.
+         * Information about the user associated with the mailbox. This includes their account type, display name, email address, and time zone.
          * 
          * More information is under {@link Office.UserProfile}
          */
@@ -4779,7 +5411,7 @@ export declare namespace Office {
         /**
          * Adds an event handler for a supported event.
          *
-         * Currently the only supported event type is Office.EventType.ItemChanged, which is invoked when the user selects a new item. This event is used by add-ins that implement a pinnable taskpane, and allows the add-in to refresh the taskpane UI based on the currently selected item.
+         * Currently, the only supported event type is `Office.EventType.ItemChanged`.
          *
          * [Api set: Mailbox 1.5]
          *
@@ -4790,15 +5422,18 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          *
          * @param eventType - The event that should invoke the handler.
-         * @param handler - The function to handle the event. The function must accept a single parameter, which is an object literal. The type property on the parameter will match the eventType parameter passed to addHandlerAsync.
+         * @param handler - The function to handle the event. The function must accept a single parameter, which is an object literal. 
+         *                The type property on the parameter will match the eventType parameter passed to addHandlerAsync.
          * @param options - Optional. Provides an option for preserving context data of any type, unchanged, for use in a callback.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          */
-        addHandlerAsync(eventType: Office.EventType, handler: (type: EventType) => void, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        addHandlerAsync(eventType: Office.EventType, handler: (type: EventType) => void, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Converts an item ID formatted for REST into EWS format.
          *
-         * Item IDs retrieved via a REST API (such as the Outlook Mail API or the Microsoft Graph) use a different format than the format used by Exchange Web Services (EWS). The convertToEwsId method converts a REST-formatted ID into the proper format for EWS.
+         * Item IDs retrieved via a REST API (such as the Outlook Mail API or the Microsoft Graph) use a different format than the format used by 
+         * Exchange Web Services (EWS). The convertToEwsId method converts a REST-formatted ID into the proper format for EWS.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -4817,9 +5452,15 @@ export declare namespace Office {
         /**
          * Gets a dictionary containing time information in local client time.
          *
-         * The dates and times used by a mail app for Outlook or Outlook Web App can use different time zones. Outlook uses the client computer time zone; Outlook Web App uses the time zone set on the Exchange Admin Center (EAC). You should handle date and time values so that the values you display on the user interface are always consistent with the time zone that the user expects.
+         * The dates and times used by a mail app for Outlook or Outlook Web App can use different time zones. 
+         * Outlook uses the client computer time zone; Outlook Web App uses the time zone set on the Exchange Admin Center (EAC). 
+         * You should handle date and time values so that the values you display on the user interface are always consistent with the time zone that 
+         * the user expects.
          *
-         * If the mail app is running in Outlook, the convertToLocalClientTime method will return a dictionary object with the values set to the client computer time zone. If the mail app is running in Outlook Web App, the convertToLocalClientTime method will return a dictionary object with the values set to the time zone specified in the EAC.
+         * If the mail app is running in Outlook, the convertToLocalClientTime method will return a dictionary object with the values set to the 
+         * client computer time zone. 
+         * If the mail app is running in Outlook Web App, the convertToLocalClientTime method will return a dictionary object with the values set to 
+         * the time zone specified in the EAC.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -4845,7 +5486,9 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          *
-         * Item IDs retrieved via EWS or via the itemId property use a different format than the format used by REST APIs (such as the {@link https://docs.microsoft.com/previous-versions/office/office-365-api/api/version-2.0/mail-rest-operations | Outlook Mail API} or the {@link http://graph.microsoft.io/ | Microsoft Graph}. The convertToRestId method converts an EWS-formatted ID into the proper format for REST.
+         * Item IDs retrieved via EWS or via the itemId property use a different format than the format used by REST APIs (such as the 
+         * {@link https://docs.microsoft.com/previous-versions/office/office-365-api/api/version-2.0/mail-rest-operations | Outlook Mail API} or the {@link http://graph.microsoft.io/ | Microsoft Graph}. 
+         * The convertToRestId method converts an EWS-formatted ID into the proper format for REST.
          *
          * @param itemId - An item ID formatted for Exchange Web Services (EWS)
          * @param restVersion - A value indicating the version of the Outlook REST API that the converted ID will be used with.
@@ -4854,7 +5497,8 @@ export declare namespace Office {
         /**
          * Gets a Date object from a dictionary containing time information.
          *
-         * The convertToUtcClientTime method converts a dictionary containing a local date and time to a Date object with the correct values for the local date and time.
+         * The convertToUtcClientTime method converts a dictionary containing a local date and time to a Date object with the correct values for the 
+         * local date and time.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -4871,13 +5515,17 @@ export declare namespace Office {
         /**
          * Displays an existing calendar appointment.
          *
-         * The displayAppointmentForm method opens an existing calendar appointment in a new window on the desktop or in a dialog box on mobile devices.
+         * The displayAppointmentForm method opens an existing calendar appointment in a new window on the desktop or in a dialog box on 
+         * mobile devices.
          *
-         * In Outlook for Mac, you can use this method to display a single appointment that is not part of a recurring series, or the master appointment of a recurring series, but you cannot display an instance of the series. This is because in Outlook for Mac, you cannot access the properties (including the item ID) of instances of a recurring series.
+         * In Outlook for Mac, you can use this method to display a single appointment that is not part of a recurring series, or the 
+         * master appointment of a recurring series, but you cannot display an instance of the series. 
+         * This is because in Outlook for Mac, you cannot access the properties (including the item ID) of instances of a recurring series.
          *
          * In Outlook Web App, this method opens the specified form only if the body of the form is less than or equal to 32KB number of characters.
          *
-         * If the specified item identifier does not identify an existing appointment, a blank pane opens on the client computer or device, and no error message will be returned.
+         * If the specified item identifier does not identify an existing appointment, a blank pane opens on the client computer or device, and 
+         * no error message will be returned.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -4899,9 +5547,11 @@ export declare namespace Office {
          *
          * In Outlook Web App, this method opens the specified form only if the body of the form is less than or equal to 32 KB number of characters.
          *
-         * If the specified item identifier does not identify an existing message, no message will be displayed on the client computer, and no error message will be returned.
+         * If the specified item identifier does not identify an existing message, no message will be displayed on the client computer, and 
+         * no error message will be returned.
          *
-         * Do not use the displayMessageForm with an itemId that represents an appointment. Use the displayAppointmentForm method to display an existing appointment, and displayNewAppointmentForm to display a form to create a new appointment.
+         * Do not use the displayMessageForm with an itemId that represents an appointment. Use the displayAppointmentForm method to display 
+         * an existing appointment, and displayNewAppointmentForm to display a form to create a new appointment.
          *
          * Note: This method is not supported in Outlook for iOS or Outlook for Android.
          *
@@ -4919,11 +5569,16 @@ export declare namespace Office {
         /**
          * Displays a form for creating a new calendar appointment.
          *
-         * The displayNewAppointmentForm method opens a form that enables the user to create a new appointment or meeting. If parameters are specified, the appointment form fields are automatically populated with the contents of the parameters.
+         * The displayNewAppointmentForm method opens a form that enables the user to create a new appointment or meeting. 
+         * If parameters are specified, the appointment form fields are automatically populated with the contents of the parameters.
          *
-         * In Outlook Web App and OWA for Devices, this method always displays a form with an attendees field. If you do not specify any attendees as input arguments, the method displays a form with a Save button. If you have specified attendees, the form would include the attendees and a Send button.
+         * In Outlook Web App and OWA for Devices, this method always displays a form with an attendees field. 
+         * If you do not specify any attendees as input arguments, the method displays a form with a Save button. 
+         * If you have specified attendees, the form would include the attendees and a Send button.
          *
-         * In the Outlook rich client and Outlook RT, if you specify any attendees or resources in the requiredAttendees, optionalAttendees, or resources parameter, this method displays a meeting form with a Send button. If you don't specify any recipients, this method displays an appointment form with a Save & Close button.
+         * In the Outlook rich client and Outlook RT, if you specify any attendees or resources in the requiredAttendees, optionalAttendees, or 
+         * resources parameter, this method displays a meeting form with a Send button. 
+         * If you don't specify any recipients, this method displays an appointment form with a Save & Close button.
          *
          * If any of the parameters exceed the specified size limits, or if an unknown parameter name is specified, an exception is thrown.
          *
@@ -4943,7 +5598,8 @@ export declare namespace Office {
         /**
          * Displays a form for creating a new message.
          *
-         * The displayNewMessageForm method opens a form that enables the user to create a new message. If parameters are specified, the message form fields are automatically populated with the contents of the parameters.
+         * The displayNewMessageForm method opens a form that enables the user to create a new message. If parameters are specified, the message form 
+         * fields are automatically populated with the contents of the parameters.
          *
          * If any of the parameters exceed the specified size limits, or if an unknown parameter name is specified, an exception is thrown.
          *
@@ -4956,33 +5612,55 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Read</td></tr></table>
          *
          * @param parameters - A dictionary containing all values to be filled in for the user in the new form. All parameters are optional.
-         *        toRecipients: An array of strings containing the email addresses or an array containing an {@link Office.EmailAddressDetails} object for each of the recipients on the To line. The array is limited to a maximum of 100 entries.
-         *        ccRecipients: An array of strings containing the email addresses or an array containing an {@link Office.EmailAddressDetails} object for each of the recipients on the Cc line. The array is limited to a maximum of 100 entries.
-         *        bccRecipients: An array of strings containing the email addresses or an array containing an {@link Office.EmailAddressDetails} object for each of the recipients on the Bcc line. The array is limited to a maximum of 100 entries.
+         * 
+         *        toRecipients: An array of strings containing the email addresses or an array containing an {@link Office.EmailAddressDetails} object 
+         *        for each of the recipients on the To line. The array is limited to a maximum of 100 entries.
+         * 
+         *        ccRecipients: An array of strings containing the email addresses or an array containing an {@link Office.EmailAddressDetails} object 
+         *        for each of the recipients on the Cc line. The array is limited to a maximum of 100 entries.
+         * 
+         *        bccRecipients: An array of strings containing the email addresses or an array containing an {@link Office.EmailAddressDetails} object 
+         *        for each of the recipients on the Bcc line. The array is limited to a maximum of 100 entries.
+         * 
          *        subject: A string containing the subject of the message. The string is limited to a maximum of 255 characters.
+         * 
          *        htmlBody: The HTML body of the message. The body content is limited to a maximum size of 32 KB.
+         * 
          *        attachments: An array of JSON objects that are either file or item attachments.
+         * 
          *        attachments.type: Indicates the type of attachment. Must be file for a file attachment or item for an item attachment.
+         * 
          *        attachments.name: A string that contains the name of the attachment, up to 255 characters in length.
+         * 
          *        attachments.url: Only used if type is set to file. The URI of the location for the file.
-         *        attachments.isInline: Only used if type is set to file. If true, indicates that the attachment will be shown inline in the message body, and should not be displayed in the attachment list.
-         *        attachments.itemId: Only used if type is set to item. The EWS item id of the attachment. This is a string up to 100 characters.
+         * 
+         *        attachments.isInline: Only used if type is set to file. If true, indicates that the attachment will be shown inline in the 
+         *        message body, and should not be displayed in the attachment list.
+         * 
+         *        attachments.itemId: Only used if type is set to item. The EWS item id of the existing e-mail you want to attach to the new message. 
+         *        This is a string up to 100 characters.
          */
         displayNewMessageForm(parameters: any): void;
         /**
          * Gets a string that contains a token used to call REST APIs or Exchange Web Services.
          *
-         * The getCallbackTokenAsync method makes an asynchronous call to get an opaque token from the Exchange Server that hosts the user's mailbox. The lifetime of the callback token is 5 minutes.
+         * The getCallbackTokenAsync method makes an asynchronous call to get an opaque token from the Exchange Server that hosts the user's mailbox. 
+         * The lifetime of the callback token is 5 minutes.
          *
          * *REST Tokens*
          *
-         * When a REST token is requested (options.isRest = true), the resulting token will not work to authenticate Exchange Web Services calls. The token will be limited in scope to read-only access to the current item and its attachments, unless the add-in has specified the ReadWriteMailbox permission in its manifest. If the ReadWriteMailbox permission is specified, the resulting token will grant read/write access to mail, calendar, and contacts, including the ability to send mail.
+         * When a REST token is requested (options.isRest = true), the resulting token will not work to authenticate Exchange Web Services calls. 
+         * The token will be limited in scope to read-only access to the current item and its attachments, unless the add-in has specified the 
+         * ReadWriteMailbox permission in its manifest. 
+         * If the ReadWriteMailbox permission is specified, the resulting token will grant read/write access to mail, calendar, and contacts, 
+         * including the ability to send mail.
          *
          * The add-in should use the restUrl property to determine the correct URL to use when making REST API calls.
          *
          * *EWS Tokens*
          *
-         * When an EWS token is requested (options.isRest = false), the resulting token will not work to authenticate REST API calls. The token will be limited in scope to accessing the current item.
+         * When an EWS token is requested (options.isRest = false), the resulting token will not work to authenticate REST API calls. 
+         * The token will be limited in scope to accessing the current item.
          *
          * The add-in should use the ewsUrl property to determine the correct URL to use when making EWS calls.
          *
@@ -4998,26 +5676,31 @@ export declare namespace Office {
          * 
          * In addition to this signature, the method has the following signatures:
          * 
-         * `getCallbackTokenAsync(callback: (result: AsyncResult) => void): void;`
+         * `getCallbackTokenAsync(callback: (result: AsyncResult<string>) => void): void;`
          * 
-         * `getCallbackTokenAsync(callback: (result: AsyncResult) => void, userContext?: any): void;`
+         * `getCallbackTokenAsync(callback: (result: AsyncResult<string>) => void, userContext?: any): void;`
          *
          * @param options - An object literal that contains one or more of the following properties.
          *        isRest: Determines if the token provided will be used for the Outlook REST APIs or Exchange Web Services. Default value is false.
          *        asyncContext: Any state data that is passed to the asynchronous method.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. The token is provided as a string in the asyncResult.value property.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. The token is provided as a string in the asyncResult.value property.
          */
-        getCallbackTokenAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;
+        getCallbackTokenAsync(options: Office.AsyncContextOptions & { isRest?: boolean }, callback: (result: AsyncResult<string>) => void): void;
         /**
          * Gets a string that contains a token used to get an attachment or item from an Exchange Server.
          *
-         * The getCallbackTokenAsync method makes an asynchronous call to get an opaque token from the Exchange Server that hosts the user's mailbox. The lifetime of the callback token is 5 minutes.
+         * The getCallbackTokenAsync method makes an asynchronous call to get an opaque token from the Exchange Server that hosts the user's mailbox. 
+         * The lifetime of the callback token is 5 minutes.
          *
-         * You can pass the token and an attachment identifier or item identifier to a third-party system. The third-party system uses the token as a bearer authorization token to call the Exchange Web Services (EWS) GetAttachment or GetItem operation to return an attachment or item. For example, you can create a remote service to get attachments from the selected item.
+         * You can pass the token and an attachment identifier or item identifier to a third-party system. 
+         * The third-party system uses the token as a bearer authorization token to call the Exchange Web Services (EWS) GetAttachment or 
+         * GetItem operation to return an attachment or item. For example, you can create a remote service to get attachments from the selected item.
          *
          * Your app must have the ReadItem permission specified in its manifest to call the getCallbackTokenAsync method in read mode.
          *
-         * In compose mode you must call the saveAsync method to get an item identifier to pass to the getCallbackTokenAsync method. Your app must have ReadWriteItem permissions to call the saveAsync method.
+         * In compose mode you must call the saveAsync method to get an item identifier to pass to the getCallbackTokenAsync method. 
+         * Your app must have ReadWriteItem permissions to call the saveAsync method.
          *
          * [Api set: Mailbox 1.5]
          *
@@ -5027,19 +5710,24 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose and read</td></tr></table>
          *
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. The token is provided as a string in the asyncResult.value property.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. 
+         *                 The token is provided as a string in the asyncResult.value property.
          */
-        getCallbackTokenAsync(callback: (result: AsyncResult) => void): void;
+        getCallbackTokenAsync(callback: (result: AsyncResult<string>) => void): void;
         /**
          * Gets a string that contains a token used to get an attachment or item from an Exchange Server.
          *
-         * The getCallbackTokenAsync method makes an asynchronous call to get an opaque token from the Exchange Server that hosts the user's mailbox. The lifetime of the callback token is 5 minutes.
+         * The getCallbackTokenAsync method makes an asynchronous call to get an opaque token from the Exchange Server that hosts the user's mailbox. 
+         * The lifetime of the callback token is 5 minutes.
          *
-         * You can pass the token and an attachment identifier or item identifier to a third-party system. The third-party system uses the token as a bearer authorization token to call the Exchange Web Services (EWS) GetAttachment or GetItem operation to return an attachment or item. For example, you can create a remote service to get attachments from the selected item.
+         * You can pass the token and an attachment identifier or item identifier to a third-party system. 
+         * The third-party system uses the token as a bearer authorization token to call the Exchange Web Services (EWS) GetAttachment or 
+         * GetItem operation to return an attachment or item. For example, you can create a remote service to get attachments from the selected item.
          *
          * Your app must have the ReadItem permission specified in its manifest to call the getCallbackTokenAsync method in read mode.
          *
-         * In compose mode you must call the saveAsync method to get an item identifier to pass to the getCallbackTokenAsync method. Your app must have ReadWriteItem permissions to call the saveAsync method.
+         * In compose mode you must call the saveAsync method to get an item identifier to pass to the getCallbackTokenAsync method. 
+         * Your app must have ReadWriteItem permissions to call the saveAsync method.
          *
          * [Api set: Mailbox 1.3]
          *
@@ -5049,10 +5737,11 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose and read</td></tr></table>
          *
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. The token is provided as a string in the asyncResult.value property.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. The token is provided as a string in the asyncResult.value property.
          * @param userContext - Optional. Any state data that is passed to the asynchronous method.
          */
-        getCallbackTokenAsync(callback: (result: AsyncResult) => void, userContext?: any): void;
+        getCallbackTokenAsync(callback: (result: AsyncResult<string>) => void, userContext?: any): void;
         /**
          * Gets a token identifying the user and the Office Add-in.
          *
@@ -5066,12 +5755,15 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose and read</td></tr></table>
          *
-         * The getUserIdentityTokenAsync method returns a token that you can use to identify and {@link https://docs.microsoft.com/outlook/add-ins/authentication | authenticate the add-in and user with a third-party system}.
+         * The getUserIdentityTokenAsync method returns a token that you can use to identify and 
+         * {@link https://docs.microsoft.com/outlook/add-ins/authentication | authenticate the add-in and user with a third-party system}.
          *
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
+         *                 The token is provided as a string in the asyncResult.value property.
          * @param userContext - Optional. Any state data that is passed to the asynchronous method.|
          */
-        getUserIdentityTokenAsync(callback: (result: AsyncResult) => void, userContext?: any): void;
+        getUserIdentityTokenAsync(callback: (result: AsyncResult<string>) => void, userContext?: any): void;
         /**
          * Makes an asynchronous request to an Exchange Web Services (EWS) service on the Exchange server that hosts the user's mailbox.
          *
@@ -5083,21 +5775,32 @@ export declare namespace Office {
          *
          * The XML request must specify UTF-8 encoding. \<?xml version="1.0" encoding="utf-8"?\>
          *
-         * Your add-in must have the ReadWriteMailbox permission to use the makeEwsRequestAsync method. For information about using the ReadWriteMailbox permission and the EWS operations that you can call with the makeEwsRequestAsync method, see Specify permissions for mail add-in access to the user's mailbox.
+         * Your add-in must have the ReadWriteMailbox permission to use the makeEwsRequestAsync method. 
+         * For information about using the ReadWriteMailbox permission and the EWS operations that you can call with the makeEwsRequestAsync method, 
+         * see {@link https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions | Specify permissions for mail add-in access to the user's mailbox}.
          *
-         * The XML result of the EWS call is provided as a string in the asyncResult.value property. If the result exceeds 1 MB in size, an error message is returned instead.
+         * The XML result of the EWS call is provided as a string in the asyncResult.value property. 
+         * If the result exceeds 1 MB in size, an error message is returned instead.
          *
-         * Note: This method is not supported in the following scenarios. - In Outlook for iOS or Outlook for Android - When the add-in is loaded in a Gmail mailbox
+         * Note: This method is not supported in the following scenarios:
+         * 
+         * - In Outlook for iOS or Outlook for Android.
+         * 
+         * - When the add-in is loaded in a Gmail mailbox.
          *
-         * Note: The server administrator must set OAuthAuthentication to true on the Client Access Server EWS directory to enable the makeEwsRequestAsync method to make EWS requests.
+         * Note: The server administrator must set OAuthAuthentication to true on the Client Access Server EWS directory to enable the 
+         * makeEwsRequestAsync method to make EWS requests.
          *
          * *Version differences*
          *
-         * When you use the makeEwsRequestAsync method in mail apps running in Outlook versions earlier than version 15.0.4535.1004, you should set the encoding value to ISO-8859-1.
+         * When you use the makeEwsRequestAsync method in mail apps running in Outlook versions earlier than version 15.0.4535.1004, you should set 
+         * the encoding value to ISO-8859-1.
          *
          * `<?xml version="1.0" encoding="iso-8859-1"?>`
          *
-         * You do not need to set the encoding value when your mail app is running in Outlook on the web. You can determine whether your mail app is running in Outlook or Outlook on the web by using the mailbox.diagnostics.hostName property. You can determine what version of Outlook is running by using the mailbox.diagnostics.hostVersion property.
+         * You do not need to set the encoding value when your mail app is running in Outlook on the web. 
+         * You can determine whether your mail app is running in Outlook or Outlook on the web by using the mailbox.diagnostics.hostName property. 
+         * You can determine what version of Outlook is running by using the mailbox.diagnostics.hostVersion property.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -5108,18 +5811,44 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose and read</td></tr></table>
          *
          * @param data - The EWS request.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult.
+         *                 The `value` property of the result is the XML of the EWS request provided as a string. 
+         *                 If the result exceeds 1 MB in size, an error message is returned instead.
          * @param userContext - Optional. Any state data that is passed to the asynchronous method.
          */
-        makeEwsRequestAsync(data: any, callback: (result: AsyncResult) => void, userContext?: any): void;
+        makeEwsRequestAsync(data: any, callback: (result: AsyncResult<string>) => void, userContext?: any): void;
+        /**
+         * Removes an event handler for a supported event.
+         *
+         * Currently, the only supported event type is `Office.EventType.ItemChanged`.
+         *
+         * [Api set: Mailbox 1.5]
+         *
+         * @remarks
+         *
+         * <table><tr><td>{@link https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions | Minimum permission level}</td><td>ReadItem</td></tr>
+         *
+         * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
+         *
+         * @param eventType - The event that should revoke the handler.
+         * @param handler - The function to handle the event. The function must accept a single parameter, which is an object literal. 
+         *                The type property on the parameter will match the eventType parameter passed to addHandlerAsync.
+         * @param options - Optional. Provides an option for preserving context data of any type, unchanged, for use in a callback.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
+         */
+        removeHandlerAsync(eventType: Office.EventType, handler: (type: EventType) => void, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
     }
 
     /**
      * Represents a suggested meeting found in an item. Read mode only.
      *
-     * The list of meetings suggested in an email message is returned in the meetingSuggestions property of the Entities object that is returned when the getEntities or getEntitiesByType method is called on the active item.
+     * The list of meetings suggested in an email message is returned in the meetingSuggestions property of the Entities object that is returned when 
+     * the getEntities or getEntitiesByType method is called on the active item.
      *
-     * The start and end values are string representations of a Date object that contains the date and time at which the suggested meeting is to begin and end. The values are in the default time zone specified for the current user.
+     * The start and end values are string representations of a Date object that contains the date and time at which the suggested meeting is to 
+     * begin and end. 
+     * The values are in the default time zone specified for the current user.
      *
      * [Api set: Mailbox 1.0]
      *
@@ -5170,19 +5899,27 @@ export declare namespace Office {
          */
         key?: string;
         /**
-         * Specifies the ItemNotificationMessageType of message. If type is ProgressIndicator or ErrorMessage, an icon is automatically supplied and the message is not persistent. Therefore the icon and persistent properties are not valid for these types of messages. Including them will result in an ArgumentException. If type is ProgressIndicator, the developer should remove or replace the progress indicator when the action is complete.
+         * Specifies the ItemNotificationMessageType of message. If type is ProgressIndicator or ErrorMessage, an icon is automatically supplied and 
+         * the message is not persistent. Therefore the icon and persistent properties are not valid for these types of messages. 
+         * Including them will result in an ArgumentException. 
+         * If type is ProgressIndicator, the developer should remove or replace the progress indicator when the action is complete.
          */
         type: Office.MailboxEnums.ItemNotificationMessageType;
         /**
-         * A reference to an icon that is defined in the manifest in the Resources section. It appears in the infobar area. It is only applicable if the type is InformationalMessage. Specifying this parameter for an unsupported type results in an exception.
+         * A reference to an icon that is defined in the manifest in the Resources section. It appears in the infobar area. 
+         * It is only applicable if the type is InformationalMessage. Specifying this parameter for an unsupported type results in an exception.
          */
         icon?: string;
         /**
-         * The text of the notification message. Maximum length is 150 characters. If the developer passes in a longer string, an ArgumentOutOfRange exception is thrown.
+         * The text of the notification message. Maximum length is 150 characters. 
+         * If the developer passes in a longer string, an ArgumentOutOfRange exception is thrown.
          */
         message: string;
         /**
-         * Only applicable when type is InformationalMessage. If true, the message remains until removed by this add-in or dismissed by the user. If false, it is removed when the user navigates to a different item. For error notifications, the message persists until the user sees it once. Specifying this parameter for an unsupported type throws an exception.
+         * Only applicable when type is InformationalMessage. If true, the message remains until removed by this add-in or dismissed by the user. 
+         * If false, it is removed when the user navigates to a different item. 
+         * For error notifications, the message persists until the user sees it once. 
+         * Specifying this parameter for an unsupported type throws an exception.
          */
         persistent?: Boolean;
     }
@@ -5202,11 +5939,14 @@ export declare namespace Office {
          *
          * There are a maximum of 5 notifications per message. Setting more will return a NumberOfNotificationMessagesExceeded error.
          *
-         * @param key - A developer-specified key used to reference this notification message. Developers can use it to modify this message later. It can't be longer than 32 characters.
-         * @param JSONmessage - A JSON object that contains the notification message to be added to the item. It contains a NotificationMessageDetails object.
+         * @param key - A developer-specified key used to reference this notification message. 
+         *             Developers can use it to modify this message later. It can't be longer than 32 characters.
+         * @param JSONmessage - A JSON object that contains the notification message to be added to the item. 
+         *                    It contains a NotificationMessageDetails object.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          *
          * [Api set: Mailbox 1.3]
          *
@@ -5221,17 +5961,19 @@ export declare namespace Office {
          * 
          * `addAsync(key: string, JSONmessage: NotificationMessageDetails, options: Office.AsyncContextOptions): void;`
          * 
-         * `addAsync(key: string, JSONmessage: NotificationMessageDetails, callback: (result: AsyncResult) => void): void;`
+         * `addAsync(key: string, JSONmessage: NotificationMessageDetails, callback: (result: AsyncResult<void>) => void): void;`
          * 
          */
-        addAsync(key: string, JSONmessage: NotificationMessageDetails, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        addAsync(key: string, JSONmessage: NotificationMessageDetails, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Adds a notification to an item.
          *
          * There are a maximum of 5 notifications per message. Setting more will return a NumberOfNotificationMessagesExceeded error.
          *
-         * @param key - A developer-specified key used to reference this notification message. Developers can use it to modify this message later. It can't be longer than 32 characters.
-         * @param JSONmessage - A JSON object that contains the notification message to be added to the item. It contains a NotificationMessageDetails object.
+         * @param key - A developer-specified key used to reference this notification message. Developers can use it to modify this message later. 
+         *             It can't be longer than 32 characters.
+         * @param JSONmessage - A JSON object that contains the notification message to be added to the item. 
+         *                    It contains a NotificationMessageDetails object.
          *
          * [Api set: Mailbox 1.3]
          *
@@ -5246,8 +5988,10 @@ export declare namespace Office {
          *
          * There are a maximum of 5 notifications per message. Setting more will return a NumberOfNotificationMessagesExceeded error.
          *
-         * @param key - A developer-specified key used to reference this notification message. Developers can use it to modify this message later. It can't be longer than 32 characters.
-         * @param JSONmessage - A JSON object that contains the notification message to be added to the item. It contains a NotificationMessageDetails object.
+         * @param key - A developer-specified key used to reference this notification message. Developers can use it to modify this message later. 
+         *             It can't be longer than 32 characters.
+         * @param JSONmessage - A JSON object that contains the notification message to be added to the item. 
+         *                    It contains a NotificationMessageDetails object.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
          *
@@ -5264,9 +6008,12 @@ export declare namespace Office {
          *
          * There are a maximum of 5 notifications per message. Setting more will return a NumberOfNotificationMessagesExceeded error.
          *
-         * @param key - A developer-specified key used to reference this notification message. Developers can use it to modify this message later. It can't be longer than 32 characters.
-         * @param JSONmessage - A JSON object that contains the notification message to be added to the item. It contains a NotificationMessageDetails object.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param key - A developer-specified key used to reference this notification message. Developers can use it to modify this message later. 
+         *             It can't be longer than 32 characters.
+         * @param JSONmessage - A JSON object that contains the notification message to be added to the item. 
+         *                    It contains a NotificationMessageDetails object.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          *
          * [Api set: Mailbox 1.3]
          *
@@ -5275,7 +6022,7 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          */
-        addAsync(key: string, JSONmessage: NotificationMessageDetails, callback: (result: AsyncResult) => void): void;
+        addAsync(key: string, JSONmessage: NotificationMessageDetails, callback: (result: AsyncResult<void>) => void): void;
         /**
          * Returns all keys and messages for an item.
          *
@@ -5286,15 +6033,16 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          * 
-         * In addition to the main signature, this method also has this signature:
+         * In addition to this signature, this method also has the following signature:
          * 
-         * `getAllAsync(callback: (result: AsyncResult) => void): void;`
+         * `getAllAsync(callback: (result: AsyncResult<Office.NotificationMessageDetails[]>) => void): void;`
          *
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult.
+         *                 The `value` property of the result is an array of NotificationMessageDetails objects.
          */
-        getAllAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        getAllAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<Office.NotificationMessageDetails[]>) => void): void;
         /**
          * Returns all keys and messages for an item.
          *
@@ -5305,9 +6053,10 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          *
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult.
+         *                 The `value` property of the result is an array of NotificationMessageDetails objects.
          */
-        getAllAsync(callback: (result: AsyncResult) => void): void;
+        getAllAsync(callback: (result: AsyncResult<Office.NotificationMessageDetails[]>) => void): void;
         /**
          * Removes a notification message for an item.
          *
@@ -5318,20 +6067,21 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          * 
-         * In addition to the main signature, this method also has these signatures:
+         * In addition to this signature, this method also has the following signatures:
          * 
          * `removeAsync(key: string): void;`
          * 
          * `removeAsync(key: string, options: Office.AsyncContextOptions): void;`
          * 
-         * `removeAsync(key: string, callback: (result: AsyncResult) => void): void;`
+         * `removeAsync(key: string, callback: (result: AsyncResult<void>) => void): void;`
          *
          * @param key - The key for the notification message to remove.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          */
-        removeAsync(key: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        removeAsync(key: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Removes a notification message for an item.
          *
@@ -5371,9 +6121,10 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          *
          * @param key - The key for the notification message to remove.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          */
-        removeAsync(key: string, callback: (result: AsyncResult) => void): void;
+        removeAsync(key: string, callback: (result: AsyncResult<void>) => void): void;
         /**
          * Replaces a notification message that has a given key with another message.
          *
@@ -5386,21 +6137,23 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          * 
-         * In addition to the main signature, this method also has these signatures:
+         * In addition to this signature, this method also has the following signatures:
          * 
          * `replaceAsync(key: string, JSONmessage: NotificationMessageDetails): void;`
          * 
          * `replaceAsync(key: string, JSONmessage: NotificationMessageDetails, options: Office.AsyncContextOptions): void;`
          * 
-         * `replaceAsync(key: string, JSONmessage: NotificationMessageDetails, callback: (result: AsyncResult) => void): void;`
+         * `replaceAsync(key: string, JSONmessage: NotificationMessageDetails, callback: (result: AsyncResult<void>) => void): void;`
          *
          * @param key - The key for the notification message to replace. It can't be longer than 32 characters.
-         * @param JSONmessage - A JSON object that contains the new notification message to replace the existing message. It contains a NotificationMessageDetails object.
+         * @param JSONmessage - A JSON object that contains the new notification message to replace the existing message. 
+         *                    It contains a NotificationMessageDetails object.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          */
-        replaceAsync(key: string, JSONmessage: NotificationMessageDetails, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        replaceAsync(key: string, JSONmessage: NotificationMessageDetails, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Replaces a notification message that has a given key with another message.
          *
@@ -5414,7 +6167,8 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          *
          * @param key - The key for the notification message to replace. It can't be longer than 32 characters.
-         * @param JSONmessage - A JSON object that contains the new notification message to replace the existing message. It contains a NotificationMessageDetails object.
+         * @param JSONmessage - A JSON object that contains the new notification message to replace the existing message. 
+         *                    It contains a NotificationMessageDetails object.
          */
         replaceAsync(key: string, JSONmessage: NotificationMessageDetails): void;
         /**
@@ -5430,7 +6184,8 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          *
          * @param key - The key for the notification message to replace. It can't be longer than 32 characters.
-         * @param JSONmessage - A JSON object that contains the new notification message to replace the existing message. It contains a NotificationMessageDetails object.
+         * @param JSONmessage - A JSON object that contains the new notification message to replace the existing message. 
+         *                    It contains a NotificationMessageDetails object.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
          */
@@ -5448,15 +6203,18 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          *
          * @param key - The key for the notification message to replace. It can't be longer than 32 characters.
-         * @param JSONmessage - A JSON object that contains the new notification message to replace the existing message. It contains a NotificationMessageDetails object.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param JSONmessage - A JSON object that contains the new notification message to replace the existing message. 
+         *                    It contains a NotificationMessageDetails object.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          */
-        replaceAsync(key: string, JSONmessage: NotificationMessageDetails, callback: (result: AsyncResult) => void): void;
+        replaceAsync(key: string, JSONmessage: NotificationMessageDetails, callback: (result: AsyncResult<void>) => void): void;
     }
     /**
      * Represents a phone number identified in an item. Read mode only.
      *
-     * An array of PhoneNumber objects containing the phone numbers found in an email message is returned in the phoneNumbers property of the Entities object that is returned when you call the getEntities method on the selected item.
+     * An array of PhoneNumber objects containing the phone numbers found in an email message is returned in the phoneNumbers property of the 
+     * Entities object that is returned when you call the getEntities method on the selected item.
      *
      * [Api set: Mailbox 1.0]
      *
@@ -5508,20 +6266,21 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>NumberOfRecipientsExceeded - The number of recipients exceeded 100 entries.</td></tr></table>
          * 
-         * In addition to the main signature, this method also has these signatures:
+         * In addition to this signature, this method also has the following signatures:
          * 
          * `addAsync(recipients: (string | EmailUser | EmailAddressDetails)[]): void;`
          * 
          * `addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options: Office.AsyncContextOptions): void;`
          * 
-         * `addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult) => void): void;`
+         * `addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult<void>) => void): void;`
          *
          * @param recipients - The recipients to add to the recipients list.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If adding the recipients fails, the asyncResult.error property will contain an error code.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. If adding the recipients fails, the asyncResult.error property will contain an error code.
          */
-        addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Adds a recipient list to the existing recipients for an appointment or message.
          *
@@ -5591,13 +6350,14 @@ export declare namespace Office {
          * <tr><td>Errors</td><td>NumberOfRecipientsExceeded - The number of recipients exceeded 100 entries.</td></tr></table>
          *
          * @param recipients - The recipients to add to the recipients list.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If adding the recipients fails, the asyncResult.error property will contain an error code.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. If adding the recipients fails, the asyncResult.error property will contain an error code.
          */
-        addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult) => void): void;
+        addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult<void>) => void): void;
         /**
          * Gets a recipient list for an appointment or message.
          *
-         * When the call completes, the asyncResult.value property will contain an array of{@link Office.EmailAddressDetails} objects.
+         * When the call completes, the asyncResult.value property will contain an array of {@link Office.EmailAddressDetails} objects.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -5606,15 +6366,17 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose</td></tr></table>
          * 
-         * In addition to the main signature, this method also has this signature:
+         * In addition to this signature, this method also has the following signature:
          * 
-         * `getAsync(callback: (result: AsyncResult) => void): void;`
+         * `getAsync(callback: (result: AsyncResult<Office.EmailAddressDetails[]>) => void): void;`
          *
          * @param options - An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
+         *                 The `value` property of the result is an array of EmailAddressDetails objects.
          */
-        getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;
+        getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult<Office.EmailAddressDetails[]>) => void): void;
         /**
          * Gets a recipient list for an appointment or message.
          *
@@ -5627,9 +6389,11 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose</td></tr></table>
          *
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
+         *                 The `value` property of the result is an array of EmailAddressDetails objects.
          */
-        getAsync(callback: (result: AsyncResult) => void): void;
+        getAsync(callback: (result: AsyncResult<Office.EmailAddressDetails[]>) => void): void;
         /**
          * Sets a recipient list for an appointment or message.
          *
@@ -5652,20 +6416,23 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>NumberOfRecipientsExceeded - The number of recipients exceeded 100 entries.</td></tr></table>
          * 
-         * In addition to the main signature, this method also has these signatures:
+         * In addition to this signature, this method also has the following signatures:
          * 
          * `setAsync(recipients: (string | EmailUser | EmailAddressDetails)[]): void;`
          * 
          * `setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options: Office.AsyncContextOptions): void;`
          * 
-         * `setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult) => void): void;`
+         * `setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult<void>) => void): void;`
          *
          * @param recipients - The recipients to add to the recipients list.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.  If setting the recipients fails the asyncResult.error property will contain a code that indicates any error that occurred while adding the data.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
+         *                 If setting the recipients fails the asyncResult.error property will contain a code that indicates any error that occurred 
+         *                 while adding the data.
          */
-        setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Sets a recipient list for an appointment or message.
          *
@@ -5741,9 +6508,12 @@ export declare namespace Office {
          * <tr><td>Errors</td><td>NumberOfRecipientsExceeded - The number of recipients exceeded 100 entries.</td></tr></table>
          *
          * @param recipients - The recipients to add to the recipients list.
-         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.  If setting the recipients fails the asyncResult.error property will contain a code that indicates any error that occurred while adding the data.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. 
+         *                 If setting the recipients fails the asyncResult.error property will contain a code that indicates any error that occurred 
+         *                 while adding the data.
          */
-        setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult) => void): void;
+        setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult<void>) => void): void;
 
     }
 
@@ -5764,7 +6534,8 @@ export declare namespace Office {
          */
         url?: string;
         /**
-         * Only used if type is set to file. If true, indicates that the attachment will be shown inline in the message body, and should not be displayed in the attachment list.
+         * Only used if type is set to file. If true, indicates that the attachment will be shown inline in the message body, and should not be 
+         * displayed in the attachment list.
          */
         inLine?: boolean;
         /**
@@ -5786,20 +6557,27 @@ export declare namespace Office {
          */
         attachments?: ReplyFormAttachment[];
         /**
-         * When the reply display call completes, the function passed in the callback parameter is called with a single parameter, asyncResult, which is an AsyncResult object.
+         * When the reply display call completes, the function passed in the callback parameter is called with a single parameter, 
+         * asyncResult, which is an Office.AsyncResult object.
          */
-        callback?: (result: AsyncResult) => void;
+        callback?: (result: AsyncResult<any>) => void;
     }
     /**
-     * The settings created by using the methods of the RoamingSettings object are saved per add-in and per user. That is, they are available only to the add-in that created them, and only from the user's mail box in which they are saved.
+     * The settings created by using the methods of the RoamingSettings object are saved per add-in and per user. 
+     * That is, they are available only to the add-in that created them, and only from the user's mail box in which they are saved.
      *
-     * While the Outlook add-in API limits access to these settings to only the add-in that created them, these settings should not be considered secure storage. They can be accessed by Exchange Web Services or Extended MAPI. They should not be used to store sensitive information such as user credentials or security tokens.
+     * While the Outlook Add-in API limits access to these settings to only the add-in that created them, these settings should not be considered 
+     * secure storage. They can be accessed by Exchange Web Services or Extended MAPI. 
+     * They should not be used to store sensitive information such as user credentials or security tokens.
      *
      * The name of a setting is a String, while the value can be a String, Number, Boolean, null, Object, or Array.
      *
      * The RoamingSettings object is accessible via the roamingSettings property in the Office.context namespace.
      *
-     * Important: The RoamingSettings object is initialized from the persisted storage only when the add-in is first loaded. For task panes, this means that it is only initialized when the task pane first opens. If the task pane navigates to another page or reloads the current page, the in-memory object is reset to its initial values, even if your add-in has persisted changes. The persisted changes will not be available until the task pane is closed and reopened.
+     * Important: The RoamingSettings object is initialized from the persisted storage only when the add-in is first loaded. 
+     * For task panes, this means that it is only initialized when the task pane first opens. 
+     * If the task pane navigates to another page or reloads the current page, the in-memory object is reset to its initial values, even if 
+     * your add-in has persisted changes. The persisted changes will not be available until the task pane is closed and reopened.
      *
      * [Api set: Mailbox 1.0]
      *
@@ -5839,7 +6617,9 @@ export declare namespace Office {
         /**
          * Saves the settings.
          *
-         * Any settings previously saved by an add-in are loaded when it is initialized, so during the lifetime of the session you can just use the set and get methods to work with the in-memory copy of the settings property bag. When you want to persist the settings so that they are available the next time the add-in is used, use the saveAsync method.
+         * Any settings previously saved by an add-in are loaded when it is initialized, so during the lifetime of the session you can just use 
+         * the set and get methods to work with the in-memory copy of the settings property bag. 
+         * When you want to persist the settings so that they are available the next time the add-in is used, use the saveAsync method.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -5848,13 +6628,15 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          *
-         * @param callback - Optional? When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
          */
-        saveAsync(callback?: (result: AsyncResult) => void): void;
+        saveAsync(callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Sets or creates the specified setting.
          *
-         * The set method creates a new setting of the specified name if it does not already exist, or sets an existing setting of the specified name. The value is stored in the document as the serialized JSON representation of its data type.
+         * The set method creates a new setting of the specified name if it does not already exist, or sets an existing setting of the specified name. 
+         * The value is stored in the document as the serialized JSON representation of its data type.
          *
          * A maximum of 32KB is available for the settings of each add-in.
          *
@@ -5872,6 +6654,7 @@ export declare namespace Office {
          */
         set(name: string, value: any): void;
     }
+    
     /**
      * Provides methods to get and set the subject of an appointment or message in an Outlook add-in.
      *
@@ -5895,17 +6678,20 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose</td></tr></table>
          * 
-         * In addition to the main signature, this method also has this signature:
+         * In addition to this signature, this method also has the following signature:
          * 
-         * `getAsync(callback: (result: AsyncResult) => void): void;`
+         * `getAsync(callback: (result: AsyncResult<string>) => void): void;`
          *
          * @param options - An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
+         *                 The `value` property of the result is the subject of the item.
          */
-        getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;
+        getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult<string>) => void): void;
         /**
          * Gets the subject of an appointment or message.
+         * 
          * The getAsync method starts an asynchronous call to the Exchange server to get the subject of an appointment or message.
          *
          * [Api set: Mailbox 1.1]
@@ -5916,12 +6702,14 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose</td></tr></table>
          *
          * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         *                  The `value` property of the result is the subject of the item.
          */
-        getAsync(callback: (result: AsyncResult) => void): void;
+        getAsync(callback: (result: AsyncResult<string>) => void): void;
         /**
          * Sets the subject of an appointment or message.
          *
-         * The setAsync method starts an asynchronous call to the Exchange server to set the subject of an appointment or message. Setting the subject overwrites the current subject, but leaves any prefixes, such as "Fwd:" or "Re:" in place.
+         * The setAsync method starts an asynchronous call to the Exchange server to set the subject of an appointment or message. 
+         * Setting the subject overwrites the current subject, but leaves any prefixes, such as "Fwd:" or "Re:" in place.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -5932,24 +6720,26 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>DataExceedsMaximumSize - The subject parameter is longer than 255 characters.</td></tr></table>
          * 
-         * In addition to the main signature, this method also has these signatures:
+         * In addition to this signature, this method also has the following signatures:
          * 
          * `setAsync(subject: string): void;`
          * 
          * `setAsync(subject: string, options: Office.AsyncContextOptions): void;`
          * 
-         * `setAsync(subject: string, callback: (result: AsyncResult) => void): void;`
+         * `setAsync(subject: string, callback: (result: AsyncResult<void>) => void): void;`
          *
          * @param subject - The subject of the appointment or message. The string is limited to 255 characters.
          * @param options - An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If setting the subject fails, the asyncResult.error property will contain an error code.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. If setting the subject fails, the asyncResult.error property will contain an error code.
          */
-        setAsync(subject: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        setAsync(subject: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Sets the subject of an appointment or message.
          *
-         * The setAsync method starts an asynchronous call to the Exchange server to set the subject of an appointment or message. Setting the subject overwrites the current subject, but leaves any prefixes, such as "Fwd:" or "Re:" in place.
+         * The setAsync method starts an asynchronous call to the Exchange server to set the subject of an appointment or message. 
+         * Setting the subject overwrites the current subject, but leaves any prefixes, such as "Fwd:" or "Re:" in place.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -5966,7 +6756,8 @@ export declare namespace Office {
         /**
          * Sets the subject of an appointment or message.
          *
-         * The setAsync method starts an asynchronous call to the Exchange server to set the subject of an appointment or message. Setting the subject overwrites the current subject, but leaves any prefixes, such as "Fwd:" or "Re:" in place.
+         * The setAsync method starts an asynchronous call to the Exchange server to set the subject of an appointment or message. 
+         * Setting the subject overwrites the current subject, but leaves any prefixes, such as "Fwd:" or "Re:" in place.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -5985,7 +6776,8 @@ export declare namespace Office {
         /**
          * Sets the subject of an appointment or message.
          *
-         * The setAsync method starts an asynchronous call to the Exchange server to set the subject of an appointment or message. Setting the subject overwrites the current subject, but leaves any prefixes, such as "Fwd:" or "Re:" in place.
+         * The setAsync method starts an asynchronous call to the Exchange server to set the subject of an appointment or message. 
+         * Setting the subject overwrites the current subject, but leaves any prefixes, such as "Fwd:" or "Re:" in place.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -5997,15 +6789,17 @@ export declare namespace Office {
          * <tr><td>Errors</td><td>DataExceedsMaximumSize - The subject parameter is longer than 255 characters.</td></tr></table>
          *
          * @param subject - The subject of the appointment or message. The string is limited to 255 characters.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If setting the subject fails, the asyncResult.error property will contain an error code.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. If setting the subject fails, the asyncResult.error property will contain an error code.
          */
-        setAsync(data: string, callback: (result: AsyncResult) => void): void;
+        setAsync(data: string, callback: (result: AsyncResult<void>) => void): void;
 
     }
     /**
      * Represents a suggested task identified in an item. Read mode only.
      *
-     * The list of tasks suggested in an email message is returned in the taskSuggestions property of the [Entities]Entities object that is returned when the getEntities or getEntitiesByType method is called on the active item.
+     * The list of tasks suggested in an email message is returned in the taskSuggestions property of the {@link Office.Entities | Entities} object 
+     * that is returned when the getEntities or getEntitiesByType method is called on the active item.
      *
      * [Api set: Mailbox 1.0]
      *
@@ -6038,7 +6832,8 @@ export declare namespace Office {
         /**
          * Gets the start or end time of an appointment.
          *
-         * The date and time is provided as a Date object in the asyncResult.value property. The value is in Coordinated Universal Time (UTC). You can convert the UTC time to the local client time by using the convertToLocalClientTime method.
+         * The date and time is provided as a Date object in the asyncResult.value property. The value is in Coordinated Universal Time (UTC). 
+         * You can convert the UTC time to the local client time by using the convertToLocalClientTime method.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -6047,19 +6842,21 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose</td></tr></table>
          * 
-         * In addition to the main signature, this method also has this signature:
+         * In addition to this signature, this method also has the following signature:
          * 
-         * `getAsync(callback: (result: AsyncResult) => void): void;`
+         * `getAsync(callback: (result: AsyncResult<Date>) => void): void;`
          *
          * @param options - An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
          * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         *                  The `value` property of the result is a Date object.
          */
-        getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;
+        getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult<Date>) => void): void;
         /**
          * Gets the start or end time of an appointment.
          *
-         * The date and time is provided as a Date object in the asyncResult.value property. The value is in Coordinated Universal Time (UTC). You can convert the UTC time to the local client time by using the convertToLocalClientTime method.
+         * The date and time is provided as a Date object in the asyncResult.value property. The value is in Coordinated Universal Time (UTC). 
+         * You can convert the UTC time to the local client time by using the convertToLocalClientTime method.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -6069,12 +6866,14 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose</td></tr></table>
          *
          * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult.
+         *                  The `value` property of the result is a Date object.
          */
-        getAsync(callback: (result: AsyncResult) => void): void;
+        getAsync(callback: (result: AsyncResult<Date>) => void): void;
         /**
          * Sets the start or end time of an appointment.
          *
-         * If the setAsync method is called on the start property, the end property will be adjusted to maintain the duration of the appointment as previously set. If the setAsync method is called on the end property, the duration of the appointment will be extended to the new end time.
+         * If the setAsync method is called on the start property, the end property will be adjusted to maintain the duration of the appointment as 
+         * previously set. If the setAsync method is called on the end property, the duration of the appointment will be extended to the new end time.
          *
          * The time must be in UTC; you can get the correct UTC time by using the convertToUtcClientTime method.
          *
@@ -6087,24 +6886,27 @@ export declare namespace Office {
          *
          * <tr><td>Errors</td><td>InvalidEndTime - The appointment end time is before the appointment start time.</td></tr></table>
          * 
-         * In addition to the main signature, this method also has these signatures:
+         * In addition to this signature, this method also has the following signatures:
          * 
          * `setAsync(dateTime: Date): void;`
          * 
          * `setAsync(dateTime: Date, options: Office.AsyncContextOptions): void;`
          * 
-         * `setAsync(dateTime: Date, callback: (result: AsyncResult) => void): void;`
+         * `setAsync(dateTime: Date, callback: (result: AsyncResult<void>) => void): void;`
          *
          * @param dateTime - A date-time object in Coordinated Universal Time (UTC).
          * @param options - An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If setting the date and time fails, the asyncResult.error property will contain an error code.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. 
+         *                 If setting the date and time fails, the asyncResult.error property will contain an error code.
          */
-        setAsync(dateTime: Date, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;
+        setAsync(dateTime: Date, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Sets the start or end time of an appointment.
          *
-         * If the setAsync method is called on the start property, the end property will be adjusted to maintain the duration of the appointment as previously set. If the setAsync method is called on the end property, the duration of the appointment will be extended to the new end time.
+         * If the setAsync method is called on the start property, the end property will be adjusted to maintain the duration of the appointment as 
+         * previously set. If the setAsync method is called on the end property, the duration of the appointment will be extended to the new end time.
          *
          * The time must be in UTC; you can get the correct UTC time by using the convertToUtcClientTime method.
          *
@@ -6123,7 +6925,8 @@ export declare namespace Office {
         /**
          * Sets the start or end time of an appointment.
          *
-         * If the setAsync method is called on the start property, the end property will be adjusted to maintain the duration of the appointment as previously set. If the setAsync method is called on the end property, the duration of the appointment will be extended to the new end time.
+         * If the setAsync method is called on the start property, the end property will be adjusted to maintain the duration of the appointment as 
+         * previously set. If the setAsync method is called on the end property, the duration of the appointment will be extended to the new end time.
          *
          * The time must be in UTC; you can get the correct UTC time by using the convertToUtcClientTime method.
          *
@@ -6144,7 +6947,8 @@ export declare namespace Office {
         /**
          * Sets the start or end time of an appointment.
          *
-         * If the setAsync method is called on the start property, the end property will be adjusted to maintain the duration of the appointment as previously set. If the setAsync method is called on the end property, the duration of the appointment will be extended to the new end time.
+         * If the setAsync method is called on the start property, the end property will be adjusted to maintain the duration of the appointment as 
+         * previously set. If the setAsync method is called on the end property, the duration of the appointment will be extended to the new end time.
          *
          * The time must be in UTC; you can get the correct UTC time by using the convertToUtcClientTime method.
          *
@@ -6158,9 +6962,11 @@ export declare namespace Office {
          * <tr><td>Errors</td><td>InvalidEndTime - The appointment end time is before the appointment start time.</td></tr></table>
          *
          * @param dateTime - A date-time object in Coordinated Universal Time (UTC).
-         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If setting the date and time fails, the asyncResult.error property will contain an error code.
+         * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult. 
+         *                 If setting the date and time fails, the asyncResult.error property will contain an error code.
          */
-        setAsync(dateTime: Date, callback: (result: AsyncResult) => void): void;
+        setAsync(dateTime: Date, callback: (result: AsyncResult<void>) => void): void;
 
     }
     /**

--- a/generate-docs/api-extractor-inputs-outlook-legacy/Outlook_1_7/Outlook_1_7.d.ts
+++ b/generate-docs/api-extractor-inputs-outlook-legacy/Outlook_1_7/Outlook_1_7.d.ts
@@ -2267,7 +2267,8 @@ export declare namespace Office {
         /**
          * Adds an event handler for a supported event.
          * 
-         * Currently the supported event types are `Office.EventType.AppointmentTimeChanged`, `Office.EventType.RecipientsChanged`, and `Office.EventType.RecurrenceChanged`.
+         * Currently the supported event types are `Office.EventType.AppointmentTimeChanged`, `Office.EventType.RecipientsChanged`, and 
+         * `Office.EventType.RecurrenceChanged`.
          * 
          * [Api set: Mailbox 1.7]
          *
@@ -2537,8 +2538,8 @@ export declare namespace Office {
          * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
          * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
          * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
-         * A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form 
-         * to continue in a separate window.
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -2571,8 +2572,8 @@ export declare namespace Office {
          * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
          * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
          * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
-         * A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form 
-         * to continue in a separate window.
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -2593,8 +2594,8 @@ export declare namespace Office {
          * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
          * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
          * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
-         * A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form 
-         * to continue in a separate window.
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -2618,8 +2619,8 @@ export declare namespace Office {
          * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
          * in the same session. 
          * In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
-         * A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form 
-         * to continue in a separate window.
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -2655,7 +2656,7 @@ export declare namespace Office {
         * 
         * `removeHandlerAsync(eventType:EventType, handler: any, callback?: (result: AsyncResult<void>) => void): void;`
         * 
-        * @param eventType - The event that should invoke the handler.
+        * @param eventType - The event that should revoke the handler.
         * @param handler - The function to handle the event. The function must accept a single parameter, which is an object literal. 
         *                The type property on the parameter will match the eventType parameter passed to removeHandlerAsync.
         * @param options - Optional. An object literal that contains one or more of the following properties.
@@ -2667,7 +2668,8 @@ export declare namespace Office {
        /**
         * Removes an event handler for a supported event.
         * 
-        * Currently the supported event types are `Office.EventType.AppointmentTimeChanged`, `Office.EventType.RecipientsChanged`, and `Office.EventType.RecurrenceChanged`.
+        * Currently the supported event types are `Office.EventType.AppointmentTimeChanged`, `Office.EventType.RecipientsChanged`, and 
+        * `Office.EventType.RecurrenceChanged`.
         * 
         * [Api set: Mailbox 1.7]
         *
@@ -2677,7 +2679,7 @@ export declare namespace Office {
         *
         * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Appointment Organizer</td></tr></table>
         * 
-        * @param eventType - The event that should invoke the handler.
+        * @param eventType - The event that should revoke the handler.
         * @param handler - The function to handle the event. The function must accept a single parameter, which is an object literal. 
         *                The type property on the parameter will match the eventType parameter passed to removeHandlerAsync.
         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter, 
@@ -2952,7 +2954,7 @@ export declare namespace Office {
      */
     export interface AppointmentRead extends Appointment, ItemRead {
         /**
-         * Gets an array of attachments for the item.
+         * Gets the item's attachments as an array.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -3600,7 +3602,7 @@ export declare namespace Office {
         * 
         * `removeHandlerAsync(eventType:EventType, handler: any, callback?: (result: AsyncResult<void>) => void): void;`
         * 
-        * @param eventType - The event that should invoke the handler.
+        * @param eventType - The event that should revoke the handler.
         * @param handler - The function to handle the event. The function must accept a single parameter, which is an object literal. 
         *                The type property on the parameter will match the eventType parameter passed to removeHandlerAsync.
         * @param options - Optional. An object literal that contains one or more of the following properties.
@@ -3623,7 +3625,7 @@ export declare namespace Office {
         *
         * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Appointment Attendee</td></tr></table>
         * 
-        * @param eventType - The event that should invoke the handler.
+        * @param eventType - The event that should revoke the handler.
         * @param handler - The function to handle the event. The function must accept a single parameter, which is an object literal. 
         *                The type property on the parameter will match the eventType parameter passed to removeHandlerAsync.
         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter, 
@@ -3760,7 +3762,8 @@ export declare namespace Office {
         /**
          * Adds an event handler for a supported event.
          * 
-         * Currently the supported event types are `Office.EventType.AppointmentTimeChanged`, `Office.EventType.RecipientsChanged`, and `Office.EventType.RecurrenceChanged`.
+         * Currently the supported event types are `Office.EventType.AppointmentTimeChanged`, `Office.EventType.RecipientsChanged`, and 
+         * `Office.EventType.RecurrenceChanged`.
          * 
          * [Api set: Mailbox 1.7]
          *
@@ -3787,7 +3790,8 @@ export declare namespace Office {
         /**
          * Adds an event handler for a supported event.
          * 
-         * Currently the supported event types are `Office.EventType.AppointmentTimeChanged`, `Office.EventType.RecipientsChanged`, and `Office.EventType.RecurrenceChanged`.
+         * Currently the supported event types are `Office.EventType.AppointmentTimeChanged`, `Office.EventType.RecipientsChanged`, and 
+         * `Office.EventType.RecurrenceChanged`.
          * 
          * [Api set: Mailbox 1.7]
          *
@@ -3804,7 +3808,7 @@ export declare namespace Office {
          *                 asyncResult, which is an Office.AsyncResult object.
          */
         addHandlerAsync(eventType: Office.EventType, handler: any, callback?: (result: AsyncResult<void>) => void): void;
-		
+
        /**
         * Asynchronously loads custom properties for this add-in on the selected item.
         *
@@ -3849,7 +3853,7 @@ export declare namespace Office {
         * 
         * `removeHandlerAsync(eventType: Office.EventType, handler: any, callback?: (result: AsyncResult<void>) => void): void;`
         * 
-        * @param eventType - The event that should invoke the handler.
+        * @param eventType - The event that should revoke the handler.
         * @param handler - The function to handle the event. The function must accept a single parameter, which is an object literal. 
         *                The type property on the parameter will match the eventType parameter passed to removeHandlerAsync.
         * @param options - Optional. An object literal that contains one or more of the following properties.
@@ -3873,7 +3877,7 @@ export declare namespace Office {
         *
         * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
         * 
-        * @param eventType - The event that should invoke the handler.
+        * @param eventType - The event that should revoke the handler.
         * @param handler - The function to handle the event. The function must accept a single parameter, which is an object literal. 
         *                The type property on the parameter will match the eventType parameter passed to removeHandlerAsync.
         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter, 
@@ -4214,8 +4218,8 @@ export declare namespace Office {
          * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
          * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
          * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
-         * A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form 
-         * to continue in a separate window.
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -4249,8 +4253,8 @@ export declare namespace Office {
          * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
          * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
          * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
-         * A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form 
-         * to continue in a separate window.
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -4271,8 +4275,8 @@ export declare namespace Office {
          * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
          * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
          * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
-         * A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form 
-         * to continue in a separate window.
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -4295,8 +4299,8 @@ export declare namespace Office {
          * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
          * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
          * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
-         * A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form 
-         * to continue in a separate window.
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -4588,7 +4592,7 @@ export declare namespace Office {
      */
     export interface ItemRead extends Item {
         /**
-         * Gets an array of attachments for the item.
+         * Gets the item's attachments as an array.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -5294,7 +5298,8 @@ export declare namespace Office {
         /**
          * Adds an event handler for a supported event.
          * 
-         * Currently the supported event types are `Office.EventType.AppointmentTimeChanged`, `Office.EventType.RecipientsChanged`, and `Office.EventType.RecurrenceChanged`.
+         * Currently the supported event types are `Office.EventType.AppointmentTimeChanged`, `Office.EventType.RecipientsChanged`, and 
+         * `Office.EventType.RecurrenceChanged`.
          * 
          * [Api set: Mailbox 1.7]
          *
@@ -5567,8 +5572,8 @@ export declare namespace Office {
          * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
          * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
          * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
-         * A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form 
-         * to continue in a separate window.
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -5602,8 +5607,8 @@ export declare namespace Office {
          * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
          * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
          * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
-         * A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form 
-         * to continue in a separate window.
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -5624,8 +5629,8 @@ export declare namespace Office {
          * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
          * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
          * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
-         * A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form 
-         * to continue in a separate window.
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -5648,8 +5653,8 @@ export declare namespace Office {
          * The removeAttachmentAsync method removes the attachment with the specified identifier from the item. 
          * As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment 
          * in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. 
-         * A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form 
-         * to continue in a separate window.
+         * A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to 
+         * continue in a separate window.
          *
          * [Api set: Mailbox 1.1]
          *
@@ -5685,7 +5690,7 @@ export declare namespace Office {
          * 
          * `removeHandlerAsync(eventType:EventType, handler: any, callback?: (result: AsyncResult<void>) => void): void;`
          * 
-         * @param eventType - The event that should invoke the handler.
+         * @param eventType - The event that should revoke the handler.
          * @param handler - The function to handle the event. The function must accept a single parameter, which is an object literal. 
          *                The type property on the parameter will match the eventType parameter passed to removeHandlerAsync.
          * @param options - Optional. An object literal that contains one or more of the following properties.
@@ -5708,7 +5713,7 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Message Compose</td></tr></table>
          * 
-         * @param eventType - The event that should invoke the handler.
+         * @param eventType - The event that should revoke the handler.
          * @param handler - The function to handle the event. The function must accept a single parameter, which is an object literal. 
          *                The type property on the parameter will match the eventType parameter passed to removeHandlerAsync.
          * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter, 
@@ -5983,7 +5988,7 @@ export declare namespace Office {
      */
     export interface MessageRead extends Message, ItemRead {
         /**
-         * Gets an array of attachments for the item.
+         * Gets the item's attachments as an array.
          *
          * [Api set: Mailbox 1.0]
          *
@@ -6648,7 +6653,7 @@ export declare namespace Office {
          * 
          * `removeHandlerAsync(eventType:EventType, handler: any, callback?: (result: AsyncResult<void>) => void): void;`
          * 
-         * @param eventType - The event that should invoke the handler.
+         * @param eventType - The event that should revoke the handler.
          * @param handler - The function to handle the event. The function must accept a single parameter, which is an object literal. 
          *                The type property on the parameter will match the eventType parameter passed to removeHandlerAsync.
          * @param options - Optional. An object literal that contains one or more of the following properties.
@@ -6671,7 +6676,7 @@ export declare namespace Office {
          *
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Message Read</td></tr></table>
          * 
-         * @param eventType - The event that should invoke the handler.
+         * @param eventType - The event that should revoke the handler.
          * @param handler - The function to handle the event. The function must accept a single parameter, which is an object literal. 
          *                The type property on the parameter will match the eventType parameter passed to removeHandlerAsync.
          * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter, 
@@ -6960,7 +6965,7 @@ export declare namespace Office {
          */
         restUrl: string;
         /**
-         * Information about the user associated with the mailbox. This includes their account type, display name, email adddress, and time zone.
+         * Information about the user associated with the mailbox. This includes their account type, display name, email address, and time zone.
          * 
          * More information is under {@link Office.UserProfile}
          */
@@ -6968,7 +6973,7 @@ export declare namespace Office {
         /**
          * Adds an event handler for a supported event.
          *
-         * Currently, the supported event types are `Office.EventType.ItemChanged` and `Office.EventType.OfficeThemeChanged`.
+         * Currently, the only supported event type is `Office.EventType.ItemChanged`.
          *
          * [Api set: Mailbox 1.5]
          *
@@ -7374,6 +7379,27 @@ export declare namespace Office {
          * @param userContext - Optional. Any state data that is passed to the asynchronous method.
          */
         makeEwsRequestAsync(data: any, callback: (result: AsyncResult<string>) => void, userContext?: any): void;
+        /**
+         * Removes an event handler for a supported event.
+         *
+         * Currently, the only supported event type is `Office.EventType.ItemChanged`.
+         *
+         * [Api set: Mailbox 1.5]
+         *
+         * @remarks
+         *
+         * <table><tr><td>{@link https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions | Minimum permission level}</td><td>ReadItem</td></tr>
+         *
+         * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
+         *
+         * @param eventType - The event that should revoke the handler.
+         * @param handler - The function to handle the event. The function must accept a single parameter, which is an object literal. 
+         *                The type property on the parameter will match the eventType parameter passed to addHandlerAsync.
+         * @param options - Optional. Provides an option for preserving context data of any type, unchanged, for use in a callback.
+         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
+         *                 type Office.AsyncResult.
+         */
+        removeHandlerAsync(eventType: Office.EventType, handler: (type: EventType) => void, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
     }
 
     /**

--- a/generate-docs/json/Outlook_1_1.api.json
+++ b/generate-docs/json/Outlook_1_1.api.json
@@ -69,7 +69,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Office.context.mailbox.item"
+                  "text": " Office.context.mailbox.item"
                 }
               ],
               "target": {
@@ -88,7 +88,16 @@
             },
             {
               "kind": "text",
-              "text": "Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information."
+              "text": "Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of "
+            },
+            {
+              "kind": "code",
+              "text": "Office.context.mailbox.item",
+              "highlighter": "plain"
+            },
+            {
+              "kind": "text",
+              "text": ". Refer to the Object Model pages for more information."
             }
           ],
           "remarks": [],
@@ -97,7 +106,7 @@
           "members": {
             "addFileAttachmentAsync": {
               "kind": "method",
-              "signature": "addFileAttachmentAsync(uri: string, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "addFileAttachmentAsync(uri: string, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -152,7 +161,7 @@
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<string>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -185,10 +194,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -205,7 +210,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -246,7 +251,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -377,22 +382,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addFileAttachmentAsync(uri: string, attachmentName: string): void;`"
+                  "kind": "code",
+                  "text": "addFileAttachmentAsync(uri: string, attachmentName: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addFileAttachmentAsync(uri: string, attachmentName: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "addFileAttachmentAsync(uri: string, attachmentName: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -402,7 +410,7 @@
             },
             "addItemAttachmentAsync": {
               "kind": "method",
-              "signature": "addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -452,12 +460,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<string>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -485,7 +493,7 @@
                 },
                 {
                   "kind": "text",
-                  "text": "If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended."
+                  "text": "If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended."
                 },
                 {
                   "kind": "paragraph"
@@ -496,10 +504,6 @@
                 }
               ],
               "remarks": [
-                {
-                  "kind": "text",
-                  "text": ""
-                },
                 {
                   "kind": "html-tag",
                   "token": "<table>"
@@ -517,7 +521,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -558,7 +562,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -627,28 +631,31 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has these signatures:"
+                  "text": "In addition to this signature, this method also has the following signatures:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addItemAttachmentAsync(itemId: any, attachmentName: string): void;`"
+                  "kind": "code",
+                  "text": "addItemAttachmentAsync(itemId: any, attachmentName: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -695,7 +702,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -736,7 +743,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -764,10 +771,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -815,7 +818,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -856,7 +859,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -884,10 +887,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -935,7 +934,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -976,7 +975,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -1091,7 +1090,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -1132,7 +1131,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -1160,10 +1159,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -1218,7 +1213,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -1259,7 +1254,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -1287,10 +1282,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -1301,7 +1292,7 @@
             },
             "loadCustomPropertiesAsync": {
               "kind": "method",
-              "signature": "loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;",
+              "signature": "loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -1315,12 +1306,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<Office.CustomProperties>) => void"
                 },
                 "userContext": {
                   "name": "userContext",
@@ -1381,7 +1372,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -1422,7 +1413,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -1450,10 +1441,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -1519,7 +1506,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -1560,7 +1547,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -1588,10 +1575,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -1658,7 +1641,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -1699,7 +1682,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -1727,10 +1710,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -1741,7 +1720,7 @@
             },
             "removeAttachmentAsync": {
               "kind": "method",
-              "signature": "removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -1779,12 +1758,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -1798,7 +1777,7 @@
                 },
                 {
                   "kind": "text",
-                  "text": "The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window."
+                  "text": "The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to continue in a separate window."
                 },
                 {
                   "kind": "paragraph"
@@ -1826,7 +1805,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -1867,7 +1846,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -1942,22 +1921,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAttachmentAsync(attachmentIndex: string): void;`"
+                  "kind": "code",
+                  "text": "removeAttachmentAsync(attachmentIndex: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -2023,7 +2005,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -2064,7 +2046,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -2092,10 +2074,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -2176,7 +2154,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -2217,7 +2195,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -2245,10 +2223,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -2310,7 +2284,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -2351,7 +2325,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -2379,10 +2353,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -2414,10 +2384,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -2434,7 +2400,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -2475,7 +2441,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -2503,10 +2469,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -2551,7 +2513,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -2592,7 +2554,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -2620,10 +2582,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -2713,7 +2671,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -2754,7 +2712,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -2782,10 +2740,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -2861,7 +2815,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -2903,7 +2857,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -2931,10 +2885,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -3010,7 +2960,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -3051,7 +3001,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -3079,10 +3029,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -3158,7 +3104,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -3199,7 +3145,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -3227,10 +3173,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -3336,7 +3278,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -3377,7 +3319,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -3405,10 +3347,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -3491,7 +3429,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -3532,7 +3470,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -3560,10 +3498,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -3590,7 +3524,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Office.context.mailbox.item"
+                  "text": " Office.context.mailbox.item"
                 }
               ],
               "target": {
@@ -3627,7 +3561,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Gets an array of attachments for the item."
+                  "text": "Gets the item's attachments as an array."
                 },
                 {
                   "kind": "paragraph"
@@ -3655,7 +3589,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -3696,7 +3630,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -3737,7 +3671,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Blocked attachments in Outlook"
+                      "text": " Blocked attachments in Outlook"
                     }
                   ],
                   "targetUrl": "https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519"
@@ -3792,7 +3726,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -3833,7 +3767,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -3861,10 +3795,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -3912,7 +3842,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -3953,7 +3883,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -3981,10 +3911,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -4032,7 +3958,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -4073,7 +3999,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -4132,7 +4058,7 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB OR An"
+                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB OR An "
                     },
                     {
                       "kind": "api-link",
@@ -4203,10 +4129,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -4223,7 +4145,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -4264,7 +4186,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -4292,10 +4214,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -4319,7 +4237,7 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB. OR An"
+                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB. OR An "
                     },
                     {
                       "kind": "api-link",
@@ -4406,7 +4324,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -4447,7 +4365,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -4475,10 +4393,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -4539,7 +4453,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -4580,7 +4494,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -4608,10 +4522,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -4635,7 +4545,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Gets the entities found in the selected item."
+                  "text": "Gets the entities found in the selected item's body."
                 },
                 {
                   "kind": "paragraph"
@@ -4670,7 +4580,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -4711,7 +4621,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -4739,10 +4649,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -4761,7 +4667,7 @@
                 "description": [
                   {
                     "kind": "text",
-                    "text": "If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. If no entities of the specified type are present on the item, the method returns an empty array. Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter."
+                    "text": "If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. If no entities of the specified type are present in the item's body, the method returns an empty array. Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter."
                   }
                 ]
               },
@@ -4783,7 +4689,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Gets an array of all the entities of the specified entity type found in the selected item."
+                  "text": "Gets an array of all the entities of the specified entity type found in the selected item's body."
                 },
                 {
                   "kind": "paragraph"
@@ -4802,10 +4708,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -4822,7 +4724,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -4863,7 +4765,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -5425,10 +5327,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -5511,7 +5409,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -5552,7 +5450,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -5580,10 +5478,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -5660,7 +5554,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -5701,7 +5595,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -5729,10 +5623,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -5822,7 +5712,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -5863,7 +5753,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -5891,10 +5781,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -5948,7 +5834,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -5989,7 +5875,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -6264,7 +6150,21 @@
                 },
                 {
                   "kind": "text",
-                  "text": "Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more details, see Use the Outlook REST APIs from an Outlook add-in."
+                  "text": "Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more details, see "
+                },
+                {
+                  "kind": "web-link",
+                  "elements": [
+                    {
+                      "kind": "text",
+                      "text": " Use the Outlook REST APIs from an Outlook add-in"
+                    }
+                  ],
+                  "targetUrl": "https://docs.microsoft.com/outlook/add-ins/use-rest-api#get-the-item-id"
+                },
+                {
+                  "kind": "text",
+                  "text": "."
                 },
                 {
                   "kind": "paragraph"
@@ -6292,7 +6192,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -6333,7 +6233,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -6361,10 +6261,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -6419,7 +6315,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -6460,7 +6356,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -6488,10 +6384,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -6502,7 +6394,7 @@
             },
             "loadCustomPropertiesAsync": {
               "kind": "method",
-              "signature": "loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;",
+              "signature": "loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -6516,12 +6408,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<Office.CustomProperties>) => void"
                 },
                 "userContext": {
                   "name": "userContext",
@@ -6582,7 +6474,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -6623,7 +6515,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -6651,10 +6543,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -6708,7 +6596,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -6749,7 +6637,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -6777,10 +6665,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -6835,7 +6719,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -6876,7 +6760,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -6904,10 +6788,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -6981,7 +6861,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -7022,7 +6902,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -7050,10 +6930,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -7073,7 +6949,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Gets the email address of the meeting organizer for a specified meeting. Read mode only."
+                  "text": "Gets the email address of the meeting organizer for a specified meeting."
                 },
                 {
                   "kind": "paragraph"
@@ -7101,7 +6977,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -7142,7 +7018,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -7170,10 +7046,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -7247,7 +7119,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -7288,7 +7160,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -7316,10 +7188,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -7374,7 +7242,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -7415,7 +7283,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -7443,10 +7311,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -7508,7 +7372,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -7549,7 +7413,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -7577,10 +7441,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -7619,10 +7479,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -7639,7 +7495,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -7680,7 +7536,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -7708,10 +7564,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -7866,10 +7718,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -7886,7 +7734,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -7927,7 +7775,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -7955,10 +7803,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -7966,7 +7810,7 @@
           "members": {
             "getTypeAsync": {
               "kind": "method",
-              "signature": "getTypeAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "getTypeAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<Office.CoercionType>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -7992,12 +7836,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. The content type is returned as one of the CoercionType values in the asyncResult.value property."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. The content type is returned as one of the CoercionType values in the asyncResult.value property."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<Office.CoercionType>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -8016,10 +7860,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -8036,7 +7876,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -8077,7 +7917,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -8105,10 +7945,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -8118,7 +7954,7 @@
             },
             "prependAsync": {
               "kind": "method",
-              "signature": "prependAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "prependAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -8156,12 +7992,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. Any errors encountered will be provided in the asyncResult.error property."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. Any errors encountered will be provided in the asyncResult.error property."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -8202,10 +8038,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -8222,7 +8054,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -8263,7 +8095,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -8332,28 +8164,31 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has these signatures:"
+                  "text": "In addition to this signature, this method also has the following signatures:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`prependAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`"
+                  "kind": "code",
+                  "text": "prependAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`prependAsync(data: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "prependAsync(data: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`prependAsync(data: string): void;`"
+                  "kind": "code",
+                  "text": "prependAsync(data: string): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -8363,7 +8198,7 @@
             },
             "setSelectedDataAsync": {
               "kind": "method",
-              "signature": "setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -8401,12 +8236,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. Any errors encountered will be provided in the asyncResult.error property."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. Any errors encountered will be provided in the asyncResult.error property."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -8447,10 +8282,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -8467,7 +8298,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -8508,7 +8339,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -8605,28 +8436,31 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has these signatures:"
+                  "text": "In addition to this signature, this method also has the following signatures:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -8712,10 +8546,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -8732,7 +8562,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -8773,7 +8603,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -8801,10 +8631,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -8966,10 +8792,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -8986,7 +8808,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -9027,7 +8849,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -9055,10 +8877,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -9109,10 +8927,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -9129,7 +8943,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -9170,7 +8984,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -9198,10 +9012,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -9225,7 +9035,14 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "The name of the property to be removed. [Api set: Mailbox 1.0]"
+                      "text": "The name of the property to be removed."
+                    },
+                    {
+                      "kind": "paragraph"
+                    },
+                    {
+                      "kind": "text",
+                      "text": "[Api set: Mailbox 1.0]"
                     }
                   ],
                   "isOptional": false,
@@ -9249,10 +9066,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -9269,7 +9082,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -9310,7 +9123,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -9338,10 +9151,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -9351,7 +9160,7 @@
             },
             "saveAsync": {
               "kind": "method",
-              "signature": "saveAsync(callback?: (result: AsyncResult) => void, asyncContext?: any): void;",
+              "signature": "saveAsync(callback?: (result: AsyncResult<void>) => void, asyncContext?: any): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -9365,19 +9174,26 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 },
                 "asyncContext": {
                   "name": "asyncContext",
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. Any state data that is passed to the callback method. [Api set: Mailbox 1.0]"
+                      "text": "Optional. Any state data that is passed to the callback method."
+                    },
+                    {
+                      "kind": "paragraph"
+                    },
+                    {
+                      "kind": "text",
+                      "text": "[Api set: Mailbox 1.0]"
                     }
                   ],
                   "isOptional": true,
@@ -9408,10 +9224,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -9428,7 +9240,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -9469,7 +9281,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -9497,10 +9309,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -9574,10 +9382,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -9594,7 +9398,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -9635,7 +9439,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -9663,10 +9467,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -9697,10 +9497,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -9717,7 +9513,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -9758,7 +9554,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -9786,10 +9582,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -9825,10 +9617,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -9845,7 +9633,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -9886,7 +9674,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -9914,10 +9702,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -9956,10 +9740,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -9976,7 +9756,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -10017,7 +9797,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -10045,10 +9825,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -10059,11 +9835,11 @@
             },
             "OWAView": {
               "kind": "property",
-              "signature": "OWAView: \"string\";",
+              "signature": "OWAView: MailboxEnums.OWAView | \"OneColumn\" | \"TwoColumns\" | \"ThreeColumns\";",
               "isOptional": false,
               "isReadOnly": false,
               "isStatic": false,
-              "type": "\"string\"",
+              "type": "MailboxEnums.OWAView | \"OneColumn\" | \"TwoColumns\" | \"ThreeColumns\"",
               "deprecatedMessage": [],
               "summary": [
                 {
@@ -10122,10 +9898,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -10142,7 +9914,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -10183,7 +9955,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -10211,10 +9983,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -10246,10 +10014,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -10266,7 +10030,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -10307,7 +10071,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -10335,10 +10099,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -10451,10 +10211,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -10471,7 +10227,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -10512,7 +10268,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -10540,10 +10296,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -10656,10 +10408,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -10676,7 +10424,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -10717,7 +10465,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -10745,10 +10493,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -10912,7 +10656,16 @@
           "summary": [
             {
               "kind": "text",
-              "text": "The item namespace is used to access the currently selected message, meeting request, or appointment. You can determine the type of the item by using the `itemType` property."
+              "text": "The item namespace is used to access the currently selected message, meeting request, or appointment. You can determine the type of the item by using the "
+            },
+            {
+              "kind": "code",
+              "text": "itemType",
+              "highlighter": "plain"
+            },
+            {
+              "kind": "text",
+              "text": " property."
             },
             {
               "kind": "paragraph"
@@ -10923,10 +10676,6 @@
             }
           ],
           "remarks": [
-            {
-              "kind": "text",
-              "text": ""
-            },
             {
               "kind": "html-tag",
               "token": "<table>"
@@ -10944,7 +10693,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -10985,7 +10734,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -11013,10 +10762,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -11061,7 +10806,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -11102,7 +10847,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -11130,10 +10875,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -11181,7 +10922,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -11222,7 +10963,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -11250,10 +10991,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -11301,7 +11038,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -11342,7 +11079,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -11431,7 +11168,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -11472,7 +11209,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -11500,10 +11237,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -11514,7 +11247,7 @@
             },
             "loadCustomPropertiesAsync": {
               "kind": "method",
-              "signature": "loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;",
+              "signature": "loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -11528,12 +11261,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<Office.CustomProperties>) => void"
                 },
                 "userContext": {
                   "name": "userContext",
@@ -11594,7 +11327,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -11635,7 +11368,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -11663,10 +11396,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -11692,7 +11421,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Office.context.mailbox.item"
+                  "text": " Office.context.mailbox.item"
                 }
               ],
               "target": {
@@ -11711,7 +11440,16 @@
             },
             {
               "kind": "text",
-              "text": "Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information."
+              "text": "Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of "
+            },
+            {
+              "kind": "code",
+              "text": "Office.context.mailbox.item",
+              "highlighter": "plain"
+            },
+            {
+              "kind": "text",
+              "text": ". Refer to the Object Model pages for more information."
             }
           ],
           "remarks": [],
@@ -11720,7 +11458,7 @@
           "members": {
             "addFileAttachmentAsync": {
               "kind": "method",
-              "signature": "addFileAttachmentAsync(uri: string, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "addFileAttachmentAsync(uri: string, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -11775,7 +11513,7 @@
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<string>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -11808,10 +11546,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -11828,7 +11562,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -11869,7 +11603,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -11992,22 +11726,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addFileAttachmentAsync(uri: string, attachmentName: string): void;`"
+                  "kind": "code",
+                  "text": "addFileAttachmentAsync(uri: string, attachmentName: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addFileAttachmentAsync(uri: string, attachmentName: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "addFileAttachmentAsync(uri: string, attachmentName: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -12017,7 +11754,7 @@
             },
             "addItemAttachmentAsync": {
               "kind": "method",
-              "signature": "addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -12067,12 +11804,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<string>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -12100,7 +11837,7 @@
                 },
                 {
                   "kind": "text",
-                  "text": "If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended."
+                  "text": "If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended."
                 },
                 {
                   "kind": "paragraph"
@@ -12111,10 +11848,6 @@
                 }
               ],
               "remarks": [
-                {
-                  "kind": "text",
-                  "text": ""
-                },
                 {
                   "kind": "html-tag",
                   "token": "<table>"
@@ -12132,7 +11865,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -12173,7 +11906,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -12242,28 +11975,31 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has these signatures:"
+                  "text": "In addition to this signature, this method also has the following signatures:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addItemAttachmentAsync(itemId: any, attachmentName: string): void;`"
+                  "kind": "code",
+                  "text": "addItemAttachmentAsync(itemId: any, attachmentName: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -12273,7 +12009,7 @@
             },
             "removeAttachmentAsync": {
               "kind": "method",
-              "signature": "removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -12311,12 +12047,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -12330,7 +12066,7 @@
                 },
                 {
                   "kind": "text",
-                  "text": "The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window."
+                  "text": "The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to continue in a separate window."
                 },
                 {
                   "kind": "paragraph"
@@ -12358,7 +12094,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -12399,7 +12135,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -12474,22 +12210,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAttachmentAsync(attachmentIndex: string): void;`"
+                  "kind": "code",
+                  "text": "removeAttachmentAsync(attachmentIndex: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -12550,7 +12289,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -12591,7 +12330,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -12619,10 +12358,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -12649,7 +12384,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Office.context.mailbox.item"
+                  "text": " Office.context.mailbox.item"
                 }
               ],
               "target": {
@@ -12668,7 +12403,16 @@
             },
             {
               "kind": "text",
-              "text": "Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information."
+              "text": "Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of "
+            },
+            {
+              "kind": "code",
+              "text": "Office.context.mailbox.item",
+              "highlighter": "plain"
+            },
+            {
+              "kind": "text",
+              "text": ". Refer to the Object Model pages for more information."
             }
           ],
           "remarks": [],
@@ -12686,7 +12430,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Gets an array of attachments for the item."
+                  "text": "Gets the item's attachments as an array."
                 },
                 {
                   "kind": "paragraph"
@@ -12697,10 +12441,6 @@
                 }
               ],
               "remarks": [
-                {
-                  "kind": "text",
-                  "text": ""
-                },
                 {
                   "kind": "html-tag",
                   "token": "<table>"
@@ -12718,7 +12458,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -12759,7 +12499,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -12800,7 +12540,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Blocked attachments in Outlook"
+                      "text": " Blocked attachments in Outlook"
                     }
                   ],
                   "targetUrl": "https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519"
@@ -12832,7 +12572,7 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB OR An"
+                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB OR An "
                     },
                     {
                       "kind": "api-link",
@@ -12903,10 +12643,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -12923,7 +12659,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -12964,7 +12700,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -12992,10 +12728,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -13019,7 +12751,7 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB. OR An"
+                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB. OR An "
                     },
                     {
                       "kind": "api-link",
@@ -13106,7 +12838,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -13147,7 +12879,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -13175,10 +12907,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -13201,7 +12929,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Gets the entities found in the selected item."
+                  "text": "Gets the entities found in the selected item's body."
                 },
                 {
                   "kind": "paragraph"
@@ -13236,7 +12964,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -13277,7 +13005,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -13305,10 +13033,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -13327,7 +13051,7 @@
                 "description": [
                   {
                     "kind": "text",
-                    "text": "If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. If no entities of the specified type are present on the item, the method returns an empty array. Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter."
+                    "text": "If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. If no entities of the specified type are present in the item's body, the method returns an empty array. Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter."
                   }
                 ]
               },
@@ -13349,7 +13073,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Gets an array of all the entities of the specified entity type found in the selected item."
+                  "text": "Gets an array of all the entities of the specified entity type found in the selected item's body."
                 },
                 {
                   "kind": "paragraph"
@@ -13368,10 +13092,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -13388,7 +13108,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -13429,7 +13149,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -13991,10 +13711,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -14077,7 +13793,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -14118,7 +13834,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -14146,10 +13862,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -14226,7 +13938,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -14267,7 +13979,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -14295,10 +14007,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -14388,7 +14096,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -14429,7 +14137,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -14457,10 +14165,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -14514,7 +14218,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -14555,7 +14259,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -14797,10 +14501,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -14834,7 +14534,21 @@
                 },
                 {
                   "kind": "text",
-                  "text": "Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more details, see Use the Outlook REST APIs from an Outlook add-in."
+                  "text": "Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more details, see "
+                },
+                {
+                  "kind": "web-link",
+                  "elements": [
+                    {
+                      "kind": "text",
+                      "text": " Use the Outlook REST APIs from an Outlook add-in"
+                    }
+                  ],
+                  "targetUrl": "https://docs.microsoft.com/outlook/add-ins/use-rest-api#get-the-item-id"
+                },
+                {
+                  "kind": "text",
+                  "text": "."
                 },
                 {
                   "kind": "paragraph"
@@ -14862,7 +14576,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -14903,7 +14617,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -14931,10 +14645,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -14989,7 +14699,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -15030,7 +14740,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -15058,10 +14768,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -15123,7 +14829,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -15164,7 +14870,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -15192,10 +14898,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -15243,7 +14945,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -15284,7 +14986,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -15312,10 +15014,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -15512,10 +15210,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -15532,7 +15226,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -15573,7 +15267,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -15601,10 +15295,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -15612,7 +15302,7 @@
           "members": {
             "getAsync": {
               "kind": "method",
-              "signature": "getAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "getAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -15638,12 +15328,19 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. [Api set: Mailbox 1.1]"
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
+                    },
+                    {
+                      "kind": "paragraph"
+                    },
+                    {
+                      "kind": "text",
+                      "text": "[Api set: Mailbox 1.1]"
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<string>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -15662,10 +15359,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -15682,7 +15375,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -15723,7 +15416,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -15763,8 +15456,9 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`getAsync(callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "getAsync(callback: (result: AsyncResult<string>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -15774,7 +15468,7 @@
             },
             "setAsync": {
               "kind": "method",
-              "signature": "setAsync(location: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "setAsync(location: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -15812,12 +15506,19 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If setting the location fails, the asyncResult.error property will contain an error code. [Api set: Mailbox 1.1]"
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. If setting the location fails, the asyncResult.error property will contain an error code."
+                    },
+                    {
+                      "kind": "paragraph"
+                    },
+                    {
+                      "kind": "text",
+                      "text": "[Api set: Mailbox 1.1]"
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -15836,10 +15537,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -15856,7 +15553,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -15897,7 +15594,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -15972,22 +15669,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(location: string): void;`"
+                  "kind": "code",
+                  "text": "setAsync(location: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(location: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "setAsync(location: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(location: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "setAsync(location: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -16006,7 +15706,7 @@
           "summary": [
             {
               "kind": "text",
-              "text": "Provides access to the Outlook add-in object model for Microsoft Outlook and Microsoft Outlook on the web."
+              "text": "Provides access to the Outlook Add-in object model for Microsoft Outlook and Microsoft Outlook on the web."
             },
             {
               "kind": "paragraph"
@@ -16046,10 +15746,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -16066,7 +15762,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -16107,7 +15803,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -16135,10 +15831,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -16214,7 +15906,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -16255,7 +15947,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -16283,10 +15975,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -16362,7 +16050,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -16403,7 +16091,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -16431,10 +16119,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -16481,7 +16165,7 @@
                 },
                 {
                   "kind": "text",
-                  "text": "- OWAView (string): A string that represents the current view of Outlook Web App. If the host application is not Outlook Web App, then accessing this property results in undefined. Outlook Web App has three views (OneColumn - displayed when the screen is narrow, TwoColumns - displayed when the screen is wider, and ThreeColumns - displayed when the screen is wide.) that correspond to the width of the screen and the window, and the number of columns that can be displayed."
+                  "text": "- OWAView (MailboxEnums.OWAView or string): An enum (or string literal) that represents the current view of Outlook Web App. If the host application is not Outlook Web App, then accessing this property results in undefined. Outlook Web App has three views (OneColumn - displayed when the screen is narrow, TwoColumns - displayed when the screen is wider, and ThreeColumns - displayed when the screen is wide) that correspond to the width of the screen and the window, and the number of columns that can be displayed."
                 },
                 {
                   "kind": "paragraph"
@@ -16519,10 +16203,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -16539,7 +16219,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -16580,7 +16260,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -16608,10 +16288,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -16711,7 +16387,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -16752,7 +16428,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -16780,10 +16456,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -16882,7 +16554,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -16923,7 +16595,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -16951,10 +16623,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -17053,7 +16721,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -17094,7 +16762,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -17122,10 +16790,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -17186,7 +16850,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -17227,7 +16891,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -17268,7 +16932,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "get attachments from the selected item"
+                      "text": " get attachments from the selected item"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/get-attachments-of-an-outlook-item"
@@ -17293,7 +16957,7 @@
             },
             "getUserIdentityTokenAsync": {
               "kind": "method",
-              "signature": "getUserIdentityTokenAsync(callback: (result: AsyncResult) => void, userContext?: any): void;",
+              "signature": "getUserIdentityTokenAsync(callback: (result: AsyncResult<string>) => void, userContext?: any): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -17307,12 +16971,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. The token is provided as a string in the asyncResult.value property."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<string>) => void"
                 },
                 "userContext": {
                   "name": "userContext",
@@ -17366,7 +17030,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -17407,7 +17071,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -17448,7 +17112,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "authenticate the add-in and user with a third-party system"
+                      "text": " authenticate the add-in and user with a third-party system"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/authentication"
@@ -17474,7 +17138,57 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "The mailbox item. Depending on the context in which the add-in opened, the item may be of any number of types. If you want to see IntelliSense for only a specific type, you should cast this item to one of the following: `ItemCompose`, `ItemRead`, `MessageCompose`, `MessageRead`, `AppointmentCompose`, `AppointmentRead`"
+                  "text": "The mailbox item. Depending on the context in which the add-in opened, the item may be of any number of types. If you want to see IntelliSense for only a specific type, you should cast this item to one of the following: "
+                },
+                {
+                  "kind": "code",
+                  "text": "ItemCompose",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": ", "
+                },
+                {
+                  "kind": "code",
+                  "text": "ItemRead",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": ", "
+                },
+                {
+                  "kind": "code",
+                  "text": "MessageCompose",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": ", "
+                },
+                {
+                  "kind": "code",
+                  "text": "MessageRead",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": ", "
+                },
+                {
+                  "kind": "code",
+                  "text": "AppointmentCompose",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": ", "
+                },
+                {
+                  "kind": "code",
+                  "text": "AppointmentRead",
+                  "highlighter": "plain"
                 }
               ],
               "remarks": [],
@@ -17486,7 +17200,7 @@
             },
             "makeEwsRequestAsync": {
               "kind": "method",
-              "signature": "makeEwsRequestAsync(data: any, callback: (result: AsyncResult) => void, userContext?: any): void;",
+              "signature": "makeEwsRequestAsync(data: any, callback: (result: AsyncResult<string>) => void, userContext?: any): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -17512,12 +17226,21 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. The "
+                    },
+                    {
+                      "kind": "code",
+                      "text": "value",
+                      "highlighter": "plain"
+                    },
+                    {
+                      "kind": "text",
+                      "text": " property of the result is the XML of the EWS request provided as a string. If the result exceeds 1 MB in size, an error message is returned instead."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<string>) => void"
                 },
                 "userContext": {
                   "name": "userContext",
@@ -17571,7 +17294,21 @@
                 },
                 {
                   "kind": "text",
-                  "text": "Your add-in must have the ReadWriteMailbox permission to use the makeEwsRequestAsync method. For information about using the ReadWriteMailbox permission and the EWS operations that you can call with the makeEwsRequestAsync method, see Specify permissions for mail add-in access to the user's mailbox."
+                  "text": "Your add-in must have the ReadWriteMailbox permission to use the makeEwsRequestAsync method. For information about using the ReadWriteMailbox permission and the EWS operations that you can call with the makeEwsRequestAsync method, see "
+                },
+                {
+                  "kind": "web-link",
+                  "elements": [
+                    {
+                      "kind": "text",
+                      "text": " Specify permissions for mail add-in access to the user's mailbox"
+                    }
+                  ],
+                  "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
+                },
+                {
+                  "kind": "text",
+                  "text": "."
                 },
                 {
                   "kind": "paragraph"
@@ -17585,7 +17322,21 @@
                 },
                 {
                   "kind": "text",
-                  "text": "Note: This method is not supported in the following scenarios. - In Outlook for iOS or Outlook for Android - When the add-in is loaded in a Gmail mailbox"
+                  "text": "Note: This method is not supported in the following scenarios:"
+                },
+                {
+                  "kind": "paragraph"
+                },
+                {
+                  "kind": "text",
+                  "text": "- In Outlook for iOS or Outlook for Android."
+                },
+                {
+                  "kind": "paragraph"
+                },
+                {
+                  "kind": "text",
+                  "text": "- When the add-in is loaded in a Gmail mailbox."
                 },
                 {
                   "kind": "paragraph"
@@ -17612,8 +17363,9 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`<?xml version=\"1.0\" encoding=\"iso-8859-1\"?>`"
+                  "kind": "code",
+                  "text": "<?xml version=\"1.0\" encoding=\"iso-8859-1\"?>",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
@@ -17648,7 +17400,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -17689,7 +17441,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -17717,10 +17469,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -17739,7 +17487,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Information about the user associated with the mailbox. This includes their account type, display name, email adddress, and time zone."
+                  "text": "Information about the user associated with the mailbox. This includes their account type, display name, email address, and time zone."
                 },
                 {
                   "kind": "paragraph"
@@ -17762,10 +17510,6 @@
                     "exportName": "Office",
                     "memberName": "UserProfile"
                   }
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "remarks": [],
@@ -17843,10 +17587,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -17867,7 +17607,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -17899,10 +17639,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false
@@ -18018,10 +17754,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -18042,7 +17774,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -18074,10 +17806,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false
@@ -18128,10 +17856,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -18152,7 +17876,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -18184,12 +17908,61 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
+              "isBeta": false
+            },
+            "OWAView": {
+              "kind": "enum",
+              "values": {
+                "OneColumn": {
+                  "kind": "enum value",
+                  "value": "\"OneColumn\"",
+                  "deprecatedMessage": [],
+                  "summary": [
+                    {
+                      "kind": "text",
+                      "text": "One column view. Displayed when the screen is narrow. Outlook Web App uses this single-column layout on the entire screen of a smartphone."
+                    }
+                  ],
+                  "remarks": [],
+                  "isBeta": false
+                },
+                "ThreeColumns": {
+                  "kind": "enum value",
+                  "value": "\"ThreeColumns\"",
+                  "deprecatedMessage": [],
+                  "summary": [
+                    {
+                      "kind": "text",
+                      "text": "Three column view. Displayed when the screen is wide. For example, Outlook Web App uses this view in a full screen window on a desktop computer."
+                    }
+                  ],
+                  "remarks": [],
+                  "isBeta": false
+                },
+                "TwoColumns": {
+                  "kind": "enum value",
+                  "value": "\"TwoColumns\"",
+                  "deprecatedMessage": [],
+                  "summary": [
+                    {
+                      "kind": "text",
+                      "text": "Two column view. Displayed when the screen is wider. Outlook Web App uses this view on most tablets."
+                    }
+                  ],
+                  "remarks": [],
+                  "isBeta": false
+                }
+              },
+              "deprecatedMessage": [],
+              "summary": [
+                {
+                  "kind": "text",
+                  "text": "Represents the current view of Outlook Web App."
+                }
+              ],
+              "remarks": [],
               "isBeta": false
             },
             "RecipientType": {
@@ -18264,10 +18037,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -18288,7 +18057,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -18320,10 +18089,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false
@@ -18413,10 +18178,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -18437,7 +18198,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -18469,10 +18230,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false
@@ -18514,10 +18271,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -18534,7 +18287,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -18575,7 +18328,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -18603,10 +18356,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -18775,7 +18524,16 @@
             },
             {
               "kind": "text",
-              "text": "Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information."
+              "text": "Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of "
+            },
+            {
+              "kind": "code",
+              "text": "Office.context.mailbox.item",
+              "highlighter": "plain"
+            },
+            {
+              "kind": "text",
+              "text": ". Refer to the Object Model pages for more information."
             }
           ],
           "remarks": [],
@@ -18835,7 +18593,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -18876,7 +18634,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -18904,10 +18662,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -18934,7 +18688,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Office.context.mailbox.item"
+                  "text": " Office.context.mailbox.item"
                 }
               ],
               "target": {
@@ -18953,7 +18707,16 @@
             },
             {
               "kind": "text",
-              "text": "Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information."
+              "text": "Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of "
+            },
+            {
+              "kind": "code",
+              "text": "Office.context.mailbox.item",
+              "highlighter": "plain"
+            },
+            {
+              "kind": "text",
+              "text": ". Refer to the Object Model pages for more information."
             }
           ],
           "remarks": [],
@@ -18962,7 +18725,7 @@
           "members": {
             "addFileAttachmentAsync": {
               "kind": "method",
-              "signature": "addFileAttachmentAsync(uri: string, attachmentName: string, options?: AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "addFileAttachmentAsync(uri: string, attachmentName: string, options?: AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -19012,12 +18775,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type asyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of the error."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of the error."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<string>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -19050,10 +18813,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -19070,7 +18829,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -19111,7 +18870,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -19242,22 +19001,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addFileAttachmentAsync(uri: string, attachmentName: string): void;`"
+                  "kind": "code",
+                  "text": "addFileAttachmentAsync(uri: string, attachmentName: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addFileAttachmentAsync(uri: string, attachmentName: string, options: AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "addFileAttachmentAsync(uri: string, attachmentName: string, options: AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -19267,7 +19029,7 @@
             },
             "addItemAttachmentAsync": {
               "kind": "method",
-              "signature": "addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -19322,7 +19084,7 @@
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<string>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -19350,7 +19112,7 @@
                 },
                 {
                   "kind": "text",
-                  "text": "If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended."
+                  "text": "If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended."
                 },
                 {
                   "kind": "paragraph"
@@ -19361,10 +19123,6 @@
                 }
               ],
               "remarks": [
-                {
-                  "kind": "text",
-                  "text": ""
-                },
                 {
                   "kind": "html-tag",
                   "token": "<table>"
@@ -19382,7 +19140,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -19423,7 +19181,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -19492,28 +19250,31 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has these signatures:"
+                  "text": "In addition to this signature, this method also has the following signatures:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addItemAttachmentAsync(itemId: any, attachmentName: string): void;`"
+                  "kind": "code",
+                  "text": "addItemAttachmentAsync(itemId: any, attachmentName: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -19560,7 +19321,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -19601,7 +19362,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -19629,10 +19390,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -19680,7 +19437,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -19721,7 +19478,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -19749,10 +19506,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -19826,7 +19579,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -19867,7 +19620,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -19895,10 +19648,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -19960,7 +19709,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -20001,7 +19750,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -20029,10 +19778,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -20080,7 +19825,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -20121,7 +19866,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -20149,10 +19894,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -20200,7 +19941,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -20241,7 +19982,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -20330,7 +20071,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -20371,7 +20112,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -20399,10 +20140,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -20413,7 +20150,7 @@
             },
             "loadCustomPropertiesAsync": {
               "kind": "method",
-              "signature": "loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;",
+              "signature": "loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -20427,12 +20164,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<Office.CustomProperties>) => void"
                 },
                 "userContext": {
                   "name": "userContext",
@@ -20493,7 +20230,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -20534,7 +20271,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -20562,10 +20299,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -20575,7 +20308,7 @@
             },
             "removeAttachmentAsync": {
               "kind": "method",
-              "signature": "removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -20613,12 +20346,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -20632,7 +20365,7 @@
                 },
                 {
                   "kind": "text",
-                  "text": "The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window."
+                  "text": "The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to continue in a separate window."
                 },
                 {
                   "kind": "paragraph"
@@ -20660,7 +20393,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -20701,7 +20434,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -20776,22 +20509,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAttachmentAsync(attachmentIndex: string): void;`"
+                  "kind": "code",
+                  "text": "removeAttachmentAsync(attachmentIndex: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -20852,7 +20588,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -20893,7 +20629,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -20921,10 +20657,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -20979,7 +20711,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -21020,7 +20752,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -21048,10 +20780,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -21078,7 +20806,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Office.context.mailbox.item"
+                  "text": " Office.context.mailbox.item"
                 }
               ],
               "target": {
@@ -21115,7 +20843,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Gets an array of attachments for the item."
+                  "text": "Gets the item's attachments as an array."
                 },
                 {
                   "kind": "paragraph"
@@ -21143,7 +20871,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -21184,7 +20912,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -21225,7 +20953,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Blocked attachments in Outlook"
+                      "text": " Blocked attachments in Outlook"
                     }
                   ],
                   "targetUrl": "https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519"
@@ -21280,7 +21008,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -21321,7 +21049,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -21349,10 +21077,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -21407,7 +21131,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -21448,7 +21172,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -21476,10 +21200,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -21541,7 +21261,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -21582,7 +21302,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -21610,10 +21330,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -21661,7 +21377,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -21702,7 +21418,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -21730,10 +21446,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -21781,7 +21493,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -21822,7 +21534,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -21881,7 +21593,7 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB OR An"
+                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB OR An "
                     },
                     {
                       "kind": "api-link",
@@ -21952,10 +21664,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -21972,7 +21680,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -22013,7 +21721,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -22041,10 +21749,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -22068,7 +21772,7 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB. OR An"
+                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB. OR An "
                     },
                     {
                       "kind": "api-link",
@@ -22155,7 +21859,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -22196,7 +21900,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -22224,10 +21928,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -22295,7 +21995,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -22336,7 +22036,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -22364,10 +22064,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -22391,7 +22087,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Gets the entities found in the selected item."
+                  "text": "Gets the entities found in the selected item's body."
                 },
                 {
                   "kind": "paragraph"
@@ -22426,7 +22122,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -22467,7 +22163,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -22495,10 +22191,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -22517,7 +22209,7 @@
                 "description": [
                   {
                     "kind": "text",
-                    "text": "If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. If no entities of the specified type are present on the item, the method returns an empty array. Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter."
+                    "text": "If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. If no entities of the specified type are present in the item's body, the method returns an empty array. Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter."
                   }
                 ]
               },
@@ -22539,7 +22231,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Gets an array of all the entities of the specified entity type found in the selected item."
+                  "text": "Gets an array of all the entities of the specified entity type found in the selected item's body."
                 },
                 {
                   "kind": "paragraph"
@@ -22574,7 +22266,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -22615,7 +22307,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -23177,10 +22869,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -23263,7 +22951,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -23304,7 +22992,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -23332,10 +23020,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -23412,7 +23096,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -23453,7 +23137,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -23481,10 +23165,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -23574,7 +23254,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -23615,7 +23295,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -23643,10 +23323,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -23693,7 +23369,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -23734,7 +23410,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -23762,10 +23438,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -23820,7 +23492,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -23861,7 +23533,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -24136,7 +23808,21 @@
                 },
                 {
                   "kind": "text",
-                  "text": "Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more details, see Use the Outlook REST APIs from an Outlook add-in."
+                  "text": "Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more details, see "
+                },
+                {
+                  "kind": "web-link",
+                  "elements": [
+                    {
+                      "kind": "text",
+                      "text": " Use the Outlook REST APIs from an Outlook add-in"
+                    }
+                  ],
+                  "targetUrl": "https://docs.microsoft.com/outlook/add-ins/use-rest-api#get-the-item-id"
+                },
+                {
+                  "kind": "text",
+                  "text": "."
                 },
                 {
                   "kind": "paragraph"
@@ -24164,7 +23850,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -24205,7 +23891,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -24233,10 +23919,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -24291,7 +23973,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -24332,7 +24014,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -24360,10 +24042,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -24374,7 +24052,7 @@
             },
             "loadCustomPropertiesAsync": {
               "kind": "method",
-              "signature": "loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;",
+              "signature": "loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -24388,12 +24066,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<Office.CustomProperties>) => void"
                 },
                 "userContext": {
                   "name": "userContext",
@@ -24454,7 +24132,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -24495,7 +24173,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -24523,10 +24201,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -24580,7 +24254,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -24621,7 +24295,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -24649,10 +24323,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -24714,7 +24384,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -24755,7 +24425,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -24783,10 +24453,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -24848,7 +24514,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -24889,7 +24555,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -24917,10 +24583,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -24975,7 +24637,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -25016,7 +24678,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -25044,10 +24706,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -25086,10 +24744,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -25106,7 +24760,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -25147,7 +24801,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -25175,10 +24829,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -25263,10 +24913,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -25283,7 +24929,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -25324,7 +24970,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -25352,10 +24998,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -25363,7 +25005,7 @@
           "members": {
             "addAsync": {
               "kind": "method",
-              "signature": "addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -25401,12 +25043,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If adding the recipients fails, the asyncResult.error property will contain an error code."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. If adding the recipients fails, the asyncResult.error property will contain an error code."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -25453,10 +25095,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -25473,7 +25111,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -25514,7 +25152,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -25583,28 +25221,31 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has these signatures:"
+                  "text": "In addition to this signature, this method also has the following signatures:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addAsync(recipients: (string | EmailUser | EmailAddressDetails)[]): void;`"
+                  "kind": "code",
+                  "text": "addAsync(recipients: (string | EmailUser | EmailAddressDetails)[]): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -25614,7 +25255,7 @@
             },
             "getAsync": {
               "kind": "method",
-              "signature": "getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;",
+              "signature": "getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult<Office.EmailAddressDetails[]>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -25640,12 +25281,21 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. The "
+                    },
+                    {
+                      "kind": "code",
+                      "text": "value",
+                      "highlighter": "plain"
+                    },
+                    {
+                      "kind": "text",
+                      "text": " property of the result is an array of EmailAddressDetails objects."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<Office.EmailAddressDetails[]>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -25659,7 +25309,7 @@
                 },
                 {
                   "kind": "text",
-                  "text": "When the call completes, the asyncResult.value property will contain an array of"
+                  "text": "When the call completes, the asyncResult.value property will contain an array of "
                 },
                 {
                   "kind": "api-link",
@@ -25690,10 +25340,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -25710,7 +25356,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -25751,7 +25397,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -25785,14 +25431,15 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has this signature:"
+                  "text": "In addition to this signature, this method also has the following signature:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`getAsync(callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "getAsync(callback: (result: AsyncResult<Office.EmailAddressDetails[]>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -25802,7 +25449,7 @@
             },
             "setAsync": {
               "kind": "method",
-              "signature": "setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -25840,12 +25487,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If setting the recipients fails the asyncResult.error property will contain a code that indicates any error that occurred while adding the data."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. If setting the recipients fails the asyncResult.error property will contain a code that indicates any error that occurred while adding the data."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -25937,10 +25584,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -25957,7 +25600,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -25998,7 +25641,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -26067,28 +25710,31 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has these signatures:"
+                  "text": "In addition to this signature, this method also has the following signatures:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(recipients: (string | EmailUser | EmailAddressDetails)[]): void;`"
+                  "kind": "code",
+                  "text": "setAsync(recipients: (string | EmailUser | EmailAddressDetails)[]): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -26279,16 +25925,16 @@
             },
             "callback": {
               "kind": "property",
-              "signature": "callback?: (result: AsyncResult) => void;",
+              "signature": "callback?: (result: AsyncResult<any>) => void;",
               "isOptional": true,
               "isReadOnly": false,
               "isStatic": false,
-              "type": "(result: AsyncResult) => void",
+              "type": "(result: AsyncResult<any>) => void",
               "deprecatedMessage": [],
               "summary": [
                 {
                   "kind": "text",
-                  "text": "When the reply display call completes, the function passed in the callback parameter is called with a single parameter, asyncResult, which is an AsyncResult object."
+                  "text": "When the reply display call completes, the function passed in the callback parameter is called with a single parameter, asyncResult, which is an Office.AsyncResult object."
                 }
               ],
               "remarks": [],
@@ -26337,7 +25983,7 @@
             },
             {
               "kind": "text",
-              "text": "While the Outlook add-in API limits access to these settings to only the add-in that created them, these settings should not be considered secure storage. They can be accessed by Exchange Web Services or Extended MAPI. They should not be used to store sensitive information such as user credentials or security tokens."
+              "text": "While the Outlook Add-in API limits access to these settings to only the add-in that created them, these settings should not be considered secure storage. They can be accessed by Exchange Web Services or Extended MAPI. They should not be used to store sensitive information such as user credentials or security tokens."
             },
             {
               "kind": "paragraph"
@@ -26370,10 +26016,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -26390,7 +26032,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -26431,7 +26073,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -26459,10 +26101,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -26513,10 +26151,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -26533,7 +26167,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -26574,7 +26208,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -26602,10 +26236,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -26653,10 +26283,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -26673,7 +26299,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -26714,7 +26340,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -26742,10 +26368,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -26755,7 +26377,7 @@
             },
             "saveAsync": {
               "kind": "method",
-              "signature": "saveAsync(callback?: (result: AsyncResult) => void): void;",
+              "signature": "saveAsync(callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -26769,12 +26391,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional? When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -26800,10 +26422,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -26820,7 +26438,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -26861,7 +26479,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -26889,10 +26507,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -26973,10 +26587,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -26993,7 +26603,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -27034,7 +26644,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -27062,10 +26672,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -27131,10 +26737,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -27151,7 +26753,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -27192,7 +26794,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -27220,10 +26822,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -27231,7 +26829,7 @@
           "members": {
             "getAsync": {
               "kind": "method",
-              "signature": "getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;",
+              "signature": "getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult<string>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -27257,12 +26855,21 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. The "
+                    },
+                    {
+                      "kind": "code",
+                      "text": "value",
+                      "highlighter": "plain"
+                    },
+                    {
+                      "kind": "text",
+                      "text": " property of the result is the subject of the item."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<string>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -27288,10 +26895,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -27308,7 +26911,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -27349,7 +26952,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -27383,14 +26986,15 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has this signature:"
+                  "text": "In addition to this signature, this method also has the following signature:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`getAsync(callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "getAsync(callback: (result: AsyncResult<string>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -27400,7 +27004,7 @@
             },
             "setAsync": {
               "kind": "method",
-              "signature": "setAsync(subject: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "setAsync(subject: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -27438,12 +27042,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If setting the subject fails, the asyncResult.error property will contain an error code."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. If setting the subject fails, the asyncResult.error property will contain an error code."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -27469,10 +27073,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -27489,7 +27089,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -27530,7 +27130,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -27599,28 +27199,31 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has these signatures:"
+                  "text": "In addition to this signature, this method also has the following signatures:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(subject: string): void;`"
+                  "kind": "code",
+                  "text": "setAsync(subject: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(subject: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "setAsync(subject: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(subject: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "setAsync(subject: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -27646,7 +27249,26 @@
             },
             {
               "kind": "text",
-              "text": "The list of tasks suggested in an email message is returned in the taskSuggestions property of the [Entities]Entities object that is returned when the getEntities or getEntitiesByType method is called on the active item."
+              "text": "The list of tasks suggested in an email message is returned in the taskSuggestions property of the "
+            },
+            {
+              "kind": "api-link",
+              "elements": [
+                {
+                  "kind": "text",
+                  "text": " Entities"
+                }
+              ],
+              "target": {
+                "scopeName": "",
+                "packageName": "Outlook_1_1",
+                "exportName": "Office",
+                "memberName": "Entities"
+              }
+            },
+            {
+              "kind": "text",
+              "text": " object that is returned when the getEntities or getEntitiesByType method is called on the active item."
             },
             {
               "kind": "paragraph"
@@ -27657,10 +27279,6 @@
             }
           ],
           "remarks": [
-            {
-              "kind": "text",
-              "text": ""
-            },
             {
               "kind": "html-tag",
               "token": "<table>"
@@ -27678,7 +27296,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -27719,7 +27337,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -27747,10 +27365,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -27821,10 +27435,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -27841,7 +27451,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -27882,7 +27492,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -27910,10 +27520,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -27921,7 +27527,7 @@
           "members": {
             "getAsync": {
               "kind": "method",
-              "signature": "getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;",
+              "signature": "getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult<Date>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -27947,12 +27553,21 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. The "
+                    },
+                    {
+                      "kind": "code",
+                      "text": "value",
+                      "highlighter": "plain"
+                    },
+                    {
+                      "kind": "text",
+                      "text": " property of the result is a Date object."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<Date>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -27978,10 +27593,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -27998,7 +27609,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -28039,7 +27650,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -28073,14 +27684,15 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has this signature:"
+                  "text": "In addition to this signature, this method also has the following signature:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`getAsync(callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "getAsync(callback: (result: AsyncResult<Date>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -28090,7 +27702,7 @@
             },
             "setAsync": {
               "kind": "method",
-              "signature": "setAsync(dateTime: Date, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "setAsync(dateTime: Date, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -28128,12 +27740,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If setting the date and time fails, the asyncResult.error property will contain an error code."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. If setting the date and time fails, the asyncResult.error property will contain an error code."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -28166,10 +27778,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -28186,7 +27794,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -28227,7 +27835,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -28296,28 +27904,31 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has these signatures:"
+                  "text": "In addition to this signature, this method also has the following signatures:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(dateTime: Date): void;`"
+                  "kind": "code",
+                  "text": "setAsync(dateTime: Date): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(dateTime: Date, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "setAsync(dateTime: Date, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(dateTime: Date, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "setAsync(dateTime: Date, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -28348,10 +27959,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -28368,7 +27975,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -28409,7 +28016,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -28437,10 +28044,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -28469,10 +28072,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -28489,7 +28088,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -28530,7 +28129,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -28558,10 +28157,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -28593,10 +28188,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -28613,7 +28204,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -28654,7 +28245,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -28682,10 +28273,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -28717,10 +28304,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -28737,7 +28320,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -28778,7 +28361,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -28806,10 +28389,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,

--- a/generate-docs/json/Outlook_1_2.api.json
+++ b/generate-docs/json/Outlook_1_2.api.json
@@ -69,7 +69,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Office.context.mailbox.item"
+                  "text": " Office.context.mailbox.item"
                 }
               ],
               "target": {
@@ -88,7 +88,16 @@
             },
             {
               "kind": "text",
-              "text": "Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information."
+              "text": "Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of "
+            },
+            {
+              "kind": "code",
+              "text": "Office.context.mailbox.item",
+              "highlighter": "plain"
+            },
+            {
+              "kind": "text",
+              "text": ". Refer to the Object Model pages for more information."
             }
           ],
           "remarks": [],
@@ -97,7 +106,7 @@
           "members": {
             "addFileAttachmentAsync": {
               "kind": "method",
-              "signature": "addFileAttachmentAsync(uri: string, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "addFileAttachmentAsync(uri: string, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -152,7 +161,7 @@
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<string>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -185,10 +194,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -205,7 +210,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -246,7 +251,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -377,22 +382,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addFileAttachmentAsync(uri: string, attachmentName: string): void;`"
+                  "kind": "code",
+                  "text": "addFileAttachmentAsync(uri: string, attachmentName: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addFileAttachmentAsync(uri: string, attachmentName: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "addFileAttachmentAsync(uri: string, attachmentName: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -402,7 +410,7 @@
             },
             "addItemAttachmentAsync": {
               "kind": "method",
-              "signature": "addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -452,12 +460,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<string>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -485,7 +493,7 @@
                 },
                 {
                   "kind": "text",
-                  "text": "If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended."
+                  "text": "If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended."
                 },
                 {
                   "kind": "paragraph"
@@ -496,10 +504,6 @@
                 }
               ],
               "remarks": [
-                {
-                  "kind": "text",
-                  "text": ""
-                },
                 {
                   "kind": "html-tag",
                   "token": "<table>"
@@ -517,7 +521,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -558,7 +562,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -627,28 +631,31 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has these signatures:"
+                  "text": "In addition to this signature, this method also has the following signatures:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addItemAttachmentAsync(itemId: any, attachmentName: string): void;`"
+                  "kind": "code",
+                  "text": "addItemAttachmentAsync(itemId: any, attachmentName: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -695,7 +702,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -736,7 +743,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -764,10 +771,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -815,7 +818,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -856,7 +859,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -884,10 +887,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -935,7 +934,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -976,7 +975,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -1091,7 +1090,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -1132,7 +1131,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -1160,10 +1159,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -1174,7 +1169,7 @@
             },
             "getSelectedDataAsync": {
               "kind": "method",
-              "signature": "getSelectedDataAsync(coerciontype: Office.CoercionType, options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;",
+              "signature": "getSelectedDataAsync(coerciontype: Office.CoercionType, options: Office.AsyncContextOptions, callback: (result: AsyncResult<any>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -1217,7 +1212,7 @@
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<any>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -1266,7 +1261,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -1307,7 +1302,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -1335,10 +1330,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -1392,7 +1383,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -1433,7 +1424,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -1461,10 +1452,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -1475,7 +1462,7 @@
             },
             "loadCustomPropertiesAsync": {
               "kind": "method",
-              "signature": "loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;",
+              "signature": "loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -1489,12 +1476,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<Office.CustomProperties>) => void"
                 },
                 "userContext": {
                   "name": "userContext",
@@ -1555,7 +1542,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -1596,7 +1583,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -1624,10 +1611,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -1693,7 +1676,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -1734,7 +1717,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -1762,10 +1745,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -1832,7 +1811,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -1873,7 +1852,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -1901,10 +1880,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -1915,7 +1890,7 @@
             },
             "removeAttachmentAsync": {
               "kind": "method",
-              "signature": "removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -1953,12 +1928,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -1972,7 +1947,7 @@
                 },
                 {
                   "kind": "text",
-                  "text": "The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window."
+                  "text": "The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to continue in a separate window."
                 },
                 {
                   "kind": "paragraph"
@@ -2000,7 +1975,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -2041,7 +2016,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -2116,22 +2091,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAttachmentAsync(attachmentIndex: string): void;`"
+                  "kind": "code",
+                  "text": "removeAttachmentAsync(attachmentIndex: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -2197,7 +2175,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -2238,7 +2216,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -2266,10 +2244,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -2280,7 +2254,7 @@
             },
             "setSelectedDataAsync": {
               "kind": "method",
-              "signature": "setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -2318,12 +2292,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -2365,7 +2339,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -2406,7 +2380,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -2481,22 +2455,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -2576,7 +2553,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -2617,7 +2594,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -2645,10 +2622,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -2710,7 +2683,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -2751,7 +2724,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -2779,10 +2752,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -2814,10 +2783,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -2834,7 +2799,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -2875,7 +2840,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -2903,10 +2868,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -2951,7 +2912,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -2992,7 +2953,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -3020,10 +2981,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -3113,7 +3070,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -3154,7 +3111,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -3182,10 +3139,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -3261,7 +3214,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -3303,7 +3256,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -3331,10 +3284,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -3410,7 +3359,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -3451,7 +3400,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -3479,10 +3428,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -3558,7 +3503,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -3599,7 +3544,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -3627,10 +3572,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -3736,7 +3677,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -3777,7 +3718,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -3805,10 +3746,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -3891,7 +3828,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -3932,7 +3869,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -3960,10 +3897,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -3990,7 +3923,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Office.context.mailbox.item"
+                  "text": " Office.context.mailbox.item"
                 }
               ],
               "target": {
@@ -4027,7 +3960,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Gets an array of attachments for the item."
+                  "text": "Gets the item's attachments as an array."
                 },
                 {
                   "kind": "paragraph"
@@ -4055,7 +3988,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -4096,7 +4029,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -4137,7 +4070,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Blocked attachments in Outlook"
+                      "text": " Blocked attachments in Outlook"
                     }
                   ],
                   "targetUrl": "https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519"
@@ -4192,7 +4125,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -4233,7 +4166,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -4261,10 +4194,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -4312,7 +4241,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -4353,7 +4282,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -4381,10 +4310,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -4432,7 +4357,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -4473,7 +4398,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -4532,7 +4457,7 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB OR An"
+                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB OR An "
                     },
                     {
                       "kind": "api-link",
@@ -4603,10 +4528,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -4623,7 +4544,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -4664,7 +4585,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -4692,10 +4613,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -4719,7 +4636,7 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB. OR An"
+                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB. OR An "
                     },
                     {
                       "kind": "api-link",
@@ -4806,7 +4723,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -4847,7 +4764,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -4875,10 +4792,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -4939,7 +4852,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -4980,7 +4893,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -5008,10 +4921,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -5035,7 +4944,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Gets the entities found in the selected item."
+                  "text": "Gets the entities found in the selected item's body."
                 },
                 {
                   "kind": "paragraph"
@@ -5070,7 +4979,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -5111,7 +5020,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -5139,10 +5048,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -5161,7 +5066,7 @@
                 "description": [
                   {
                     "kind": "text",
-                    "text": "If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. If no entities of the specified type are present on the item, the method returns an empty array. Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter."
+                    "text": "If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. If no entities of the specified type are present in the item's body, the method returns an empty array. Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter."
                   }
                 ]
               },
@@ -5183,7 +5088,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Gets an array of all the entities of the specified entity type found in the selected item."
+                  "text": "Gets an array of all the entities of the specified entity type found in the selected item's body."
                 },
                 {
                   "kind": "paragraph"
@@ -5202,10 +5107,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -5222,7 +5123,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -5263,7 +5164,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -5825,10 +5726,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -5911,7 +5808,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -5952,7 +5849,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -5980,10 +5877,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -6060,7 +5953,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -6101,7 +5994,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -6129,10 +6022,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -6222,7 +6111,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -6263,7 +6152,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -6291,10 +6180,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -6348,7 +6233,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -6389,7 +6274,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -6664,7 +6549,21 @@
                 },
                 {
                   "kind": "text",
-                  "text": "Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more details, see Use the Outlook REST APIs from an Outlook add-in."
+                  "text": "Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more details, see "
+                },
+                {
+                  "kind": "web-link",
+                  "elements": [
+                    {
+                      "kind": "text",
+                      "text": " Use the Outlook REST APIs from an Outlook add-in"
+                    }
+                  ],
+                  "targetUrl": "https://docs.microsoft.com/outlook/add-ins/use-rest-api#get-the-item-id"
+                },
+                {
+                  "kind": "text",
+                  "text": "."
                 },
                 {
                   "kind": "paragraph"
@@ -6692,7 +6591,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -6733,7 +6632,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -6761,10 +6660,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -6819,7 +6714,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -6860,7 +6755,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -6888,10 +6783,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -6902,7 +6793,7 @@
             },
             "loadCustomPropertiesAsync": {
               "kind": "method",
-              "signature": "loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;",
+              "signature": "loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -6916,12 +6807,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<Office.CustomProperties>) => void"
                 },
                 "userContext": {
                   "name": "userContext",
@@ -6982,7 +6873,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -7023,7 +6914,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -7051,10 +6942,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -7108,7 +6995,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -7149,7 +7036,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -7177,10 +7064,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -7235,7 +7118,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -7276,7 +7159,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -7304,10 +7187,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -7381,7 +7260,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -7422,7 +7301,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -7450,10 +7329,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -7473,7 +7348,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Gets the email address of the meeting organizer for a specified meeting. Read mode only."
+                  "text": "Gets the email address of the meeting organizer for a specified meeting."
                 },
                 {
                   "kind": "paragraph"
@@ -7501,7 +7376,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -7542,7 +7417,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -7570,10 +7445,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -7647,7 +7518,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -7688,7 +7559,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -7716,10 +7587,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -7774,7 +7641,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -7815,7 +7682,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -7843,10 +7710,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -7908,7 +7771,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -7949,7 +7812,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -7977,10 +7840,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -8019,10 +7878,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -8039,7 +7894,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -8080,7 +7935,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -8108,10 +7963,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -8266,10 +8117,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -8286,7 +8133,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -8327,7 +8174,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -8355,10 +8202,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -8366,7 +8209,7 @@
           "members": {
             "getTypeAsync": {
               "kind": "method",
-              "signature": "getTypeAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "getTypeAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<Office.CoercionType>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -8392,12 +8235,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. The content type is returned as one of the CoercionType values in the asyncResult.value property."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. The content type is returned as one of the CoercionType values in the asyncResult.value property."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<Office.CoercionType>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -8416,10 +8259,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -8436,7 +8275,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -8477,7 +8316,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -8505,10 +8344,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -8518,7 +8353,7 @@
             },
             "prependAsync": {
               "kind": "method",
-              "signature": "prependAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "prependAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -8556,12 +8391,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. Any errors encountered will be provided in the asyncResult.error property."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. Any errors encountered will be provided in the asyncResult.error property."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -8602,10 +8437,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -8622,7 +8453,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -8663,7 +8494,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -8732,28 +8563,31 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has these signatures:"
+                  "text": "In addition to this signature, this method also has the following signatures:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`prependAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`"
+                  "kind": "code",
+                  "text": "prependAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`prependAsync(data: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "prependAsync(data: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`prependAsync(data: string): void;`"
+                  "kind": "code",
+                  "text": "prependAsync(data: string): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -8763,7 +8597,7 @@
             },
             "setSelectedDataAsync": {
               "kind": "method",
-              "signature": "setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -8801,12 +8635,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. Any errors encountered will be provided in the asyncResult.error property."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. Any errors encountered will be provided in the asyncResult.error property."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -8847,10 +8681,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -8867,7 +8697,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -8908,7 +8738,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -9005,28 +8835,31 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has these signatures:"
+                  "text": "In addition to this signature, this method also has the following signatures:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -9112,10 +8945,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -9132,7 +8961,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -9173,7 +9002,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -9201,10 +9030,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -9366,10 +9191,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -9386,7 +9207,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -9427,7 +9248,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -9455,10 +9276,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -9509,10 +9326,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -9529,7 +9342,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -9570,7 +9383,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -9598,10 +9411,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -9625,7 +9434,14 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "The name of the property to be removed. [Api set: Mailbox 1.0]"
+                      "text": "The name of the property to be removed."
+                    },
+                    {
+                      "kind": "paragraph"
+                    },
+                    {
+                      "kind": "text",
+                      "text": "[Api set: Mailbox 1.0]"
                     }
                   ],
                   "isOptional": false,
@@ -9649,10 +9465,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -9669,7 +9481,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -9710,7 +9522,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -9738,10 +9550,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -9751,7 +9559,7 @@
             },
             "saveAsync": {
               "kind": "method",
-              "signature": "saveAsync(callback?: (result: AsyncResult) => void, asyncContext?: any): void;",
+              "signature": "saveAsync(callback?: (result: AsyncResult<void>) => void, asyncContext?: any): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -9765,19 +9573,26 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 },
                 "asyncContext": {
                   "name": "asyncContext",
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. Any state data that is passed to the callback method. [Api set: Mailbox 1.0]"
+                      "text": "Optional. Any state data that is passed to the callback method."
+                    },
+                    {
+                      "kind": "paragraph"
+                    },
+                    {
+                      "kind": "text",
+                      "text": "[Api set: Mailbox 1.0]"
                     }
                   ],
                   "isOptional": true,
@@ -9808,10 +9623,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -9828,7 +9639,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -9869,7 +9680,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -9897,10 +9708,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -9974,10 +9781,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -9994,7 +9797,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -10035,7 +9838,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -10063,10 +9866,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -10097,10 +9896,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -10117,7 +9912,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -10158,7 +9953,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -10186,10 +9981,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -10225,10 +10016,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -10245,7 +10032,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -10286,7 +10073,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -10314,10 +10101,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -10356,10 +10139,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -10376,7 +10155,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -10417,7 +10196,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -10445,10 +10224,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -10459,11 +10234,11 @@
             },
             "OWAView": {
               "kind": "property",
-              "signature": "OWAView: \"string\";",
+              "signature": "OWAView: MailboxEnums.OWAView | \"OneColumn\" | \"TwoColumns\" | \"ThreeColumns\";",
               "isOptional": false,
               "isReadOnly": false,
               "isStatic": false,
-              "type": "\"string\"",
+              "type": "MailboxEnums.OWAView | \"OneColumn\" | \"TwoColumns\" | \"ThreeColumns\"",
               "deprecatedMessage": [],
               "summary": [
                 {
@@ -10522,10 +10297,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -10542,7 +10313,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -10583,7 +10354,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -10611,10 +10382,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -10646,10 +10413,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -10666,7 +10429,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -10707,7 +10470,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -10735,10 +10498,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -10851,10 +10610,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -10871,7 +10626,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -10912,7 +10667,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -10940,10 +10695,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -11056,10 +10807,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -11076,7 +10823,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -11117,7 +10864,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -11145,10 +10892,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -11312,7 +11055,16 @@
           "summary": [
             {
               "kind": "text",
-              "text": "The item namespace is used to access the currently selected message, meeting request, or appointment. You can determine the type of the item by using the `itemType` property."
+              "text": "The item namespace is used to access the currently selected message, meeting request, or appointment. You can determine the type of the item by using the "
+            },
+            {
+              "kind": "code",
+              "text": "itemType",
+              "highlighter": "plain"
+            },
+            {
+              "kind": "text",
+              "text": " property."
             },
             {
               "kind": "paragraph"
@@ -11323,10 +11075,6 @@
             }
           ],
           "remarks": [
-            {
-              "kind": "text",
-              "text": ""
-            },
             {
               "kind": "html-tag",
               "token": "<table>"
@@ -11344,7 +11092,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -11385,7 +11133,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -11413,10 +11161,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -11461,7 +11205,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -11502,7 +11246,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -11530,10 +11274,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -11581,7 +11321,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -11622,7 +11362,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -11650,10 +11390,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -11701,7 +11437,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -11742,7 +11478,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -11831,7 +11567,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -11872,7 +11608,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -11900,10 +11636,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -11914,7 +11646,7 @@
             },
             "loadCustomPropertiesAsync": {
               "kind": "method",
-              "signature": "loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;",
+              "signature": "loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -11928,12 +11660,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<Office.CustomProperties>) => void"
                 },
                 "userContext": {
                   "name": "userContext",
@@ -11994,7 +11726,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -12035,7 +11767,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -12063,10 +11795,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -12092,7 +11820,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Office.context.mailbox.item"
+                  "text": " Office.context.mailbox.item"
                 }
               ],
               "target": {
@@ -12111,7 +11839,16 @@
             },
             {
               "kind": "text",
-              "text": "Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information."
+              "text": "Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of "
+            },
+            {
+              "kind": "code",
+              "text": "Office.context.mailbox.item",
+              "highlighter": "plain"
+            },
+            {
+              "kind": "text",
+              "text": ". Refer to the Object Model pages for more information."
             }
           ],
           "remarks": [],
@@ -12120,7 +11857,7 @@
           "members": {
             "addFileAttachmentAsync": {
               "kind": "method",
-              "signature": "addFileAttachmentAsync(uri: string, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "addFileAttachmentAsync(uri: string, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -12175,7 +11912,7 @@
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<string>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -12208,10 +11945,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -12228,7 +11961,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -12269,7 +12002,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -12392,22 +12125,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addFileAttachmentAsync(uri: string, attachmentName: string): void;`"
+                  "kind": "code",
+                  "text": "addFileAttachmentAsync(uri: string, attachmentName: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addFileAttachmentAsync(uri: string, attachmentName: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "addFileAttachmentAsync(uri: string, attachmentName: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -12417,7 +12153,7 @@
             },
             "addItemAttachmentAsync": {
               "kind": "method",
-              "signature": "addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -12467,12 +12203,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<string>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -12500,7 +12236,7 @@
                 },
                 {
                   "kind": "text",
-                  "text": "If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended."
+                  "text": "If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended."
                 },
                 {
                   "kind": "paragraph"
@@ -12511,10 +12247,6 @@
                 }
               ],
               "remarks": [
-                {
-                  "kind": "text",
-                  "text": ""
-                },
                 {
                   "kind": "html-tag",
                   "token": "<table>"
@@ -12532,7 +12264,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -12573,7 +12305,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -12642,28 +12374,31 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has these signatures:"
+                  "text": "In addition to this signature, this method also has the following signatures:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addItemAttachmentAsync(itemId: any, attachmentName: string): void;`"
+                  "kind": "code",
+                  "text": "addItemAttachmentAsync(itemId: any, attachmentName: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -12673,7 +12408,7 @@
             },
             "getSelectedDataAsync": {
               "kind": "method",
-              "signature": "getSelectedDataAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult) => void): void;",
+              "signature": "getSelectedDataAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult<any>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -12699,12 +12434,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<any>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -12753,7 +12488,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -12794,7 +12529,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -12822,10 +12557,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -12835,7 +12566,7 @@
             },
             "removeAttachmentAsync": {
               "kind": "method",
-              "signature": "removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -12873,12 +12604,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -12892,7 +12623,7 @@
                 },
                 {
                   "kind": "text",
-                  "text": "The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window."
+                  "text": "The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to continue in a separate window."
                 },
                 {
                   "kind": "paragraph"
@@ -12920,7 +12651,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -12961,7 +12692,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -13036,22 +12767,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAttachmentAsync(attachmentIndex: string): void;`"
+                  "kind": "code",
+                  "text": "removeAttachmentAsync(attachmentIndex: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -13061,7 +12795,7 @@
             },
             "setSelectedDataAsync": {
               "kind": "method",
-              "signature": "setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -13099,12 +12833,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -13146,7 +12880,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -13187,7 +12921,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -13262,22 +12996,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -13338,7 +13075,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -13379,7 +13116,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -13407,10 +13144,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -13437,7 +13170,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Office.context.mailbox.item"
+                  "text": " Office.context.mailbox.item"
                 }
               ],
               "target": {
@@ -13456,7 +13189,16 @@
             },
             {
               "kind": "text",
-              "text": "Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information."
+              "text": "Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of "
+            },
+            {
+              "kind": "code",
+              "text": "Office.context.mailbox.item",
+              "highlighter": "plain"
+            },
+            {
+              "kind": "text",
+              "text": ". Refer to the Object Model pages for more information."
             }
           ],
           "remarks": [],
@@ -13474,7 +13216,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Gets an array of attachments for the item."
+                  "text": "Gets the item's attachments as an array."
                 },
                 {
                   "kind": "paragraph"
@@ -13485,10 +13227,6 @@
                 }
               ],
               "remarks": [
-                {
-                  "kind": "text",
-                  "text": ""
-                },
                 {
                   "kind": "html-tag",
                   "token": "<table>"
@@ -13506,7 +13244,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -13547,7 +13285,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -13588,7 +13326,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Blocked attachments in Outlook"
+                      "text": " Blocked attachments in Outlook"
                     }
                   ],
                   "targetUrl": "https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519"
@@ -13620,7 +13358,7 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB OR An"
+                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB OR An "
                     },
                     {
                       "kind": "api-link",
@@ -13691,10 +13429,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -13711,7 +13445,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -13752,7 +13486,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -13780,10 +13514,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -13807,7 +13537,7 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB. OR An"
+                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB. OR An "
                     },
                     {
                       "kind": "api-link",
@@ -13894,7 +13624,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -13935,7 +13665,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -13963,10 +13693,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -13989,7 +13715,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Gets the entities found in the selected item."
+                  "text": "Gets the entities found in the selected item's body."
                 },
                 {
                   "kind": "paragraph"
@@ -14024,7 +13750,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -14065,7 +13791,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -14093,10 +13819,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -14115,7 +13837,7 @@
                 "description": [
                   {
                     "kind": "text",
-                    "text": "If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. If no entities of the specified type are present on the item, the method returns an empty array. Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter."
+                    "text": "If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. If no entities of the specified type are present in the item's body, the method returns an empty array. Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter."
                   }
                 ]
               },
@@ -14137,7 +13859,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Gets an array of all the entities of the specified entity type found in the selected item."
+                  "text": "Gets an array of all the entities of the specified entity type found in the selected item's body."
                 },
                 {
                   "kind": "paragraph"
@@ -14156,10 +13878,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -14176,7 +13894,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -14217,7 +13935,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -14779,10 +14497,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -14865,7 +14579,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -14906,7 +14620,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -14934,10 +14648,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -15014,7 +14724,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -15055,7 +14765,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -15083,10 +14793,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -15176,7 +14882,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -15217,7 +14923,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -15245,10 +14951,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -15302,7 +15004,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -15343,7 +15045,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -15585,10 +15287,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -15622,7 +15320,21 @@
                 },
                 {
                   "kind": "text",
-                  "text": "Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more details, see Use the Outlook REST APIs from an Outlook add-in."
+                  "text": "Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more details, see "
+                },
+                {
+                  "kind": "web-link",
+                  "elements": [
+                    {
+                      "kind": "text",
+                      "text": " Use the Outlook REST APIs from an Outlook add-in"
+                    }
+                  ],
+                  "targetUrl": "https://docs.microsoft.com/outlook/add-ins/use-rest-api#get-the-item-id"
+                },
+                {
+                  "kind": "text",
+                  "text": "."
                 },
                 {
                   "kind": "paragraph"
@@ -15650,7 +15362,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -15691,7 +15403,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -15719,10 +15431,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -15777,7 +15485,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -15818,7 +15526,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -15846,10 +15554,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -15911,7 +15615,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -15952,7 +15656,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -15980,10 +15684,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -16031,7 +15731,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -16072,7 +15772,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -16100,10 +15800,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -16300,10 +15996,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -16320,7 +16012,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -16361,7 +16053,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -16389,10 +16081,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -16400,7 +16088,7 @@
           "members": {
             "getAsync": {
               "kind": "method",
-              "signature": "getAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "getAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -16426,12 +16114,19 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. [Api set: Mailbox 1.1]"
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
+                    },
+                    {
+                      "kind": "paragraph"
+                    },
+                    {
+                      "kind": "text",
+                      "text": "[Api set: Mailbox 1.1]"
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<string>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -16450,10 +16145,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -16470,7 +16161,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -16511,7 +16202,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -16551,8 +16242,9 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`getAsync(callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "getAsync(callback: (result: AsyncResult<string>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -16562,7 +16254,7 @@
             },
             "setAsync": {
               "kind": "method",
-              "signature": "setAsync(location: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "setAsync(location: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -16600,12 +16292,19 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If setting the location fails, the asyncResult.error property will contain an error code. [Api set: Mailbox 1.1]"
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. If setting the location fails, the asyncResult.error property will contain an error code."
+                    },
+                    {
+                      "kind": "paragraph"
+                    },
+                    {
+                      "kind": "text",
+                      "text": "[Api set: Mailbox 1.1]"
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -16624,10 +16323,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -16644,7 +16339,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -16685,7 +16380,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -16760,22 +16455,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(location: string): void;`"
+                  "kind": "code",
+                  "text": "setAsync(location: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(location: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "setAsync(location: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(location: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "setAsync(location: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -16794,7 +16492,7 @@
           "summary": [
             {
               "kind": "text",
-              "text": "Provides access to the Outlook add-in object model for Microsoft Outlook and Microsoft Outlook on the web."
+              "text": "Provides access to the Outlook Add-in object model for Microsoft Outlook and Microsoft Outlook on the web."
             },
             {
               "kind": "paragraph"
@@ -16834,10 +16532,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -16854,7 +16548,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -16895,7 +16589,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -16923,10 +16617,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -17002,7 +16692,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -17043,7 +16733,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -17071,10 +16761,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -17150,7 +16836,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -17191,7 +16877,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -17219,10 +16905,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -17269,7 +16951,7 @@
                 },
                 {
                   "kind": "text",
-                  "text": "- OWAView (string): A string that represents the current view of Outlook Web App. If the host application is not Outlook Web App, then accessing this property results in undefined. Outlook Web App has three views (OneColumn - displayed when the screen is narrow, TwoColumns - displayed when the screen is wider, and ThreeColumns - displayed when the screen is wide.) that correspond to the width of the screen and the window, and the number of columns that can be displayed."
+                  "text": "- OWAView (MailboxEnums.OWAView or string): An enum (or string literal) that represents the current view of Outlook Web App. If the host application is not Outlook Web App, then accessing this property results in undefined. Outlook Web App has three views (OneColumn - displayed when the screen is narrow, TwoColumns - displayed when the screen is wider, and ThreeColumns - displayed when the screen is wide) that correspond to the width of the screen and the window, and the number of columns that can be displayed."
                 },
                 {
                   "kind": "paragraph"
@@ -17307,10 +16989,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -17327,7 +17005,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -17368,7 +17046,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -17396,10 +17074,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -17499,7 +17173,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -17540,7 +17214,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -17568,10 +17242,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -17670,7 +17340,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -17711,7 +17381,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -17739,10 +17409,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -17841,7 +17507,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -17882,7 +17548,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -17910,10 +17576,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -17974,7 +17636,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -18015,7 +17677,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -18056,7 +17718,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "get attachments from the selected item"
+                      "text": " get attachments from the selected item"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/get-attachments-of-an-outlook-item"
@@ -18081,7 +17743,7 @@
             },
             "getUserIdentityTokenAsync": {
               "kind": "method",
-              "signature": "getUserIdentityTokenAsync(callback: (result: AsyncResult) => void, userContext?: any): void;",
+              "signature": "getUserIdentityTokenAsync(callback: (result: AsyncResult<string>) => void, userContext?: any): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -18095,12 +17757,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. The token is provided as a string in the asyncResult.value property."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<string>) => void"
                 },
                 "userContext": {
                   "name": "userContext",
@@ -18154,7 +17816,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -18195,7 +17857,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -18236,7 +17898,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "authenticate the add-in and user with a third-party system"
+                      "text": " authenticate the add-in and user with a third-party system"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/authentication"
@@ -18262,7 +17924,57 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "The mailbox item. Depending on the context in which the add-in opened, the item may be of any number of types. If you want to see IntelliSense for only a specific type, you should cast this item to one of the following: `ItemCompose`, `ItemRead`, `MessageCompose`, `MessageRead`, `AppointmentCompose`, `AppointmentRead`"
+                  "text": "The mailbox item. Depending on the context in which the add-in opened, the item may be of any number of types. If you want to see IntelliSense for only a specific type, you should cast this item to one of the following: "
+                },
+                {
+                  "kind": "code",
+                  "text": "ItemCompose",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": ", "
+                },
+                {
+                  "kind": "code",
+                  "text": "ItemRead",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": ", "
+                },
+                {
+                  "kind": "code",
+                  "text": "MessageCompose",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": ", "
+                },
+                {
+                  "kind": "code",
+                  "text": "MessageRead",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": ", "
+                },
+                {
+                  "kind": "code",
+                  "text": "AppointmentCompose",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": ", "
+                },
+                {
+                  "kind": "code",
+                  "text": "AppointmentRead",
+                  "highlighter": "plain"
                 }
               ],
               "remarks": [],
@@ -18274,7 +17986,7 @@
             },
             "makeEwsRequestAsync": {
               "kind": "method",
-              "signature": "makeEwsRequestAsync(data: any, callback: (result: AsyncResult) => void, userContext?: any): void;",
+              "signature": "makeEwsRequestAsync(data: any, callback: (result: AsyncResult<string>) => void, userContext?: any): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -18300,12 +18012,21 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. The "
+                    },
+                    {
+                      "kind": "code",
+                      "text": "value",
+                      "highlighter": "plain"
+                    },
+                    {
+                      "kind": "text",
+                      "text": " property of the result is the XML of the EWS request provided as a string. If the result exceeds 1 MB in size, an error message is returned instead."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<string>) => void"
                 },
                 "userContext": {
                   "name": "userContext",
@@ -18359,7 +18080,21 @@
                 },
                 {
                   "kind": "text",
-                  "text": "Your add-in must have the ReadWriteMailbox permission to use the makeEwsRequestAsync method. For information about using the ReadWriteMailbox permission and the EWS operations that you can call with the makeEwsRequestAsync method, see Specify permissions for mail add-in access to the user's mailbox."
+                  "text": "Your add-in must have the ReadWriteMailbox permission to use the makeEwsRequestAsync method. For information about using the ReadWriteMailbox permission and the EWS operations that you can call with the makeEwsRequestAsync method, see "
+                },
+                {
+                  "kind": "web-link",
+                  "elements": [
+                    {
+                      "kind": "text",
+                      "text": " Specify permissions for mail add-in access to the user's mailbox"
+                    }
+                  ],
+                  "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
+                },
+                {
+                  "kind": "text",
+                  "text": "."
                 },
                 {
                   "kind": "paragraph"
@@ -18373,7 +18108,21 @@
                 },
                 {
                   "kind": "text",
-                  "text": "Note: This method is not supported in the following scenarios. - In Outlook for iOS or Outlook for Android - When the add-in is loaded in a Gmail mailbox"
+                  "text": "Note: This method is not supported in the following scenarios:"
+                },
+                {
+                  "kind": "paragraph"
+                },
+                {
+                  "kind": "text",
+                  "text": "- In Outlook for iOS or Outlook for Android."
+                },
+                {
+                  "kind": "paragraph"
+                },
+                {
+                  "kind": "text",
+                  "text": "- When the add-in is loaded in a Gmail mailbox."
                 },
                 {
                   "kind": "paragraph"
@@ -18400,8 +18149,9 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`<?xml version=\"1.0\" encoding=\"iso-8859-1\"?>`"
+                  "kind": "code",
+                  "text": "<?xml version=\"1.0\" encoding=\"iso-8859-1\"?>",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
@@ -18436,7 +18186,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -18477,7 +18227,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -18505,10 +18255,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -18527,7 +18273,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Information about the user associated with the mailbox. This includes their account type, display name, email adddress, and time zone."
+                  "text": "Information about the user associated with the mailbox. This includes their account type, display name, email address, and time zone."
                 },
                 {
                   "kind": "paragraph"
@@ -18550,10 +18296,6 @@
                     "exportName": "Office",
                     "memberName": "UserProfile"
                   }
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "remarks": [],
@@ -18631,10 +18373,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -18655,7 +18393,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -18687,10 +18425,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false
@@ -18806,10 +18540,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -18830,7 +18560,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -18862,10 +18592,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false
@@ -18916,10 +18642,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -18940,7 +18662,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -18972,12 +18694,61 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
+              "isBeta": false
+            },
+            "OWAView": {
+              "kind": "enum",
+              "values": {
+                "OneColumn": {
+                  "kind": "enum value",
+                  "value": "\"OneColumn\"",
+                  "deprecatedMessage": [],
+                  "summary": [
+                    {
+                      "kind": "text",
+                      "text": "One column view. Displayed when the screen is narrow. Outlook Web App uses this single-column layout on the entire screen of a smartphone."
+                    }
+                  ],
+                  "remarks": [],
+                  "isBeta": false
+                },
+                "ThreeColumns": {
+                  "kind": "enum value",
+                  "value": "\"ThreeColumns\"",
+                  "deprecatedMessage": [],
+                  "summary": [
+                    {
+                      "kind": "text",
+                      "text": "Three column view. Displayed when the screen is wide. For example, Outlook Web App uses this view in a full screen window on a desktop computer."
+                    }
+                  ],
+                  "remarks": [],
+                  "isBeta": false
+                },
+                "TwoColumns": {
+                  "kind": "enum value",
+                  "value": "\"TwoColumns\"",
+                  "deprecatedMessage": [],
+                  "summary": [
+                    {
+                      "kind": "text",
+                      "text": "Two column view. Displayed when the screen is wider. Outlook Web App uses this view on most tablets."
+                    }
+                  ],
+                  "remarks": [],
+                  "isBeta": false
+                }
+              },
+              "deprecatedMessage": [],
+              "summary": [
+                {
+                  "kind": "text",
+                  "text": "Represents the current view of Outlook Web App."
+                }
+              ],
+              "remarks": [],
               "isBeta": false
             },
             "RecipientType": {
@@ -19052,10 +18823,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -19076,7 +18843,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -19108,10 +18875,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false
@@ -19201,10 +18964,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -19225,7 +18984,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -19257,10 +19016,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false
@@ -19302,10 +19057,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -19322,7 +19073,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -19363,7 +19114,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -19391,10 +19142,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -19563,7 +19310,16 @@
             },
             {
               "kind": "text",
-              "text": "Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information."
+              "text": "Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of "
+            },
+            {
+              "kind": "code",
+              "text": "Office.context.mailbox.item",
+              "highlighter": "plain"
+            },
+            {
+              "kind": "text",
+              "text": ". Refer to the Object Model pages for more information."
             }
           ],
           "remarks": [],
@@ -19623,7 +19379,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -19664,7 +19420,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -19692,10 +19448,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -19722,7 +19474,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Office.context.mailbox.item"
+                  "text": " Office.context.mailbox.item"
                 }
               ],
               "target": {
@@ -19741,7 +19493,16 @@
             },
             {
               "kind": "text",
-              "text": "Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information."
+              "text": "Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of "
+            },
+            {
+              "kind": "code",
+              "text": "Office.context.mailbox.item",
+              "highlighter": "plain"
+            },
+            {
+              "kind": "text",
+              "text": ". Refer to the Object Model pages for more information."
             }
           ],
           "remarks": [],
@@ -19750,7 +19511,7 @@
           "members": {
             "addFileAttachmentAsync": {
               "kind": "method",
-              "signature": "addFileAttachmentAsync(uri: string, attachmentName: string, options?: AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "addFileAttachmentAsync(uri: string, attachmentName: string, options?: AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -19800,12 +19561,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type asyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of the error."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of the error."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<string>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -19838,10 +19599,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -19858,7 +19615,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -19899,7 +19656,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -20030,22 +19787,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addFileAttachmentAsync(uri: string, attachmentName: string): void;`"
+                  "kind": "code",
+                  "text": "addFileAttachmentAsync(uri: string, attachmentName: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addFileAttachmentAsync(uri: string, attachmentName: string, options: AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "addFileAttachmentAsync(uri: string, attachmentName: string, options: AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -20055,7 +19815,7 @@
             },
             "addItemAttachmentAsync": {
               "kind": "method",
-              "signature": "addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -20110,7 +19870,7 @@
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<string>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -20138,7 +19898,7 @@
                 },
                 {
                   "kind": "text",
-                  "text": "If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended."
+                  "text": "If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended."
                 },
                 {
                   "kind": "paragraph"
@@ -20149,10 +19909,6 @@
                 }
               ],
               "remarks": [
-                {
-                  "kind": "text",
-                  "text": ""
-                },
                 {
                   "kind": "html-tag",
                   "token": "<table>"
@@ -20170,7 +19926,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -20211,7 +19967,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -20280,28 +20036,31 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has these signatures:"
+                  "text": "In addition to this signature, this method also has the following signatures:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addItemAttachmentAsync(itemId: any, attachmentName: string): void;`"
+                  "kind": "code",
+                  "text": "addItemAttachmentAsync(itemId: any, attachmentName: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -20348,7 +20107,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -20389,7 +20148,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -20417,10 +20176,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -20468,7 +20223,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -20509,7 +20264,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -20537,10 +20292,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -20614,7 +20365,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -20655,7 +20406,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -20683,10 +20434,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -20748,7 +20495,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -20789,7 +20536,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -20817,10 +20564,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -20868,7 +20611,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -20909,7 +20652,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -20937,10 +20680,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -20988,7 +20727,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -21029,7 +20768,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -21074,7 +20813,7 @@
             },
             "getSelectedDataAsync": {
               "kind": "method",
-              "signature": "getSelectedDataAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult) => void): void;",
+              "signature": "getSelectedDataAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult<any>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -21100,12 +20839,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<any>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -21154,7 +20893,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -21195,7 +20934,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -21223,10 +20962,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -21280,7 +21015,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -21321,7 +21056,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -21349,10 +21084,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -21363,7 +21094,7 @@
             },
             "loadCustomPropertiesAsync": {
               "kind": "method",
-              "signature": "loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;",
+              "signature": "loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -21377,12 +21108,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<Office.CustomProperties>) => void"
                 },
                 "userContext": {
                   "name": "userContext",
@@ -21443,7 +21174,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -21484,7 +21215,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -21512,10 +21243,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -21525,7 +21252,7 @@
             },
             "removeAttachmentAsync": {
               "kind": "method",
-              "signature": "removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -21563,12 +21290,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -21582,7 +21309,7 @@
                 },
                 {
                   "kind": "text",
-                  "text": "The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window."
+                  "text": "The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to continue in a separate window."
                 },
                 {
                   "kind": "paragraph"
@@ -21610,7 +21337,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -21651,7 +21378,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -21726,22 +21453,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAttachmentAsync(attachmentIndex: string): void;`"
+                  "kind": "code",
+                  "text": "removeAttachmentAsync(attachmentIndex: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -21751,7 +21481,7 @@
             },
             "setSelectedDataAsync": {
               "kind": "method",
-              "signature": "setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -21789,12 +21519,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -21836,7 +21566,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -21877,7 +21607,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -21952,22 +21682,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -22028,7 +21761,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -22069,7 +21802,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -22097,10 +21830,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -22155,7 +21884,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -22196,7 +21925,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -22224,10 +21953,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -22254,7 +21979,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Office.context.mailbox.item"
+                  "text": " Office.context.mailbox.item"
                 }
               ],
               "target": {
@@ -22291,7 +22016,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Gets an array of attachments for the item."
+                  "text": "Gets the item's attachments as an array."
                 },
                 {
                   "kind": "paragraph"
@@ -22319,7 +22044,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -22360,7 +22085,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -22401,7 +22126,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Blocked attachments in Outlook"
+                      "text": " Blocked attachments in Outlook"
                     }
                   ],
                   "targetUrl": "https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519"
@@ -22456,7 +22181,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -22497,7 +22222,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -22525,10 +22250,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -22583,7 +22304,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -22624,7 +22345,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -22652,10 +22373,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -22717,7 +22434,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -22758,7 +22475,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -22786,10 +22503,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -22837,7 +22550,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -22878,7 +22591,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -22906,10 +22619,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -22957,7 +22666,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -22998,7 +22707,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -23057,7 +22766,7 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB OR An"
+                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB OR An "
                     },
                     {
                       "kind": "api-link",
@@ -23128,10 +22837,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -23148,7 +22853,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -23189,7 +22894,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -23217,10 +22922,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -23244,7 +22945,7 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB. OR An"
+                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB. OR An "
                     },
                     {
                       "kind": "api-link",
@@ -23331,7 +23032,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -23372,7 +23073,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -23400,10 +23101,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -23471,7 +23168,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -23512,7 +23209,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -23540,10 +23237,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -23567,7 +23260,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Gets the entities found in the selected item."
+                  "text": "Gets the entities found in the selected item's body."
                 },
                 {
                   "kind": "paragraph"
@@ -23602,7 +23295,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -23643,7 +23336,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -23671,10 +23364,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -23693,7 +23382,7 @@
                 "description": [
                   {
                     "kind": "text",
-                    "text": "If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. If no entities of the specified type are present on the item, the method returns an empty array. Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter."
+                    "text": "If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. If no entities of the specified type are present in the item's body, the method returns an empty array. Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter."
                   }
                 ]
               },
@@ -23715,7 +23404,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Gets an array of all the entities of the specified entity type found in the selected item."
+                  "text": "Gets an array of all the entities of the specified entity type found in the selected item's body."
                 },
                 {
                   "kind": "paragraph"
@@ -23750,7 +23439,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -23791,7 +23480,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -24353,10 +24042,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -24439,7 +24124,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -24480,7 +24165,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -24508,10 +24193,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -24588,7 +24269,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -24629,7 +24310,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -24657,10 +24338,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -24750,7 +24427,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -24791,7 +24468,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -24819,10 +24496,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -24869,7 +24542,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -24910,7 +24583,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -24938,10 +24611,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -24996,7 +24665,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -25037,7 +24706,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -25312,7 +24981,21 @@
                 },
                 {
                   "kind": "text",
-                  "text": "Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more details, see Use the Outlook REST APIs from an Outlook add-in."
+                  "text": "Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more details, see "
+                },
+                {
+                  "kind": "web-link",
+                  "elements": [
+                    {
+                      "kind": "text",
+                      "text": " Use the Outlook REST APIs from an Outlook add-in"
+                    }
+                  ],
+                  "targetUrl": "https://docs.microsoft.com/outlook/add-ins/use-rest-api#get-the-item-id"
+                },
+                {
+                  "kind": "text",
+                  "text": "."
                 },
                 {
                   "kind": "paragraph"
@@ -25340,7 +25023,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -25381,7 +25064,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -25409,10 +25092,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -25467,7 +25146,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -25508,7 +25187,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -25536,10 +25215,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -25550,7 +25225,7 @@
             },
             "loadCustomPropertiesAsync": {
               "kind": "method",
-              "signature": "loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;",
+              "signature": "loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -25564,12 +25239,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<Office.CustomProperties>) => void"
                 },
                 "userContext": {
                   "name": "userContext",
@@ -25630,7 +25305,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -25671,7 +25346,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -25699,10 +25374,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -25756,7 +25427,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -25797,7 +25468,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -25825,10 +25496,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -25890,7 +25557,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -25931,7 +25598,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -25959,10 +25626,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -26024,7 +25687,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -26065,7 +25728,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -26093,10 +25756,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -26151,7 +25810,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -26192,7 +25851,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -26220,10 +25879,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -26262,10 +25917,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -26282,7 +25933,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -26323,7 +25974,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -26351,10 +26002,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -26439,10 +26086,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -26459,7 +26102,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -26500,7 +26143,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -26528,10 +26171,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -26539,7 +26178,7 @@
           "members": {
             "addAsync": {
               "kind": "method",
-              "signature": "addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -26577,12 +26216,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If adding the recipients fails, the asyncResult.error property will contain an error code."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. If adding the recipients fails, the asyncResult.error property will contain an error code."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -26629,10 +26268,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -26649,7 +26284,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -26690,7 +26325,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -26759,28 +26394,31 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has these signatures:"
+                  "text": "In addition to this signature, this method also has the following signatures:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addAsync(recipients: (string | EmailUser | EmailAddressDetails)[]): void;`"
+                  "kind": "code",
+                  "text": "addAsync(recipients: (string | EmailUser | EmailAddressDetails)[]): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -26790,7 +26428,7 @@
             },
             "getAsync": {
               "kind": "method",
-              "signature": "getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;",
+              "signature": "getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult<Office.EmailAddressDetails[]>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -26816,12 +26454,21 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. The "
+                    },
+                    {
+                      "kind": "code",
+                      "text": "value",
+                      "highlighter": "plain"
+                    },
+                    {
+                      "kind": "text",
+                      "text": " property of the result is an array of EmailAddressDetails objects."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<Office.EmailAddressDetails[]>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -26835,7 +26482,7 @@
                 },
                 {
                   "kind": "text",
-                  "text": "When the call completes, the asyncResult.value property will contain an array of"
+                  "text": "When the call completes, the asyncResult.value property will contain an array of "
                 },
                 {
                   "kind": "api-link",
@@ -26866,10 +26513,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -26886,7 +26529,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -26927,7 +26570,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -26961,14 +26604,15 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has this signature:"
+                  "text": "In addition to this signature, this method also has the following signature:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`getAsync(callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "getAsync(callback: (result: AsyncResult<Office.EmailAddressDetails[]>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -26978,7 +26622,7 @@
             },
             "setAsync": {
               "kind": "method",
-              "signature": "setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -27016,12 +26660,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If setting the recipients fails the asyncResult.error property will contain a code that indicates any error that occurred while adding the data."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. If setting the recipients fails the asyncResult.error property will contain a code that indicates any error that occurred while adding the data."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -27113,10 +26757,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -27133,7 +26773,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -27174,7 +26814,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -27243,28 +26883,31 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has these signatures:"
+                  "text": "In addition to this signature, this method also has the following signatures:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(recipients: (string | EmailUser | EmailAddressDetails)[]): void;`"
+                  "kind": "code",
+                  "text": "setAsync(recipients: (string | EmailUser | EmailAddressDetails)[]): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -27455,16 +27098,16 @@
             },
             "callback": {
               "kind": "property",
-              "signature": "callback?: (result: AsyncResult) => void;",
+              "signature": "callback?: (result: AsyncResult<any>) => void;",
               "isOptional": true,
               "isReadOnly": false,
               "isStatic": false,
-              "type": "(result: AsyncResult) => void",
+              "type": "(result: AsyncResult<any>) => void",
               "deprecatedMessage": [],
               "summary": [
                 {
                   "kind": "text",
-                  "text": "When the reply display call completes, the function passed in the callback parameter is called with a single parameter, asyncResult, which is an AsyncResult object."
+                  "text": "When the reply display call completes, the function passed in the callback parameter is called with a single parameter, asyncResult, which is an Office.AsyncResult object."
                 }
               ],
               "remarks": [],
@@ -27513,7 +27156,7 @@
             },
             {
               "kind": "text",
-              "text": "While the Outlook add-in API limits access to these settings to only the add-in that created them, these settings should not be considered secure storage. They can be accessed by Exchange Web Services or Extended MAPI. They should not be used to store sensitive information such as user credentials or security tokens."
+              "text": "While the Outlook Add-in API limits access to these settings to only the add-in that created them, these settings should not be considered secure storage. They can be accessed by Exchange Web Services or Extended MAPI. They should not be used to store sensitive information such as user credentials or security tokens."
             },
             {
               "kind": "paragraph"
@@ -27546,10 +27189,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -27566,7 +27205,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -27607,7 +27246,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -27635,10 +27274,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -27689,10 +27324,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -27709,7 +27340,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -27750,7 +27381,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -27778,10 +27409,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -27829,10 +27456,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -27849,7 +27472,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -27890,7 +27513,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -27918,10 +27541,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -27931,7 +27550,7 @@
             },
             "saveAsync": {
               "kind": "method",
-              "signature": "saveAsync(callback?: (result: AsyncResult) => void): void;",
+              "signature": "saveAsync(callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -27945,12 +27564,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional? When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -27976,10 +27595,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -27996,7 +27611,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -28037,7 +27652,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -28065,10 +27680,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -28149,10 +27760,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -28169,7 +27776,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -28210,7 +27817,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -28238,10 +27845,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -28307,10 +27910,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -28327,7 +27926,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -28368,7 +27967,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -28396,10 +27995,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -28407,7 +28002,7 @@
           "members": {
             "getAsync": {
               "kind": "method",
-              "signature": "getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;",
+              "signature": "getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult<string>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -28433,12 +28028,21 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. The "
+                    },
+                    {
+                      "kind": "code",
+                      "text": "value",
+                      "highlighter": "plain"
+                    },
+                    {
+                      "kind": "text",
+                      "text": " property of the result is the subject of the item."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<string>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -28464,10 +28068,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -28484,7 +28084,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -28525,7 +28125,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -28559,14 +28159,15 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has this signature:"
+                  "text": "In addition to this signature, this method also has the following signature:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`getAsync(callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "getAsync(callback: (result: AsyncResult<string>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -28576,7 +28177,7 @@
             },
             "setAsync": {
               "kind": "method",
-              "signature": "setAsync(subject: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "setAsync(subject: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -28614,12 +28215,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If setting the subject fails, the asyncResult.error property will contain an error code."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. If setting the subject fails, the asyncResult.error property will contain an error code."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -28645,10 +28246,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -28665,7 +28262,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -28706,7 +28303,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -28775,28 +28372,31 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has these signatures:"
+                  "text": "In addition to this signature, this method also has the following signatures:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(subject: string): void;`"
+                  "kind": "code",
+                  "text": "setAsync(subject: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(subject: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "setAsync(subject: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(subject: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "setAsync(subject: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -28822,7 +28422,26 @@
             },
             {
               "kind": "text",
-              "text": "The list of tasks suggested in an email message is returned in the taskSuggestions property of the [Entities]Entities object that is returned when the getEntities or getEntitiesByType method is called on the active item."
+              "text": "The list of tasks suggested in an email message is returned in the taskSuggestions property of the "
+            },
+            {
+              "kind": "api-link",
+              "elements": [
+                {
+                  "kind": "text",
+                  "text": " Entities"
+                }
+              ],
+              "target": {
+                "scopeName": "",
+                "packageName": "Outlook_1_2",
+                "exportName": "Office",
+                "memberName": "Entities"
+              }
+            },
+            {
+              "kind": "text",
+              "text": " object that is returned when the getEntities or getEntitiesByType method is called on the active item."
             },
             {
               "kind": "paragraph"
@@ -28833,10 +28452,6 @@
             }
           ],
           "remarks": [
-            {
-              "kind": "text",
-              "text": ""
-            },
             {
               "kind": "html-tag",
               "token": "<table>"
@@ -28854,7 +28469,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -28895,7 +28510,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -28923,10 +28538,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -28997,10 +28608,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -29017,7 +28624,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -29058,7 +28665,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -29086,10 +28693,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -29097,7 +28700,7 @@
           "members": {
             "getAsync": {
               "kind": "method",
-              "signature": "getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;",
+              "signature": "getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult<Date>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -29123,12 +28726,21 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. The "
+                    },
+                    {
+                      "kind": "code",
+                      "text": "value",
+                      "highlighter": "plain"
+                    },
+                    {
+                      "kind": "text",
+                      "text": " property of the result is a Date object."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<Date>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -29154,10 +28766,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -29174,7 +28782,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -29215,7 +28823,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -29249,14 +28857,15 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has this signature:"
+                  "text": "In addition to this signature, this method also has the following signature:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`getAsync(callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "getAsync(callback: (result: AsyncResult<Date>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -29266,7 +28875,7 @@
             },
             "setAsync": {
               "kind": "method",
-              "signature": "setAsync(dateTime: Date, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "setAsync(dateTime: Date, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -29304,12 +28913,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If setting the date and time fails, the asyncResult.error property will contain an error code."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. If setting the date and time fails, the asyncResult.error property will contain an error code."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -29342,10 +28951,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -29362,7 +28967,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -29403,7 +29008,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -29472,28 +29077,31 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has these signatures:"
+                  "text": "In addition to this signature, this method also has the following signatures:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(dateTime: Date): void;`"
+                  "kind": "code",
+                  "text": "setAsync(dateTime: Date): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(dateTime: Date, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "setAsync(dateTime: Date, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(dateTime: Date, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "setAsync(dateTime: Date, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -29524,10 +29132,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -29544,7 +29148,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -29585,7 +29189,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -29613,10 +29217,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -29645,10 +29245,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -29665,7 +29261,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -29706,7 +29302,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -29734,10 +29330,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -29769,10 +29361,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -29789,7 +29377,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -29830,7 +29418,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -29858,10 +29446,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -29893,10 +29477,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -29913,7 +29493,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -29954,7 +29534,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -29982,10 +29562,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,

--- a/generate-docs/json/Outlook_1_3.api.json
+++ b/generate-docs/json/Outlook_1_3.api.json
@@ -69,7 +69,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Office.context.mailbox.item"
+                  "text": " Office.context.mailbox.item"
                 }
               ],
               "target": {
@@ -88,7 +88,16 @@
             },
             {
               "kind": "text",
-              "text": "Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information."
+              "text": "Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of "
+            },
+            {
+              "kind": "code",
+              "text": "Office.context.mailbox.item",
+              "highlighter": "plain"
+            },
+            {
+              "kind": "text",
+              "text": ". Refer to the Object Model pages for more information."
             }
           ],
           "remarks": [],
@@ -97,7 +106,7 @@
           "members": {
             "addFileAttachmentAsync": {
               "kind": "method",
-              "signature": "addFileAttachmentAsync(uri: string, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "addFileAttachmentAsync(uri: string, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -152,7 +161,7 @@
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<string>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -185,10 +194,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -205,7 +210,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -246,7 +251,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -377,22 +382,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addFileAttachmentAsync(uri: string, attachmentName: string): void;`"
+                  "kind": "code",
+                  "text": "addFileAttachmentAsync(uri: string, attachmentName: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addFileAttachmentAsync(uri: string, attachmentName: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "addFileAttachmentAsync(uri: string, attachmentName: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -402,7 +410,7 @@
             },
             "addItemAttachmentAsync": {
               "kind": "method",
-              "signature": "addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -452,12 +460,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<string>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -485,7 +493,7 @@
                 },
                 {
                   "kind": "text",
-                  "text": "If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended."
+                  "text": "If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended."
                 },
                 {
                   "kind": "paragraph"
@@ -496,10 +504,6 @@
                 }
               ],
               "remarks": [
-                {
-                  "kind": "text",
-                  "text": ""
-                },
                 {
                   "kind": "html-tag",
                   "token": "<table>"
@@ -517,7 +521,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -558,7 +562,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -627,28 +631,31 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has these signatures:"
+                  "text": "In addition to this signature, this method also has the following signatures:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addItemAttachmentAsync(itemId: any, attachmentName: string): void;`"
+                  "kind": "code",
+                  "text": "addItemAttachmentAsync(itemId: any, attachmentName: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -695,7 +702,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -736,7 +743,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -764,10 +771,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -840,7 +843,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -881,7 +884,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -909,10 +912,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -959,7 +958,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -1000,7 +999,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -1028,10 +1027,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -1079,7 +1074,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -1120,7 +1115,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -1235,7 +1230,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -1276,7 +1271,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -1304,10 +1299,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -1318,7 +1309,7 @@
             },
             "getSelectedDataAsync": {
               "kind": "method",
-              "signature": "getSelectedDataAsync(coerciontype: Office.CoercionType, options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;",
+              "signature": "getSelectedDataAsync(coerciontype: Office.CoercionType, options: Office.AsyncContextOptions, callback: (result: AsyncResult<any>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -1361,7 +1352,7 @@
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<any>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -1410,7 +1401,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -1451,7 +1442,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -1479,10 +1470,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -1536,7 +1523,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -1577,7 +1564,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -1605,10 +1592,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -1619,7 +1602,7 @@
             },
             "loadCustomPropertiesAsync": {
               "kind": "method",
-              "signature": "loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;",
+              "signature": "loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -1633,12 +1616,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<Office.CustomProperties>) => void"
                 },
                 "userContext": {
                   "name": "userContext",
@@ -1699,7 +1682,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -1740,7 +1723,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -1768,10 +1751,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -1837,7 +1816,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -1878,7 +1857,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -1906,10 +1885,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -1957,7 +1932,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -1998,7 +1973,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -2026,10 +2001,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -2096,7 +2067,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -2137,7 +2108,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -2165,10 +2136,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -2179,7 +2146,7 @@
             },
             "removeAttachmentAsync": {
               "kind": "method",
-              "signature": "removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -2217,12 +2184,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -2236,7 +2203,7 @@
                 },
                 {
                   "kind": "text",
-                  "text": "The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window."
+                  "text": "The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to continue in a separate window."
                 },
                 {
                   "kind": "paragraph"
@@ -2264,7 +2231,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -2305,7 +2272,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -2380,22 +2347,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAttachmentAsync(attachmentIndex: string): void;`"
+                  "kind": "code",
+                  "text": "removeAttachmentAsync(attachmentIndex: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -2461,7 +2431,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -2502,7 +2472,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -2530,10 +2500,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -2544,7 +2510,7 @@
             },
             "saveAsync": {
               "kind": "method",
-              "signature": "saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -2570,12 +2536,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -2652,7 +2618,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -2693,7 +2659,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -2768,22 +2734,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`saveAsync(): void;`"
+                  "kind": "code",
+                  "text": "saveAsync(): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`saveAsync(options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "saveAsync(options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`saveAsync(callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "saveAsync(callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -2793,7 +2762,7 @@
             },
             "setSelectedDataAsync": {
               "kind": "method",
-              "signature": "setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -2831,12 +2800,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -2878,7 +2847,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -2919,7 +2888,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -2994,22 +2963,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -3089,7 +3061,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -3130,7 +3102,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -3158,10 +3130,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -3223,7 +3191,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -3264,7 +3232,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -3292,10 +3260,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -3327,10 +3291,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -3347,7 +3307,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -3388,7 +3348,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -3416,10 +3376,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -3464,7 +3420,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -3505,7 +3461,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -3533,10 +3489,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -3626,7 +3578,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -3667,7 +3619,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -3695,10 +3647,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -3774,7 +3722,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -3816,7 +3764,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -3844,10 +3792,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -3923,7 +3867,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -3964,7 +3908,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -3992,10 +3936,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -4071,7 +4011,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -4112,7 +4052,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -4140,10 +4080,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -4249,7 +4185,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -4290,7 +4226,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -4318,10 +4254,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -4404,7 +4336,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -4445,7 +4377,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -4473,10 +4405,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -4503,7 +4431,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Office.context.mailbox.item"
+                  "text": " Office.context.mailbox.item"
                 }
               ],
               "target": {
@@ -4540,7 +4468,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Gets an array of attachments for the item."
+                  "text": "Gets the item's attachments as an array."
                 },
                 {
                   "kind": "paragraph"
@@ -4568,7 +4496,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -4609,7 +4537,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -4650,7 +4578,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Blocked attachments in Outlook"
+                      "text": " Blocked attachments in Outlook"
                     }
                   ],
                   "targetUrl": "https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519"
@@ -4705,7 +4633,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -4746,7 +4674,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -4774,10 +4702,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -4825,7 +4749,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -4866,7 +4790,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -4894,10 +4818,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -4945,7 +4865,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -4986,7 +4906,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -5045,7 +4965,7 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB OR An"
+                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB OR An "
                     },
                     {
                       "kind": "api-link",
@@ -5116,10 +5036,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -5136,7 +5052,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -5177,7 +5093,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -5205,10 +5121,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -5232,7 +5144,7 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB. OR An"
+                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB. OR An "
                     },
                     {
                       "kind": "api-link",
@@ -5319,7 +5231,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -5360,7 +5272,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -5388,10 +5300,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -5452,7 +5360,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -5493,7 +5401,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -5521,10 +5429,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -5548,7 +5452,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Gets the entities found in the selected item."
+                  "text": "Gets the entities found in the selected item's body."
                 },
                 {
                   "kind": "paragraph"
@@ -5583,7 +5487,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -5624,7 +5528,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -5652,10 +5556,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -5674,7 +5574,7 @@
                 "description": [
                   {
                     "kind": "text",
-                    "text": "If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. If no entities of the specified type are present on the item, the method returns an empty array. Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter."
+                    "text": "If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. If no entities of the specified type are present in the item's body, the method returns an empty array. Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter."
                   }
                 ]
               },
@@ -5696,7 +5596,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Gets an array of all the entities of the specified entity type found in the selected item."
+                  "text": "Gets an array of all the entities of the specified entity type found in the selected item's body."
                 },
                 {
                   "kind": "paragraph"
@@ -5715,10 +5615,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -5735,7 +5631,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -5776,7 +5672,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -6338,10 +6234,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -6424,7 +6316,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -6465,7 +6357,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -6493,10 +6385,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -6573,7 +6461,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -6614,7 +6502,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -6642,10 +6530,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -6735,7 +6619,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -6776,7 +6660,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -6804,10 +6688,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -6861,7 +6741,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -6902,7 +6782,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -7177,7 +7057,21 @@
                 },
                 {
                   "kind": "text",
-                  "text": "Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more details, see Use the Outlook REST APIs from an Outlook add-in."
+                  "text": "Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more details, see "
+                },
+                {
+                  "kind": "web-link",
+                  "elements": [
+                    {
+                      "kind": "text",
+                      "text": " Use the Outlook REST APIs from an Outlook add-in"
+                    }
+                  ],
+                  "targetUrl": "https://docs.microsoft.com/outlook/add-ins/use-rest-api#get-the-item-id"
+                },
+                {
+                  "kind": "text",
+                  "text": "."
                 },
                 {
                   "kind": "paragraph"
@@ -7205,7 +7099,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -7246,7 +7140,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -7274,10 +7168,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -7332,7 +7222,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -7373,7 +7263,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -7401,10 +7291,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -7415,7 +7301,7 @@
             },
             "loadCustomPropertiesAsync": {
               "kind": "method",
-              "signature": "loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;",
+              "signature": "loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -7429,12 +7315,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<Office.CustomProperties>) => void"
                 },
                 "userContext": {
                   "name": "userContext",
@@ -7495,7 +7381,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -7536,7 +7422,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -7564,10 +7450,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -7621,7 +7503,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -7662,7 +7544,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -7690,10 +7572,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -7748,7 +7626,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -7789,7 +7667,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -7817,10 +7695,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -7868,7 +7742,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -7909,7 +7783,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -7937,10 +7811,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -8014,7 +7884,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -8055,7 +7925,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -8083,10 +7953,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -8106,7 +7972,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Gets the email address of the meeting organizer for a specified meeting. Read mode only."
+                  "text": "Gets the email address of the meeting organizer for a specified meeting."
                 },
                 {
                   "kind": "paragraph"
@@ -8134,7 +8000,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -8175,7 +8041,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -8203,10 +8069,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -8280,7 +8142,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -8321,7 +8183,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -8349,10 +8211,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -8407,7 +8265,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -8448,7 +8306,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -8476,10 +8334,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -8541,7 +8395,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -8582,7 +8436,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -8610,10 +8464,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -8652,10 +8502,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -8672,7 +8518,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -8713,7 +8559,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -8741,10 +8587,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -8899,10 +8741,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -8919,7 +8757,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -8960,7 +8798,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -8988,10 +8826,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -8999,7 +8833,7 @@
           "members": {
             "getAsync": {
               "kind": "method",
-              "signature": "getAsync(coerciontype: Office.CoercionType, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "getAsync(coerciontype: Office.CoercionType, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<Office.Body>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -9037,7 +8871,7 @@
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<Office.Body>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -9070,10 +8904,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -9090,7 +8920,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -9131,7 +8961,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -9165,14 +8995,15 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has this signature:"
+                  "text": "In addition to this signature, this method also has the following signature:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`getAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "getAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult<Office.Body>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -9182,7 +9013,7 @@
             },
             "getTypeAsync": {
               "kind": "method",
-              "signature": "getTypeAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "getTypeAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<Office.CoercionType>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -9208,12 +9039,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. The content type is returned as one of the CoercionType values in the asyncResult.value property."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. The content type is returned as one of the CoercionType values in the asyncResult.value property."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<Office.CoercionType>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -9232,10 +9063,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -9252,7 +9079,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -9293,7 +9120,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -9321,10 +9148,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -9334,7 +9157,7 @@
             },
             "prependAsync": {
               "kind": "method",
-              "signature": "prependAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "prependAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -9372,12 +9195,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. Any errors encountered will be provided in the asyncResult.error property."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. Any errors encountered will be provided in the asyncResult.error property."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -9418,10 +9241,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -9438,7 +9257,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -9479,7 +9298,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -9548,28 +9367,31 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has these signatures:"
+                  "text": "In addition to this signature, this method also has the following signatures:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`prependAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`"
+                  "kind": "code",
+                  "text": "prependAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`prependAsync(data: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "prependAsync(data: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`prependAsync(data: string): void;`"
+                  "kind": "code",
+                  "text": "prependAsync(data: string): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -9579,7 +9401,7 @@
             },
             "setAsync": {
               "kind": "method",
-              "signature": "setAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "setAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -9617,12 +9439,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. Any errors encountered will be provided in the asyncResult.error property."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. Any errors encountered will be provided in the asyncResult.error property."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -9663,10 +9485,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -9683,7 +9501,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -9724,7 +9542,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -9821,28 +9639,31 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has these signatures:"
+                  "text": "In addition to this signature, this method also has the following signatures:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`"
+                  "kind": "code",
+                  "text": "setAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(data: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "setAsync(data: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(data: string): void;`"
+                  "kind": "code",
+                  "text": "setAsync(data: string): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -9852,7 +9673,7 @@
             },
             "setSelectedDataAsync": {
               "kind": "method",
-              "signature": "setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -9890,12 +9711,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. Any errors encountered will be provided in the asyncResult.error property."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. Any errors encountered will be provided in the asyncResult.error property."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -9936,10 +9757,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -9956,7 +9773,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -9997,7 +9814,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -10094,28 +9911,31 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has these signatures:"
+                  "text": "In addition to this signature, this method also has the following signatures:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -10201,10 +10021,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -10221,7 +10037,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -10262,7 +10078,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -10290,10 +10106,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -10455,10 +10267,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -10475,7 +10283,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -10516,7 +10324,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -10544,10 +10352,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -10598,10 +10402,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -10618,7 +10418,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -10659,7 +10459,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -10687,10 +10487,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -10714,7 +10510,14 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "The name of the property to be removed. [Api set: Mailbox 1.0]"
+                      "text": "The name of the property to be removed."
+                    },
+                    {
+                      "kind": "paragraph"
+                    },
+                    {
+                      "kind": "text",
+                      "text": "[Api set: Mailbox 1.0]"
                     }
                   ],
                   "isOptional": false,
@@ -10738,10 +10541,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -10758,7 +10557,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -10799,7 +10598,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -10827,10 +10626,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -10840,7 +10635,7 @@
             },
             "saveAsync": {
               "kind": "method",
-              "signature": "saveAsync(callback?: (result: AsyncResult) => void, asyncContext?: any): void;",
+              "signature": "saveAsync(callback?: (result: AsyncResult<void>) => void, asyncContext?: any): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -10854,19 +10649,26 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 },
                 "asyncContext": {
                   "name": "asyncContext",
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. Any state data that is passed to the callback method. [Api set: Mailbox 1.0]"
+                      "text": "Optional. Any state data that is passed to the callback method."
+                    },
+                    {
+                      "kind": "paragraph"
+                    },
+                    {
+                      "kind": "text",
+                      "text": "[Api set: Mailbox 1.0]"
                     }
                   ],
                   "isOptional": true,
@@ -10897,10 +10699,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -10917,7 +10715,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -10958,7 +10756,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -10986,10 +10784,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -11063,10 +10857,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -11083,7 +10873,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -11124,7 +10914,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -11152,10 +10942,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -11186,10 +10972,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -11206,7 +10988,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -11247,7 +11029,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -11275,10 +11057,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -11314,10 +11092,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -11334,7 +11108,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -11375,7 +11149,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -11403,10 +11177,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -11445,10 +11215,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -11465,7 +11231,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -11506,7 +11272,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -11534,10 +11300,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -11548,11 +11310,11 @@
             },
             "OWAView": {
               "kind": "property",
-              "signature": "OWAView: \"string\";",
+              "signature": "OWAView: MailboxEnums.OWAView | \"OneColumn\" | \"TwoColumns\" | \"ThreeColumns\";",
               "isOptional": false,
               "isReadOnly": false,
               "isStatic": false,
-              "type": "\"string\"",
+              "type": "MailboxEnums.OWAView | \"OneColumn\" | \"TwoColumns\" | \"ThreeColumns\"",
               "deprecatedMessage": [],
               "summary": [
                 {
@@ -11611,10 +11373,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -11631,7 +11389,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -11672,7 +11430,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -11700,10 +11458,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -11735,10 +11489,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -11755,7 +11505,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -11796,7 +11546,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -11824,10 +11574,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -11940,10 +11686,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -11960,7 +11702,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -12001,7 +11743,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -12029,10 +11771,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -12145,10 +11883,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -12165,7 +11899,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -12206,7 +11940,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -12234,10 +11968,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -12401,7 +12131,16 @@
           "summary": [
             {
               "kind": "text",
-              "text": "The item namespace is used to access the currently selected message, meeting request, or appointment. You can determine the type of the item by using the `itemType` property."
+              "text": "The item namespace is used to access the currently selected message, meeting request, or appointment. You can determine the type of the item by using the "
+            },
+            {
+              "kind": "code",
+              "text": "itemType",
+              "highlighter": "plain"
+            },
+            {
+              "kind": "text",
+              "text": " property."
             },
             {
               "kind": "paragraph"
@@ -12412,10 +12151,6 @@
             }
           ],
           "remarks": [
-            {
-              "kind": "text",
-              "text": ""
-            },
             {
               "kind": "html-tag",
               "token": "<table>"
@@ -12433,7 +12168,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -12474,7 +12209,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -12502,10 +12237,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -12550,7 +12281,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -12591,7 +12322,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -12619,10 +12350,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -12670,7 +12397,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -12711,7 +12438,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -12739,10 +12466,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -12790,7 +12513,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -12831,7 +12554,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -12920,7 +12643,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -12961,7 +12684,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -12989,10 +12712,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -13003,7 +12722,7 @@
             },
             "loadCustomPropertiesAsync": {
               "kind": "method",
-              "signature": "loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;",
+              "signature": "loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -13017,12 +12736,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<Office.CustomProperties>) => void"
                 },
                 "userContext": {
                   "name": "userContext",
@@ -13083,7 +12802,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -13124,7 +12843,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -13152,10 +12871,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -13202,7 +12917,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -13243,7 +12958,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -13271,10 +12986,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -13301,7 +13012,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Office.context.mailbox.item"
+                  "text": " Office.context.mailbox.item"
                 }
               ],
               "target": {
@@ -13320,7 +13031,16 @@
             },
             {
               "kind": "text",
-              "text": "Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information."
+              "text": "Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of "
+            },
+            {
+              "kind": "code",
+              "text": "Office.context.mailbox.item",
+              "highlighter": "plain"
+            },
+            {
+              "kind": "text",
+              "text": ". Refer to the Object Model pages for more information."
             }
           ],
           "remarks": [],
@@ -13329,7 +13049,7 @@
           "members": {
             "addFileAttachmentAsync": {
               "kind": "method",
-              "signature": "addFileAttachmentAsync(uri: string, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "addFileAttachmentAsync(uri: string, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -13384,7 +13104,7 @@
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<string>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -13417,10 +13137,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -13437,7 +13153,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -13478,7 +13194,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -13601,22 +13317,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addFileAttachmentAsync(uri: string, attachmentName: string): void;`"
+                  "kind": "code",
+                  "text": "addFileAttachmentAsync(uri: string, attachmentName: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addFileAttachmentAsync(uri: string, attachmentName: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "addFileAttachmentAsync(uri: string, attachmentName: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -13626,7 +13345,7 @@
             },
             "addItemAttachmentAsync": {
               "kind": "method",
-              "signature": "addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -13676,12 +13395,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<string>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -13709,7 +13428,7 @@
                 },
                 {
                   "kind": "text",
-                  "text": "If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended."
+                  "text": "If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended."
                 },
                 {
                   "kind": "paragraph"
@@ -13720,10 +13439,6 @@
                 }
               ],
               "remarks": [
-                {
-                  "kind": "text",
-                  "text": ""
-                },
                 {
                   "kind": "html-tag",
                   "token": "<table>"
@@ -13741,7 +13456,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -13782,7 +13497,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -13851,28 +13566,31 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has these signatures:"
+                  "text": "In addition to this signature, this method also has the following signatures:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addItemAttachmentAsync(itemId: any, attachmentName: string): void;`"
+                  "kind": "code",
+                  "text": "addItemAttachmentAsync(itemId: any, attachmentName: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -13944,7 +13662,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -13985,7 +13703,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -14013,10 +13731,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -14026,7 +13740,7 @@
             },
             "getSelectedDataAsync": {
               "kind": "method",
-              "signature": "getSelectedDataAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult) => void): void;",
+              "signature": "getSelectedDataAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult<any>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -14052,12 +13766,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<any>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -14106,7 +13820,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -14147,7 +13861,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -14175,10 +13889,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -14188,7 +13898,7 @@
             },
             "removeAttachmentAsync": {
               "kind": "method",
-              "signature": "removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -14226,12 +13936,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -14245,7 +13955,7 @@
                 },
                 {
                   "kind": "text",
-                  "text": "The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window."
+                  "text": "The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to continue in a separate window."
                 },
                 {
                   "kind": "paragraph"
@@ -14273,7 +13983,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -14314,7 +14024,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -14389,22 +14099,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAttachmentAsync(attachmentIndex: string): void;`"
+                  "kind": "code",
+                  "text": "removeAttachmentAsync(attachmentIndex: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -14414,7 +14127,7 @@
             },
             "saveAsync": {
               "kind": "method",
-              "signature": "saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -14440,12 +14153,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -14522,7 +14235,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -14563,7 +14276,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -14638,22 +14351,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`saveAsync(): void;`"
+                  "kind": "code",
+                  "text": "saveAsync(): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`saveAsync(options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "saveAsync(options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`saveAsync(callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "saveAsync(callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -14663,7 +14379,7 @@
             },
             "setSelectedDataAsync": {
               "kind": "method",
-              "signature": "setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -14701,12 +14417,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -14748,7 +14464,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -14789,7 +14505,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -14864,22 +14580,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -14940,7 +14659,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -14981,7 +14700,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -15009,10 +14728,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -15039,7 +14754,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Office.context.mailbox.item"
+                  "text": " Office.context.mailbox.item"
                 }
               ],
               "target": {
@@ -15058,7 +14773,16 @@
             },
             {
               "kind": "text",
-              "text": "Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information."
+              "text": "Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of "
+            },
+            {
+              "kind": "code",
+              "text": "Office.context.mailbox.item",
+              "highlighter": "plain"
+            },
+            {
+              "kind": "text",
+              "text": ". Refer to the Object Model pages for more information."
             }
           ],
           "remarks": [],
@@ -15076,7 +14800,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Gets an array of attachments for the item."
+                  "text": "Gets the item's attachments as an array."
                 },
                 {
                   "kind": "paragraph"
@@ -15087,10 +14811,6 @@
                 }
               ],
               "remarks": [
-                {
-                  "kind": "text",
-                  "text": ""
-                },
                 {
                   "kind": "html-tag",
                   "token": "<table>"
@@ -15108,7 +14828,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -15149,7 +14869,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -15190,7 +14910,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Blocked attachments in Outlook"
+                      "text": " Blocked attachments in Outlook"
                     }
                   ],
                   "targetUrl": "https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519"
@@ -15222,7 +14942,7 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB OR An"
+                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB OR An "
                     },
                     {
                       "kind": "api-link",
@@ -15293,10 +15013,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -15313,7 +15029,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -15354,7 +15070,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -15382,10 +15098,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -15409,7 +15121,7 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB. OR An"
+                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB. OR An "
                     },
                     {
                       "kind": "api-link",
@@ -15496,7 +15208,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -15537,7 +15249,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -15565,10 +15277,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -15591,7 +15299,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Gets the entities found in the selected item."
+                  "text": "Gets the entities found in the selected item's body."
                 },
                 {
                   "kind": "paragraph"
@@ -15626,7 +15334,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -15667,7 +15375,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -15695,10 +15403,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -15717,7 +15421,7 @@
                 "description": [
                   {
                     "kind": "text",
-                    "text": "If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. If no entities of the specified type are present on the item, the method returns an empty array. Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter."
+                    "text": "If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. If no entities of the specified type are present in the item's body, the method returns an empty array. Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter."
                   }
                 ]
               },
@@ -15739,7 +15443,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Gets an array of all the entities of the specified entity type found in the selected item."
+                  "text": "Gets an array of all the entities of the specified entity type found in the selected item's body."
                 },
                 {
                   "kind": "paragraph"
@@ -15758,10 +15462,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -15778,7 +15478,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -15819,7 +15519,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -16381,10 +16081,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -16467,7 +16163,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -16508,7 +16204,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -16536,10 +16232,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -16616,7 +16308,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -16657,7 +16349,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -16685,10 +16377,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -16778,7 +16466,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -16819,7 +16507,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -16847,10 +16535,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -16904,7 +16588,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -16945,7 +16629,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -17187,10 +16871,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -17224,7 +16904,21 @@
                 },
                 {
                   "kind": "text",
-                  "text": "Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more details, see Use the Outlook REST APIs from an Outlook add-in."
+                  "text": "Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more details, see "
+                },
+                {
+                  "kind": "web-link",
+                  "elements": [
+                    {
+                      "kind": "text",
+                      "text": " Use the Outlook REST APIs from an Outlook add-in"
+                    }
+                  ],
+                  "targetUrl": "https://docs.microsoft.com/outlook/add-ins/use-rest-api#get-the-item-id"
+                },
+                {
+                  "kind": "text",
+                  "text": "."
                 },
                 {
                   "kind": "paragraph"
@@ -17252,7 +16946,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -17293,7 +16987,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -17321,10 +17015,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -17379,7 +17069,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -17420,7 +17110,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -17448,10 +17138,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -17513,7 +17199,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -17554,7 +17240,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -17582,10 +17268,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -17633,7 +17315,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -17674,7 +17356,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -17702,10 +17384,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -17902,10 +17580,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -17922,7 +17596,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -17963,7 +17637,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -17991,10 +17665,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -18002,7 +17672,7 @@
           "members": {
             "getAsync": {
               "kind": "method",
-              "signature": "getAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "getAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -18028,12 +17698,19 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. [Api set: Mailbox 1.1]"
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
+                    },
+                    {
+                      "kind": "paragraph"
+                    },
+                    {
+                      "kind": "text",
+                      "text": "[Api set: Mailbox 1.1]"
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<string>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -18052,10 +17729,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -18072,7 +17745,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -18113,7 +17786,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -18153,8 +17826,9 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`getAsync(callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "getAsync(callback: (result: AsyncResult<string>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -18164,7 +17838,7 @@
             },
             "setAsync": {
               "kind": "method",
-              "signature": "setAsync(location: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "setAsync(location: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -18202,12 +17876,19 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If setting the location fails, the asyncResult.error property will contain an error code. [Api set: Mailbox 1.1]"
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. If setting the location fails, the asyncResult.error property will contain an error code."
+                    },
+                    {
+                      "kind": "paragraph"
+                    },
+                    {
+                      "kind": "text",
+                      "text": "[Api set: Mailbox 1.1]"
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -18226,10 +17907,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -18246,7 +17923,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -18287,7 +17964,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -18362,22 +18039,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(location: string): void;`"
+                  "kind": "code",
+                  "text": "setAsync(location: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(location: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "setAsync(location: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(location: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "setAsync(location: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -18396,7 +18076,7 @@
           "summary": [
             {
               "kind": "text",
-              "text": "Provides access to the Outlook add-in object model for Microsoft Outlook and Microsoft Outlook on the web."
+              "text": "Provides access to the Outlook Add-in object model for Microsoft Outlook and Microsoft Outlook on the web."
             },
             {
               "kind": "paragraph"
@@ -18436,10 +18116,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -18456,7 +18132,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -18497,7 +18173,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -18525,10 +18201,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -18616,7 +18288,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -18657,7 +18329,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -18685,10 +18357,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -18766,7 +18434,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -18807,7 +18475,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -18835,10 +18503,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -18921,7 +18585,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -18962,7 +18626,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -19003,7 +18667,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Outlook Mail API"
+                      "text": " Outlook Mail API"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/previous-versions/office/office-365-api/api/version-2.0/mail-rest-operations"
@@ -19017,7 +18681,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Microsoft Graph"
+                      "text": " Microsoft Graph"
                     }
                   ],
                   "targetUrl": "http://graph.microsoft.io/"
@@ -19100,7 +18764,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -19141,7 +18805,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -19169,10 +18833,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -19219,7 +18879,7 @@
                 },
                 {
                   "kind": "text",
-                  "text": "- OWAView (string): A string that represents the current view of Outlook Web App. If the host application is not Outlook Web App, then accessing this property results in undefined. Outlook Web App has three views (OneColumn - displayed when the screen is narrow, TwoColumns - displayed when the screen is wider, and ThreeColumns - displayed when the screen is wide.) that correspond to the width of the screen and the window, and the number of columns that can be displayed."
+                  "text": "- OWAView (MailboxEnums.OWAView or string): An enum (or string literal) that represents the current view of Outlook Web App. If the host application is not Outlook Web App, then accessing this property results in undefined. Outlook Web App has three views (OneColumn - displayed when the screen is narrow, TwoColumns - displayed when the screen is wider, and ThreeColumns - displayed when the screen is wide) that correspond to the width of the screen and the window, and the number of columns that can be displayed."
                 },
                 {
                   "kind": "paragraph"
@@ -19257,10 +18917,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -19277,7 +18933,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -19318,7 +18974,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -19346,10 +19002,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -19449,7 +19101,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -19490,7 +19142,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -19518,10 +19170,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -19620,7 +19268,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -19661,7 +19309,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -19689,10 +19337,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -19791,7 +19435,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -19832,7 +19476,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -19860,10 +19504,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -19924,7 +19564,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -19965,7 +19605,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -20006,7 +19646,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "get attachments from the selected item"
+                      "text": " get attachments from the selected item"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/get-attachments-of-an-outlook-item"
@@ -20031,7 +19671,7 @@
             },
             "getCallbackTokenAsync": {
               "kind": "method",
-              "signature": "getCallbackTokenAsync(callback: (result: AsyncResult) => void, userContext?: any): void;",
+              "signature": "getCallbackTokenAsync(callback: (result: AsyncResult<string>) => void, userContext?: any): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -20045,12 +19685,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. The token is provided as a string in the asyncResult.value property."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. The token is provided as a string in the asyncResult.value property."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<string>) => void"
                 },
                 "userContext": {
                   "name": "userContext",
@@ -20125,7 +19765,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -20166,7 +19806,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -20194,10 +19834,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -20207,7 +19843,7 @@
             },
             "getUserIdentityTokenAsync": {
               "kind": "method",
-              "signature": "getUserIdentityTokenAsync(callback: (result: AsyncResult) => void, userContext?: any): void;",
+              "signature": "getUserIdentityTokenAsync(callback: (result: AsyncResult<string>) => void, userContext?: any): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -20221,12 +19857,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. The token is provided as a string in the asyncResult.value property."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<string>) => void"
                 },
                 "userContext": {
                   "name": "userContext",
@@ -20280,7 +19916,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -20321,7 +19957,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -20362,7 +19998,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "authenticate the add-in and user with a third-party system"
+                      "text": " authenticate the add-in and user with a third-party system"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/authentication"
@@ -20388,7 +20024,57 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "The mailbox item. Depending on the context in which the add-in opened, the item may be of any number of types. If you want to see IntelliSense for only a specific type, you should cast this item to one of the following: `ItemCompose`, `ItemRead`, `MessageCompose`, `MessageRead`, `AppointmentCompose`, `AppointmentRead`"
+                  "text": "The mailbox item. Depending on the context in which the add-in opened, the item may be of any number of types. If you want to see IntelliSense for only a specific type, you should cast this item to one of the following: "
+                },
+                {
+                  "kind": "code",
+                  "text": "ItemCompose",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": ", "
+                },
+                {
+                  "kind": "code",
+                  "text": "ItemRead",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": ", "
+                },
+                {
+                  "kind": "code",
+                  "text": "MessageCompose",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": ", "
+                },
+                {
+                  "kind": "code",
+                  "text": "MessageRead",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": ", "
+                },
+                {
+                  "kind": "code",
+                  "text": "AppointmentCompose",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": ", "
+                },
+                {
+                  "kind": "code",
+                  "text": "AppointmentRead",
+                  "highlighter": "plain"
                 }
               ],
               "remarks": [],
@@ -20400,7 +20086,7 @@
             },
             "makeEwsRequestAsync": {
               "kind": "method",
-              "signature": "makeEwsRequestAsync(data: any, callback: (result: AsyncResult) => void, userContext?: any): void;",
+              "signature": "makeEwsRequestAsync(data: any, callback: (result: AsyncResult<string>) => void, userContext?: any): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -20426,12 +20112,21 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. The "
+                    },
+                    {
+                      "kind": "code",
+                      "text": "value",
+                      "highlighter": "plain"
+                    },
+                    {
+                      "kind": "text",
+                      "text": " property of the result is the XML of the EWS request provided as a string. If the result exceeds 1 MB in size, an error message is returned instead."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<string>) => void"
                 },
                 "userContext": {
                   "name": "userContext",
@@ -20485,7 +20180,21 @@
                 },
                 {
                   "kind": "text",
-                  "text": "Your add-in must have the ReadWriteMailbox permission to use the makeEwsRequestAsync method. For information about using the ReadWriteMailbox permission and the EWS operations that you can call with the makeEwsRequestAsync method, see Specify permissions for mail add-in access to the user's mailbox."
+                  "text": "Your add-in must have the ReadWriteMailbox permission to use the makeEwsRequestAsync method. For information about using the ReadWriteMailbox permission and the EWS operations that you can call with the makeEwsRequestAsync method, see "
+                },
+                {
+                  "kind": "web-link",
+                  "elements": [
+                    {
+                      "kind": "text",
+                      "text": " Specify permissions for mail add-in access to the user's mailbox"
+                    }
+                  ],
+                  "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
+                },
+                {
+                  "kind": "text",
+                  "text": "."
                 },
                 {
                   "kind": "paragraph"
@@ -20499,7 +20208,21 @@
                 },
                 {
                   "kind": "text",
-                  "text": "Note: This method is not supported in the following scenarios. - In Outlook for iOS or Outlook for Android - When the add-in is loaded in a Gmail mailbox"
+                  "text": "Note: This method is not supported in the following scenarios:"
+                },
+                {
+                  "kind": "paragraph"
+                },
+                {
+                  "kind": "text",
+                  "text": "- In Outlook for iOS or Outlook for Android."
+                },
+                {
+                  "kind": "paragraph"
+                },
+                {
+                  "kind": "text",
+                  "text": "- When the add-in is loaded in a Gmail mailbox."
                 },
                 {
                   "kind": "paragraph"
@@ -20526,8 +20249,9 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`<?xml version=\"1.0\" encoding=\"iso-8859-1\"?>`"
+                  "kind": "code",
+                  "text": "<?xml version=\"1.0\" encoding=\"iso-8859-1\"?>",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
@@ -20562,7 +20286,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -20603,7 +20327,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -20631,10 +20355,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -20653,7 +20373,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Information about the user associated with the mailbox. This includes their account type, display name, email adddress, and time zone."
+                  "text": "Information about the user associated with the mailbox. This includes their account type, display name, email address, and time zone."
                 },
                 {
                   "kind": "paragraph"
@@ -20676,10 +20396,6 @@
                     "exportName": "Office",
                     "memberName": "UserProfile"
                   }
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "remarks": [],
@@ -20757,10 +20473,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -20781,7 +20493,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -20813,10 +20525,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false
@@ -20932,10 +20640,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -20956,7 +20660,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -20988,10 +20692,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false
@@ -21055,10 +20755,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -21079,7 +20775,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -21111,10 +20807,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false
@@ -21165,10 +20857,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -21189,7 +20877,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -21221,12 +20909,61 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
+              "isBeta": false
+            },
+            "OWAView": {
+              "kind": "enum",
+              "values": {
+                "OneColumn": {
+                  "kind": "enum value",
+                  "value": "\"OneColumn\"",
+                  "deprecatedMessage": [],
+                  "summary": [
+                    {
+                      "kind": "text",
+                      "text": "One column view. Displayed when the screen is narrow. Outlook Web App uses this single-column layout on the entire screen of a smartphone."
+                    }
+                  ],
+                  "remarks": [],
+                  "isBeta": false
+                },
+                "ThreeColumns": {
+                  "kind": "enum value",
+                  "value": "\"ThreeColumns\"",
+                  "deprecatedMessage": [],
+                  "summary": [
+                    {
+                      "kind": "text",
+                      "text": "Three column view. Displayed when the screen is wide. For example, Outlook Web App uses this view in a full screen window on a desktop computer."
+                    }
+                  ],
+                  "remarks": [],
+                  "isBeta": false
+                },
+                "TwoColumns": {
+                  "kind": "enum value",
+                  "value": "\"TwoColumns\"",
+                  "deprecatedMessage": [],
+                  "summary": [
+                    {
+                      "kind": "text",
+                      "text": "Two column view. Displayed when the screen is wider. Outlook Web App uses this view on most tablets."
+                    }
+                  ],
+                  "remarks": [],
+                  "isBeta": false
+                }
+              },
+              "deprecatedMessage": [],
+              "summary": [
+                {
+                  "kind": "text",
+                  "text": "Represents the current view of Outlook Web App."
+                }
+              ],
+              "remarks": [],
               "isBeta": false
             },
             "RecipientType": {
@@ -21301,10 +21038,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -21325,7 +21058,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -21357,10 +21090,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false
@@ -21450,10 +21179,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -21474,7 +21199,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -21506,10 +21231,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false
@@ -21573,10 +21294,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -21597,7 +21314,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -21629,10 +21346,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false
@@ -21674,10 +21387,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -21694,7 +21403,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -21735,7 +21444,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -21763,10 +21472,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -21935,7 +21640,16 @@
             },
             {
               "kind": "text",
-              "text": "Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information."
+              "text": "Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of "
+            },
+            {
+              "kind": "code",
+              "text": "Office.context.mailbox.item",
+              "highlighter": "plain"
+            },
+            {
+              "kind": "text",
+              "text": ". Refer to the Object Model pages for more information."
             }
           ],
           "remarks": [],
@@ -21995,7 +21709,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -22036,7 +21750,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -22064,10 +21778,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -22094,7 +21804,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Office.context.mailbox.item"
+                  "text": " Office.context.mailbox.item"
                 }
               ],
               "target": {
@@ -22113,7 +21823,16 @@
             },
             {
               "kind": "text",
-              "text": "Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information."
+              "text": "Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of "
+            },
+            {
+              "kind": "code",
+              "text": "Office.context.mailbox.item",
+              "highlighter": "plain"
+            },
+            {
+              "kind": "text",
+              "text": ". Refer to the Object Model pages for more information."
             }
           ],
           "remarks": [],
@@ -22122,7 +21841,7 @@
           "members": {
             "addFileAttachmentAsync": {
               "kind": "method",
-              "signature": "addFileAttachmentAsync(uri: string, attachmentName: string, options?: AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "addFileAttachmentAsync(uri: string, attachmentName: string, options?: AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -22172,12 +21891,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type asyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of the error."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of the error."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<string>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -22210,10 +21929,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -22230,7 +21945,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -22271,7 +21986,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -22402,22 +22117,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addFileAttachmentAsync(uri: string, attachmentName: string): void;`"
+                  "kind": "code",
+                  "text": "addFileAttachmentAsync(uri: string, attachmentName: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addFileAttachmentAsync(uri: string, attachmentName: string, options: AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "addFileAttachmentAsync(uri: string, attachmentName: string, options: AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -22427,7 +22145,7 @@
             },
             "addItemAttachmentAsync": {
               "kind": "method",
-              "signature": "addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -22482,7 +22200,7 @@
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<string>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -22510,7 +22228,7 @@
                 },
                 {
                   "kind": "text",
-                  "text": "If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended."
+                  "text": "If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended."
                 },
                 {
                   "kind": "paragraph"
@@ -22521,10 +22239,6 @@
                 }
               ],
               "remarks": [
-                {
-                  "kind": "text",
-                  "text": ""
-                },
                 {
                   "kind": "html-tag",
                   "token": "<table>"
@@ -22542,7 +22256,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -22583,7 +22297,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -22652,28 +22366,31 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has these signatures:"
+                  "text": "In addition to this signature, this method also has the following signatures:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addItemAttachmentAsync(itemId: any, attachmentName: string): void;`"
+                  "kind": "code",
+                  "text": "addItemAttachmentAsync(itemId: any, attachmentName: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -22720,7 +22437,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -22761,7 +22478,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -22789,10 +22506,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -22840,7 +22553,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -22881,7 +22594,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -22909,10 +22622,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -22986,7 +22695,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -23027,7 +22736,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -23055,10 +22764,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -23131,7 +22836,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -23172,7 +22877,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -23200,10 +22905,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -23264,7 +22965,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -23305,7 +23006,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -23333,10 +23034,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -23384,7 +23081,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -23425,7 +23122,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -23453,10 +23150,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -23504,7 +23197,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -23545,7 +23238,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -23590,7 +23283,7 @@
             },
             "getSelectedDataAsync": {
               "kind": "method",
-              "signature": "getSelectedDataAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult) => void): void;",
+              "signature": "getSelectedDataAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult<any>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -23616,12 +23309,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<any>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -23670,7 +23363,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -23711,7 +23404,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -23739,10 +23432,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -23796,7 +23485,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -23837,7 +23526,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -23865,10 +23554,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -23879,7 +23564,7 @@
             },
             "loadCustomPropertiesAsync": {
               "kind": "method",
-              "signature": "loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;",
+              "signature": "loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -23893,12 +23578,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<Office.CustomProperties>) => void"
                 },
                 "userContext": {
                   "name": "userContext",
@@ -23959,7 +23644,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -24000,7 +23685,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -24028,10 +23713,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -24078,7 +23759,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -24119,7 +23800,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -24147,10 +23828,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -24161,7 +23838,7 @@
             },
             "removeAttachmentAsync": {
               "kind": "method",
-              "signature": "removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -24199,12 +23876,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -24218,7 +23895,7 @@
                 },
                 {
                   "kind": "text",
-                  "text": "The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window."
+                  "text": "The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to continue in a separate window."
                 },
                 {
                   "kind": "paragraph"
@@ -24246,7 +23923,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -24287,7 +23964,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -24362,22 +24039,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAttachmentAsync(attachmentIndex: string): void;`"
+                  "kind": "code",
+                  "text": "removeAttachmentAsync(attachmentIndex: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -24387,7 +24067,7 @@
             },
             "saveAsync": {
               "kind": "method",
-              "signature": "saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -24413,12 +24093,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -24495,7 +24175,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -24536,7 +24216,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -24611,22 +24291,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`saveAsync(): void;`"
+                  "kind": "code",
+                  "text": "saveAsync(): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`saveAsync(options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "saveAsync(options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`saveAsync(callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "saveAsync(callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -24636,7 +24319,7 @@
             },
             "setSelectedDataAsync": {
               "kind": "method",
-              "signature": "setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -24674,12 +24357,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -24721,7 +24404,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -24762,7 +24445,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -24837,22 +24520,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -24913,7 +24599,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -24954,7 +24640,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -24982,10 +24668,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -25040,7 +24722,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -25081,7 +24763,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -25109,10 +24791,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -25139,7 +24817,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Office.context.mailbox.item"
+                  "text": " Office.context.mailbox.item"
                 }
               ],
               "target": {
@@ -25176,7 +24854,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Gets an array of attachments for the item."
+                  "text": "Gets the item's attachments as an array."
                 },
                 {
                   "kind": "paragraph"
@@ -25204,7 +24882,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -25245,7 +24923,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -25286,7 +24964,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Blocked attachments in Outlook"
+                      "text": " Blocked attachments in Outlook"
                     }
                   ],
                   "targetUrl": "https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519"
@@ -25341,7 +25019,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -25382,7 +25060,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -25410,10 +25088,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -25468,7 +25142,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -25509,7 +25183,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -25537,10 +25211,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -25602,7 +25272,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -25643,7 +25313,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -25671,10 +25341,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -25722,7 +25388,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -25763,7 +25429,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -25791,10 +25457,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -25842,7 +25504,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -25883,7 +25545,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -25942,7 +25604,7 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB OR An"
+                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB OR An "
                     },
                     {
                       "kind": "api-link",
@@ -26013,10 +25675,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -26033,7 +25691,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -26074,7 +25732,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -26102,10 +25760,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -26129,7 +25783,7 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB. OR An"
+                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB. OR An "
                     },
                     {
                       "kind": "api-link",
@@ -26216,7 +25870,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -26257,7 +25911,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -26285,10 +25939,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -26356,7 +26006,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -26397,7 +26047,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -26425,10 +26075,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -26452,7 +26098,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Gets the entities found in the selected item."
+                  "text": "Gets the entities found in the selected item's body."
                 },
                 {
                   "kind": "paragraph"
@@ -26487,7 +26133,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -26528,7 +26174,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -26556,10 +26202,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -26578,7 +26220,7 @@
                 "description": [
                   {
                     "kind": "text",
-                    "text": "If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. If no entities of the specified type are present on the item, the method returns an empty array. Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter."
+                    "text": "If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. If no entities of the specified type are present in the item's body, the method returns an empty array. Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter."
                   }
                 ]
               },
@@ -26600,7 +26242,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Gets an array of all the entities of the specified entity type found in the selected item."
+                  "text": "Gets an array of all the entities of the specified entity type found in the selected item's body."
                 },
                 {
                   "kind": "paragraph"
@@ -26635,7 +26277,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -26676,7 +26318,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -27238,10 +26880,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -27324,7 +26962,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -27365,7 +27003,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -27393,10 +27031,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -27473,7 +27107,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -27514,7 +27148,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -27542,10 +27176,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -27635,7 +27265,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -27676,7 +27306,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -27704,10 +27334,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -27754,7 +27380,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -27795,7 +27421,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -27823,10 +27449,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -27881,7 +27503,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -27922,7 +27544,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -28197,7 +27819,21 @@
                 },
                 {
                   "kind": "text",
-                  "text": "Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more details, see Use the Outlook REST APIs from an Outlook add-in."
+                  "text": "Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more details, see "
+                },
+                {
+                  "kind": "web-link",
+                  "elements": [
+                    {
+                      "kind": "text",
+                      "text": " Use the Outlook REST APIs from an Outlook add-in"
+                    }
+                  ],
+                  "targetUrl": "https://docs.microsoft.com/outlook/add-ins/use-rest-api#get-the-item-id"
+                },
+                {
+                  "kind": "text",
+                  "text": "."
                 },
                 {
                   "kind": "paragraph"
@@ -28225,7 +27861,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -28266,7 +27902,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -28294,10 +27930,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -28352,7 +27984,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -28393,7 +28025,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -28421,10 +28053,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -28435,7 +28063,7 @@
             },
             "loadCustomPropertiesAsync": {
               "kind": "method",
-              "signature": "loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;",
+              "signature": "loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -28449,12 +28077,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<Office.CustomProperties>) => void"
                 },
                 "userContext": {
                   "name": "userContext",
@@ -28515,7 +28143,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -28556,7 +28184,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -28584,10 +28212,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -28641,7 +28265,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -28682,7 +28306,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -28710,10 +28334,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -28761,7 +28381,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -28802,7 +28422,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -28830,10 +28450,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -28895,7 +28511,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -28936,7 +28552,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -28964,10 +28580,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -29029,7 +28641,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -29070,7 +28682,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -29098,10 +28710,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -29156,7 +28764,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -29197,7 +28805,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -29225,10 +28833,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -29260,10 +28864,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -29280,7 +28880,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -29321,7 +28921,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -29349,10 +28949,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -29486,10 +29082,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -29506,7 +29098,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -29547,7 +29139,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -29575,10 +29167,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -29586,7 +29174,7 @@
           "members": {
             "addAsync": {
               "kind": "method",
-              "signature": "addAsync(key: string, JSONmessage: NotificationMessageDetails, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "addAsync(key: string, JSONmessage: NotificationMessageDetails, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -29636,12 +29224,19 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. [Api set: Mailbox 1.3]"
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
+                    },
+                    {
+                      "kind": "paragraph"
+                    },
+                    {
+                      "kind": "text",
+                      "text": "[Api set: Mailbox 1.3]"
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -29660,10 +29255,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -29680,7 +29271,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -29721,7 +29312,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -29761,22 +29352,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addAsync(key: string, JSONmessage: NotificationMessageDetails): void;`"
+                  "kind": "code",
+                  "text": "addAsync(key: string, JSONmessage: NotificationMessageDetails): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addAsync(key: string, JSONmessage: NotificationMessageDetails, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "addAsync(key: string, JSONmessage: NotificationMessageDetails, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addAsync(key: string, JSONmessage: NotificationMessageDetails, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "addAsync(key: string, JSONmessage: NotificationMessageDetails, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -29786,7 +29380,7 @@
             },
             "getAllAsync": {
               "kind": "method",
-              "signature": "getAllAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "getAllAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<Office.NotificationMessageDetails[]>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -29812,12 +29406,21 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. The "
+                    },
+                    {
+                      "kind": "code",
+                      "text": "value",
+                      "highlighter": "plain"
+                    },
+                    {
+                      "kind": "text",
+                      "text": " property of the result is an array of NotificationMessageDetails objects."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<Office.NotificationMessageDetails[]>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -29836,10 +29439,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -29856,7 +29455,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -29897,7 +29496,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -29931,14 +29530,15 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has this signature:"
+                  "text": "In addition to this signature, this method also has the following signature:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`getAllAsync(callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "getAllAsync(callback: (result: AsyncResult<Office.NotificationMessageDetails[]>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -29948,7 +29548,7 @@
             },
             "removeAsync": {
               "kind": "method",
-              "signature": "removeAsync(key: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "removeAsync(key: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -29986,12 +29586,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -30010,10 +29610,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -30030,7 +29626,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -30071,7 +29667,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -30105,28 +29701,31 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has these signatures:"
+                  "text": "In addition to this signature, this method also has the following signatures:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAsync(key: string): void;`"
+                  "kind": "code",
+                  "text": "removeAsync(key: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAsync(key: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "removeAsync(key: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAsync(key: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "removeAsync(key: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -30136,7 +29735,7 @@
             },
             "replaceAsync": {
               "kind": "method",
-              "signature": "replaceAsync(key: string, JSONmessage: NotificationMessageDetails, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "replaceAsync(key: string, JSONmessage: NotificationMessageDetails, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -30186,12 +29785,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -30217,10 +29816,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -30237,7 +29832,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -30278,7 +29873,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -30312,28 +29907,31 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has these signatures:"
+                  "text": "In addition to this signature, this method also has the following signatures:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`replaceAsync(key: string, JSONmessage: NotificationMessageDetails): void;`"
+                  "kind": "code",
+                  "text": "replaceAsync(key: string, JSONmessage: NotificationMessageDetails): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`replaceAsync(key: string, JSONmessage: NotificationMessageDetails, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "replaceAsync(key: string, JSONmessage: NotificationMessageDetails, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`replaceAsync(key: string, JSONmessage: NotificationMessageDetails, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "replaceAsync(key: string, JSONmessage: NotificationMessageDetails, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -30371,10 +29969,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -30391,7 +29985,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -30432,7 +30026,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -30460,10 +30054,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -30548,10 +30138,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -30568,7 +30154,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -30609,7 +30195,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -30637,10 +30223,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -30648,7 +30230,7 @@
           "members": {
             "addAsync": {
               "kind": "method",
-              "signature": "addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -30686,12 +30268,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If adding the recipients fails, the asyncResult.error property will contain an error code."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. If adding the recipients fails, the asyncResult.error property will contain an error code."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -30738,10 +30320,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -30758,7 +30336,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -30799,7 +30377,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -30868,28 +30446,31 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has these signatures:"
+                  "text": "In addition to this signature, this method also has the following signatures:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addAsync(recipients: (string | EmailUser | EmailAddressDetails)[]): void;`"
+                  "kind": "code",
+                  "text": "addAsync(recipients: (string | EmailUser | EmailAddressDetails)[]): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -30899,7 +30480,7 @@
             },
             "getAsync": {
               "kind": "method",
-              "signature": "getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;",
+              "signature": "getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult<Office.EmailAddressDetails[]>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -30925,12 +30506,21 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. The "
+                    },
+                    {
+                      "kind": "code",
+                      "text": "value",
+                      "highlighter": "plain"
+                    },
+                    {
+                      "kind": "text",
+                      "text": " property of the result is an array of EmailAddressDetails objects."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<Office.EmailAddressDetails[]>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -30944,7 +30534,7 @@
                 },
                 {
                   "kind": "text",
-                  "text": "When the call completes, the asyncResult.value property will contain an array of"
+                  "text": "When the call completes, the asyncResult.value property will contain an array of "
                 },
                 {
                   "kind": "api-link",
@@ -30975,10 +30565,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -30995,7 +30581,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -31036,7 +30622,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -31070,14 +30656,15 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has this signature:"
+                  "text": "In addition to this signature, this method also has the following signature:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`getAsync(callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "getAsync(callback: (result: AsyncResult<Office.EmailAddressDetails[]>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -31087,7 +30674,7 @@
             },
             "setAsync": {
               "kind": "method",
-              "signature": "setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -31125,12 +30712,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If setting the recipients fails the asyncResult.error property will contain a code that indicates any error that occurred while adding the data."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. If setting the recipients fails the asyncResult.error property will contain a code that indicates any error that occurred while adding the data."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -31222,10 +30809,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -31242,7 +30825,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -31283,7 +30866,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -31352,28 +30935,31 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has these signatures:"
+                  "text": "In addition to this signature, this method also has the following signatures:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(recipients: (string | EmailUser | EmailAddressDetails)[]): void;`"
+                  "kind": "code",
+                  "text": "setAsync(recipients: (string | EmailUser | EmailAddressDetails)[]): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -31564,16 +31150,16 @@
             },
             "callback": {
               "kind": "property",
-              "signature": "callback?: (result: AsyncResult) => void;",
+              "signature": "callback?: (result: AsyncResult<any>) => void;",
               "isOptional": true,
               "isReadOnly": false,
               "isStatic": false,
-              "type": "(result: AsyncResult) => void",
+              "type": "(result: AsyncResult<any>) => void",
               "deprecatedMessage": [],
               "summary": [
                 {
                   "kind": "text",
-                  "text": "When the reply display call completes, the function passed in the callback parameter is called with a single parameter, asyncResult, which is an AsyncResult object."
+                  "text": "When the reply display call completes, the function passed in the callback parameter is called with a single parameter, asyncResult, which is an Office.AsyncResult object."
                 }
               ],
               "remarks": [],
@@ -31622,7 +31208,7 @@
             },
             {
               "kind": "text",
-              "text": "While the Outlook add-in API limits access to these settings to only the add-in that created them, these settings should not be considered secure storage. They can be accessed by Exchange Web Services or Extended MAPI. They should not be used to store sensitive information such as user credentials or security tokens."
+              "text": "While the Outlook Add-in API limits access to these settings to only the add-in that created them, these settings should not be considered secure storage. They can be accessed by Exchange Web Services or Extended MAPI. They should not be used to store sensitive information such as user credentials or security tokens."
             },
             {
               "kind": "paragraph"
@@ -31655,10 +31241,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -31675,7 +31257,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -31716,7 +31298,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -31744,10 +31326,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -31798,10 +31376,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -31818,7 +31392,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -31859,7 +31433,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -31887,10 +31461,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -31938,10 +31508,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -31958,7 +31524,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -31999,7 +31565,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -32027,10 +31593,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -32040,7 +31602,7 @@
             },
             "saveAsync": {
               "kind": "method",
-              "signature": "saveAsync(callback?: (result: AsyncResult) => void): void;",
+              "signature": "saveAsync(callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -32054,12 +31616,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional? When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -32085,10 +31647,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -32105,7 +31663,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -32146,7 +31704,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -32174,10 +31732,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -32258,10 +31812,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -32278,7 +31828,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -32319,7 +31869,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -32347,10 +31897,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -32416,10 +31962,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -32436,7 +31978,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -32477,7 +32019,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -32505,10 +32047,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -32516,7 +32054,7 @@
           "members": {
             "getAsync": {
               "kind": "method",
-              "signature": "getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;",
+              "signature": "getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult<string>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -32542,12 +32080,21 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. The "
+                    },
+                    {
+                      "kind": "code",
+                      "text": "value",
+                      "highlighter": "plain"
+                    },
+                    {
+                      "kind": "text",
+                      "text": " property of the result is the subject of the item."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<string>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -32573,10 +32120,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -32593,7 +32136,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -32634,7 +32177,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -32668,14 +32211,15 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has this signature:"
+                  "text": "In addition to this signature, this method also has the following signature:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`getAsync(callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "getAsync(callback: (result: AsyncResult<string>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -32685,7 +32229,7 @@
             },
             "setAsync": {
               "kind": "method",
-              "signature": "setAsync(subject: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "setAsync(subject: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -32723,12 +32267,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If setting the subject fails, the asyncResult.error property will contain an error code."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. If setting the subject fails, the asyncResult.error property will contain an error code."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -32754,10 +32298,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -32774,7 +32314,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -32815,7 +32355,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -32884,28 +32424,31 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has these signatures:"
+                  "text": "In addition to this signature, this method also has the following signatures:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(subject: string): void;`"
+                  "kind": "code",
+                  "text": "setAsync(subject: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(subject: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "setAsync(subject: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(subject: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "setAsync(subject: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -32931,7 +32474,26 @@
             },
             {
               "kind": "text",
-              "text": "The list of tasks suggested in an email message is returned in the taskSuggestions property of the [Entities]Entities object that is returned when the getEntities or getEntitiesByType method is called on the active item."
+              "text": "The list of tasks suggested in an email message is returned in the taskSuggestions property of the "
+            },
+            {
+              "kind": "api-link",
+              "elements": [
+                {
+                  "kind": "text",
+                  "text": " Entities"
+                }
+              ],
+              "target": {
+                "scopeName": "",
+                "packageName": "Outlook_1_3",
+                "exportName": "Office",
+                "memberName": "Entities"
+              }
+            },
+            {
+              "kind": "text",
+              "text": " object that is returned when the getEntities or getEntitiesByType method is called on the active item."
             },
             {
               "kind": "paragraph"
@@ -32942,10 +32504,6 @@
             }
           ],
           "remarks": [
-            {
-              "kind": "text",
-              "text": ""
-            },
             {
               "kind": "html-tag",
               "token": "<table>"
@@ -32963,7 +32521,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -33004,7 +32562,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -33032,10 +32590,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -33106,10 +32660,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -33126,7 +32676,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -33167,7 +32717,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -33195,10 +32745,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -33206,7 +32752,7 @@
           "members": {
             "getAsync": {
               "kind": "method",
-              "signature": "getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;",
+              "signature": "getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult<Date>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -33232,12 +32778,21 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. The "
+                    },
+                    {
+                      "kind": "code",
+                      "text": "value",
+                      "highlighter": "plain"
+                    },
+                    {
+                      "kind": "text",
+                      "text": " property of the result is a Date object."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<Date>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -33263,10 +32818,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -33283,7 +32834,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -33324,7 +32875,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -33358,14 +32909,15 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has this signature:"
+                  "text": "In addition to this signature, this method also has the following signature:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`getAsync(callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "getAsync(callback: (result: AsyncResult<Date>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -33375,7 +32927,7 @@
             },
             "setAsync": {
               "kind": "method",
-              "signature": "setAsync(dateTime: Date, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "setAsync(dateTime: Date, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -33413,12 +32965,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If setting the date and time fails, the asyncResult.error property will contain an error code."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. If setting the date and time fails, the asyncResult.error property will contain an error code."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -33451,10 +33003,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -33471,7 +33019,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -33512,7 +33060,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -33581,28 +33129,31 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has these signatures:"
+                  "text": "In addition to this signature, this method also has the following signatures:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(dateTime: Date): void;`"
+                  "kind": "code",
+                  "text": "setAsync(dateTime: Date): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(dateTime: Date, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "setAsync(dateTime: Date, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(dateTime: Date, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "setAsync(dateTime: Date, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -33633,10 +33184,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -33653,7 +33200,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -33694,7 +33241,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -33722,10 +33269,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -33754,10 +33297,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -33774,7 +33313,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -33815,7 +33354,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -33843,10 +33382,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -33878,10 +33413,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -33898,7 +33429,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -33939,7 +33470,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -33967,10 +33498,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -34002,10 +33529,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -34022,7 +33545,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -34063,7 +33586,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -34091,10 +33614,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,

--- a/generate-docs/json/Outlook_1_4.api.json
+++ b/generate-docs/json/Outlook_1_4.api.json
@@ -69,7 +69,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Office.context.mailbox.item"
+                  "text": " Office.context.mailbox.item"
                 }
               ],
               "target": {
@@ -88,7 +88,16 @@
             },
             {
               "kind": "text",
-              "text": "Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information."
+              "text": "Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of "
+            },
+            {
+              "kind": "code",
+              "text": "Office.context.mailbox.item",
+              "highlighter": "plain"
+            },
+            {
+              "kind": "text",
+              "text": ". Refer to the Object Model pages for more information."
             }
           ],
           "remarks": [],
@@ -97,7 +106,7 @@
           "members": {
             "addFileAttachmentAsync": {
               "kind": "method",
-              "signature": "addFileAttachmentAsync(uri: string, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "addFileAttachmentAsync(uri: string, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -152,7 +161,7 @@
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<string>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -185,10 +194,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -205,7 +210,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -246,7 +251,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -377,22 +382,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addFileAttachmentAsync(uri: string, attachmentName: string): void;`"
+                  "kind": "code",
+                  "text": "addFileAttachmentAsync(uri: string, attachmentName: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addFileAttachmentAsync(uri: string, attachmentName: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "addFileAttachmentAsync(uri: string, attachmentName: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -402,7 +410,7 @@
             },
             "addItemAttachmentAsync": {
               "kind": "method",
-              "signature": "addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -452,12 +460,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<string>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -485,7 +493,7 @@
                 },
                 {
                   "kind": "text",
-                  "text": "If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended."
+                  "text": "If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended."
                 },
                 {
                   "kind": "paragraph"
@@ -496,10 +504,6 @@
                 }
               ],
               "remarks": [
-                {
-                  "kind": "text",
-                  "text": ""
-                },
                 {
                   "kind": "html-tag",
                   "token": "<table>"
@@ -517,7 +521,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -558,7 +562,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -627,28 +631,31 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has these signatures:"
+                  "text": "In addition to this signature, this method also has the following signatures:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addItemAttachmentAsync(itemId: any, attachmentName: string): void;`"
+                  "kind": "code",
+                  "text": "addItemAttachmentAsync(itemId: any, attachmentName: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -695,7 +702,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -736,7 +743,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -764,10 +771,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -840,7 +843,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -881,7 +884,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -909,10 +912,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -959,7 +958,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -1000,7 +999,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -1028,10 +1027,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -1079,7 +1074,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -1120,7 +1115,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -1235,7 +1230,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -1276,7 +1271,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -1304,10 +1299,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -1318,7 +1309,7 @@
             },
             "getSelectedDataAsync": {
               "kind": "method",
-              "signature": "getSelectedDataAsync(coerciontype: Office.CoercionType, options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;",
+              "signature": "getSelectedDataAsync(coerciontype: Office.CoercionType, options: Office.AsyncContextOptions, callback: (result: AsyncResult<any>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -1361,7 +1352,7 @@
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<any>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -1410,7 +1401,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -1451,7 +1442,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -1479,10 +1470,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -1536,7 +1523,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -1577,7 +1564,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -1605,10 +1592,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -1619,7 +1602,7 @@
             },
             "loadCustomPropertiesAsync": {
               "kind": "method",
-              "signature": "loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;",
+              "signature": "loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -1633,12 +1616,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<Office.CustomProperties>) => void"
                 },
                 "userContext": {
                   "name": "userContext",
@@ -1699,7 +1682,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -1740,7 +1723,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -1768,10 +1751,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -1837,7 +1816,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -1878,7 +1857,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -1906,10 +1885,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -1957,7 +1932,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -1998,7 +1973,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -2026,10 +2001,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -2096,7 +2067,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -2137,7 +2108,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -2165,10 +2136,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -2179,7 +2146,7 @@
             },
             "removeAttachmentAsync": {
               "kind": "method",
-              "signature": "removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -2217,12 +2184,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -2236,7 +2203,7 @@
                 },
                 {
                   "kind": "text",
-                  "text": "The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window."
+                  "text": "The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to continue in a separate window."
                 },
                 {
                   "kind": "paragraph"
@@ -2264,7 +2231,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -2305,7 +2272,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -2380,22 +2347,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAttachmentAsync(attachmentIndex: string): void;`"
+                  "kind": "code",
+                  "text": "removeAttachmentAsync(attachmentIndex: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -2461,7 +2431,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -2502,7 +2472,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -2530,10 +2500,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -2544,7 +2510,7 @@
             },
             "saveAsync": {
               "kind": "method",
-              "signature": "saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -2570,12 +2536,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -2652,7 +2618,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -2693,7 +2659,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -2768,22 +2734,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`saveAsync(): void;`"
+                  "kind": "code",
+                  "text": "saveAsync(): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`saveAsync(options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "saveAsync(options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`saveAsync(callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "saveAsync(callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -2793,7 +2762,7 @@
             },
             "setSelectedDataAsync": {
               "kind": "method",
-              "signature": "setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -2831,12 +2800,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -2878,7 +2847,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -2919,7 +2888,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -2994,22 +2963,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -3089,7 +3061,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -3130,7 +3102,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -3158,10 +3130,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -3223,7 +3191,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -3264,7 +3232,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -3292,10 +3260,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -3327,10 +3291,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -3347,7 +3307,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -3388,7 +3348,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -3416,10 +3376,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -3464,7 +3420,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -3505,7 +3461,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -3533,10 +3489,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -3626,7 +3578,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -3667,7 +3619,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -3695,10 +3647,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -3774,7 +3722,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -3816,7 +3764,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -3844,10 +3792,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -3923,7 +3867,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -3964,7 +3908,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -3992,10 +3936,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -4071,7 +4011,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -4112,7 +4052,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -4140,10 +4080,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -4249,7 +4185,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -4290,7 +4226,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -4318,10 +4254,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -4404,7 +4336,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -4445,7 +4377,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -4473,10 +4405,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -4503,7 +4431,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Office.context.mailbox.item"
+                  "text": " Office.context.mailbox.item"
                 }
               ],
               "target": {
@@ -4540,7 +4468,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Gets an array of attachments for the item."
+                  "text": "Gets the item's attachments as an array."
                 },
                 {
                   "kind": "paragraph"
@@ -4568,7 +4496,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -4609,7 +4537,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -4650,7 +4578,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Blocked attachments in Outlook"
+                      "text": " Blocked attachments in Outlook"
                     }
                   ],
                   "targetUrl": "https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519"
@@ -4705,7 +4633,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -4746,7 +4674,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -4774,10 +4702,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -4825,7 +4749,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -4866,7 +4790,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -4894,10 +4818,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -4945,7 +4865,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -4986,7 +4906,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -5045,7 +4965,7 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB OR An"
+                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB OR An "
                     },
                     {
                       "kind": "api-link",
@@ -5116,10 +5036,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -5136,7 +5052,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -5177,7 +5093,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -5205,10 +5121,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -5232,7 +5144,7 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB. OR An"
+                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB. OR An "
                     },
                     {
                       "kind": "api-link",
@@ -5319,7 +5231,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -5360,7 +5272,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -5388,10 +5300,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -5452,7 +5360,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -5493,7 +5401,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -5521,10 +5429,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -5548,7 +5452,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Gets the entities found in the selected item."
+                  "text": "Gets the entities found in the selected item's body."
                 },
                 {
                   "kind": "paragraph"
@@ -5583,7 +5487,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -5624,7 +5528,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -5652,10 +5556,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -5674,7 +5574,7 @@
                 "description": [
                   {
                     "kind": "text",
-                    "text": "If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. If no entities of the specified type are present on the item, the method returns an empty array. Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter."
+                    "text": "If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. If no entities of the specified type are present in the item's body, the method returns an empty array. Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter."
                   }
                 ]
               },
@@ -5696,7 +5596,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Gets an array of all the entities of the specified entity type found in the selected item."
+                  "text": "Gets an array of all the entities of the specified entity type found in the selected item's body."
                 },
                 {
                   "kind": "paragraph"
@@ -5715,10 +5615,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -5735,7 +5631,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -5776,7 +5672,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -6338,10 +6234,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -6424,7 +6316,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -6465,7 +6357,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -6493,10 +6385,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -6573,7 +6461,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -6614,7 +6502,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -6642,10 +6530,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -6735,7 +6619,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -6776,7 +6660,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -6804,10 +6688,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -6861,7 +6741,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -6902,7 +6782,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -7177,7 +7057,21 @@
                 },
                 {
                   "kind": "text",
-                  "text": "Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more details, see Use the Outlook REST APIs from an Outlook add-in."
+                  "text": "Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more details, see "
+                },
+                {
+                  "kind": "web-link",
+                  "elements": [
+                    {
+                      "kind": "text",
+                      "text": " Use the Outlook REST APIs from an Outlook add-in"
+                    }
+                  ],
+                  "targetUrl": "https://docs.microsoft.com/outlook/add-ins/use-rest-api#get-the-item-id"
+                },
+                {
+                  "kind": "text",
+                  "text": "."
                 },
                 {
                   "kind": "paragraph"
@@ -7205,7 +7099,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -7246,7 +7140,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -7274,10 +7168,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -7332,7 +7222,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -7373,7 +7263,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -7401,10 +7291,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -7415,7 +7301,7 @@
             },
             "loadCustomPropertiesAsync": {
               "kind": "method",
-              "signature": "loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;",
+              "signature": "loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -7429,12 +7315,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<Office.CustomProperties>) => void"
                 },
                 "userContext": {
                   "name": "userContext",
@@ -7495,7 +7381,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -7536,7 +7422,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -7564,10 +7450,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -7621,7 +7503,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -7662,7 +7544,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -7690,10 +7572,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -7748,7 +7626,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -7789,7 +7667,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -7817,10 +7695,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -7868,7 +7742,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -7909,7 +7783,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -7937,10 +7811,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -8014,7 +7884,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -8055,7 +7925,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -8083,10 +7953,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -8106,7 +7972,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Gets the email address of the meeting organizer for a specified meeting. Read mode only."
+                  "text": "Gets the email address of the meeting organizer for a specified meeting."
                 },
                 {
                   "kind": "paragraph"
@@ -8134,7 +8000,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -8175,7 +8041,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -8203,10 +8069,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -8280,7 +8142,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -8321,7 +8183,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -8349,10 +8211,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -8407,7 +8265,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -8448,7 +8306,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -8476,10 +8334,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -8541,7 +8395,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -8582,7 +8436,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -8610,10 +8464,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -8652,10 +8502,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -8672,7 +8518,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -8713,7 +8559,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -8741,10 +8587,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -8899,10 +8741,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -8919,7 +8757,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -8960,7 +8798,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -8988,10 +8826,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -8999,7 +8833,7 @@
           "members": {
             "getAsync": {
               "kind": "method",
-              "signature": "getAsync(coerciontype: Office.CoercionType, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "getAsync(coerciontype: Office.CoercionType, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<Office.Body>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -9037,7 +8871,7 @@
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<Office.Body>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -9070,10 +8904,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -9090,7 +8920,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -9131,7 +8961,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -9165,14 +8995,15 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has this signature:"
+                  "text": "In addition to this signature, this method also has the following signature:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`getAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "getAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult<Office.Body>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -9182,7 +9013,7 @@
             },
             "getTypeAsync": {
               "kind": "method",
-              "signature": "getTypeAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "getTypeAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<Office.CoercionType>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -9208,12 +9039,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. The content type is returned as one of the CoercionType values in the asyncResult.value property."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. The content type is returned as one of the CoercionType values in the asyncResult.value property."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<Office.CoercionType>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -9232,10 +9063,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -9252,7 +9079,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -9293,7 +9120,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -9321,10 +9148,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -9334,7 +9157,7 @@
             },
             "prependAsync": {
               "kind": "method",
-              "signature": "prependAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "prependAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -9372,12 +9195,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. Any errors encountered will be provided in the asyncResult.error property."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. Any errors encountered will be provided in the asyncResult.error property."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -9418,10 +9241,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -9438,7 +9257,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -9479,7 +9298,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -9548,28 +9367,31 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has these signatures:"
+                  "text": "In addition to this signature, this method also has the following signatures:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`prependAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`"
+                  "kind": "code",
+                  "text": "prependAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`prependAsync(data: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "prependAsync(data: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`prependAsync(data: string): void;`"
+                  "kind": "code",
+                  "text": "prependAsync(data: string): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -9579,7 +9401,7 @@
             },
             "setAsync": {
               "kind": "method",
-              "signature": "setAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "setAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -9617,12 +9439,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. Any errors encountered will be provided in the asyncResult.error property."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. Any errors encountered will be provided in the asyncResult.error property."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -9663,10 +9485,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -9683,7 +9501,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -9724,7 +9542,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -9821,28 +9639,31 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has these signatures:"
+                  "text": "In addition to this signature, this method also has the following signatures:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`"
+                  "kind": "code",
+                  "text": "setAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(data: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "setAsync(data: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(data: string): void;`"
+                  "kind": "code",
+                  "text": "setAsync(data: string): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -9852,7 +9673,7 @@
             },
             "setSelectedDataAsync": {
               "kind": "method",
-              "signature": "setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -9890,12 +9711,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. Any errors encountered will be provided in the asyncResult.error property."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. Any errors encountered will be provided in the asyncResult.error property."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -9936,10 +9757,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -9956,7 +9773,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -9997,7 +9814,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -10094,28 +9911,31 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has these signatures:"
+                  "text": "In addition to this signature, this method also has the following signatures:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -10201,10 +10021,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -10221,7 +10037,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -10262,7 +10078,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -10290,10 +10106,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -10455,10 +10267,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -10475,7 +10283,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -10516,7 +10324,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -10544,10 +10352,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -10598,10 +10402,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -10618,7 +10418,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -10659,7 +10459,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -10687,10 +10487,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -10714,7 +10510,14 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "The name of the property to be removed. [Api set: Mailbox 1.0]"
+                      "text": "The name of the property to be removed."
+                    },
+                    {
+                      "kind": "paragraph"
+                    },
+                    {
+                      "kind": "text",
+                      "text": "[Api set: Mailbox 1.0]"
                     }
                   ],
                   "isOptional": false,
@@ -10738,10 +10541,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -10758,7 +10557,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -10799,7 +10598,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -10827,10 +10626,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -10840,7 +10635,7 @@
             },
             "saveAsync": {
               "kind": "method",
-              "signature": "saveAsync(callback?: (result: AsyncResult) => void, asyncContext?: any): void;",
+              "signature": "saveAsync(callback?: (result: AsyncResult<void>) => void, asyncContext?: any): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -10854,19 +10649,26 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 },
                 "asyncContext": {
                   "name": "asyncContext",
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. Any state data that is passed to the callback method. [Api set: Mailbox 1.0]"
+                      "text": "Optional. Any state data that is passed to the callback method."
+                    },
+                    {
+                      "kind": "paragraph"
+                    },
+                    {
+                      "kind": "text",
+                      "text": "[Api set: Mailbox 1.0]"
                     }
                   ],
                   "isOptional": true,
@@ -10897,10 +10699,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -10917,7 +10715,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -10958,7 +10756,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -10986,10 +10784,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -11063,10 +10857,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -11083,7 +10873,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -11124,7 +10914,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -11152,10 +10942,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -11186,10 +10972,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -11206,7 +10988,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -11247,7 +11029,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -11275,10 +11057,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -11314,10 +11092,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -11334,7 +11108,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -11375,7 +11149,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -11403,10 +11177,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -11445,10 +11215,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -11465,7 +11231,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -11506,7 +11272,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -11534,10 +11300,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -11548,11 +11310,11 @@
             },
             "OWAView": {
               "kind": "property",
-              "signature": "OWAView: \"string\";",
+              "signature": "OWAView: MailboxEnums.OWAView | \"OneColumn\" | \"TwoColumns\" | \"ThreeColumns\";",
               "isOptional": false,
               "isReadOnly": false,
               "isStatic": false,
-              "type": "\"string\"",
+              "type": "MailboxEnums.OWAView | \"OneColumn\" | \"TwoColumns\" | \"ThreeColumns\"",
               "deprecatedMessage": [],
               "summary": [
                 {
@@ -11611,10 +11373,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -11631,7 +11389,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -11672,7 +11430,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -11700,10 +11458,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -11735,10 +11489,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -11755,7 +11505,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -11796,7 +11546,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -11824,10 +11574,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -11940,10 +11686,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -11960,7 +11702,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -12001,7 +11743,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -12029,10 +11771,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -12145,10 +11883,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -12165,7 +11899,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -12206,7 +11940,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -12234,10 +11968,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -12401,7 +12131,16 @@
           "summary": [
             {
               "kind": "text",
-              "text": "The item namespace is used to access the currently selected message, meeting request, or appointment. You can determine the type of the item by using the `itemType` property."
+              "text": "The item namespace is used to access the currently selected message, meeting request, or appointment. You can determine the type of the item by using the "
+            },
+            {
+              "kind": "code",
+              "text": "itemType",
+              "highlighter": "plain"
+            },
+            {
+              "kind": "text",
+              "text": " property."
             },
             {
               "kind": "paragraph"
@@ -12412,10 +12151,6 @@
             }
           ],
           "remarks": [
-            {
-              "kind": "text",
-              "text": ""
-            },
             {
               "kind": "html-tag",
               "token": "<table>"
@@ -12433,7 +12168,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -12474,7 +12209,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -12502,10 +12237,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -12550,7 +12281,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -12591,7 +12322,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -12619,10 +12350,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -12670,7 +12397,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -12711,7 +12438,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -12739,10 +12466,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -12790,7 +12513,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -12831,7 +12554,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -12920,7 +12643,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -12961,7 +12684,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -12989,10 +12712,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -13003,7 +12722,7 @@
             },
             "loadCustomPropertiesAsync": {
               "kind": "method",
-              "signature": "loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;",
+              "signature": "loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -13017,12 +12736,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<Office.CustomProperties>) => void"
                 },
                 "userContext": {
                   "name": "userContext",
@@ -13083,7 +12802,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -13124,7 +12843,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -13152,10 +12871,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -13202,7 +12917,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -13243,7 +12958,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -13271,10 +12986,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -13301,7 +13012,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Office.context.mailbox.item"
+                  "text": " Office.context.mailbox.item"
                 }
               ],
               "target": {
@@ -13320,7 +13031,16 @@
             },
             {
               "kind": "text",
-              "text": "Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information."
+              "text": "Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of "
+            },
+            {
+              "kind": "code",
+              "text": "Office.context.mailbox.item",
+              "highlighter": "plain"
+            },
+            {
+              "kind": "text",
+              "text": ". Refer to the Object Model pages for more information."
             }
           ],
           "remarks": [],
@@ -13329,7 +13049,7 @@
           "members": {
             "addFileAttachmentAsync": {
               "kind": "method",
-              "signature": "addFileAttachmentAsync(uri: string, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "addFileAttachmentAsync(uri: string, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -13384,7 +13104,7 @@
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<string>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -13417,10 +13137,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -13437,7 +13153,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -13478,7 +13194,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -13601,22 +13317,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addFileAttachmentAsync(uri: string, attachmentName: string): void;`"
+                  "kind": "code",
+                  "text": "addFileAttachmentAsync(uri: string, attachmentName: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addFileAttachmentAsync(uri: string, attachmentName: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "addFileAttachmentAsync(uri: string, attachmentName: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -13626,7 +13345,7 @@
             },
             "addItemAttachmentAsync": {
               "kind": "method",
-              "signature": "addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -13676,12 +13395,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<string>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -13709,7 +13428,7 @@
                 },
                 {
                   "kind": "text",
-                  "text": "If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended."
+                  "text": "If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended."
                 },
                 {
                   "kind": "paragraph"
@@ -13720,10 +13439,6 @@
                 }
               ],
               "remarks": [
-                {
-                  "kind": "text",
-                  "text": ""
-                },
                 {
                   "kind": "html-tag",
                   "token": "<table>"
@@ -13741,7 +13456,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -13782,7 +13497,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -13851,28 +13566,31 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has these signatures:"
+                  "text": "In addition to this signature, this method also has the following signatures:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addItemAttachmentAsync(itemId: any, attachmentName: string): void;`"
+                  "kind": "code",
+                  "text": "addItemAttachmentAsync(itemId: any, attachmentName: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -13944,7 +13662,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -13985,7 +13703,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -14013,10 +13731,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -14026,7 +13740,7 @@
             },
             "getSelectedDataAsync": {
               "kind": "method",
-              "signature": "getSelectedDataAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult) => void): void;",
+              "signature": "getSelectedDataAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult<any>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -14052,12 +13766,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<any>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -14106,7 +13820,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -14147,7 +13861,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -14175,10 +13889,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -14188,7 +13898,7 @@
             },
             "removeAttachmentAsync": {
               "kind": "method",
-              "signature": "removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -14226,12 +13936,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -14245,7 +13955,7 @@
                 },
                 {
                   "kind": "text",
-                  "text": "The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window."
+                  "text": "The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to continue in a separate window."
                 },
                 {
                   "kind": "paragraph"
@@ -14273,7 +13983,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -14314,7 +14024,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -14389,22 +14099,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAttachmentAsync(attachmentIndex: string): void;`"
+                  "kind": "code",
+                  "text": "removeAttachmentAsync(attachmentIndex: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -14414,7 +14127,7 @@
             },
             "saveAsync": {
               "kind": "method",
-              "signature": "saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -14440,12 +14153,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -14522,7 +14235,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -14563,7 +14276,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -14638,22 +14351,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`saveAsync(): void;`"
+                  "kind": "code",
+                  "text": "saveAsync(): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`saveAsync(options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "saveAsync(options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`saveAsync(callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "saveAsync(callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -14663,7 +14379,7 @@
             },
             "setSelectedDataAsync": {
               "kind": "method",
-              "signature": "setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -14701,12 +14417,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -14748,7 +14464,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -14789,7 +14505,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -14864,22 +14580,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -14940,7 +14659,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -14981,7 +14700,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -15009,10 +14728,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -15039,7 +14754,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Office.context.mailbox.item"
+                  "text": " Office.context.mailbox.item"
                 }
               ],
               "target": {
@@ -15058,7 +14773,16 @@
             },
             {
               "kind": "text",
-              "text": "Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information."
+              "text": "Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of "
+            },
+            {
+              "kind": "code",
+              "text": "Office.context.mailbox.item",
+              "highlighter": "plain"
+            },
+            {
+              "kind": "text",
+              "text": ". Refer to the Object Model pages for more information."
             }
           ],
           "remarks": [],
@@ -15076,7 +14800,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Gets an array of attachments for the item."
+                  "text": "Gets the item's attachments as an array."
                 },
                 {
                   "kind": "paragraph"
@@ -15087,10 +14811,6 @@
                 }
               ],
               "remarks": [
-                {
-                  "kind": "text",
-                  "text": ""
-                },
                 {
                   "kind": "html-tag",
                   "token": "<table>"
@@ -15108,7 +14828,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -15149,7 +14869,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -15190,7 +14910,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Blocked attachments in Outlook"
+                      "text": " Blocked attachments in Outlook"
                     }
                   ],
                   "targetUrl": "https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519"
@@ -15222,7 +14942,7 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB OR An"
+                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB OR An "
                     },
                     {
                       "kind": "api-link",
@@ -15293,10 +15013,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -15313,7 +15029,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -15354,7 +15070,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -15382,10 +15098,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -15409,7 +15121,7 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB. OR An"
+                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB. OR An "
                     },
                     {
                       "kind": "api-link",
@@ -15496,7 +15208,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -15537,7 +15249,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -15565,10 +15277,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -15591,7 +15299,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Gets the entities found in the selected item."
+                  "text": "Gets the entities found in the selected item's body."
                 },
                 {
                   "kind": "paragraph"
@@ -15626,7 +15334,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -15667,7 +15375,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -15695,10 +15403,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -15717,7 +15421,7 @@
                 "description": [
                   {
                     "kind": "text",
-                    "text": "If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. If no entities of the specified type are present on the item, the method returns an empty array. Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter."
+                    "text": "If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. If no entities of the specified type are present in the item's body, the method returns an empty array. Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter."
                   }
                 ]
               },
@@ -15739,7 +15443,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Gets an array of all the entities of the specified entity type found in the selected item."
+                  "text": "Gets an array of all the entities of the specified entity type found in the selected item's body."
                 },
                 {
                   "kind": "paragraph"
@@ -15758,10 +15462,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -15778,7 +15478,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -15819,7 +15519,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -16381,10 +16081,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -16467,7 +16163,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -16508,7 +16204,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -16536,10 +16232,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -16616,7 +16308,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -16657,7 +16349,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -16685,10 +16377,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -16778,7 +16466,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -16819,7 +16507,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -16847,10 +16535,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -16904,7 +16588,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -16945,7 +16629,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -17187,10 +16871,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -17224,7 +16904,21 @@
                 },
                 {
                   "kind": "text",
-                  "text": "Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more details, see Use the Outlook REST APIs from an Outlook add-in."
+                  "text": "Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more details, see "
+                },
+                {
+                  "kind": "web-link",
+                  "elements": [
+                    {
+                      "kind": "text",
+                      "text": " Use the Outlook REST APIs from an Outlook add-in"
+                    }
+                  ],
+                  "targetUrl": "https://docs.microsoft.com/outlook/add-ins/use-rest-api#get-the-item-id"
+                },
+                {
+                  "kind": "text",
+                  "text": "."
                 },
                 {
                   "kind": "paragraph"
@@ -17252,7 +16946,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -17293,7 +16987,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -17321,10 +17015,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -17379,7 +17069,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -17420,7 +17110,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -17448,10 +17138,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -17513,7 +17199,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -17554,7 +17240,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -17582,10 +17268,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -17633,7 +17315,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -17674,7 +17356,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -17702,10 +17384,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -17902,10 +17580,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -17922,7 +17596,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -17963,7 +17637,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -17991,10 +17665,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -18002,7 +17672,7 @@
           "members": {
             "getAsync": {
               "kind": "method",
-              "signature": "getAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "getAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -18028,12 +17698,19 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. [Api set: Mailbox 1.1]"
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
+                    },
+                    {
+                      "kind": "paragraph"
+                    },
+                    {
+                      "kind": "text",
+                      "text": "[Api set: Mailbox 1.1]"
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<string>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -18052,10 +17729,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -18072,7 +17745,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -18113,7 +17786,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -18153,8 +17826,9 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`getAsync(callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "getAsync(callback: (result: AsyncResult<string>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -18164,7 +17838,7 @@
             },
             "setAsync": {
               "kind": "method",
-              "signature": "setAsync(location: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "setAsync(location: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -18202,12 +17876,19 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If setting the location fails, the asyncResult.error property will contain an error code. [Api set: Mailbox 1.1]"
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. If setting the location fails, the asyncResult.error property will contain an error code."
+                    },
+                    {
+                      "kind": "paragraph"
+                    },
+                    {
+                      "kind": "text",
+                      "text": "[Api set: Mailbox 1.1]"
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -18226,10 +17907,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -18246,7 +17923,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -18287,7 +17964,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -18362,22 +18039,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(location: string): void;`"
+                  "kind": "code",
+                  "text": "setAsync(location: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(location: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "setAsync(location: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(location: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "setAsync(location: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -18396,7 +18076,7 @@
           "summary": [
             {
               "kind": "text",
-              "text": "Provides access to the Outlook add-in object model for Microsoft Outlook and Microsoft Outlook on the web."
+              "text": "Provides access to the Outlook Add-in object model for Microsoft Outlook and Microsoft Outlook on the web."
             },
             {
               "kind": "paragraph"
@@ -18436,10 +18116,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -18456,7 +18132,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -18497,7 +18173,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -18525,10 +18201,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -18616,7 +18288,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -18657,7 +18329,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -18685,10 +18357,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -18766,7 +18434,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -18807,7 +18475,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -18835,10 +18503,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -18921,7 +18585,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -18962,7 +18626,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -19003,7 +18667,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Outlook Mail API"
+                      "text": " Outlook Mail API"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/previous-versions/office/office-365-api/api/version-2.0/mail-rest-operations"
@@ -19017,7 +18681,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Microsoft Graph"
+                      "text": " Microsoft Graph"
                     }
                   ],
                   "targetUrl": "http://graph.microsoft.io/"
@@ -19100,7 +18764,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -19141,7 +18805,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -19169,10 +18833,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -19219,7 +18879,7 @@
                 },
                 {
                   "kind": "text",
-                  "text": "- OWAView (string): A string that represents the current view of Outlook Web App. If the host application is not Outlook Web App, then accessing this property results in undefined. Outlook Web App has three views (OneColumn - displayed when the screen is narrow, TwoColumns - displayed when the screen is wider, and ThreeColumns - displayed when the screen is wide.) that correspond to the width of the screen and the window, and the number of columns that can be displayed."
+                  "text": "- OWAView (MailboxEnums.OWAView or string): An enum (or string literal) that represents the current view of Outlook Web App. If the host application is not Outlook Web App, then accessing this property results in undefined. Outlook Web App has three views (OneColumn - displayed when the screen is narrow, TwoColumns - displayed when the screen is wider, and ThreeColumns - displayed when the screen is wide) that correspond to the width of the screen and the window, and the number of columns that can be displayed."
                 },
                 {
                   "kind": "paragraph"
@@ -19257,10 +18917,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -19277,7 +18933,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -19318,7 +18974,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -19346,10 +19002,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -19449,7 +19101,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -19490,7 +19142,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -19518,10 +19170,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -19620,7 +19268,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -19661,7 +19309,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -19689,10 +19337,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -19791,7 +19435,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -19832,7 +19476,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -19860,10 +19504,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -19924,7 +19564,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -19965,7 +19605,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -20006,7 +19646,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "get attachments from the selected item"
+                      "text": " get attachments from the selected item"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/get-attachments-of-an-outlook-item"
@@ -20031,7 +19671,7 @@
             },
             "getCallbackTokenAsync": {
               "kind": "method",
-              "signature": "getCallbackTokenAsync(callback: (result: AsyncResult) => void, userContext?: any): void;",
+              "signature": "getCallbackTokenAsync(callback: (result: AsyncResult<string>) => void, userContext?: any): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -20045,12 +19685,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. The token is provided as a string in the asyncResult.value property."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. The token is provided as a string in the asyncResult.value property."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<string>) => void"
                 },
                 "userContext": {
                   "name": "userContext",
@@ -20125,7 +19765,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -20166,7 +19806,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -20194,10 +19834,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -20207,7 +19843,7 @@
             },
             "getUserIdentityTokenAsync": {
               "kind": "method",
-              "signature": "getUserIdentityTokenAsync(callback: (result: AsyncResult) => void, userContext?: any): void;",
+              "signature": "getUserIdentityTokenAsync(callback: (result: AsyncResult<string>) => void, userContext?: any): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -20221,12 +19857,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. The token is provided as a string in the asyncResult.value property."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<string>) => void"
                 },
                 "userContext": {
                   "name": "userContext",
@@ -20280,7 +19916,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -20321,7 +19957,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -20362,7 +19998,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "authenticate the add-in and user with a third-party system"
+                      "text": " authenticate the add-in and user with a third-party system"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/authentication"
@@ -20388,7 +20024,57 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "The mailbox item. Depending on the context in which the add-in opened, the item may be of any number of types. If you want to see IntelliSense for only a specific type, you should cast this item to one of the following: `ItemCompose`, `ItemRead`, `MessageCompose`, `MessageRead`, `AppointmentCompose`, `AppointmentRead`"
+                  "text": "The mailbox item. Depending on the context in which the add-in opened, the item may be of any number of types. If you want to see IntelliSense for only a specific type, you should cast this item to one of the following: "
+                },
+                {
+                  "kind": "code",
+                  "text": "ItemCompose",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": ", "
+                },
+                {
+                  "kind": "code",
+                  "text": "ItemRead",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": ", "
+                },
+                {
+                  "kind": "code",
+                  "text": "MessageCompose",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": ", "
+                },
+                {
+                  "kind": "code",
+                  "text": "MessageRead",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": ", "
+                },
+                {
+                  "kind": "code",
+                  "text": "AppointmentCompose",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": ", "
+                },
+                {
+                  "kind": "code",
+                  "text": "AppointmentRead",
+                  "highlighter": "plain"
                 }
               ],
               "remarks": [],
@@ -20400,7 +20086,7 @@
             },
             "makeEwsRequestAsync": {
               "kind": "method",
-              "signature": "makeEwsRequestAsync(data: any, callback: (result: AsyncResult) => void, userContext?: any): void;",
+              "signature": "makeEwsRequestAsync(data: any, callback: (result: AsyncResult<string>) => void, userContext?: any): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -20426,12 +20112,21 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. The "
+                    },
+                    {
+                      "kind": "code",
+                      "text": "value",
+                      "highlighter": "plain"
+                    },
+                    {
+                      "kind": "text",
+                      "text": " property of the result is the XML of the EWS request provided as a string. If the result exceeds 1 MB in size, an error message is returned instead."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<string>) => void"
                 },
                 "userContext": {
                   "name": "userContext",
@@ -20485,7 +20180,21 @@
                 },
                 {
                   "kind": "text",
-                  "text": "Your add-in must have the ReadWriteMailbox permission to use the makeEwsRequestAsync method. For information about using the ReadWriteMailbox permission and the EWS operations that you can call with the makeEwsRequestAsync method, see Specify permissions for mail add-in access to the user's mailbox."
+                  "text": "Your add-in must have the ReadWriteMailbox permission to use the makeEwsRequestAsync method. For information about using the ReadWriteMailbox permission and the EWS operations that you can call with the makeEwsRequestAsync method, see "
+                },
+                {
+                  "kind": "web-link",
+                  "elements": [
+                    {
+                      "kind": "text",
+                      "text": " Specify permissions for mail add-in access to the user's mailbox"
+                    }
+                  ],
+                  "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
+                },
+                {
+                  "kind": "text",
+                  "text": "."
                 },
                 {
                   "kind": "paragraph"
@@ -20499,7 +20208,21 @@
                 },
                 {
                   "kind": "text",
-                  "text": "Note: This method is not supported in the following scenarios. - In Outlook for iOS or Outlook for Android - When the add-in is loaded in a Gmail mailbox"
+                  "text": "Note: This method is not supported in the following scenarios:"
+                },
+                {
+                  "kind": "paragraph"
+                },
+                {
+                  "kind": "text",
+                  "text": "- In Outlook for iOS or Outlook for Android."
+                },
+                {
+                  "kind": "paragraph"
+                },
+                {
+                  "kind": "text",
+                  "text": "- When the add-in is loaded in a Gmail mailbox."
                 },
                 {
                   "kind": "paragraph"
@@ -20526,8 +20249,9 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`<?xml version=\"1.0\" encoding=\"iso-8859-1\"?>`"
+                  "kind": "code",
+                  "text": "<?xml version=\"1.0\" encoding=\"iso-8859-1\"?>",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
@@ -20562,7 +20286,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -20603,7 +20327,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -20631,10 +20355,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -20653,7 +20373,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Information about the user associated with the mailbox. This includes their account type, display name, email adddress, and time zone."
+                  "text": "Information about the user associated with the mailbox. This includes their account type, display name, email address, and time zone."
                 },
                 {
                   "kind": "paragraph"
@@ -20676,10 +20396,6 @@
                     "exportName": "Office",
                     "memberName": "UserProfile"
                   }
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "remarks": [],
@@ -20757,10 +20473,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -20781,7 +20493,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -20813,10 +20525,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false
@@ -20932,10 +20640,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -20956,7 +20660,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -20988,10 +20692,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false
@@ -21055,10 +20755,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -21079,7 +20775,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -21111,10 +20807,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false
@@ -21165,10 +20857,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -21189,7 +20877,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -21221,12 +20909,61 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
+              "isBeta": false
+            },
+            "OWAView": {
+              "kind": "enum",
+              "values": {
+                "OneColumn": {
+                  "kind": "enum value",
+                  "value": "\"OneColumn\"",
+                  "deprecatedMessage": [],
+                  "summary": [
+                    {
+                      "kind": "text",
+                      "text": "One column view. Displayed when the screen is narrow. Outlook Web App uses this single-column layout on the entire screen of a smartphone."
+                    }
+                  ],
+                  "remarks": [],
+                  "isBeta": false
+                },
+                "ThreeColumns": {
+                  "kind": "enum value",
+                  "value": "\"ThreeColumns\"",
+                  "deprecatedMessage": [],
+                  "summary": [
+                    {
+                      "kind": "text",
+                      "text": "Three column view. Displayed when the screen is wide. For example, Outlook Web App uses this view in a full screen window on a desktop computer."
+                    }
+                  ],
+                  "remarks": [],
+                  "isBeta": false
+                },
+                "TwoColumns": {
+                  "kind": "enum value",
+                  "value": "\"TwoColumns\"",
+                  "deprecatedMessage": [],
+                  "summary": [
+                    {
+                      "kind": "text",
+                      "text": "Two column view. Displayed when the screen is wider. Outlook Web App uses this view on most tablets."
+                    }
+                  ],
+                  "remarks": [],
+                  "isBeta": false
+                }
+              },
+              "deprecatedMessage": [],
+              "summary": [
+                {
+                  "kind": "text",
+                  "text": "Represents the current view of Outlook Web App."
+                }
+              ],
+              "remarks": [],
               "isBeta": false
             },
             "RecipientType": {
@@ -21301,10 +21038,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -21325,7 +21058,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -21357,10 +21090,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false
@@ -21450,10 +21179,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -21474,7 +21199,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -21506,10 +21231,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false
@@ -21573,10 +21294,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -21597,7 +21314,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -21629,10 +21346,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false
@@ -21674,10 +21387,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -21694,7 +21403,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -21735,7 +21444,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -21763,10 +21472,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -21935,7 +21640,16 @@
             },
             {
               "kind": "text",
-              "text": "Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information."
+              "text": "Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of "
+            },
+            {
+              "kind": "code",
+              "text": "Office.context.mailbox.item",
+              "highlighter": "plain"
+            },
+            {
+              "kind": "text",
+              "text": ". Refer to the Object Model pages for more information."
             }
           ],
           "remarks": [],
@@ -21995,7 +21709,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -22036,7 +21750,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -22064,10 +21778,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -22094,7 +21804,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Office.context.mailbox.item"
+                  "text": " Office.context.mailbox.item"
                 }
               ],
               "target": {
@@ -22113,7 +21823,16 @@
             },
             {
               "kind": "text",
-              "text": "Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information."
+              "text": "Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of "
+            },
+            {
+              "kind": "code",
+              "text": "Office.context.mailbox.item",
+              "highlighter": "plain"
+            },
+            {
+              "kind": "text",
+              "text": ". Refer to the Object Model pages for more information."
             }
           ],
           "remarks": [],
@@ -22122,7 +21841,7 @@
           "members": {
             "addFileAttachmentAsync": {
               "kind": "method",
-              "signature": "addFileAttachmentAsync(uri: string, attachmentName: string, options?: AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "addFileAttachmentAsync(uri: string, attachmentName: string, options?: AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -22172,12 +21891,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type asyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of the error."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of the error."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<string>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -22210,10 +21929,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -22230,7 +21945,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -22271,7 +21986,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -22402,22 +22117,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addFileAttachmentAsync(uri: string, attachmentName: string): void;`"
+                  "kind": "code",
+                  "text": "addFileAttachmentAsync(uri: string, attachmentName: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addFileAttachmentAsync(uri: string, attachmentName: string, options: AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "addFileAttachmentAsync(uri: string, attachmentName: string, options: AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -22427,7 +22145,7 @@
             },
             "addItemAttachmentAsync": {
               "kind": "method",
-              "signature": "addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -22482,7 +22200,7 @@
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<string>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -22510,7 +22228,7 @@
                 },
                 {
                   "kind": "text",
-                  "text": "If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended."
+                  "text": "If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended."
                 },
                 {
                   "kind": "paragraph"
@@ -22521,10 +22239,6 @@
                 }
               ],
               "remarks": [
-                {
-                  "kind": "text",
-                  "text": ""
-                },
                 {
                   "kind": "html-tag",
                   "token": "<table>"
@@ -22542,7 +22256,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -22583,7 +22297,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -22652,28 +22366,31 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has these signatures:"
+                  "text": "In addition to this signature, this method also has the following signatures:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addItemAttachmentAsync(itemId: any, attachmentName: string): void;`"
+                  "kind": "code",
+                  "text": "addItemAttachmentAsync(itemId: any, attachmentName: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -22720,7 +22437,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -22761,7 +22478,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -22789,10 +22506,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -22840,7 +22553,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -22881,7 +22594,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -22909,10 +22622,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -22986,7 +22695,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -23027,7 +22736,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -23055,10 +22764,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -23131,7 +22836,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -23172,7 +22877,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -23200,10 +22905,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -23264,7 +22965,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -23305,7 +23006,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -23333,10 +23034,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -23384,7 +23081,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -23425,7 +23122,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -23453,10 +23150,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -23504,7 +23197,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -23545,7 +23238,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -23590,7 +23283,7 @@
             },
             "getSelectedDataAsync": {
               "kind": "method",
-              "signature": "getSelectedDataAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult) => void): void;",
+              "signature": "getSelectedDataAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult<any>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -23616,12 +23309,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<any>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -23670,7 +23363,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -23711,7 +23404,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -23739,10 +23432,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -23796,7 +23485,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -23837,7 +23526,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -23865,10 +23554,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -23879,7 +23564,7 @@
             },
             "loadCustomPropertiesAsync": {
               "kind": "method",
-              "signature": "loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;",
+              "signature": "loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -23893,12 +23578,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<Office.CustomProperties>) => void"
                 },
                 "userContext": {
                   "name": "userContext",
@@ -23959,7 +23644,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -24000,7 +23685,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -24028,10 +23713,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -24078,7 +23759,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -24119,7 +23800,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -24147,10 +23828,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -24161,7 +23838,7 @@
             },
             "removeAttachmentAsync": {
               "kind": "method",
-              "signature": "removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -24199,12 +23876,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -24218,7 +23895,7 @@
                 },
                 {
                   "kind": "text",
-                  "text": "The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window."
+                  "text": "The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to continue in a separate window."
                 },
                 {
                   "kind": "paragraph"
@@ -24246,7 +23923,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -24287,7 +23964,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -24362,22 +24039,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAttachmentAsync(attachmentIndex: string): void;`"
+                  "kind": "code",
+                  "text": "removeAttachmentAsync(attachmentIndex: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -24387,7 +24067,7 @@
             },
             "saveAsync": {
               "kind": "method",
-              "signature": "saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -24413,12 +24093,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -24495,7 +24175,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -24536,7 +24216,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -24611,22 +24291,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`saveAsync(): void;`"
+                  "kind": "code",
+                  "text": "saveAsync(): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`saveAsync(options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "saveAsync(options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`saveAsync(callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "saveAsync(callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -24636,7 +24319,7 @@
             },
             "setSelectedDataAsync": {
               "kind": "method",
-              "signature": "setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -24674,12 +24357,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -24721,7 +24404,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -24762,7 +24445,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -24837,22 +24520,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -24913,7 +24599,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -24954,7 +24640,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -24982,10 +24668,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -25040,7 +24722,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -25081,7 +24763,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -25109,10 +24791,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -25139,7 +24817,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Office.context.mailbox.item"
+                  "text": " Office.context.mailbox.item"
                 }
               ],
               "target": {
@@ -25176,7 +24854,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Gets an array of attachments for the item."
+                  "text": "Gets the item's attachments as an array."
                 },
                 {
                   "kind": "paragraph"
@@ -25204,7 +24882,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -25245,7 +24923,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -25286,7 +24964,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Blocked attachments in Outlook"
+                      "text": " Blocked attachments in Outlook"
                     }
                   ],
                   "targetUrl": "https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519"
@@ -25341,7 +25019,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -25382,7 +25060,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -25410,10 +25088,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -25468,7 +25142,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -25509,7 +25183,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -25537,10 +25211,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -25602,7 +25272,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -25643,7 +25313,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -25671,10 +25341,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -25722,7 +25388,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -25763,7 +25429,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -25791,10 +25457,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -25842,7 +25504,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -25883,7 +25545,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -25942,7 +25604,7 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB OR An"
+                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB OR An "
                     },
                     {
                       "kind": "api-link",
@@ -26013,10 +25675,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -26033,7 +25691,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -26074,7 +25732,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -26102,10 +25760,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -26129,7 +25783,7 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB. OR An"
+                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB. OR An "
                     },
                     {
                       "kind": "api-link",
@@ -26216,7 +25870,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -26257,7 +25911,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -26285,10 +25939,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -26356,7 +26006,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -26397,7 +26047,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -26425,10 +26075,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -26452,7 +26098,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Gets the entities found in the selected item."
+                  "text": "Gets the entities found in the selected item's body."
                 },
                 {
                   "kind": "paragraph"
@@ -26487,7 +26133,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -26528,7 +26174,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -26556,10 +26202,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -26578,7 +26220,7 @@
                 "description": [
                   {
                     "kind": "text",
-                    "text": "If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. If no entities of the specified type are present on the item, the method returns an empty array. Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter."
+                    "text": "If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. If no entities of the specified type are present in the item's body, the method returns an empty array. Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter."
                   }
                 ]
               },
@@ -26600,7 +26242,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Gets an array of all the entities of the specified entity type found in the selected item."
+                  "text": "Gets an array of all the entities of the specified entity type found in the selected item's body."
                 },
                 {
                   "kind": "paragraph"
@@ -26635,7 +26277,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -26676,7 +26318,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -27238,10 +26880,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -27324,7 +26962,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -27365,7 +27003,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -27393,10 +27031,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -27473,7 +27107,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -27514,7 +27148,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -27542,10 +27176,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -27635,7 +27265,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -27676,7 +27306,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -27704,10 +27334,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -27754,7 +27380,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -27795,7 +27421,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -27823,10 +27449,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -27881,7 +27503,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -27922,7 +27544,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -28197,7 +27819,21 @@
                 },
                 {
                   "kind": "text",
-                  "text": "Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more details, see Use the Outlook REST APIs from an Outlook add-in."
+                  "text": "Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more details, see "
+                },
+                {
+                  "kind": "web-link",
+                  "elements": [
+                    {
+                      "kind": "text",
+                      "text": " Use the Outlook REST APIs from an Outlook add-in"
+                    }
+                  ],
+                  "targetUrl": "https://docs.microsoft.com/outlook/add-ins/use-rest-api#get-the-item-id"
+                },
+                {
+                  "kind": "text",
+                  "text": "."
                 },
                 {
                   "kind": "paragraph"
@@ -28225,7 +27861,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -28266,7 +27902,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -28294,10 +27930,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -28352,7 +27984,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -28393,7 +28025,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -28421,10 +28053,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -28435,7 +28063,7 @@
             },
             "loadCustomPropertiesAsync": {
               "kind": "method",
-              "signature": "loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;",
+              "signature": "loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -28449,12 +28077,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<Office.CustomProperties>) => void"
                 },
                 "userContext": {
                   "name": "userContext",
@@ -28515,7 +28143,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -28556,7 +28184,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -28584,10 +28212,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -28641,7 +28265,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -28682,7 +28306,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -28710,10 +28334,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -28761,7 +28381,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -28802,7 +28422,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -28830,10 +28450,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -28895,7 +28511,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -28936,7 +28552,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -28964,10 +28580,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -29029,7 +28641,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -29070,7 +28682,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -29098,10 +28710,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -29156,7 +28764,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -29197,7 +28805,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -29225,10 +28833,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -29260,10 +28864,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -29280,7 +28880,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -29321,7 +28921,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -29349,10 +28949,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -29486,10 +29082,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -29506,7 +29098,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -29547,7 +29139,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -29575,10 +29167,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -29586,7 +29174,7 @@
           "members": {
             "addAsync": {
               "kind": "method",
-              "signature": "addAsync(key: string, JSONmessage: NotificationMessageDetails, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "addAsync(key: string, JSONmessage: NotificationMessageDetails, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -29636,12 +29224,19 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. [Api set: Mailbox 1.3]"
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
+                    },
+                    {
+                      "kind": "paragraph"
+                    },
+                    {
+                      "kind": "text",
+                      "text": "[Api set: Mailbox 1.3]"
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -29660,10 +29255,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -29680,7 +29271,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -29721,7 +29312,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -29761,22 +29352,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addAsync(key: string, JSONmessage: NotificationMessageDetails): void;`"
+                  "kind": "code",
+                  "text": "addAsync(key: string, JSONmessage: NotificationMessageDetails): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addAsync(key: string, JSONmessage: NotificationMessageDetails, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "addAsync(key: string, JSONmessage: NotificationMessageDetails, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addAsync(key: string, JSONmessage: NotificationMessageDetails, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "addAsync(key: string, JSONmessage: NotificationMessageDetails, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -29786,7 +29380,7 @@
             },
             "getAllAsync": {
               "kind": "method",
-              "signature": "getAllAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "getAllAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<Office.NotificationMessageDetails[]>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -29812,12 +29406,21 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. The "
+                    },
+                    {
+                      "kind": "code",
+                      "text": "value",
+                      "highlighter": "plain"
+                    },
+                    {
+                      "kind": "text",
+                      "text": " property of the result is an array of NotificationMessageDetails objects."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<Office.NotificationMessageDetails[]>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -29836,10 +29439,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -29856,7 +29455,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -29897,7 +29496,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -29931,14 +29530,15 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has this signature:"
+                  "text": "In addition to this signature, this method also has the following signature:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`getAllAsync(callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "getAllAsync(callback: (result: AsyncResult<Office.NotificationMessageDetails[]>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -29948,7 +29548,7 @@
             },
             "removeAsync": {
               "kind": "method",
-              "signature": "removeAsync(key: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "removeAsync(key: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -29986,12 +29586,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -30010,10 +29610,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -30030,7 +29626,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -30071,7 +29667,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -30105,28 +29701,31 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has these signatures:"
+                  "text": "In addition to this signature, this method also has the following signatures:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAsync(key: string): void;`"
+                  "kind": "code",
+                  "text": "removeAsync(key: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAsync(key: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "removeAsync(key: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAsync(key: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "removeAsync(key: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -30136,7 +29735,7 @@
             },
             "replaceAsync": {
               "kind": "method",
-              "signature": "replaceAsync(key: string, JSONmessage: NotificationMessageDetails, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "replaceAsync(key: string, JSONmessage: NotificationMessageDetails, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -30186,12 +29785,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -30217,10 +29816,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -30237,7 +29832,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -30278,7 +29873,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -30312,28 +29907,31 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has these signatures:"
+                  "text": "In addition to this signature, this method also has the following signatures:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`replaceAsync(key: string, JSONmessage: NotificationMessageDetails): void;`"
+                  "kind": "code",
+                  "text": "replaceAsync(key: string, JSONmessage: NotificationMessageDetails): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`replaceAsync(key: string, JSONmessage: NotificationMessageDetails, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "replaceAsync(key: string, JSONmessage: NotificationMessageDetails, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`replaceAsync(key: string, JSONmessage: NotificationMessageDetails, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "replaceAsync(key: string, JSONmessage: NotificationMessageDetails, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -30371,10 +29969,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -30391,7 +29985,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -30432,7 +30026,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -30460,10 +30054,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -30548,10 +30138,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -30568,7 +30154,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -30609,7 +30195,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -30637,10 +30223,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -30648,7 +30230,7 @@
           "members": {
             "addAsync": {
               "kind": "method",
-              "signature": "addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -30686,12 +30268,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If adding the recipients fails, the asyncResult.error property will contain an error code."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. If adding the recipients fails, the asyncResult.error property will contain an error code."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -30738,10 +30320,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -30758,7 +30336,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -30799,7 +30377,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -30868,28 +30446,31 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has these signatures:"
+                  "text": "In addition to this signature, this method also has the following signatures:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addAsync(recipients: (string | EmailUser | EmailAddressDetails)[]): void;`"
+                  "kind": "code",
+                  "text": "addAsync(recipients: (string | EmailUser | EmailAddressDetails)[]): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -30899,7 +30480,7 @@
             },
             "getAsync": {
               "kind": "method",
-              "signature": "getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;",
+              "signature": "getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult<Office.EmailAddressDetails[]>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -30925,12 +30506,21 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. The "
+                    },
+                    {
+                      "kind": "code",
+                      "text": "value",
+                      "highlighter": "plain"
+                    },
+                    {
+                      "kind": "text",
+                      "text": " property of the result is an array of EmailAddressDetails objects."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<Office.EmailAddressDetails[]>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -30944,7 +30534,7 @@
                 },
                 {
                   "kind": "text",
-                  "text": "When the call completes, the asyncResult.value property will contain an array of"
+                  "text": "When the call completes, the asyncResult.value property will contain an array of "
                 },
                 {
                   "kind": "api-link",
@@ -30975,10 +30565,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -30995,7 +30581,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -31036,7 +30622,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -31070,14 +30656,15 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has this signature:"
+                  "text": "In addition to this signature, this method also has the following signature:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`getAsync(callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "getAsync(callback: (result: AsyncResult<Office.EmailAddressDetails[]>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -31087,7 +30674,7 @@
             },
             "setAsync": {
               "kind": "method",
-              "signature": "setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -31125,12 +30712,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If setting the recipients fails the asyncResult.error property will contain a code that indicates any error that occurred while adding the data."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. If setting the recipients fails the asyncResult.error property will contain a code that indicates any error that occurred while adding the data."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -31222,10 +30809,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -31242,7 +30825,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -31283,7 +30866,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -31352,28 +30935,31 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has these signatures:"
+                  "text": "In addition to this signature, this method also has the following signatures:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(recipients: (string | EmailUser | EmailAddressDetails)[]): void;`"
+                  "kind": "code",
+                  "text": "setAsync(recipients: (string | EmailUser | EmailAddressDetails)[]): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -31564,16 +31150,16 @@
             },
             "callback": {
               "kind": "property",
-              "signature": "callback?: (result: AsyncResult) => void;",
+              "signature": "callback?: (result: AsyncResult<any>) => void;",
               "isOptional": true,
               "isReadOnly": false,
               "isStatic": false,
-              "type": "(result: AsyncResult) => void",
+              "type": "(result: AsyncResult<any>) => void",
               "deprecatedMessage": [],
               "summary": [
                 {
                   "kind": "text",
-                  "text": "When the reply display call completes, the function passed in the callback parameter is called with a single parameter, asyncResult, which is an AsyncResult object."
+                  "text": "When the reply display call completes, the function passed in the callback parameter is called with a single parameter, asyncResult, which is an Office.AsyncResult object."
                 }
               ],
               "remarks": [],
@@ -31622,7 +31208,7 @@
             },
             {
               "kind": "text",
-              "text": "While the Outlook add-in API limits access to these settings to only the add-in that created them, these settings should not be considered secure storage. They can be accessed by Exchange Web Services or Extended MAPI. They should not be used to store sensitive information such as user credentials or security tokens."
+              "text": "While the Outlook Add-in API limits access to these settings to only the add-in that created them, these settings should not be considered secure storage. They can be accessed by Exchange Web Services or Extended MAPI. They should not be used to store sensitive information such as user credentials or security tokens."
             },
             {
               "kind": "paragraph"
@@ -31655,10 +31241,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -31675,7 +31257,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -31716,7 +31298,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -31744,10 +31326,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -31798,10 +31376,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -31818,7 +31392,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -31859,7 +31433,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -31887,10 +31461,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -31938,10 +31508,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -31958,7 +31524,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -31999,7 +31565,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -32027,10 +31593,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -32040,7 +31602,7 @@
             },
             "saveAsync": {
               "kind": "method",
-              "signature": "saveAsync(callback?: (result: AsyncResult) => void): void;",
+              "signature": "saveAsync(callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -32054,12 +31616,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional? When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -32085,10 +31647,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -32105,7 +31663,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -32146,7 +31704,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -32174,10 +31732,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -32258,10 +31812,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -32278,7 +31828,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -32319,7 +31869,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -32347,10 +31897,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -32416,10 +31962,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -32436,7 +31978,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -32477,7 +32019,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -32505,10 +32047,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -32516,7 +32054,7 @@
           "members": {
             "getAsync": {
               "kind": "method",
-              "signature": "getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;",
+              "signature": "getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult<string>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -32542,12 +32080,21 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. The "
+                    },
+                    {
+                      "kind": "code",
+                      "text": "value",
+                      "highlighter": "plain"
+                    },
+                    {
+                      "kind": "text",
+                      "text": " property of the result is the subject of the item."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<string>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -32573,10 +32120,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -32593,7 +32136,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -32634,7 +32177,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -32668,14 +32211,15 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has this signature:"
+                  "text": "In addition to this signature, this method also has the following signature:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`getAsync(callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "getAsync(callback: (result: AsyncResult<string>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -32685,7 +32229,7 @@
             },
             "setAsync": {
               "kind": "method",
-              "signature": "setAsync(subject: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "setAsync(subject: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -32723,12 +32267,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If setting the subject fails, the asyncResult.error property will contain an error code."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. If setting the subject fails, the asyncResult.error property will contain an error code."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -32754,10 +32298,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -32774,7 +32314,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -32815,7 +32355,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -32884,28 +32424,31 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has these signatures:"
+                  "text": "In addition to this signature, this method also has the following signatures:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(subject: string): void;`"
+                  "kind": "code",
+                  "text": "setAsync(subject: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(subject: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "setAsync(subject: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(subject: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "setAsync(subject: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -32931,7 +32474,26 @@
             },
             {
               "kind": "text",
-              "text": "The list of tasks suggested in an email message is returned in the taskSuggestions property of the [Entities]Entities object that is returned when the getEntities or getEntitiesByType method is called on the active item."
+              "text": "The list of tasks suggested in an email message is returned in the taskSuggestions property of the "
+            },
+            {
+              "kind": "api-link",
+              "elements": [
+                {
+                  "kind": "text",
+                  "text": " Entities"
+                }
+              ],
+              "target": {
+                "scopeName": "",
+                "packageName": "Outlook_1_4",
+                "exportName": "Office",
+                "memberName": "Entities"
+              }
+            },
+            {
+              "kind": "text",
+              "text": " object that is returned when the getEntities or getEntitiesByType method is called on the active item."
             },
             {
               "kind": "paragraph"
@@ -32942,10 +32504,6 @@
             }
           ],
           "remarks": [
-            {
-              "kind": "text",
-              "text": ""
-            },
             {
               "kind": "html-tag",
               "token": "<table>"
@@ -32963,7 +32521,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -33004,7 +32562,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -33032,10 +32590,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -33106,10 +32660,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -33126,7 +32676,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -33167,7 +32717,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -33195,10 +32745,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -33206,7 +32752,7 @@
           "members": {
             "getAsync": {
               "kind": "method",
-              "signature": "getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;",
+              "signature": "getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult<Date>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -33232,12 +32778,21 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. The "
+                    },
+                    {
+                      "kind": "code",
+                      "text": "value",
+                      "highlighter": "plain"
+                    },
+                    {
+                      "kind": "text",
+                      "text": " property of the result is a Date object."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<Date>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -33263,10 +32818,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -33283,7 +32834,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -33324,7 +32875,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -33358,14 +32909,15 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has this signature:"
+                  "text": "In addition to this signature, this method also has the following signature:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`getAsync(callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "getAsync(callback: (result: AsyncResult<Date>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -33375,7 +32927,7 @@
             },
             "setAsync": {
               "kind": "method",
-              "signature": "setAsync(dateTime: Date, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "setAsync(dateTime: Date, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -33413,12 +32965,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If setting the date and time fails, the asyncResult.error property will contain an error code."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. If setting the date and time fails, the asyncResult.error property will contain an error code."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -33451,10 +33003,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -33471,7 +33019,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -33512,7 +33060,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -33581,28 +33129,31 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has these signatures:"
+                  "text": "In addition to this signature, this method also has the following signatures:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(dateTime: Date): void;`"
+                  "kind": "code",
+                  "text": "setAsync(dateTime: Date): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(dateTime: Date, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "setAsync(dateTime: Date, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(dateTime: Date, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "setAsync(dateTime: Date, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -33633,10 +33184,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -33653,7 +33200,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -33694,7 +33241,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -33722,10 +33269,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -33754,10 +33297,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -33774,7 +33313,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -33815,7 +33354,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -33843,10 +33382,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -33878,10 +33413,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -33898,7 +33429,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -33939,7 +33470,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -33967,10 +33498,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -34002,10 +33529,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -34022,7 +33545,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -34063,7 +33586,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -34091,10 +33614,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,

--- a/generate-docs/json/Outlook_1_5.api.json
+++ b/generate-docs/json/Outlook_1_5.api.json
@@ -69,7 +69,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Office.context.mailbox.item"
+                  "text": " Office.context.mailbox.item"
                 }
               ],
               "target": {
@@ -88,7 +88,16 @@
             },
             {
               "kind": "text",
-              "text": "Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information."
+              "text": "Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of "
+            },
+            {
+              "kind": "code",
+              "text": "Office.context.mailbox.item",
+              "highlighter": "plain"
+            },
+            {
+              "kind": "text",
+              "text": ". Refer to the Object Model pages for more information."
             }
           ],
           "remarks": [],
@@ -97,7 +106,7 @@
           "members": {
             "addFileAttachmentAsync": {
               "kind": "method",
-              "signature": "addFileAttachmentAsync(uri: string, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "addFileAttachmentAsync(uri: string, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -152,7 +161,7 @@
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<string>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -185,10 +194,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -205,7 +210,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -246,7 +251,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -377,22 +382,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addFileAttachmentAsync(uri: string, attachmentName: string): void;`"
+                  "kind": "code",
+                  "text": "addFileAttachmentAsync(uri: string, attachmentName: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addFileAttachmentAsync(uri: string, attachmentName: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "addFileAttachmentAsync(uri: string, attachmentName: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -402,7 +410,7 @@
             },
             "addItemAttachmentAsync": {
               "kind": "method",
-              "signature": "addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -452,12 +460,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<string>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -485,7 +493,7 @@
                 },
                 {
                   "kind": "text",
-                  "text": "If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended."
+                  "text": "If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended."
                 },
                 {
                   "kind": "paragraph"
@@ -496,10 +504,6 @@
                 }
               ],
               "remarks": [
-                {
-                  "kind": "text",
-                  "text": ""
-                },
                 {
                   "kind": "html-tag",
                   "token": "<table>"
@@ -517,7 +521,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -558,7 +562,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -627,28 +631,31 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has these signatures:"
+                  "text": "In addition to this signature, this method also has the following signatures:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addItemAttachmentAsync(itemId: any, attachmentName: string): void;`"
+                  "kind": "code",
+                  "text": "addItemAttachmentAsync(itemId: any, attachmentName: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -695,7 +702,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -736,7 +743,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -764,10 +771,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -840,7 +843,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -881,7 +884,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -909,10 +912,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -959,7 +958,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -1000,7 +999,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -1028,10 +1027,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -1079,7 +1074,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -1120,7 +1115,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -1235,7 +1230,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -1276,7 +1271,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -1304,10 +1299,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -1318,7 +1309,7 @@
             },
             "getSelectedDataAsync": {
               "kind": "method",
-              "signature": "getSelectedDataAsync(coerciontype: Office.CoercionType, options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;",
+              "signature": "getSelectedDataAsync(coerciontype: Office.CoercionType, options: Office.AsyncContextOptions, callback: (result: AsyncResult<any>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -1361,7 +1352,7 @@
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<any>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -1410,7 +1401,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -1451,7 +1442,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -1479,10 +1470,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -1536,7 +1523,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -1577,7 +1564,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -1605,10 +1592,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -1619,7 +1602,7 @@
             },
             "loadCustomPropertiesAsync": {
               "kind": "method",
-              "signature": "loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;",
+              "signature": "loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -1633,12 +1616,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<Office.CustomProperties>) => void"
                 },
                 "userContext": {
                   "name": "userContext",
@@ -1699,7 +1682,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -1740,7 +1723,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -1768,10 +1751,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -1837,7 +1816,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -1878,7 +1857,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -1906,10 +1885,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -1957,7 +1932,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -1998,7 +1973,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -2026,10 +2001,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -2096,7 +2067,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -2137,7 +2108,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -2165,10 +2136,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -2179,7 +2146,7 @@
             },
             "removeAttachmentAsync": {
               "kind": "method",
-              "signature": "removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -2217,12 +2184,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -2236,7 +2203,7 @@
                 },
                 {
                   "kind": "text",
-                  "text": "The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window."
+                  "text": "The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to continue in a separate window."
                 },
                 {
                   "kind": "paragraph"
@@ -2264,7 +2231,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -2305,7 +2272,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -2380,22 +2347,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAttachmentAsync(attachmentIndex: string): void;`"
+                  "kind": "code",
+                  "text": "removeAttachmentAsync(attachmentIndex: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -2461,7 +2431,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -2502,7 +2472,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -2530,10 +2500,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -2544,7 +2510,7 @@
             },
             "saveAsync": {
               "kind": "method",
-              "signature": "saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -2570,12 +2536,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -2652,7 +2618,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -2693,7 +2659,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -2768,22 +2734,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`saveAsync(): void;`"
+                  "kind": "code",
+                  "text": "saveAsync(): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`saveAsync(options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "saveAsync(options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`saveAsync(callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "saveAsync(callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -2793,7 +2762,7 @@
             },
             "setSelectedDataAsync": {
               "kind": "method",
-              "signature": "setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -2831,12 +2800,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -2878,7 +2847,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -2919,7 +2888,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -2994,22 +2963,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -3089,7 +3061,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -3130,7 +3102,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -3158,10 +3130,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -3223,7 +3191,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -3264,7 +3232,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -3292,10 +3260,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -3327,10 +3291,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -3347,7 +3307,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -3388,7 +3348,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -3416,10 +3376,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -3464,7 +3420,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -3505,7 +3461,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -3533,10 +3489,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -3626,7 +3578,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -3667,7 +3619,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -3695,10 +3647,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -3774,7 +3722,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -3816,7 +3764,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -3844,10 +3792,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -3923,7 +3867,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -3964,7 +3908,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -3992,10 +3936,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -4071,7 +4011,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -4112,7 +4052,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -4140,10 +4080,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -4249,7 +4185,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -4290,7 +4226,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -4318,10 +4254,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -4404,7 +4336,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -4445,7 +4377,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -4473,10 +4405,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -4503,7 +4431,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Office.context.mailbox.item"
+                  "text": " Office.context.mailbox.item"
                 }
               ],
               "target": {
@@ -4540,7 +4468,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Gets an array of attachments for the item."
+                  "text": "Gets the item's attachments as an array."
                 },
                 {
                   "kind": "paragraph"
@@ -4568,7 +4496,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -4609,7 +4537,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -4650,7 +4578,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Blocked attachments in Outlook"
+                      "text": " Blocked attachments in Outlook"
                     }
                   ],
                   "targetUrl": "https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519"
@@ -4705,7 +4633,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -4746,7 +4674,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -4774,10 +4702,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -4825,7 +4749,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -4866,7 +4790,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -4894,10 +4818,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -4945,7 +4865,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -4986,7 +4906,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -5045,7 +4965,7 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB OR An"
+                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB OR An "
                     },
                     {
                       "kind": "api-link",
@@ -5116,10 +5036,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -5136,7 +5052,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -5177,7 +5093,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -5205,10 +5121,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -5232,7 +5144,7 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB. OR An"
+                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB. OR An "
                     },
                     {
                       "kind": "api-link",
@@ -5319,7 +5231,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -5360,7 +5272,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -5388,10 +5300,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -5452,7 +5360,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -5493,7 +5401,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -5521,10 +5429,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -5548,7 +5452,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Gets the entities found in the selected item."
+                  "text": "Gets the entities found in the selected item's body."
                 },
                 {
                   "kind": "paragraph"
@@ -5583,7 +5487,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -5624,7 +5528,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -5652,10 +5556,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -5674,7 +5574,7 @@
                 "description": [
                   {
                     "kind": "text",
-                    "text": "If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. If no entities of the specified type are present on the item, the method returns an empty array. Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter."
+                    "text": "If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. If no entities of the specified type are present in the item's body, the method returns an empty array. Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter."
                   }
                 ]
               },
@@ -5696,7 +5596,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Gets an array of all the entities of the specified entity type found in the selected item."
+                  "text": "Gets an array of all the entities of the specified entity type found in the selected item's body."
                 },
                 {
                   "kind": "paragraph"
@@ -5715,10 +5615,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -5735,7 +5631,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -5776,7 +5672,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -6338,10 +6234,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -6424,7 +6316,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -6465,7 +6357,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -6493,10 +6385,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -6573,7 +6461,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -6614,7 +6502,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -6642,10 +6530,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -6735,7 +6619,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -6776,7 +6660,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -6804,10 +6688,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -6861,7 +6741,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -6902,7 +6782,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -7177,7 +7057,21 @@
                 },
                 {
                   "kind": "text",
-                  "text": "Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more details, see Use the Outlook REST APIs from an Outlook add-in."
+                  "text": "Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more details, see "
+                },
+                {
+                  "kind": "web-link",
+                  "elements": [
+                    {
+                      "kind": "text",
+                      "text": " Use the Outlook REST APIs from an Outlook add-in"
+                    }
+                  ],
+                  "targetUrl": "https://docs.microsoft.com/outlook/add-ins/use-rest-api#get-the-item-id"
+                },
+                {
+                  "kind": "text",
+                  "text": "."
                 },
                 {
                   "kind": "paragraph"
@@ -7205,7 +7099,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -7246,7 +7140,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -7274,10 +7168,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -7332,7 +7222,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -7373,7 +7263,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -7401,10 +7291,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -7415,7 +7301,7 @@
             },
             "loadCustomPropertiesAsync": {
               "kind": "method",
-              "signature": "loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;",
+              "signature": "loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -7429,12 +7315,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<Office.CustomProperties>) => void"
                 },
                 "userContext": {
                   "name": "userContext",
@@ -7495,7 +7381,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -7536,7 +7422,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -7564,10 +7450,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -7621,7 +7503,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -7662,7 +7544,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -7690,10 +7572,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -7748,7 +7626,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -7789,7 +7667,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -7817,10 +7695,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -7868,7 +7742,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -7909,7 +7783,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -7937,10 +7811,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -8014,7 +7884,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -8055,7 +7925,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -8083,10 +7953,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -8106,7 +7972,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Gets the email address of the meeting organizer for a specified meeting. Read mode only."
+                  "text": "Gets the email address of the meeting organizer for a specified meeting."
                 },
                 {
                   "kind": "paragraph"
@@ -8134,7 +8000,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -8175,7 +8041,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -8203,10 +8069,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -8280,7 +8142,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -8321,7 +8183,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -8349,10 +8211,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -8407,7 +8265,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -8448,7 +8306,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -8476,10 +8334,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -8541,7 +8395,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -8582,7 +8436,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -8610,10 +8464,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -8652,10 +8502,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -8672,7 +8518,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -8713,7 +8559,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -8741,10 +8587,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -8899,10 +8741,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -8919,7 +8757,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -8960,7 +8798,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -8988,10 +8826,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -8999,7 +8833,7 @@
           "members": {
             "getAsync": {
               "kind": "method",
-              "signature": "getAsync(coerciontype: Office.CoercionType, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "getAsync(coerciontype: Office.CoercionType, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<Office.Body>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -9037,7 +8871,7 @@
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<Office.Body>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -9070,10 +8904,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -9090,7 +8920,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -9131,7 +8961,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -9165,14 +8995,15 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has this signature:"
+                  "text": "In addition to this signature, this method also has the following signature:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`getAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "getAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult<Office.Body>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -9182,7 +9013,7 @@
             },
             "getTypeAsync": {
               "kind": "method",
-              "signature": "getTypeAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "getTypeAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<Office.CoercionType>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -9208,12 +9039,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. The content type is returned as one of the CoercionType values in the asyncResult.value property."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. The content type is returned as one of the CoercionType values in the asyncResult.value property."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<Office.CoercionType>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -9232,10 +9063,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -9252,7 +9079,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -9293,7 +9120,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -9321,10 +9148,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -9334,7 +9157,7 @@
             },
             "prependAsync": {
               "kind": "method",
-              "signature": "prependAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "prependAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -9372,12 +9195,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. Any errors encountered will be provided in the asyncResult.error property."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. Any errors encountered will be provided in the asyncResult.error property."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -9418,10 +9241,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -9438,7 +9257,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -9479,7 +9298,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -9548,28 +9367,31 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has these signatures:"
+                  "text": "In addition to this signature, this method also has the following signatures:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`prependAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`"
+                  "kind": "code",
+                  "text": "prependAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`prependAsync(data: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "prependAsync(data: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`prependAsync(data: string): void;`"
+                  "kind": "code",
+                  "text": "prependAsync(data: string): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -9579,7 +9401,7 @@
             },
             "setAsync": {
               "kind": "method",
-              "signature": "setAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "setAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -9617,12 +9439,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. Any errors encountered will be provided in the asyncResult.error property."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. Any errors encountered will be provided in the asyncResult.error property."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -9663,10 +9485,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -9683,7 +9501,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -9724,7 +9542,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -9821,28 +9639,31 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has these signatures:"
+                  "text": "In addition to this signature, this method also has the following signatures:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`"
+                  "kind": "code",
+                  "text": "setAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(data: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "setAsync(data: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(data: string): void;`"
+                  "kind": "code",
+                  "text": "setAsync(data: string): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -9852,7 +9673,7 @@
             },
             "setSelectedDataAsync": {
               "kind": "method",
-              "signature": "setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -9890,12 +9711,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. Any errors encountered will be provided in the asyncResult.error property."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. Any errors encountered will be provided in the asyncResult.error property."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -9936,10 +9757,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -9956,7 +9773,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -9997,7 +9814,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -10094,28 +9911,31 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has these signatures:"
+                  "text": "In addition to this signature, this method also has the following signatures:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -10201,10 +10021,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -10221,7 +10037,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -10262,7 +10078,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -10290,10 +10106,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -10455,10 +10267,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -10475,7 +10283,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -10516,7 +10324,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -10544,10 +10352,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -10598,10 +10402,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -10618,7 +10418,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -10659,7 +10459,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -10687,10 +10487,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -10714,7 +10510,14 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "The name of the property to be removed. [Api set: Mailbox 1.0]"
+                      "text": "The name of the property to be removed."
+                    },
+                    {
+                      "kind": "paragraph"
+                    },
+                    {
+                      "kind": "text",
+                      "text": "[Api set: Mailbox 1.0]"
                     }
                   ],
                   "isOptional": false,
@@ -10738,10 +10541,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -10758,7 +10557,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -10799,7 +10598,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -10827,10 +10626,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -10840,7 +10635,7 @@
             },
             "saveAsync": {
               "kind": "method",
-              "signature": "saveAsync(callback?: (result: AsyncResult) => void, asyncContext?: any): void;",
+              "signature": "saveAsync(callback?: (result: AsyncResult<void>) => void, asyncContext?: any): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -10854,19 +10649,26 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 },
                 "asyncContext": {
                   "name": "asyncContext",
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. Any state data that is passed to the callback method. [Api set: Mailbox 1.0]"
+                      "text": "Optional. Any state data that is passed to the callback method."
+                    },
+                    {
+                      "kind": "paragraph"
+                    },
+                    {
+                      "kind": "text",
+                      "text": "[Api set: Mailbox 1.0]"
                     }
                   ],
                   "isOptional": true,
@@ -10897,10 +10699,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -10917,7 +10715,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -10958,7 +10756,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -10986,10 +10784,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -11063,10 +10857,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -11083,7 +10873,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -11124,7 +10914,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -11152,10 +10942,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -11186,10 +10972,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -11206,7 +10988,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -11247,7 +11029,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -11275,10 +11057,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -11314,10 +11092,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -11334,7 +11108,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -11375,7 +11149,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -11403,10 +11177,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -11445,10 +11215,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -11465,7 +11231,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -11506,7 +11272,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -11534,10 +11300,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -11548,11 +11310,11 @@
             },
             "OWAView": {
               "kind": "property",
-              "signature": "OWAView: \"string\";",
+              "signature": "OWAView: MailboxEnums.OWAView | \"OneColumn\" | \"TwoColumns\" | \"ThreeColumns\";",
               "isOptional": false,
               "isReadOnly": false,
               "isStatic": false,
-              "type": "\"string\"",
+              "type": "MailboxEnums.OWAView | \"OneColumn\" | \"TwoColumns\" | \"ThreeColumns\"",
               "deprecatedMessage": [],
               "summary": [
                 {
@@ -11611,10 +11373,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -11631,7 +11389,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -11672,7 +11430,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -11700,10 +11458,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -11735,10 +11489,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -11755,7 +11505,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -11796,7 +11546,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -11824,10 +11574,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -11940,10 +11686,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -11960,7 +11702,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -12001,7 +11743,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -12029,10 +11771,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -12145,10 +11883,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -12165,7 +11899,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -12206,7 +11940,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -12234,10 +11968,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -12401,7 +12131,16 @@
           "summary": [
             {
               "kind": "text",
-              "text": "The item namespace is used to access the currently selected message, meeting request, or appointment. You can determine the type of the item by using the `itemType` property."
+              "text": "The item namespace is used to access the currently selected message, meeting request, or appointment. You can determine the type of the item by using the "
+            },
+            {
+              "kind": "code",
+              "text": "itemType",
+              "highlighter": "plain"
+            },
+            {
+              "kind": "text",
+              "text": " property."
             },
             {
               "kind": "paragraph"
@@ -12412,10 +12151,6 @@
             }
           ],
           "remarks": [
-            {
-              "kind": "text",
-              "text": ""
-            },
             {
               "kind": "html-tag",
               "token": "<table>"
@@ -12433,7 +12168,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -12474,7 +12209,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -12502,10 +12237,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -12550,7 +12281,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -12591,7 +12322,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -12619,10 +12350,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -12670,7 +12397,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -12711,7 +12438,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -12739,10 +12466,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -12790,7 +12513,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -12831,7 +12554,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -12920,7 +12643,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -12961,7 +12684,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -12989,10 +12712,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -13003,7 +12722,7 @@
             },
             "loadCustomPropertiesAsync": {
               "kind": "method",
-              "signature": "loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;",
+              "signature": "loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -13017,12 +12736,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<Office.CustomProperties>) => void"
                 },
                 "userContext": {
                   "name": "userContext",
@@ -13083,7 +12802,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -13124,7 +12843,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -13152,10 +12871,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -13202,7 +12917,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -13243,7 +12958,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -13271,10 +12986,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -13301,7 +13012,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Office.context.mailbox.item"
+                  "text": " Office.context.mailbox.item"
                 }
               ],
               "target": {
@@ -13320,7 +13031,16 @@
             },
             {
               "kind": "text",
-              "text": "Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information."
+              "text": "Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of "
+            },
+            {
+              "kind": "code",
+              "text": "Office.context.mailbox.item",
+              "highlighter": "plain"
+            },
+            {
+              "kind": "text",
+              "text": ". Refer to the Object Model pages for more information."
             }
           ],
           "remarks": [],
@@ -13329,7 +13049,7 @@
           "members": {
             "addFileAttachmentAsync": {
               "kind": "method",
-              "signature": "addFileAttachmentAsync(uri: string, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "addFileAttachmentAsync(uri: string, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -13384,7 +13104,7 @@
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<string>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -13417,10 +13137,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -13437,7 +13153,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -13478,7 +13194,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -13601,22 +13317,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addFileAttachmentAsync(uri: string, attachmentName: string): void;`"
+                  "kind": "code",
+                  "text": "addFileAttachmentAsync(uri: string, attachmentName: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addFileAttachmentAsync(uri: string, attachmentName: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "addFileAttachmentAsync(uri: string, attachmentName: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -13626,7 +13345,7 @@
             },
             "addItemAttachmentAsync": {
               "kind": "method",
-              "signature": "addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -13676,12 +13395,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<string>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -13709,7 +13428,7 @@
                 },
                 {
                   "kind": "text",
-                  "text": "If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended."
+                  "text": "If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended."
                 },
                 {
                   "kind": "paragraph"
@@ -13720,10 +13439,6 @@
                 }
               ],
               "remarks": [
-                {
-                  "kind": "text",
-                  "text": ""
-                },
                 {
                   "kind": "html-tag",
                   "token": "<table>"
@@ -13741,7 +13456,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -13782,7 +13497,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -13851,28 +13566,31 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has these signatures:"
+                  "text": "In addition to this signature, this method also has the following signatures:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addItemAttachmentAsync(itemId: any, attachmentName: string): void;`"
+                  "kind": "code",
+                  "text": "addItemAttachmentAsync(itemId: any, attachmentName: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -13944,7 +13662,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -13985,7 +13703,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -14013,10 +13731,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -14026,7 +13740,7 @@
             },
             "getSelectedDataAsync": {
               "kind": "method",
-              "signature": "getSelectedDataAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult) => void): void;",
+              "signature": "getSelectedDataAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult<any>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -14052,12 +13766,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<any>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -14106,7 +13820,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -14147,7 +13861,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -14175,10 +13889,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -14188,7 +13898,7 @@
             },
             "removeAttachmentAsync": {
               "kind": "method",
-              "signature": "removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -14226,12 +13936,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -14245,7 +13955,7 @@
                 },
                 {
                   "kind": "text",
-                  "text": "The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window."
+                  "text": "The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to continue in a separate window."
                 },
                 {
                   "kind": "paragraph"
@@ -14273,7 +13983,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -14314,7 +14024,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -14389,22 +14099,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAttachmentAsync(attachmentIndex: string): void;`"
+                  "kind": "code",
+                  "text": "removeAttachmentAsync(attachmentIndex: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -14414,7 +14127,7 @@
             },
             "saveAsync": {
               "kind": "method",
-              "signature": "saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -14440,12 +14153,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -14522,7 +14235,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -14563,7 +14276,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -14638,22 +14351,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`saveAsync(): void;`"
+                  "kind": "code",
+                  "text": "saveAsync(): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`saveAsync(options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "saveAsync(options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`saveAsync(callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "saveAsync(callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -14663,7 +14379,7 @@
             },
             "setSelectedDataAsync": {
               "kind": "method",
-              "signature": "setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -14701,12 +14417,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -14748,7 +14464,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -14789,7 +14505,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -14864,22 +14580,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -14940,7 +14659,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -14981,7 +14700,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -15009,10 +14728,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -15039,7 +14754,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Office.context.mailbox.item"
+                  "text": " Office.context.mailbox.item"
                 }
               ],
               "target": {
@@ -15058,7 +14773,16 @@
             },
             {
               "kind": "text",
-              "text": "Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information."
+              "text": "Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of "
+            },
+            {
+              "kind": "code",
+              "text": "Office.context.mailbox.item",
+              "highlighter": "plain"
+            },
+            {
+              "kind": "text",
+              "text": ". Refer to the Object Model pages for more information."
             }
           ],
           "remarks": [],
@@ -15076,7 +14800,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Gets an array of attachments for the item."
+                  "text": "Gets the item's attachments as an array."
                 },
                 {
                   "kind": "paragraph"
@@ -15087,10 +14811,6 @@
                 }
               ],
               "remarks": [
-                {
-                  "kind": "text",
-                  "text": ""
-                },
                 {
                   "kind": "html-tag",
                   "token": "<table>"
@@ -15108,7 +14828,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -15149,7 +14869,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -15190,7 +14910,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Blocked attachments in Outlook"
+                      "text": " Blocked attachments in Outlook"
                     }
                   ],
                   "targetUrl": "https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519"
@@ -15222,7 +14942,7 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB OR An"
+                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB OR An "
                     },
                     {
                       "kind": "api-link",
@@ -15293,10 +15013,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -15313,7 +15029,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -15354,7 +15070,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -15382,10 +15098,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -15409,7 +15121,7 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB. OR An"
+                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB. OR An "
                     },
                     {
                       "kind": "api-link",
@@ -15496,7 +15208,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -15537,7 +15249,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -15565,10 +15277,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -15591,7 +15299,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Gets the entities found in the selected item."
+                  "text": "Gets the entities found in the selected item's body."
                 },
                 {
                   "kind": "paragraph"
@@ -15626,7 +15334,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -15667,7 +15375,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -15695,10 +15403,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -15717,7 +15421,7 @@
                 "description": [
                   {
                     "kind": "text",
-                    "text": "If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. If no entities of the specified type are present on the item, the method returns an empty array. Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter."
+                    "text": "If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. If no entities of the specified type are present in the item's body, the method returns an empty array. Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter."
                   }
                 ]
               },
@@ -15739,7 +15443,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Gets an array of all the entities of the specified entity type found in the selected item."
+                  "text": "Gets an array of all the entities of the specified entity type found in the selected item's body."
                 },
                 {
                   "kind": "paragraph"
@@ -15758,10 +15462,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -15778,7 +15478,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -15819,7 +15519,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -16381,10 +16081,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -16467,7 +16163,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -16508,7 +16204,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -16536,10 +16232,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -16616,7 +16308,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -16657,7 +16349,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -16685,10 +16377,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -16778,7 +16466,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -16819,7 +16507,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -16847,10 +16535,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -16904,7 +16588,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -16945,7 +16629,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -17187,10 +16871,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -17224,7 +16904,21 @@
                 },
                 {
                   "kind": "text",
-                  "text": "Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more details, see Use the Outlook REST APIs from an Outlook add-in."
+                  "text": "Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more details, see "
+                },
+                {
+                  "kind": "web-link",
+                  "elements": [
+                    {
+                      "kind": "text",
+                      "text": " Use the Outlook REST APIs from an Outlook add-in"
+                    }
+                  ],
+                  "targetUrl": "https://docs.microsoft.com/outlook/add-ins/use-rest-api#get-the-item-id"
+                },
+                {
+                  "kind": "text",
+                  "text": "."
                 },
                 {
                   "kind": "paragraph"
@@ -17252,7 +16946,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -17293,7 +16987,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -17321,10 +17015,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -17379,7 +17069,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -17420,7 +17110,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -17448,10 +17138,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -17513,7 +17199,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -17554,7 +17240,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -17582,10 +17268,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -17633,7 +17315,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -17674,7 +17356,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -17702,10 +17384,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -17902,10 +17580,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -17922,7 +17596,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -17963,7 +17637,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -17991,10 +17665,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -18002,7 +17672,7 @@
           "members": {
             "getAsync": {
               "kind": "method",
-              "signature": "getAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "getAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -18028,12 +17698,19 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. [Api set: Mailbox 1.1]"
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
+                    },
+                    {
+                      "kind": "paragraph"
+                    },
+                    {
+                      "kind": "text",
+                      "text": "[Api set: Mailbox 1.1]"
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<string>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -18052,10 +17729,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -18072,7 +17745,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -18113,7 +17786,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -18153,8 +17826,9 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`getAsync(callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "getAsync(callback: (result: AsyncResult<string>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -18164,7 +17838,7 @@
             },
             "setAsync": {
               "kind": "method",
-              "signature": "setAsync(location: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "setAsync(location: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -18202,12 +17876,19 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If setting the location fails, the asyncResult.error property will contain an error code. [Api set: Mailbox 1.1]"
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. If setting the location fails, the asyncResult.error property will contain an error code."
+                    },
+                    {
+                      "kind": "paragraph"
+                    },
+                    {
+                      "kind": "text",
+                      "text": "[Api set: Mailbox 1.1]"
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -18226,10 +17907,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -18246,7 +17923,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -18287,7 +17964,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -18362,22 +18039,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(location: string): void;`"
+                  "kind": "code",
+                  "text": "setAsync(location: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(location: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "setAsync(location: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(location: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "setAsync(location: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -18396,7 +18076,7 @@
           "summary": [
             {
               "kind": "text",
-              "text": "Provides access to the Outlook add-in object model for Microsoft Outlook and Microsoft Outlook on the web."
+              "text": "Provides access to the Outlook Add-in object model for Microsoft Outlook and Microsoft Outlook on the web."
             },
             {
               "kind": "paragraph"
@@ -18436,10 +18116,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -18456,7 +18132,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -18497,7 +18173,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -18525,10 +18201,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -18536,7 +18208,7 @@
           "members": {
             "addHandlerAsync": {
               "kind": "method",
-              "signature": "addHandlerAsync(eventType: Office.EventType, handler: (type: EventType) => void, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "addHandlerAsync(eventType: Office.EventType, handler: (type: EventType) => void, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -18586,12 +18258,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -18605,7 +18277,16 @@
                 },
                 {
                   "kind": "text",
-                  "text": "Currently the only supported event type is Office.EventType.ItemChanged, which is invoked when the user selects a new item. This event is used by add-ins that implement a pinnable taskpane, and allows the add-in to refresh the taskpane UI based on the currently selected item."
+                  "text": "Currently, the only supported event type is "
+                },
+                {
+                  "kind": "code",
+                  "text": "Office.EventType.ItemChanged",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": "."
                 },
                 {
                   "kind": "paragraph"
@@ -18633,7 +18314,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -18674,7 +18355,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -18702,10 +18383,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -18795,7 +18472,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -18836,7 +18513,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -18864,10 +18541,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -18945,7 +18618,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -18986,7 +18659,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -19014,10 +18687,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -19100,7 +18769,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -19141,7 +18810,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -19182,7 +18851,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Outlook Mail API"
+                      "text": " Outlook Mail API"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/previous-versions/office/office-365-api/api/version-2.0/mail-rest-operations"
@@ -19196,7 +18865,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Microsoft Graph"
+                      "text": " Microsoft Graph"
                     }
                   ],
                   "targetUrl": "http://graph.microsoft.io/"
@@ -19279,7 +18948,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -19320,7 +18989,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -19348,10 +19017,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -19398,7 +19063,7 @@
                 },
                 {
                   "kind": "text",
-                  "text": "- OWAView (string): A string that represents the current view of Outlook Web App. If the host application is not Outlook Web App, then accessing this property results in undefined. Outlook Web App has three views (OneColumn - displayed when the screen is narrow, TwoColumns - displayed when the screen is wider, and ThreeColumns - displayed when the screen is wide.) that correspond to the width of the screen and the window, and the number of columns that can be displayed."
+                  "text": "- OWAView (MailboxEnums.OWAView or string): An enum (or string literal) that represents the current view of Outlook Web App. If the host application is not Outlook Web App, then accessing this property results in undefined. Outlook Web App has three views (OneColumn - displayed when the screen is narrow, TwoColumns - displayed when the screen is wider, and ThreeColumns - displayed when the screen is wide) that correspond to the width of the screen and the window, and the number of columns that can be displayed."
                 },
                 {
                   "kind": "paragraph"
@@ -19436,10 +19101,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -19456,7 +19117,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -19497,7 +19158,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -19525,10 +19186,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -19628,7 +19285,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -19669,7 +19326,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -19697,10 +19354,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -19799,7 +19452,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -19840,7 +19493,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -19868,10 +19521,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -19970,7 +19619,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -20011,7 +19660,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -20039,10 +19688,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -20103,7 +19748,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -20144,7 +19789,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -20185,7 +19830,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "get attachments from the selected item"
+                      "text": " get attachments from the selected item"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/get-attachments-of-an-outlook-item"
@@ -20210,7 +19855,7 @@
             },
             "getCallbackTokenAsync": {
               "kind": "method",
-              "signature": "getCallbackTokenAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;",
+              "signature": "getCallbackTokenAsync(options: Office.AsyncContextOptions & { isRest?: boolean }, callback: (result: AsyncResult<string>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -20229,19 +19874,19 @@
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "Office.AsyncContextOptions"
+                  "type": "Office.AsyncContextOptions & { isRest?: boolean }"
                 },
                 "callback": {
                   "name": "callback",
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. The token is provided as a string in the asyncResult.value property."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. The token is provided as a string in the asyncResult.value property."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<string>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -20332,7 +19977,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -20373,7 +20018,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -20413,15 +20058,17 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`getCallbackTokenAsync(callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "getCallbackTokenAsync(callback: (result: AsyncResult<string>) => void): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`getCallbackTokenAsync(callback: (result: AsyncResult) => void, userContext?: any): void;`"
+                  "kind": "code",
+                  "text": "getCallbackTokenAsync(callback: (result: AsyncResult<string>) => void, userContext?: any): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -20431,7 +20078,7 @@
             },
             "getUserIdentityTokenAsync": {
               "kind": "method",
-              "signature": "getUserIdentityTokenAsync(callback: (result: AsyncResult) => void, userContext?: any): void;",
+              "signature": "getUserIdentityTokenAsync(callback: (result: AsyncResult<string>) => void, userContext?: any): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -20445,12 +20092,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. The token is provided as a string in the asyncResult.value property."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<string>) => void"
                 },
                 "userContext": {
                   "name": "userContext",
@@ -20504,7 +20151,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -20545,7 +20192,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -20586,7 +20233,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "authenticate the add-in and user with a third-party system"
+                      "text": " authenticate the add-in and user with a third-party system"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/authentication"
@@ -20612,7 +20259,57 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "The mailbox item. Depending on the context in which the add-in opened, the item may be of any number of types. If you want to see IntelliSense for only a specific type, you should cast this item to one of the following: `ItemCompose`, `ItemRead`, `MessageCompose`, `MessageRead`, `AppointmentCompose`, `AppointmentRead`"
+                  "text": "The mailbox item. Depending on the context in which the add-in opened, the item may be of any number of types. If you want to see IntelliSense for only a specific type, you should cast this item to one of the following: "
+                },
+                {
+                  "kind": "code",
+                  "text": "ItemCompose",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": ", "
+                },
+                {
+                  "kind": "code",
+                  "text": "ItemRead",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": ", "
+                },
+                {
+                  "kind": "code",
+                  "text": "MessageCompose",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": ", "
+                },
+                {
+                  "kind": "code",
+                  "text": "MessageRead",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": ", "
+                },
+                {
+                  "kind": "code",
+                  "text": "AppointmentCompose",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": ", "
+                },
+                {
+                  "kind": "code",
+                  "text": "AppointmentRead",
+                  "highlighter": "plain"
                 }
               ],
               "remarks": [],
@@ -20624,7 +20321,7 @@
             },
             "makeEwsRequestAsync": {
               "kind": "method",
-              "signature": "makeEwsRequestAsync(data: any, callback: (result: AsyncResult) => void, userContext?: any): void;",
+              "signature": "makeEwsRequestAsync(data: any, callback: (result: AsyncResult<string>) => void, userContext?: any): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -20650,12 +20347,21 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. The "
+                    },
+                    {
+                      "kind": "code",
+                      "text": "value",
+                      "highlighter": "plain"
+                    },
+                    {
+                      "kind": "text",
+                      "text": " property of the result is the XML of the EWS request provided as a string. If the result exceeds 1 MB in size, an error message is returned instead."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<string>) => void"
                 },
                 "userContext": {
                   "name": "userContext",
@@ -20709,7 +20415,21 @@
                 },
                 {
                   "kind": "text",
-                  "text": "Your add-in must have the ReadWriteMailbox permission to use the makeEwsRequestAsync method. For information about using the ReadWriteMailbox permission and the EWS operations that you can call with the makeEwsRequestAsync method, see Specify permissions for mail add-in access to the user's mailbox."
+                  "text": "Your add-in must have the ReadWriteMailbox permission to use the makeEwsRequestAsync method. For information about using the ReadWriteMailbox permission and the EWS operations that you can call with the makeEwsRequestAsync method, see "
+                },
+                {
+                  "kind": "web-link",
+                  "elements": [
+                    {
+                      "kind": "text",
+                      "text": " Specify permissions for mail add-in access to the user's mailbox"
+                    }
+                  ],
+                  "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
+                },
+                {
+                  "kind": "text",
+                  "text": "."
                 },
                 {
                   "kind": "paragraph"
@@ -20723,7 +20443,21 @@
                 },
                 {
                   "kind": "text",
-                  "text": "Note: This method is not supported in the following scenarios. - In Outlook for iOS or Outlook for Android - When the add-in is loaded in a Gmail mailbox"
+                  "text": "Note: This method is not supported in the following scenarios:"
+                },
+                {
+                  "kind": "paragraph"
+                },
+                {
+                  "kind": "text",
+                  "text": "- In Outlook for iOS or Outlook for Android."
+                },
+                {
+                  "kind": "paragraph"
+                },
+                {
+                  "kind": "text",
+                  "text": "- When the add-in is loaded in a Gmail mailbox."
                 },
                 {
                   "kind": "paragraph"
@@ -20750,8 +20484,9 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`<?xml version=\"1.0\" encoding=\"iso-8859-1\"?>`"
+                  "kind": "code",
+                  "text": "<?xml version=\"1.0\" encoding=\"iso-8859-1\"?>",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
@@ -20786,7 +20521,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -20827,7 +20562,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -20855,10 +20590,190 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
+                }
+              ],
+              "isBeta": false,
+              "isSealed": false,
+              "isVirtual": false,
+              "isOverride": false
+            },
+            "removeHandlerAsync": {
+              "kind": "method",
+              "signature": "removeHandlerAsync(eventType: Office.EventType, handler: (type: EventType) => void, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
+              "accessModifier": "",
+              "isOptional": false,
+              "isStatic": false,
+              "returnValue": {
+                "type": "void",
+                "description": []
+              },
+              "parameters": {
+                "eventType": {
+                  "name": "eventType",
+                  "description": [
+                    {
+                      "kind": "text",
+                      "text": "The event that should revoke the handler."
+                    }
+                  ],
+                  "isOptional": false,
+                  "isSpread": false,
+                  "type": "Office.EventType"
+                },
+                "handler": {
+                  "name": "handler",
+                  "description": [
+                    {
+                      "kind": "text",
+                      "text": "The function to handle the event. The function must accept a single parameter, which is an object literal. The type property on the parameter will match the eventType parameter passed to addHandlerAsync."
+                    }
+                  ],
+                  "isOptional": false,
+                  "isSpread": false,
+                  "type": "(type: EventType) => void"
+                },
+                "options": {
+                  "name": "options",
+                  "description": [
+                    {
+                      "kind": "text",
+                      "text": "Optional. Provides an option for preserving context data of any type, unchanged, for use in a callback."
+                    }
+                  ],
+                  "isOptional": true,
+                  "isSpread": false,
+                  "type": "Office.AsyncContextOptions"
+                },
+                "callback": {
+                  "name": "callback",
+                  "description": [
+                    {
+                      "kind": "text",
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
+                    }
+                  ],
+                  "isOptional": true,
+                  "isSpread": false,
+                  "type": "(result: AsyncResult<void>) => void"
+                }
+              },
+              "deprecatedMessage": [],
+              "summary": [
+                {
+                  "kind": "text",
+                  "text": "Removes an event handler for a supported event."
+                },
+                {
+                  "kind": "paragraph"
                 },
                 {
                   "kind": "text",
-                  "text": ""
+                  "text": "Currently, the only supported event type is "
+                },
+                {
+                  "kind": "code",
+                  "text": "Office.EventType.ItemChanged",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": "."
+                },
+                {
+                  "kind": "paragraph"
+                },
+                {
+                  "kind": "text",
+                  "text": "[Api set: Mailbox 1.5]"
+                }
+              ],
+              "remarks": [
+                {
+                  "kind": "html-tag",
+                  "token": "<table>"
+                },
+                {
+                  "kind": "html-tag",
+                  "token": "<tr>"
+                },
+                {
+                  "kind": "html-tag",
+                  "token": "<td>"
+                },
+                {
+                  "kind": "web-link",
+                  "elements": [
+                    {
+                      "kind": "text",
+                      "text": " Minimum permission level"
+                    }
+                  ],
+                  "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
+                },
+                {
+                  "kind": "html-tag",
+                  "token": "</td>"
+                },
+                {
+                  "kind": "html-tag",
+                  "token": "<td>"
+                },
+                {
+                  "kind": "text",
+                  "text": "ReadItem"
+                },
+                {
+                  "kind": "html-tag",
+                  "token": "</td>"
+                },
+                {
+                  "kind": "html-tag",
+                  "token": "</tr>"
+                },
+                {
+                  "kind": "paragraph"
+                },
+                {
+                  "kind": "html-tag",
+                  "token": "<tr>"
+                },
+                {
+                  "kind": "html-tag",
+                  "token": "<td>"
+                },
+                {
+                  "kind": "web-link",
+                  "elements": [
+                    {
+                      "kind": "text",
+                      "text": " Applicable Outlook mode"
+                    }
+                  ],
+                  "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
+                },
+                {
+                  "kind": "html-tag",
+                  "token": "</td>"
+                },
+                {
+                  "kind": "html-tag",
+                  "token": "<td>"
+                },
+                {
+                  "kind": "text",
+                  "text": "Compose or read"
+                },
+                {
+                  "kind": "html-tag",
+                  "token": "</td>"
+                },
+                {
+                  "kind": "html-tag",
+                  "token": "</tr>"
+                },
+                {
+                  "kind": "html-tag",
+                  "token": "</table>"
                 }
               ],
               "isBeta": false,
@@ -20919,7 +20834,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -20960,7 +20875,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -21001,7 +20916,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "REST API"
+                      "text": " REST API"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/rest/"
@@ -21028,7 +20943,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Information about the user associated with the mailbox. This includes their account type, display name, email adddress, and time zone."
+                  "text": "Information about the user associated with the mailbox. This includes their account type, display name, email address, and time zone."
                 },
                 {
                   "kind": "paragraph"
@@ -21051,10 +20966,6 @@
                     "exportName": "Office",
                     "memberName": "UserProfile"
                   }
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "remarks": [],
@@ -21132,10 +21043,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -21156,7 +21063,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -21188,10 +21095,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false
@@ -21307,10 +21210,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -21331,7 +21230,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -21363,10 +21262,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false
@@ -21430,10 +21325,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -21454,7 +21345,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -21486,10 +21377,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false
@@ -21540,10 +21427,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -21564,7 +21447,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -21596,12 +21479,61 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
+              "isBeta": false
+            },
+            "OWAView": {
+              "kind": "enum",
+              "values": {
+                "OneColumn": {
+                  "kind": "enum value",
+                  "value": "\"OneColumn\"",
+                  "deprecatedMessage": [],
+                  "summary": [
+                    {
+                      "kind": "text",
+                      "text": "One column view. Displayed when the screen is narrow. Outlook Web App uses this single-column layout on the entire screen of a smartphone."
+                    }
+                  ],
+                  "remarks": [],
+                  "isBeta": false
+                },
+                "ThreeColumns": {
+                  "kind": "enum value",
+                  "value": "\"ThreeColumns\"",
+                  "deprecatedMessage": [],
+                  "summary": [
+                    {
+                      "kind": "text",
+                      "text": "Three column view. Displayed when the screen is wide. For example, Outlook Web App uses this view in a full screen window on a desktop computer."
+                    }
+                  ],
+                  "remarks": [],
+                  "isBeta": false
+                },
+                "TwoColumns": {
+                  "kind": "enum value",
+                  "value": "\"TwoColumns\"",
+                  "deprecatedMessage": [],
+                  "summary": [
+                    {
+                      "kind": "text",
+                      "text": "Two column view. Displayed when the screen is wider. Outlook Web App uses this view on most tablets."
+                    }
+                  ],
+                  "remarks": [],
+                  "isBeta": false
+                }
+              },
+              "deprecatedMessage": [],
+              "summary": [
+                {
+                  "kind": "text",
+                  "text": "Represents the current view of Outlook Web App."
+                }
+              ],
+              "remarks": [],
               "isBeta": false
             },
             "RecipientType": {
@@ -21676,10 +21608,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -21700,7 +21628,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -21732,10 +21660,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false
@@ -21825,10 +21749,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -21849,7 +21769,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -21881,10 +21801,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false
@@ -21948,10 +21864,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -21972,7 +21884,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -22004,10 +21916,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false
@@ -22049,10 +21957,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -22069,7 +21973,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -22110,7 +22014,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -22138,10 +22042,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -22310,7 +22210,16 @@
             },
             {
               "kind": "text",
-              "text": "Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information."
+              "text": "Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of "
+            },
+            {
+              "kind": "code",
+              "text": "Office.context.mailbox.item",
+              "highlighter": "plain"
+            },
+            {
+              "kind": "text",
+              "text": ". Refer to the Object Model pages for more information."
             }
           ],
           "remarks": [],
@@ -22370,7 +22279,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -22411,7 +22320,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -22439,10 +22348,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -22469,7 +22374,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Office.context.mailbox.item"
+                  "text": " Office.context.mailbox.item"
                 }
               ],
               "target": {
@@ -22488,7 +22393,16 @@
             },
             {
               "kind": "text",
-              "text": "Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information."
+              "text": "Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of "
+            },
+            {
+              "kind": "code",
+              "text": "Office.context.mailbox.item",
+              "highlighter": "plain"
+            },
+            {
+              "kind": "text",
+              "text": ". Refer to the Object Model pages for more information."
             }
           ],
           "remarks": [],
@@ -22497,7 +22411,7 @@
           "members": {
             "addFileAttachmentAsync": {
               "kind": "method",
-              "signature": "addFileAttachmentAsync(uri: string, attachmentName: string, options?: AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "addFileAttachmentAsync(uri: string, attachmentName: string, options?: AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -22547,12 +22461,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type asyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of the error."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of the error."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<string>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -22585,10 +22499,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -22605,7 +22515,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -22646,7 +22556,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -22777,22 +22687,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addFileAttachmentAsync(uri: string, attachmentName: string): void;`"
+                  "kind": "code",
+                  "text": "addFileAttachmentAsync(uri: string, attachmentName: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addFileAttachmentAsync(uri: string, attachmentName: string, options: AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "addFileAttachmentAsync(uri: string, attachmentName: string, options: AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -22802,7 +22715,7 @@
             },
             "addItemAttachmentAsync": {
               "kind": "method",
-              "signature": "addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -22857,7 +22770,7 @@
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<string>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -22885,7 +22798,7 @@
                 },
                 {
                   "kind": "text",
-                  "text": "If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended."
+                  "text": "If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended."
                 },
                 {
                   "kind": "paragraph"
@@ -22896,10 +22809,6 @@
                 }
               ],
               "remarks": [
-                {
-                  "kind": "text",
-                  "text": ""
-                },
                 {
                   "kind": "html-tag",
                   "token": "<table>"
@@ -22917,7 +22826,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -22958,7 +22867,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -23027,28 +22936,31 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has these signatures:"
+                  "text": "In addition to this signature, this method also has the following signatures:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addItemAttachmentAsync(itemId: any, attachmentName: string): void;`"
+                  "kind": "code",
+                  "text": "addItemAttachmentAsync(itemId: any, attachmentName: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -23095,7 +23007,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -23136,7 +23048,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -23164,10 +23076,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -23215,7 +23123,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -23256,7 +23164,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -23284,10 +23192,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -23361,7 +23265,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -23402,7 +23306,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -23430,10 +23334,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -23506,7 +23406,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -23547,7 +23447,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -23575,10 +23475,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -23639,7 +23535,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -23680,7 +23576,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -23708,10 +23604,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -23759,7 +23651,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -23800,7 +23692,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -23828,10 +23720,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -23879,7 +23767,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -23920,7 +23808,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -23965,7 +23853,7 @@
             },
             "getSelectedDataAsync": {
               "kind": "method",
-              "signature": "getSelectedDataAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult) => void): void;",
+              "signature": "getSelectedDataAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult<any>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -23991,12 +23879,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<any>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -24045,7 +23933,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -24086,7 +23974,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -24114,10 +24002,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -24171,7 +24055,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -24212,7 +24096,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -24240,10 +24124,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -24254,7 +24134,7 @@
             },
             "loadCustomPropertiesAsync": {
               "kind": "method",
-              "signature": "loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;",
+              "signature": "loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -24268,12 +24148,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<Office.CustomProperties>) => void"
                 },
                 "userContext": {
                   "name": "userContext",
@@ -24334,7 +24214,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -24375,7 +24255,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -24403,10 +24283,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -24453,7 +24329,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -24494,7 +24370,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -24522,10 +24398,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -24536,7 +24408,7 @@
             },
             "removeAttachmentAsync": {
               "kind": "method",
-              "signature": "removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -24574,12 +24446,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -24593,7 +24465,7 @@
                 },
                 {
                   "kind": "text",
-                  "text": "The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window."
+                  "text": "The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to continue in a separate window."
                 },
                 {
                   "kind": "paragraph"
@@ -24621,7 +24493,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -24662,7 +24534,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -24737,22 +24609,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAttachmentAsync(attachmentIndex: string): void;`"
+                  "kind": "code",
+                  "text": "removeAttachmentAsync(attachmentIndex: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -24762,7 +24637,7 @@
             },
             "saveAsync": {
               "kind": "method",
-              "signature": "saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -24788,12 +24663,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -24870,7 +24745,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -24911,7 +24786,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -24986,22 +24861,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`saveAsync(): void;`"
+                  "kind": "code",
+                  "text": "saveAsync(): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`saveAsync(options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "saveAsync(options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`saveAsync(callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "saveAsync(callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -25011,7 +24889,7 @@
             },
             "setSelectedDataAsync": {
               "kind": "method",
-              "signature": "setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -25049,12 +24927,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -25096,7 +24974,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -25137,7 +25015,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -25212,22 +25090,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -25288,7 +25169,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -25329,7 +25210,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -25357,10 +25238,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -25415,7 +25292,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -25456,7 +25333,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -25484,10 +25361,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -25514,7 +25387,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Office.context.mailbox.item"
+                  "text": " Office.context.mailbox.item"
                 }
               ],
               "target": {
@@ -25551,7 +25424,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Gets an array of attachments for the item."
+                  "text": "Gets the item's attachments as an array."
                 },
                 {
                   "kind": "paragraph"
@@ -25579,7 +25452,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -25620,7 +25493,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -25661,7 +25534,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Blocked attachments in Outlook"
+                      "text": " Blocked attachments in Outlook"
                     }
                   ],
                   "targetUrl": "https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519"
@@ -25716,7 +25589,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -25757,7 +25630,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -25785,10 +25658,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -25843,7 +25712,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -25884,7 +25753,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -25912,10 +25781,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -25977,7 +25842,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -26018,7 +25883,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -26046,10 +25911,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -26097,7 +25958,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -26138,7 +25999,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -26166,10 +26027,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -26217,7 +26074,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -26258,7 +26115,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -26317,7 +26174,7 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB OR An"
+                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB OR An "
                     },
                     {
                       "kind": "api-link",
@@ -26388,10 +26245,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -26408,7 +26261,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -26449,7 +26302,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -26477,10 +26330,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -26504,7 +26353,7 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB. OR An"
+                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB. OR An "
                     },
                     {
                       "kind": "api-link",
@@ -26591,7 +26440,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -26632,7 +26481,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -26660,10 +26509,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -26731,7 +26576,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -26772,7 +26617,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -26800,10 +26645,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -26827,7 +26668,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Gets the entities found in the selected item."
+                  "text": "Gets the entities found in the selected item's body."
                 },
                 {
                   "kind": "paragraph"
@@ -26862,7 +26703,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -26903,7 +26744,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -26931,10 +26772,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -26953,7 +26790,7 @@
                 "description": [
                   {
                     "kind": "text",
-                    "text": "If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. If no entities of the specified type are present on the item, the method returns an empty array. Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter."
+                    "text": "If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. If no entities of the specified type are present in the item's body, the method returns an empty array. Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter."
                   }
                 ]
               },
@@ -26975,7 +26812,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Gets an array of all the entities of the specified entity type found in the selected item."
+                  "text": "Gets an array of all the entities of the specified entity type found in the selected item's body."
                 },
                 {
                   "kind": "paragraph"
@@ -27010,7 +26847,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -27051,7 +26888,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -27613,10 +27450,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -27699,7 +27532,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -27740,7 +27573,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -27768,10 +27601,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -27848,7 +27677,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -27889,7 +27718,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -27917,10 +27746,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -28010,7 +27835,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -28051,7 +27876,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -28079,10 +27904,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -28129,7 +27950,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -28170,7 +27991,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -28198,10 +28019,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -28256,7 +28073,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -28297,7 +28114,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -28572,7 +28389,21 @@
                 },
                 {
                   "kind": "text",
-                  "text": "Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more details, see Use the Outlook REST APIs from an Outlook add-in."
+                  "text": "Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more details, see "
+                },
+                {
+                  "kind": "web-link",
+                  "elements": [
+                    {
+                      "kind": "text",
+                      "text": " Use the Outlook REST APIs from an Outlook add-in"
+                    }
+                  ],
+                  "targetUrl": "https://docs.microsoft.com/outlook/add-ins/use-rest-api#get-the-item-id"
+                },
+                {
+                  "kind": "text",
+                  "text": "."
                 },
                 {
                   "kind": "paragraph"
@@ -28600,7 +28431,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -28641,7 +28472,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -28669,10 +28500,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -28727,7 +28554,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -28768,7 +28595,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -28796,10 +28623,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -28810,7 +28633,7 @@
             },
             "loadCustomPropertiesAsync": {
               "kind": "method",
-              "signature": "loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;",
+              "signature": "loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -28824,12 +28647,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<Office.CustomProperties>) => void"
                 },
                 "userContext": {
                   "name": "userContext",
@@ -28890,7 +28713,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -28931,7 +28754,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -28959,10 +28782,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -29016,7 +28835,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -29057,7 +28876,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -29085,10 +28904,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -29136,7 +28951,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -29177,7 +28992,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -29205,10 +29020,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -29270,7 +29081,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -29311,7 +29122,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -29339,10 +29150,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -29404,7 +29211,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -29445,7 +29252,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -29473,10 +29280,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -29531,7 +29334,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -29572,7 +29375,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -29600,10 +29403,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -29635,10 +29434,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -29655,7 +29450,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -29696,7 +29491,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -29724,10 +29519,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -29861,10 +29652,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -29881,7 +29668,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -29922,7 +29709,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -29950,10 +29737,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -29961,7 +29744,7 @@
           "members": {
             "addAsync": {
               "kind": "method",
-              "signature": "addAsync(key: string, JSONmessage: NotificationMessageDetails, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "addAsync(key: string, JSONmessage: NotificationMessageDetails, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -30011,12 +29794,19 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. [Api set: Mailbox 1.3]"
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
+                    },
+                    {
+                      "kind": "paragraph"
+                    },
+                    {
+                      "kind": "text",
+                      "text": "[Api set: Mailbox 1.3]"
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -30035,10 +29825,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -30055,7 +29841,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -30096,7 +29882,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -30136,22 +29922,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addAsync(key: string, JSONmessage: NotificationMessageDetails): void;`"
+                  "kind": "code",
+                  "text": "addAsync(key: string, JSONmessage: NotificationMessageDetails): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addAsync(key: string, JSONmessage: NotificationMessageDetails, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "addAsync(key: string, JSONmessage: NotificationMessageDetails, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addAsync(key: string, JSONmessage: NotificationMessageDetails, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "addAsync(key: string, JSONmessage: NotificationMessageDetails, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -30161,7 +29950,7 @@
             },
             "getAllAsync": {
               "kind": "method",
-              "signature": "getAllAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "getAllAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<Office.NotificationMessageDetails[]>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -30187,12 +29976,21 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. The "
+                    },
+                    {
+                      "kind": "code",
+                      "text": "value",
+                      "highlighter": "plain"
+                    },
+                    {
+                      "kind": "text",
+                      "text": " property of the result is an array of NotificationMessageDetails objects."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<Office.NotificationMessageDetails[]>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -30211,10 +30009,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -30231,7 +30025,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -30272,7 +30066,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -30306,14 +30100,15 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has this signature:"
+                  "text": "In addition to this signature, this method also has the following signature:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`getAllAsync(callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "getAllAsync(callback: (result: AsyncResult<Office.NotificationMessageDetails[]>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -30323,7 +30118,7 @@
             },
             "removeAsync": {
               "kind": "method",
-              "signature": "removeAsync(key: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "removeAsync(key: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -30361,12 +30156,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -30385,10 +30180,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -30405,7 +30196,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -30446,7 +30237,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -30480,28 +30271,31 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has these signatures:"
+                  "text": "In addition to this signature, this method also has the following signatures:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAsync(key: string): void;`"
+                  "kind": "code",
+                  "text": "removeAsync(key: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAsync(key: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "removeAsync(key: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAsync(key: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "removeAsync(key: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -30511,7 +30305,7 @@
             },
             "replaceAsync": {
               "kind": "method",
-              "signature": "replaceAsync(key: string, JSONmessage: NotificationMessageDetails, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "replaceAsync(key: string, JSONmessage: NotificationMessageDetails, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -30561,12 +30355,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -30592,10 +30386,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -30612,7 +30402,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -30653,7 +30443,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -30687,28 +30477,31 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has these signatures:"
+                  "text": "In addition to this signature, this method also has the following signatures:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`replaceAsync(key: string, JSONmessage: NotificationMessageDetails): void;`"
+                  "kind": "code",
+                  "text": "replaceAsync(key: string, JSONmessage: NotificationMessageDetails): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`replaceAsync(key: string, JSONmessage: NotificationMessageDetails, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "replaceAsync(key: string, JSONmessage: NotificationMessageDetails, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`replaceAsync(key: string, JSONmessage: NotificationMessageDetails, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "replaceAsync(key: string, JSONmessage: NotificationMessageDetails, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -30746,10 +30539,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -30766,7 +30555,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -30807,7 +30596,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -30835,10 +30624,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -30923,10 +30708,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -30943,7 +30724,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -30984,7 +30765,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -31012,10 +30793,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -31023,7 +30800,7 @@
           "members": {
             "addAsync": {
               "kind": "method",
-              "signature": "addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -31061,12 +30838,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If adding the recipients fails, the asyncResult.error property will contain an error code."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. If adding the recipients fails, the asyncResult.error property will contain an error code."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -31113,10 +30890,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -31133,7 +30906,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -31174,7 +30947,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -31243,28 +31016,31 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has these signatures:"
+                  "text": "In addition to this signature, this method also has the following signatures:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addAsync(recipients: (string | EmailUser | EmailAddressDetails)[]): void;`"
+                  "kind": "code",
+                  "text": "addAsync(recipients: (string | EmailUser | EmailAddressDetails)[]): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -31274,7 +31050,7 @@
             },
             "getAsync": {
               "kind": "method",
-              "signature": "getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;",
+              "signature": "getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult<Office.EmailAddressDetails[]>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -31300,12 +31076,21 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. The "
+                    },
+                    {
+                      "kind": "code",
+                      "text": "value",
+                      "highlighter": "plain"
+                    },
+                    {
+                      "kind": "text",
+                      "text": " property of the result is an array of EmailAddressDetails objects."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<Office.EmailAddressDetails[]>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -31319,7 +31104,7 @@
                 },
                 {
                   "kind": "text",
-                  "text": "When the call completes, the asyncResult.value property will contain an array of"
+                  "text": "When the call completes, the asyncResult.value property will contain an array of "
                 },
                 {
                   "kind": "api-link",
@@ -31350,10 +31135,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -31370,7 +31151,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -31411,7 +31192,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -31445,14 +31226,15 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has this signature:"
+                  "text": "In addition to this signature, this method also has the following signature:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`getAsync(callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "getAsync(callback: (result: AsyncResult<Office.EmailAddressDetails[]>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -31462,7 +31244,7 @@
             },
             "setAsync": {
               "kind": "method",
-              "signature": "setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -31500,12 +31282,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If setting the recipients fails the asyncResult.error property will contain a code that indicates any error that occurred while adding the data."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. If setting the recipients fails the asyncResult.error property will contain a code that indicates any error that occurred while adding the data."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -31597,10 +31379,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -31617,7 +31395,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -31658,7 +31436,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -31727,28 +31505,31 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has these signatures:"
+                  "text": "In addition to this signature, this method also has the following signatures:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(recipients: (string | EmailUser | EmailAddressDetails)[]): void;`"
+                  "kind": "code",
+                  "text": "setAsync(recipients: (string | EmailUser | EmailAddressDetails)[]): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -31939,16 +31720,16 @@
             },
             "callback": {
               "kind": "property",
-              "signature": "callback?: (result: AsyncResult) => void;",
+              "signature": "callback?: (result: AsyncResult<any>) => void;",
               "isOptional": true,
               "isReadOnly": false,
               "isStatic": false,
-              "type": "(result: AsyncResult) => void",
+              "type": "(result: AsyncResult<any>) => void",
               "deprecatedMessage": [],
               "summary": [
                 {
                   "kind": "text",
-                  "text": "When the reply display call completes, the function passed in the callback parameter is called with a single parameter, asyncResult, which is an AsyncResult object."
+                  "text": "When the reply display call completes, the function passed in the callback parameter is called with a single parameter, asyncResult, which is an Office.AsyncResult object."
                 }
               ],
               "remarks": [],
@@ -31997,7 +31778,7 @@
             },
             {
               "kind": "text",
-              "text": "While the Outlook add-in API limits access to these settings to only the add-in that created them, these settings should not be considered secure storage. They can be accessed by Exchange Web Services or Extended MAPI. They should not be used to store sensitive information such as user credentials or security tokens."
+              "text": "While the Outlook Add-in API limits access to these settings to only the add-in that created them, these settings should not be considered secure storage. They can be accessed by Exchange Web Services or Extended MAPI. They should not be used to store sensitive information such as user credentials or security tokens."
             },
             {
               "kind": "paragraph"
@@ -32030,10 +31811,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -32050,7 +31827,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -32091,7 +31868,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -32119,10 +31896,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -32173,10 +31946,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -32193,7 +31962,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -32234,7 +32003,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -32262,10 +32031,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -32313,10 +32078,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -32333,7 +32094,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -32374,7 +32135,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -32402,10 +32163,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -32415,7 +32172,7 @@
             },
             "saveAsync": {
               "kind": "method",
-              "signature": "saveAsync(callback?: (result: AsyncResult) => void): void;",
+              "signature": "saveAsync(callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -32429,12 +32186,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional? When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -32460,10 +32217,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -32480,7 +32233,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -32521,7 +32274,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -32549,10 +32302,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -32633,10 +32382,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -32653,7 +32398,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -32694,7 +32439,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -32722,10 +32467,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -32791,10 +32532,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -32811,7 +32548,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -32852,7 +32589,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -32880,10 +32617,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -32891,7 +32624,7 @@
           "members": {
             "getAsync": {
               "kind": "method",
-              "signature": "getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;",
+              "signature": "getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult<string>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -32917,12 +32650,21 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. The "
+                    },
+                    {
+                      "kind": "code",
+                      "text": "value",
+                      "highlighter": "plain"
+                    },
+                    {
+                      "kind": "text",
+                      "text": " property of the result is the subject of the item."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<string>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -32948,10 +32690,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -32968,7 +32706,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -33009,7 +32747,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -33043,14 +32781,15 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has this signature:"
+                  "text": "In addition to this signature, this method also has the following signature:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`getAsync(callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "getAsync(callback: (result: AsyncResult<string>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -33060,7 +32799,7 @@
             },
             "setAsync": {
               "kind": "method",
-              "signature": "setAsync(subject: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "setAsync(subject: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -33098,12 +32837,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If setting the subject fails, the asyncResult.error property will contain an error code."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. If setting the subject fails, the asyncResult.error property will contain an error code."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -33129,10 +32868,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -33149,7 +32884,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -33190,7 +32925,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -33259,28 +32994,31 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has these signatures:"
+                  "text": "In addition to this signature, this method also has the following signatures:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(subject: string): void;`"
+                  "kind": "code",
+                  "text": "setAsync(subject: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(subject: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "setAsync(subject: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(subject: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "setAsync(subject: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -33306,7 +33044,26 @@
             },
             {
               "kind": "text",
-              "text": "The list of tasks suggested in an email message is returned in the taskSuggestions property of the [Entities]Entities object that is returned when the getEntities or getEntitiesByType method is called on the active item."
+              "text": "The list of tasks suggested in an email message is returned in the taskSuggestions property of the "
+            },
+            {
+              "kind": "api-link",
+              "elements": [
+                {
+                  "kind": "text",
+                  "text": " Entities"
+                }
+              ],
+              "target": {
+                "scopeName": "",
+                "packageName": "Outlook_1_5",
+                "exportName": "Office",
+                "memberName": "Entities"
+              }
+            },
+            {
+              "kind": "text",
+              "text": " object that is returned when the getEntities or getEntitiesByType method is called on the active item."
             },
             {
               "kind": "paragraph"
@@ -33317,10 +33074,6 @@
             }
           ],
           "remarks": [
-            {
-              "kind": "text",
-              "text": ""
-            },
             {
               "kind": "html-tag",
               "token": "<table>"
@@ -33338,7 +33091,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -33379,7 +33132,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -33407,10 +33160,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -33481,10 +33230,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -33501,7 +33246,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -33542,7 +33287,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -33570,10 +33315,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -33581,7 +33322,7 @@
           "members": {
             "getAsync": {
               "kind": "method",
-              "signature": "getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;",
+              "signature": "getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult<Date>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -33607,12 +33348,21 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. The "
+                    },
+                    {
+                      "kind": "code",
+                      "text": "value",
+                      "highlighter": "plain"
+                    },
+                    {
+                      "kind": "text",
+                      "text": " property of the result is a Date object."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<Date>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -33638,10 +33388,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -33658,7 +33404,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -33699,7 +33445,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -33733,14 +33479,15 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has this signature:"
+                  "text": "In addition to this signature, this method also has the following signature:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`getAsync(callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "getAsync(callback: (result: AsyncResult<Date>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -33750,7 +33497,7 @@
             },
             "setAsync": {
               "kind": "method",
-              "signature": "setAsync(dateTime: Date, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "setAsync(dateTime: Date, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -33788,12 +33535,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If setting the date and time fails, the asyncResult.error property will contain an error code."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. If setting the date and time fails, the asyncResult.error property will contain an error code."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -33826,10 +33573,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -33846,7 +33589,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -33887,7 +33630,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -33956,28 +33699,31 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has these signatures:"
+                  "text": "In addition to this signature, this method also has the following signatures:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(dateTime: Date): void;`"
+                  "kind": "code",
+                  "text": "setAsync(dateTime: Date): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(dateTime: Date, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "setAsync(dateTime: Date, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(dateTime: Date, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "setAsync(dateTime: Date, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -34008,10 +33754,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -34028,7 +33770,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -34069,7 +33811,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -34097,10 +33839,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -34129,10 +33867,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -34149,7 +33883,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -34190,7 +33924,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -34218,10 +33952,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -34253,10 +33983,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -34273,7 +33999,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -34314,7 +34040,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -34342,10 +34068,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -34377,10 +34099,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -34397,7 +34115,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -34438,7 +34156,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -34466,10 +34184,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,

--- a/generate-docs/json/Outlook_1_6.api.json
+++ b/generate-docs/json/Outlook_1_6.api.json
@@ -69,7 +69,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Office.context.mailbox.item"
+                  "text": " Office.context.mailbox.item"
                 }
               ],
               "target": {
@@ -88,7 +88,16 @@
             },
             {
               "kind": "text",
-              "text": "Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information."
+              "text": "Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of "
+            },
+            {
+              "kind": "code",
+              "text": "Office.context.mailbox.item",
+              "highlighter": "plain"
+            },
+            {
+              "kind": "text",
+              "text": ". Refer to the Object Model pages for more information."
             }
           ],
           "remarks": [],
@@ -97,7 +106,7 @@
           "members": {
             "addFileAttachmentAsync": {
               "kind": "method",
-              "signature": "addFileAttachmentAsync(uri: string, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "addFileAttachmentAsync(uri: string, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -152,7 +161,7 @@
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<string>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -185,10 +194,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -205,7 +210,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -246,7 +251,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -377,22 +382,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addFileAttachmentAsync(uri: string, attachmentName: string): void;`"
+                  "kind": "code",
+                  "text": "addFileAttachmentAsync(uri: string, attachmentName: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addFileAttachmentAsync(uri: string, attachmentName: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "addFileAttachmentAsync(uri: string, attachmentName: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -402,7 +410,7 @@
             },
             "addItemAttachmentAsync": {
               "kind": "method",
-              "signature": "addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -452,12 +460,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<string>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -485,7 +493,7 @@
                 },
                 {
                   "kind": "text",
-                  "text": "If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended."
+                  "text": "If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended."
                 },
                 {
                   "kind": "paragraph"
@@ -496,10 +504,6 @@
                 }
               ],
               "remarks": [
-                {
-                  "kind": "text",
-                  "text": ""
-                },
                 {
                   "kind": "html-tag",
                   "token": "<table>"
@@ -517,7 +521,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -558,7 +562,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -627,28 +631,31 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has these signatures:"
+                  "text": "In addition to this signature, this method also has the following signatures:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addItemAttachmentAsync(itemId: any, attachmentName: string): void;`"
+                  "kind": "code",
+                  "text": "addItemAttachmentAsync(itemId: any, attachmentName: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -695,7 +702,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -736,7 +743,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -764,10 +771,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -840,7 +843,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -881,7 +884,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -909,10 +912,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -959,7 +958,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -1000,7 +999,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -1028,10 +1027,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -1079,7 +1074,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -1120,7 +1115,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -1235,7 +1230,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -1276,7 +1271,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -1304,10 +1299,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -1318,7 +1309,7 @@
             },
             "getSelectedDataAsync": {
               "kind": "method",
-              "signature": "getSelectedDataAsync(coerciontype: Office.CoercionType, options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;",
+              "signature": "getSelectedDataAsync(coerciontype: Office.CoercionType, options: Office.AsyncContextOptions, callback: (result: AsyncResult<any>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -1361,7 +1352,7 @@
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<any>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -1410,7 +1401,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -1451,7 +1442,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -1479,10 +1470,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -1536,7 +1523,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -1577,7 +1564,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -1605,10 +1592,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -1619,7 +1602,7 @@
             },
             "loadCustomPropertiesAsync": {
               "kind": "method",
-              "signature": "loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;",
+              "signature": "loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -1633,12 +1616,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<Office.CustomProperties>) => void"
                 },
                 "userContext": {
                   "name": "userContext",
@@ -1699,7 +1682,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -1740,7 +1723,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -1768,10 +1751,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -1837,7 +1816,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -1878,7 +1857,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -1906,10 +1885,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -1957,7 +1932,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -1998,7 +1973,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -2026,10 +2001,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -2096,7 +2067,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -2137,7 +2108,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -2165,10 +2136,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -2179,7 +2146,7 @@
             },
             "removeAttachmentAsync": {
               "kind": "method",
-              "signature": "removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -2217,12 +2184,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -2236,7 +2203,7 @@
                 },
                 {
                   "kind": "text",
-                  "text": "The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window."
+                  "text": "The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to continue in a separate window."
                 },
                 {
                   "kind": "paragraph"
@@ -2264,7 +2231,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -2305,7 +2272,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -2380,22 +2347,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAttachmentAsync(attachmentIndex: string): void;`"
+                  "kind": "code",
+                  "text": "removeAttachmentAsync(attachmentIndex: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -2461,7 +2431,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -2502,7 +2472,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -2530,10 +2500,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -2544,7 +2510,7 @@
             },
             "saveAsync": {
               "kind": "method",
-              "signature": "saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -2570,12 +2536,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -2652,7 +2618,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -2693,7 +2659,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -2768,22 +2734,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`saveAsync(): void;`"
+                  "kind": "code",
+                  "text": "saveAsync(): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`saveAsync(options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "saveAsync(options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`saveAsync(callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "saveAsync(callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -2793,7 +2762,7 @@
             },
             "setSelectedDataAsync": {
               "kind": "method",
-              "signature": "setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -2831,12 +2800,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -2878,7 +2847,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -2919,7 +2888,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -2994,22 +2963,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -3089,7 +3061,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -3130,7 +3102,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -3158,10 +3130,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -3223,7 +3191,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -3264,7 +3232,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -3292,10 +3260,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -3327,10 +3291,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -3347,7 +3307,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -3388,7 +3348,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -3416,10 +3376,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -3464,7 +3420,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -3505,7 +3461,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -3533,10 +3489,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -3626,7 +3578,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -3667,7 +3619,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -3695,10 +3647,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -3774,7 +3722,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -3816,7 +3764,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -3844,10 +3792,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -3923,7 +3867,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -3964,7 +3908,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -3992,10 +3936,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -4071,7 +4011,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -4112,7 +4052,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -4140,10 +4080,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -4249,7 +4185,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -4290,7 +4226,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -4318,10 +4254,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -4404,7 +4336,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -4445,7 +4377,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -4473,10 +4405,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -4503,7 +4431,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Office.context.mailbox.item"
+                  "text": " Office.context.mailbox.item"
                 }
               ],
               "target": {
@@ -4540,7 +4468,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Gets an array of attachments for the item."
+                  "text": "Gets the item's attachments as an array."
                 },
                 {
                   "kind": "paragraph"
@@ -4568,7 +4496,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -4609,7 +4537,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -4650,7 +4578,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Blocked attachments in Outlook"
+                      "text": " Blocked attachments in Outlook"
                     }
                   ],
                   "targetUrl": "https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519"
@@ -4705,7 +4633,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -4746,7 +4674,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -4774,10 +4702,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -4825,7 +4749,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -4866,7 +4790,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -4894,10 +4818,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -4945,7 +4865,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -4986,7 +4906,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -5045,7 +4965,7 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB OR An"
+                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB OR An "
                     },
                     {
                       "kind": "api-link",
@@ -5116,10 +5036,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -5136,7 +5052,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -5177,7 +5093,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -5205,10 +5121,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -5232,7 +5144,7 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB. OR An"
+                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB. OR An "
                     },
                     {
                       "kind": "api-link",
@@ -5319,7 +5231,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -5360,7 +5272,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -5388,10 +5300,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -5452,7 +5360,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -5493,7 +5401,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -5521,10 +5429,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -5548,7 +5452,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Gets the entities found in the selected item."
+                  "text": "Gets the entities found in the selected item's body."
                 },
                 {
                   "kind": "paragraph"
@@ -5583,7 +5487,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -5624,7 +5528,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -5652,10 +5556,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -5674,7 +5574,7 @@
                 "description": [
                   {
                     "kind": "text",
-                    "text": "If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. If no entities of the specified type are present on the item, the method returns an empty array. Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter."
+                    "text": "If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. If no entities of the specified type are present in the item's body, the method returns an empty array. Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter."
                   }
                 ]
               },
@@ -5696,7 +5596,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Gets an array of all the entities of the specified entity type found in the selected item."
+                  "text": "Gets an array of all the entities of the specified entity type found in the selected item's body."
                 },
                 {
                   "kind": "paragraph"
@@ -5715,10 +5615,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -5735,7 +5631,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -5776,7 +5672,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -6338,10 +6234,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -6424,7 +6316,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -6465,7 +6357,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -6493,10 +6385,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -6573,7 +6461,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -6614,7 +6502,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -6642,10 +6530,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -6735,7 +6619,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -6776,7 +6660,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -6804,10 +6688,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -6865,7 +6745,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -6906,7 +6786,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -6934,10 +6814,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -7014,7 +6890,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -7055,7 +6931,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -7083,10 +6959,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -7140,7 +7012,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -7181,7 +7053,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -7456,7 +7328,21 @@
                 },
                 {
                   "kind": "text",
-                  "text": "Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more details, see Use the Outlook REST APIs from an Outlook add-in."
+                  "text": "Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more details, see "
+                },
+                {
+                  "kind": "web-link",
+                  "elements": [
+                    {
+                      "kind": "text",
+                      "text": " Use the Outlook REST APIs from an Outlook add-in"
+                    }
+                  ],
+                  "targetUrl": "https://docs.microsoft.com/outlook/add-ins/use-rest-api#get-the-item-id"
+                },
+                {
+                  "kind": "text",
+                  "text": "."
                 },
                 {
                   "kind": "paragraph"
@@ -7484,7 +7370,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -7525,7 +7411,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -7553,10 +7439,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -7611,7 +7493,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -7652,7 +7534,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -7680,10 +7562,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -7694,7 +7572,7 @@
             },
             "loadCustomPropertiesAsync": {
               "kind": "method",
-              "signature": "loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;",
+              "signature": "loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -7708,12 +7586,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<Office.CustomProperties>) => void"
                 },
                 "userContext": {
                   "name": "userContext",
@@ -7774,7 +7652,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -7815,7 +7693,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -7843,10 +7721,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -7900,7 +7774,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -7941,7 +7815,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -7969,10 +7843,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -8027,7 +7897,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -8068,7 +7938,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -8096,10 +7966,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -8147,7 +8013,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -8188,7 +8054,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -8216,10 +8082,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -8293,7 +8155,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -8334,7 +8196,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -8362,10 +8224,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -8385,7 +8243,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Gets the email address of the meeting organizer for a specified meeting. Read mode only."
+                  "text": "Gets the email address of the meeting organizer for a specified meeting."
                 },
                 {
                   "kind": "paragraph"
@@ -8413,7 +8271,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -8454,7 +8312,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -8482,10 +8340,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -8559,7 +8413,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -8600,7 +8454,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -8628,10 +8482,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -8686,7 +8536,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -8727,7 +8577,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -8755,10 +8605,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -8820,7 +8666,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -8861,7 +8707,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -8889,10 +8735,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -8931,10 +8773,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -8951,7 +8789,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -8992,7 +8830,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -9020,10 +8858,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -9178,10 +9012,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -9198,7 +9028,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -9239,7 +9069,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -9267,10 +9097,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -9278,7 +9104,7 @@
           "members": {
             "getAsync": {
               "kind": "method",
-              "signature": "getAsync(coerciontype: Office.CoercionType, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "getAsync(coerciontype: Office.CoercionType, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<Office.Body>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -9316,7 +9142,7 @@
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<Office.Body>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -9349,10 +9175,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -9369,7 +9191,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -9410,7 +9232,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -9444,14 +9266,15 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has this signature:"
+                  "text": "In addition to this signature, this method also has the following signature:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`getAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "getAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult<Office.Body>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -9461,7 +9284,7 @@
             },
             "getTypeAsync": {
               "kind": "method",
-              "signature": "getTypeAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "getTypeAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<Office.CoercionType>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -9487,12 +9310,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. The content type is returned as one of the CoercionType values in the asyncResult.value property."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. The content type is returned as one of the CoercionType values in the asyncResult.value property."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<Office.CoercionType>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -9511,10 +9334,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -9531,7 +9350,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -9572,7 +9391,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -9600,10 +9419,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -9613,7 +9428,7 @@
             },
             "prependAsync": {
               "kind": "method",
-              "signature": "prependAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "prependAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -9651,12 +9466,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. Any errors encountered will be provided in the asyncResult.error property."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. Any errors encountered will be provided in the asyncResult.error property."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -9697,10 +9512,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -9717,7 +9528,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -9758,7 +9569,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -9827,28 +9638,31 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has these signatures:"
+                  "text": "In addition to this signature, this method also has the following signatures:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`prependAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`"
+                  "kind": "code",
+                  "text": "prependAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`prependAsync(data: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "prependAsync(data: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`prependAsync(data: string): void;`"
+                  "kind": "code",
+                  "text": "prependAsync(data: string): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -9858,7 +9672,7 @@
             },
             "setAsync": {
               "kind": "method",
-              "signature": "setAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "setAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -9896,12 +9710,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. Any errors encountered will be provided in the asyncResult.error property."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. Any errors encountered will be provided in the asyncResult.error property."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -9942,10 +9756,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -9962,7 +9772,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -10003,7 +9813,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -10100,28 +9910,31 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has these signatures:"
+                  "text": "In addition to this signature, this method also has the following signatures:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`"
+                  "kind": "code",
+                  "text": "setAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(data: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "setAsync(data: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(data: string): void;`"
+                  "kind": "code",
+                  "text": "setAsync(data: string): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -10131,7 +9944,7 @@
             },
             "setSelectedDataAsync": {
               "kind": "method",
-              "signature": "setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -10169,12 +9982,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. Any errors encountered will be provided in the asyncResult.error property."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. Any errors encountered will be provided in the asyncResult.error property."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -10215,10 +10028,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -10235,7 +10044,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -10276,7 +10085,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -10373,28 +10182,31 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has these signatures:"
+                  "text": "In addition to this signature, this method also has the following signatures:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -10480,10 +10292,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -10500,7 +10308,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -10541,7 +10349,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -10569,10 +10377,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -10734,10 +10538,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -10754,7 +10554,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -10795,7 +10595,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -10823,10 +10623,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -10877,10 +10673,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -10897,7 +10689,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -10938,7 +10730,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -10966,10 +10758,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -10993,7 +10781,14 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "The name of the property to be removed. [Api set: Mailbox 1.0]"
+                      "text": "The name of the property to be removed."
+                    },
+                    {
+                      "kind": "paragraph"
+                    },
+                    {
+                      "kind": "text",
+                      "text": "[Api set: Mailbox 1.0]"
                     }
                   ],
                   "isOptional": false,
@@ -11017,10 +10812,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -11037,7 +10828,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -11078,7 +10869,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -11106,10 +10897,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -11119,7 +10906,7 @@
             },
             "saveAsync": {
               "kind": "method",
-              "signature": "saveAsync(callback?: (result: AsyncResult) => void, asyncContext?: any): void;",
+              "signature": "saveAsync(callback?: (result: AsyncResult<void>) => void, asyncContext?: any): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -11133,19 +10920,26 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 },
                 "asyncContext": {
                   "name": "asyncContext",
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. Any state data that is passed to the callback method. [Api set: Mailbox 1.0]"
+                      "text": "Optional. Any state data that is passed to the callback method."
+                    },
+                    {
+                      "kind": "paragraph"
+                    },
+                    {
+                      "kind": "text",
+                      "text": "[Api set: Mailbox 1.0]"
                     }
                   ],
                   "isOptional": true,
@@ -11176,10 +10970,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -11196,7 +10986,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -11237,7 +11027,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -11265,10 +11055,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -11342,10 +11128,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -11362,7 +11144,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -11403,7 +11185,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -11431,10 +11213,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -11465,10 +11243,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -11485,7 +11259,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -11526,7 +11300,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -11554,10 +11328,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -11593,10 +11363,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -11613,7 +11379,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -11654,7 +11420,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -11682,10 +11448,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -11724,10 +11486,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -11744,7 +11502,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -11785,7 +11543,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -11813,10 +11571,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -11827,11 +11581,11 @@
             },
             "OWAView": {
               "kind": "property",
-              "signature": "OWAView: \"string\";",
+              "signature": "OWAView: MailboxEnums.OWAView | \"OneColumn\" | \"TwoColumns\" | \"ThreeColumns\";",
               "isOptional": false,
               "isReadOnly": false,
               "isStatic": false,
-              "type": "\"string\"",
+              "type": "MailboxEnums.OWAView | \"OneColumn\" | \"TwoColumns\" | \"ThreeColumns\"",
               "deprecatedMessage": [],
               "summary": [
                 {
@@ -11890,10 +11644,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -11910,7 +11660,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -11951,7 +11701,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -11979,10 +11729,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -12014,10 +11760,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -12034,7 +11776,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -12075,7 +11817,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -12103,10 +11845,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -12219,10 +11957,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -12239,7 +11973,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -12280,7 +12014,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -12308,10 +12042,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -12424,10 +12154,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -12444,7 +12170,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -12485,7 +12211,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -12513,10 +12239,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -12680,7 +12402,16 @@
           "summary": [
             {
               "kind": "text",
-              "text": "The item namespace is used to access the currently selected message, meeting request, or appointment. You can determine the type of the item by using the `itemType` property."
+              "text": "The item namespace is used to access the currently selected message, meeting request, or appointment. You can determine the type of the item by using the "
+            },
+            {
+              "kind": "code",
+              "text": "itemType",
+              "highlighter": "plain"
+            },
+            {
+              "kind": "text",
+              "text": " property."
             },
             {
               "kind": "paragraph"
@@ -12691,10 +12422,6 @@
             }
           ],
           "remarks": [
-            {
-              "kind": "text",
-              "text": ""
-            },
             {
               "kind": "html-tag",
               "token": "<table>"
@@ -12712,7 +12439,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -12753,7 +12480,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -12781,10 +12508,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -12829,7 +12552,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -12870,7 +12593,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -12898,10 +12621,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -12949,7 +12668,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -12990,7 +12709,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -13018,10 +12737,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -13069,7 +12784,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -13110,7 +12825,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -13199,7 +12914,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -13240,7 +12955,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -13268,10 +12983,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -13282,7 +12993,7 @@
             },
             "loadCustomPropertiesAsync": {
               "kind": "method",
-              "signature": "loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;",
+              "signature": "loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -13296,12 +13007,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<Office.CustomProperties>) => void"
                 },
                 "userContext": {
                   "name": "userContext",
@@ -13362,7 +13073,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -13403,7 +13114,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -13431,10 +13142,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -13481,7 +13188,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -13522,7 +13229,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -13550,10 +13257,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -13580,7 +13283,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Office.context.mailbox.item"
+                  "text": " Office.context.mailbox.item"
                 }
               ],
               "target": {
@@ -13599,7 +13302,16 @@
             },
             {
               "kind": "text",
-              "text": "Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information."
+              "text": "Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of "
+            },
+            {
+              "kind": "code",
+              "text": "Office.context.mailbox.item",
+              "highlighter": "plain"
+            },
+            {
+              "kind": "text",
+              "text": ". Refer to the Object Model pages for more information."
             }
           ],
           "remarks": [],
@@ -13608,7 +13320,7 @@
           "members": {
             "addFileAttachmentAsync": {
               "kind": "method",
-              "signature": "addFileAttachmentAsync(uri: string, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "addFileAttachmentAsync(uri: string, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -13663,7 +13375,7 @@
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<string>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -13696,10 +13408,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -13716,7 +13424,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -13757,7 +13465,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -13880,22 +13588,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addFileAttachmentAsync(uri: string, attachmentName: string): void;`"
+                  "kind": "code",
+                  "text": "addFileAttachmentAsync(uri: string, attachmentName: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addFileAttachmentAsync(uri: string, attachmentName: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "addFileAttachmentAsync(uri: string, attachmentName: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -13905,7 +13616,7 @@
             },
             "addItemAttachmentAsync": {
               "kind": "method",
-              "signature": "addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -13955,12 +13666,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<string>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -13988,7 +13699,7 @@
                 },
                 {
                   "kind": "text",
-                  "text": "If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended."
+                  "text": "If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended."
                 },
                 {
                   "kind": "paragraph"
@@ -13999,10 +13710,6 @@
                 }
               ],
               "remarks": [
-                {
-                  "kind": "text",
-                  "text": ""
-                },
                 {
                   "kind": "html-tag",
                   "token": "<table>"
@@ -14020,7 +13727,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -14061,7 +13768,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -14130,28 +13837,31 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has these signatures:"
+                  "text": "In addition to this signature, this method also has the following signatures:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addItemAttachmentAsync(itemId: any, attachmentName: string): void;`"
+                  "kind": "code",
+                  "text": "addItemAttachmentAsync(itemId: any, attachmentName: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -14223,7 +13933,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -14264,7 +13974,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -14292,10 +14002,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -14305,7 +14011,7 @@
             },
             "getSelectedDataAsync": {
               "kind": "method",
-              "signature": "getSelectedDataAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult) => void): void;",
+              "signature": "getSelectedDataAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult<any>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -14331,12 +14037,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<any>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -14385,7 +14091,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -14426,7 +14132,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -14454,10 +14160,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -14467,7 +14169,7 @@
             },
             "removeAttachmentAsync": {
               "kind": "method",
-              "signature": "removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -14505,12 +14207,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -14524,7 +14226,7 @@
                 },
                 {
                   "kind": "text",
-                  "text": "The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window."
+                  "text": "The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to continue in a separate window."
                 },
                 {
                   "kind": "paragraph"
@@ -14552,7 +14254,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -14593,7 +14295,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -14668,22 +14370,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAttachmentAsync(attachmentIndex: string): void;`"
+                  "kind": "code",
+                  "text": "removeAttachmentAsync(attachmentIndex: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -14693,7 +14398,7 @@
             },
             "saveAsync": {
               "kind": "method",
-              "signature": "saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -14719,12 +14424,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -14801,7 +14506,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -14842,7 +14547,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -14917,22 +14622,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`saveAsync(): void;`"
+                  "kind": "code",
+                  "text": "saveAsync(): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`saveAsync(options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "saveAsync(options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`saveAsync(callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "saveAsync(callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -14942,7 +14650,7 @@
             },
             "setSelectedDataAsync": {
               "kind": "method",
-              "signature": "setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -14980,12 +14688,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -15027,7 +14735,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -15068,7 +14776,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -15143,22 +14851,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -15219,7 +14930,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -15260,7 +14971,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -15288,10 +14999,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -15318,7 +15025,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Office.context.mailbox.item"
+                  "text": " Office.context.mailbox.item"
                 }
               ],
               "target": {
@@ -15337,7 +15044,16 @@
             },
             {
               "kind": "text",
-              "text": "Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information."
+              "text": "Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of "
+            },
+            {
+              "kind": "code",
+              "text": "Office.context.mailbox.item",
+              "highlighter": "plain"
+            },
+            {
+              "kind": "text",
+              "text": ". Refer to the Object Model pages for more information."
             }
           ],
           "remarks": [],
@@ -15355,7 +15071,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Gets an array of attachments for the item."
+                  "text": "Gets the item's attachments as an array."
                 },
                 {
                   "kind": "paragraph"
@@ -15366,10 +15082,6 @@
                 }
               ],
               "remarks": [
-                {
-                  "kind": "text",
-                  "text": ""
-                },
                 {
                   "kind": "html-tag",
                   "token": "<table>"
@@ -15387,7 +15099,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -15428,7 +15140,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -15469,7 +15181,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Blocked attachments in Outlook"
+                      "text": " Blocked attachments in Outlook"
                     }
                   ],
                   "targetUrl": "https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519"
@@ -15501,7 +15213,7 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB OR An"
+                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB OR An "
                     },
                     {
                       "kind": "api-link",
@@ -15572,10 +15284,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -15592,7 +15300,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -15633,7 +15341,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -15661,10 +15369,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -15688,7 +15392,7 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB. OR An"
+                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB. OR An "
                     },
                     {
                       "kind": "api-link",
@@ -15775,7 +15479,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -15816,7 +15520,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -15844,10 +15548,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -15870,7 +15570,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Gets the entities found in the selected item."
+                  "text": "Gets the entities found in the selected item's body."
                 },
                 {
                   "kind": "paragraph"
@@ -15905,7 +15605,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -15946,7 +15646,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -15974,10 +15674,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -15996,7 +15692,7 @@
                 "description": [
                   {
                     "kind": "text",
-                    "text": "If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. If no entities of the specified type are present on the item, the method returns an empty array. Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter."
+                    "text": "If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. If no entities of the specified type are present in the item's body, the method returns an empty array. Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter."
                   }
                 ]
               },
@@ -16018,7 +15714,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Gets an array of all the entities of the specified entity type found in the selected item."
+                  "text": "Gets an array of all the entities of the specified entity type found in the selected item's body."
                 },
                 {
                   "kind": "paragraph"
@@ -16037,10 +15733,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -16057,7 +15749,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -16098,7 +15790,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -16660,10 +16352,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -16746,7 +16434,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -16787,7 +16475,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -16815,10 +16503,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -16895,7 +16579,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -16936,7 +16620,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -16964,10 +16648,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -17057,7 +16737,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -17098,7 +16778,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -17126,10 +16806,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -17187,7 +16863,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -17228,7 +16904,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -17256,10 +16932,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -17336,7 +17008,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -17377,7 +17049,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -17405,10 +17077,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -17462,7 +17130,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -17503,7 +17171,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -17745,10 +17413,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -17782,7 +17446,21 @@
                 },
                 {
                   "kind": "text",
-                  "text": "Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more details, see Use the Outlook REST APIs from an Outlook add-in."
+                  "text": "Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more details, see "
+                },
+                {
+                  "kind": "web-link",
+                  "elements": [
+                    {
+                      "kind": "text",
+                      "text": " Use the Outlook REST APIs from an Outlook add-in"
+                    }
+                  ],
+                  "targetUrl": "https://docs.microsoft.com/outlook/add-ins/use-rest-api#get-the-item-id"
+                },
+                {
+                  "kind": "text",
+                  "text": "."
                 },
                 {
                   "kind": "paragraph"
@@ -17810,7 +17488,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -17851,7 +17529,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -17879,10 +17557,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -17937,7 +17611,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -17978,7 +17652,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -18006,10 +17680,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -18071,7 +17741,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -18112,7 +17782,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -18140,10 +17810,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -18191,7 +17857,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -18232,7 +17898,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -18260,10 +17926,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -18460,10 +18122,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -18480,7 +18138,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -18521,7 +18179,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -18549,10 +18207,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -18560,7 +18214,7 @@
           "members": {
             "getAsync": {
               "kind": "method",
-              "signature": "getAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "getAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -18586,12 +18240,19 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. [Api set: Mailbox 1.1]"
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
+                    },
+                    {
+                      "kind": "paragraph"
+                    },
+                    {
+                      "kind": "text",
+                      "text": "[Api set: Mailbox 1.1]"
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<string>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -18610,10 +18271,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -18630,7 +18287,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -18671,7 +18328,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -18711,8 +18368,9 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`getAsync(callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "getAsync(callback: (result: AsyncResult<string>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -18722,7 +18380,7 @@
             },
             "setAsync": {
               "kind": "method",
-              "signature": "setAsync(location: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "setAsync(location: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -18760,12 +18418,19 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If setting the location fails, the asyncResult.error property will contain an error code. [Api set: Mailbox 1.1]"
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. If setting the location fails, the asyncResult.error property will contain an error code."
+                    },
+                    {
+                      "kind": "paragraph"
+                    },
+                    {
+                      "kind": "text",
+                      "text": "[Api set: Mailbox 1.1]"
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -18784,10 +18449,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -18804,7 +18465,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -18845,7 +18506,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -18920,22 +18581,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(location: string): void;`"
+                  "kind": "code",
+                  "text": "setAsync(location: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(location: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "setAsync(location: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(location: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "setAsync(location: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -18954,7 +18618,7 @@
           "summary": [
             {
               "kind": "text",
-              "text": "Provides access to the Outlook add-in object model for Microsoft Outlook and Microsoft Outlook on the web."
+              "text": "Provides access to the Outlook Add-in object model for Microsoft Outlook and Microsoft Outlook on the web."
             },
             {
               "kind": "paragraph"
@@ -18994,10 +18658,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -19014,7 +18674,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -19055,7 +18715,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -19083,10 +18743,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -19094,7 +18750,7 @@
           "members": {
             "addHandlerAsync": {
               "kind": "method",
-              "signature": "addHandlerAsync(eventType: Office.EventType, handler: (type: EventType) => void, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "addHandlerAsync(eventType: Office.EventType, handler: (type: EventType) => void, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -19144,12 +18800,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -19163,7 +18819,16 @@
                 },
                 {
                   "kind": "text",
-                  "text": "Currently the only supported event type is Office.EventType.ItemChanged, which is invoked when the user selects a new item. This event is used by add-ins that implement a pinnable taskpane, and allows the add-in to refresh the taskpane UI based on the currently selected item."
+                  "text": "Currently, the only supported event type is "
+                },
+                {
+                  "kind": "code",
+                  "text": "Office.EventType.ItemChanged",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": "."
                 },
                 {
                   "kind": "paragraph"
@@ -19191,7 +18856,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -19232,7 +18897,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -19260,10 +18925,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -19353,7 +19014,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -19394,7 +19055,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -19422,10 +19083,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -19503,7 +19160,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -19544,7 +19201,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -19572,10 +19229,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -19658,7 +19311,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -19699,7 +19352,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -19740,7 +19393,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Outlook Mail API"
+                      "text": " Outlook Mail API"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/previous-versions/office/office-365-api/api/version-2.0/mail-rest-operations"
@@ -19754,7 +19407,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Microsoft Graph"
+                      "text": " Microsoft Graph"
                     }
                   ],
                   "targetUrl": "http://graph.microsoft.io/"
@@ -19837,7 +19490,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -19878,7 +19531,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -19906,10 +19559,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -19956,7 +19605,7 @@
                 },
                 {
                   "kind": "text",
-                  "text": "- OWAView (string): A string that represents the current view of Outlook Web App. If the host application is not Outlook Web App, then accessing this property results in undefined. Outlook Web App has three views (OneColumn - displayed when the screen is narrow, TwoColumns - displayed when the screen is wider, and ThreeColumns - displayed when the screen is wide.) that correspond to the width of the screen and the window, and the number of columns that can be displayed."
+                  "text": "- OWAView (MailboxEnums.OWAView or string): An enum (or string literal) that represents the current view of Outlook Web App. If the host application is not Outlook Web App, then accessing this property results in undefined. Outlook Web App has three views (OneColumn - displayed when the screen is narrow, TwoColumns - displayed when the screen is wider, and ThreeColumns - displayed when the screen is wide) that correspond to the width of the screen and the window, and the number of columns that can be displayed."
                 },
                 {
                   "kind": "paragraph"
@@ -19994,10 +19643,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -20014,7 +19659,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -20055,7 +19700,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -20083,10 +19728,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -20186,7 +19827,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -20227,7 +19868,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -20255,10 +19896,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -20357,7 +19994,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -20398,7 +20035,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -20426,10 +20063,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -20528,7 +20161,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -20569,7 +20202,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -20597,10 +20230,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -20624,7 +20253,14 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "A dictionary containing all values to be filled in for the user in the new form. All parameters are optional. toRecipients: An array of strings containing the email addresses or an array containing an"
+                      "text": "A dictionary containing all values to be filled in for the user in the new form. All parameters are optional."
+                    },
+                    {
+                      "kind": "paragraph"
+                    },
+                    {
+                      "kind": "text",
+                      "text": "toRecipients: An array of strings containing the email addresses or an array containing an "
                     },
                     {
                       "kind": "api-link",
@@ -20643,7 +20279,14 @@
                     },
                     {
                       "kind": "text",
-                      "text": " object for each of the recipients on the To line. The array is limited to a maximum of 100 entries. ccRecipients: An array of strings containing the email addresses or an array containing an "
+                      "text": " object for each of the recipients on the To line. The array is limited to a maximum of 100 entries."
+                    },
+                    {
+                      "kind": "paragraph"
+                    },
+                    {
+                      "kind": "text",
+                      "text": "ccRecipients: An array of strings containing the email addresses or an array containing an "
                     },
                     {
                       "kind": "api-link",
@@ -20662,7 +20305,14 @@
                     },
                     {
                       "kind": "text",
-                      "text": " object for each of the recipients on the Cc line. The array is limited to a maximum of 100 entries. bccRecipients: An array of strings containing the email addresses or an array containing an "
+                      "text": " object for each of the recipients on the Cc line. The array is limited to a maximum of 100 entries."
+                    },
+                    {
+                      "kind": "paragraph"
+                    },
+                    {
+                      "kind": "text",
+                      "text": "bccRecipients: An array of strings containing the email addresses or an array containing an "
                     },
                     {
                       "kind": "api-link",
@@ -20681,7 +20331,63 @@
                     },
                     {
                       "kind": "text",
-                      "text": " object for each of the recipients on the Bcc line. The array is limited to a maximum of 100 entries. subject: A string containing the subject of the message. The string is limited to a maximum of 255 characters. htmlBody: The HTML body of the message. The body content is limited to a maximum size of 32 KB. attachments: An array of JSON objects that are either file or item attachments. attachments.type: Indicates the type of attachment. Must be file for a file attachment or item for an item attachment. attachments.name: A string that contains the name of the attachment, up to 255 characters in length. attachments.url: Only used if type is set to file. The URI of the location for the file. attachments.isInline: Only used if type is set to file. If true, indicates that the attachment will be shown inline in the message body, and should not be displayed in the attachment list. attachments.itemId: Only used if type is set to item. The EWS item id of the attachment. This is a string up to 100 characters."
+                      "text": " object for each of the recipients on the Bcc line. The array is limited to a maximum of 100 entries."
+                    },
+                    {
+                      "kind": "paragraph"
+                    },
+                    {
+                      "kind": "text",
+                      "text": "subject: A string containing the subject of the message. The string is limited to a maximum of 255 characters."
+                    },
+                    {
+                      "kind": "paragraph"
+                    },
+                    {
+                      "kind": "text",
+                      "text": "htmlBody: The HTML body of the message. The body content is limited to a maximum size of 32 KB."
+                    },
+                    {
+                      "kind": "paragraph"
+                    },
+                    {
+                      "kind": "text",
+                      "text": "attachments: An array of JSON objects that are either file or item attachments."
+                    },
+                    {
+                      "kind": "paragraph"
+                    },
+                    {
+                      "kind": "text",
+                      "text": "attachments.type: Indicates the type of attachment. Must be file for a file attachment or item for an item attachment."
+                    },
+                    {
+                      "kind": "paragraph"
+                    },
+                    {
+                      "kind": "text",
+                      "text": "attachments.name: A string that contains the name of the attachment, up to 255 characters in length."
+                    },
+                    {
+                      "kind": "paragraph"
+                    },
+                    {
+                      "kind": "text",
+                      "text": "attachments.url: Only used if type is set to file. The URI of the location for the file."
+                    },
+                    {
+                      "kind": "paragraph"
+                    },
+                    {
+                      "kind": "text",
+                      "text": "attachments.isInline: Only used if type is set to file. If true, indicates that the attachment will be shown inline in the message body, and should not be displayed in the attachment list."
+                    },
+                    {
+                      "kind": "paragraph"
+                    },
+                    {
+                      "kind": "text",
+                      "text": "attachments.itemId: Only used if type is set to item. The EWS item id of the existing e-mail you want to attach to the new message. This is a string up to 100 characters."
                     }
                   ],
                   "isOptional": false,
@@ -20735,7 +20441,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -20776,7 +20482,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -20804,10 +20510,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -20868,7 +20570,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -20909,7 +20611,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -20950,7 +20652,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "get attachments from the selected item"
+                      "text": " get attachments from the selected item"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/get-attachments-of-an-outlook-item"
@@ -20975,7 +20677,7 @@
             },
             "getCallbackTokenAsync": {
               "kind": "method",
-              "signature": "getCallbackTokenAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;",
+              "signature": "getCallbackTokenAsync(options: Office.AsyncContextOptions & { isRest?: boolean }, callback: (result: AsyncResult<string>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -20994,19 +20696,19 @@
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "Office.AsyncContextOptions"
+                  "type": "Office.AsyncContextOptions & { isRest?: boolean }"
                 },
                 "callback": {
                   "name": "callback",
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. The token is provided as a string in the asyncResult.value property."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. The token is provided as a string in the asyncResult.value property."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<string>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -21097,7 +20799,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -21138,7 +20840,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -21178,15 +20880,17 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`getCallbackTokenAsync(callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "getCallbackTokenAsync(callback: (result: AsyncResult<string>) => void): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`getCallbackTokenAsync(callback: (result: AsyncResult) => void, userContext?: any): void;`"
+                  "kind": "code",
+                  "text": "getCallbackTokenAsync(callback: (result: AsyncResult<string>) => void, userContext?: any): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -21196,7 +20900,7 @@
             },
             "getUserIdentityTokenAsync": {
               "kind": "method",
-              "signature": "getUserIdentityTokenAsync(callback: (result: AsyncResult) => void, userContext?: any): void;",
+              "signature": "getUserIdentityTokenAsync(callback: (result: AsyncResult<string>) => void, userContext?: any): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -21210,12 +20914,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. The token is provided as a string in the asyncResult.value property."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<string>) => void"
                 },
                 "userContext": {
                   "name": "userContext",
@@ -21269,7 +20973,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -21310,7 +21014,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -21351,7 +21055,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "authenticate the add-in and user with a third-party system"
+                      "text": " authenticate the add-in and user with a third-party system"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/authentication"
@@ -21377,7 +21081,57 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "The mailbox item. Depending on the context in which the add-in opened, the item may be of any number of types. If you want to see IntelliSense for only a specific type, you should cast this item to one of the following: `ItemCompose`, `ItemRead`, `MessageCompose`, `MessageRead`, `AppointmentCompose`, `AppointmentRead`"
+                  "text": "The mailbox item. Depending on the context in which the add-in opened, the item may be of any number of types. If you want to see IntelliSense for only a specific type, you should cast this item to one of the following: "
+                },
+                {
+                  "kind": "code",
+                  "text": "ItemCompose",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": ", "
+                },
+                {
+                  "kind": "code",
+                  "text": "ItemRead",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": ", "
+                },
+                {
+                  "kind": "code",
+                  "text": "MessageCompose",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": ", "
+                },
+                {
+                  "kind": "code",
+                  "text": "MessageRead",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": ", "
+                },
+                {
+                  "kind": "code",
+                  "text": "AppointmentCompose",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": ", "
+                },
+                {
+                  "kind": "code",
+                  "text": "AppointmentRead",
+                  "highlighter": "plain"
                 }
               ],
               "remarks": [],
@@ -21389,7 +21143,7 @@
             },
             "makeEwsRequestAsync": {
               "kind": "method",
-              "signature": "makeEwsRequestAsync(data: any, callback: (result: AsyncResult) => void, userContext?: any): void;",
+              "signature": "makeEwsRequestAsync(data: any, callback: (result: AsyncResult<string>) => void, userContext?: any): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -21415,12 +21169,21 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. The "
+                    },
+                    {
+                      "kind": "code",
+                      "text": "value",
+                      "highlighter": "plain"
+                    },
+                    {
+                      "kind": "text",
+                      "text": " property of the result is the XML of the EWS request provided as a string. If the result exceeds 1 MB in size, an error message is returned instead."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<string>) => void"
                 },
                 "userContext": {
                   "name": "userContext",
@@ -21474,7 +21237,21 @@
                 },
                 {
                   "kind": "text",
-                  "text": "Your add-in must have the ReadWriteMailbox permission to use the makeEwsRequestAsync method. For information about using the ReadWriteMailbox permission and the EWS operations that you can call with the makeEwsRequestAsync method, see Specify permissions for mail add-in access to the user's mailbox."
+                  "text": "Your add-in must have the ReadWriteMailbox permission to use the makeEwsRequestAsync method. For information about using the ReadWriteMailbox permission and the EWS operations that you can call with the makeEwsRequestAsync method, see "
+                },
+                {
+                  "kind": "web-link",
+                  "elements": [
+                    {
+                      "kind": "text",
+                      "text": " Specify permissions for mail add-in access to the user's mailbox"
+                    }
+                  ],
+                  "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
+                },
+                {
+                  "kind": "text",
+                  "text": "."
                 },
                 {
                   "kind": "paragraph"
@@ -21488,7 +21265,21 @@
                 },
                 {
                   "kind": "text",
-                  "text": "Note: This method is not supported in the following scenarios. - In Outlook for iOS or Outlook for Android - When the add-in is loaded in a Gmail mailbox"
+                  "text": "Note: This method is not supported in the following scenarios:"
+                },
+                {
+                  "kind": "paragraph"
+                },
+                {
+                  "kind": "text",
+                  "text": "- In Outlook for iOS or Outlook for Android."
+                },
+                {
+                  "kind": "paragraph"
+                },
+                {
+                  "kind": "text",
+                  "text": "- When the add-in is loaded in a Gmail mailbox."
                 },
                 {
                   "kind": "paragraph"
@@ -21515,8 +21306,9 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`<?xml version=\"1.0\" encoding=\"iso-8859-1\"?>`"
+                  "kind": "code",
+                  "text": "<?xml version=\"1.0\" encoding=\"iso-8859-1\"?>",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
@@ -21551,7 +21343,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -21592,7 +21384,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -21620,10 +21412,190 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
+                }
+              ],
+              "isBeta": false,
+              "isSealed": false,
+              "isVirtual": false,
+              "isOverride": false
+            },
+            "removeHandlerAsync": {
+              "kind": "method",
+              "signature": "removeHandlerAsync(eventType: Office.EventType, handler: (type: EventType) => void, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
+              "accessModifier": "",
+              "isOptional": false,
+              "isStatic": false,
+              "returnValue": {
+                "type": "void",
+                "description": []
+              },
+              "parameters": {
+                "eventType": {
+                  "name": "eventType",
+                  "description": [
+                    {
+                      "kind": "text",
+                      "text": "The event that should revoke the handler."
+                    }
+                  ],
+                  "isOptional": false,
+                  "isSpread": false,
+                  "type": "Office.EventType"
+                },
+                "handler": {
+                  "name": "handler",
+                  "description": [
+                    {
+                      "kind": "text",
+                      "text": "The function to handle the event. The function must accept a single parameter, which is an object literal. The type property on the parameter will match the eventType parameter passed to addHandlerAsync."
+                    }
+                  ],
+                  "isOptional": false,
+                  "isSpread": false,
+                  "type": "(type: EventType) => void"
+                },
+                "options": {
+                  "name": "options",
+                  "description": [
+                    {
+                      "kind": "text",
+                      "text": "Optional. Provides an option for preserving context data of any type, unchanged, for use in a callback."
+                    }
+                  ],
+                  "isOptional": true,
+                  "isSpread": false,
+                  "type": "Office.AsyncContextOptions"
+                },
+                "callback": {
+                  "name": "callback",
+                  "description": [
+                    {
+                      "kind": "text",
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
+                    }
+                  ],
+                  "isOptional": true,
+                  "isSpread": false,
+                  "type": "(result: AsyncResult<void>) => void"
+                }
+              },
+              "deprecatedMessage": [],
+              "summary": [
+                {
+                  "kind": "text",
+                  "text": "Removes an event handler for a supported event."
+                },
+                {
+                  "kind": "paragraph"
                 },
                 {
                   "kind": "text",
-                  "text": ""
+                  "text": "Currently, the only supported event type is "
+                },
+                {
+                  "kind": "code",
+                  "text": "Office.EventType.ItemChanged",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": "."
+                },
+                {
+                  "kind": "paragraph"
+                },
+                {
+                  "kind": "text",
+                  "text": "[Api set: Mailbox 1.5]"
+                }
+              ],
+              "remarks": [
+                {
+                  "kind": "html-tag",
+                  "token": "<table>"
+                },
+                {
+                  "kind": "html-tag",
+                  "token": "<tr>"
+                },
+                {
+                  "kind": "html-tag",
+                  "token": "<td>"
+                },
+                {
+                  "kind": "web-link",
+                  "elements": [
+                    {
+                      "kind": "text",
+                      "text": " Minimum permission level"
+                    }
+                  ],
+                  "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
+                },
+                {
+                  "kind": "html-tag",
+                  "token": "</td>"
+                },
+                {
+                  "kind": "html-tag",
+                  "token": "<td>"
+                },
+                {
+                  "kind": "text",
+                  "text": "ReadItem"
+                },
+                {
+                  "kind": "html-tag",
+                  "token": "</td>"
+                },
+                {
+                  "kind": "html-tag",
+                  "token": "</tr>"
+                },
+                {
+                  "kind": "paragraph"
+                },
+                {
+                  "kind": "html-tag",
+                  "token": "<tr>"
+                },
+                {
+                  "kind": "html-tag",
+                  "token": "<td>"
+                },
+                {
+                  "kind": "web-link",
+                  "elements": [
+                    {
+                      "kind": "text",
+                      "text": " Applicable Outlook mode"
+                    }
+                  ],
+                  "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
+                },
+                {
+                  "kind": "html-tag",
+                  "token": "</td>"
+                },
+                {
+                  "kind": "html-tag",
+                  "token": "<td>"
+                },
+                {
+                  "kind": "text",
+                  "text": "Compose or read"
+                },
+                {
+                  "kind": "html-tag",
+                  "token": "</td>"
+                },
+                {
+                  "kind": "html-tag",
+                  "token": "</tr>"
+                },
+                {
+                  "kind": "html-tag",
+                  "token": "</table>"
                 }
               ],
               "isBeta": false,
@@ -21684,7 +21656,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -21725,7 +21697,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -21766,7 +21738,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "REST API"
+                      "text": " REST API"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/rest/"
@@ -21793,7 +21765,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Information about the user associated with the mailbox. This includes their account type, display name, email adddress, and time zone."
+                  "text": "Information about the user associated with the mailbox. This includes their account type, display name, email address, and time zone."
                 },
                 {
                   "kind": "paragraph"
@@ -21816,10 +21788,6 @@
                     "exportName": "Office",
                     "memberName": "UserProfile"
                   }
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "remarks": [],
@@ -21897,10 +21865,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -21921,7 +21885,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -21953,10 +21917,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false
@@ -22072,10 +22032,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -22096,7 +22052,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -22128,10 +22084,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false
@@ -22195,10 +22147,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -22219,7 +22167,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -22251,10 +22199,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false
@@ -22305,10 +22249,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -22329,7 +22269,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -22361,12 +22301,61 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
+              "isBeta": false
+            },
+            "OWAView": {
+              "kind": "enum",
+              "values": {
+                "OneColumn": {
+                  "kind": "enum value",
+                  "value": "\"OneColumn\"",
+                  "deprecatedMessage": [],
+                  "summary": [
+                    {
+                      "kind": "text",
+                      "text": "One column view. Displayed when the screen is narrow. Outlook Web App uses this single-column layout on the entire screen of a smartphone."
+                    }
+                  ],
+                  "remarks": [],
+                  "isBeta": false
+                },
+                "ThreeColumns": {
+                  "kind": "enum value",
+                  "value": "\"ThreeColumns\"",
+                  "deprecatedMessage": [],
+                  "summary": [
+                    {
+                      "kind": "text",
+                      "text": "Three column view. Displayed when the screen is wide. For example, Outlook Web App uses this view in a full screen window on a desktop computer."
+                    }
+                  ],
+                  "remarks": [],
+                  "isBeta": false
+                },
+                "TwoColumns": {
+                  "kind": "enum value",
+                  "value": "\"TwoColumns\"",
+                  "deprecatedMessage": [],
+                  "summary": [
+                    {
+                      "kind": "text",
+                      "text": "Two column view. Displayed when the screen is wider. Outlook Web App uses this view on most tablets."
+                    }
+                  ],
+                  "remarks": [],
+                  "isBeta": false
+                }
+              },
+              "deprecatedMessage": [],
+              "summary": [
+                {
+                  "kind": "text",
+                  "text": "Represents the current view of Outlook Web App."
+                }
+              ],
+              "remarks": [],
               "isBeta": false
             },
             "RecipientType": {
@@ -22441,10 +22430,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -22465,7 +22450,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -22497,10 +22482,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false
@@ -22590,10 +22571,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -22614,7 +22591,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -22646,10 +22623,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false
@@ -22713,10 +22686,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -22737,7 +22706,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -22769,10 +22738,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false
@@ -22814,10 +22779,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -22834,7 +22795,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -22875,7 +22836,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -22903,10 +22864,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -23075,7 +23032,16 @@
             },
             {
               "kind": "text",
-              "text": "Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information."
+              "text": "Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of "
+            },
+            {
+              "kind": "code",
+              "text": "Office.context.mailbox.item",
+              "highlighter": "plain"
+            },
+            {
+              "kind": "text",
+              "text": ". Refer to the Object Model pages for more information."
             }
           ],
           "remarks": [],
@@ -23135,7 +23101,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -23176,7 +23142,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -23204,10 +23170,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -23234,7 +23196,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Office.context.mailbox.item"
+                  "text": " Office.context.mailbox.item"
                 }
               ],
               "target": {
@@ -23253,7 +23215,16 @@
             },
             {
               "kind": "text",
-              "text": "Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information."
+              "text": "Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of "
+            },
+            {
+              "kind": "code",
+              "text": "Office.context.mailbox.item",
+              "highlighter": "plain"
+            },
+            {
+              "kind": "text",
+              "text": ". Refer to the Object Model pages for more information."
             }
           ],
           "remarks": [],
@@ -23262,7 +23233,7 @@
           "members": {
             "addFileAttachmentAsync": {
               "kind": "method",
-              "signature": "addFileAttachmentAsync(uri: string, attachmentName: string, options?: AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "addFileAttachmentAsync(uri: string, attachmentName: string, options?: AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -23312,12 +23283,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type asyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of the error."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. On success, the attachment identifier will be provided in the asyncResult.value property. If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of the error."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<string>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -23350,10 +23321,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -23370,7 +23337,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -23411,7 +23378,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -23542,22 +23509,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addFileAttachmentAsync(uri: string, attachmentName: string): void;`"
+                  "kind": "code",
+                  "text": "addFileAttachmentAsync(uri: string, attachmentName: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addFileAttachmentAsync(uri: string, attachmentName: string, options: AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "addFileAttachmentAsync(uri: string, attachmentName: string, options: AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -23567,7 +23537,7 @@
             },
             "addItemAttachmentAsync": {
               "kind": "method",
-              "signature": "addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "addItemAttachmentAsync(itemId: any, attachmentName: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<string>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -23622,7 +23592,7 @@
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<string>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -23650,7 +23620,7 @@
                 },
                 {
                   "kind": "text",
-                  "text": "If your Office Add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended."
+                  "text": "If your Office add-in is running in Outlook Web App, the addItemAttachmentAsync method can attach items to items other than the item that you are editing; however, this is not supported and is not recommended."
                 },
                 {
                   "kind": "paragraph"
@@ -23661,10 +23631,6 @@
                 }
               ],
               "remarks": [
-                {
-                  "kind": "text",
-                  "text": ""
-                },
                 {
                   "kind": "html-tag",
                   "token": "<table>"
@@ -23682,7 +23648,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -23723,7 +23689,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -23792,28 +23758,31 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has these signatures:"
+                  "text": "In addition to this signature, this method also has the following signatures:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addItemAttachmentAsync(itemId: any, attachmentName: string): void;`"
+                  "kind": "code",
+                  "text": "addItemAttachmentAsync(itemId: any, attachmentName: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -23860,7 +23829,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -23901,7 +23870,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -23929,10 +23898,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -23980,7 +23945,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -24021,7 +23986,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -24049,10 +24014,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -24126,7 +24087,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -24167,7 +24128,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -24195,10 +24156,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -24271,7 +24228,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -24312,7 +24269,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -24340,10 +24297,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -24404,7 +24357,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -24445,7 +24398,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -24473,10 +24426,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -24524,7 +24473,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -24565,7 +24514,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -24593,10 +24542,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -24644,7 +24589,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -24685,7 +24630,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -24730,7 +24675,7 @@
             },
             "getSelectedDataAsync": {
               "kind": "method",
-              "signature": "getSelectedDataAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult) => void): void;",
+              "signature": "getSelectedDataAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult<any>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -24756,12 +24701,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<any>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -24810,7 +24755,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -24851,7 +24796,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -24879,10 +24824,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -24936,7 +24877,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -24977,7 +24918,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -25005,10 +24946,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -25019,7 +24956,7 @@
             },
             "loadCustomPropertiesAsync": {
               "kind": "method",
-              "signature": "loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;",
+              "signature": "loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -25033,12 +24970,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<Office.CustomProperties>) => void"
                 },
                 "userContext": {
                   "name": "userContext",
@@ -25099,7 +25036,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -25140,7 +25077,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -25168,10 +25105,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -25218,7 +25151,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -25259,7 +25192,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -25287,10 +25220,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -25301,7 +25230,7 @@
             },
             "removeAttachmentAsync": {
               "kind": "method",
-              "signature": "removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "removeAttachmentAsync(attachmentIndex: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -25339,12 +25268,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -25358,7 +25287,7 @@
                 },
                 {
                   "kind": "text",
-                  "text": "The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window."
+                  "text": "The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to continue in a separate window."
                 },
                 {
                   "kind": "paragraph"
@@ -25386,7 +25315,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -25427,7 +25356,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -25502,22 +25431,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAttachmentAsync(attachmentIndex: string): void;`"
+                  "kind": "code",
+                  "text": "removeAttachmentAsync(attachmentIndex: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -25527,7 +25459,7 @@
             },
             "saveAsync": {
               "kind": "method",
-              "signature": "saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "saveAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -25553,12 +25485,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -25635,7 +25567,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -25676,7 +25608,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -25751,22 +25683,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`saveAsync(): void;`"
+                  "kind": "code",
+                  "text": "saveAsync(): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`saveAsync(options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "saveAsync(options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`saveAsync(callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "saveAsync(callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -25776,7 +25711,7 @@
             },
             "setSelectedDataAsync": {
               "kind": "method",
-              "signature": "setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "setSelectedDataAsync(data: string, options?: Office.AsyncContextOptions & CoercionTypeOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -25814,12 +25749,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -25861,7 +25796,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -25902,7 +25837,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -25977,22 +25912,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -26053,7 +25991,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -26094,7 +26032,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -26122,10 +26060,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -26180,7 +26114,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -26221,7 +26155,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -26249,10 +26183,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -26279,7 +26209,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Office.context.mailbox.item"
+                  "text": " Office.context.mailbox.item"
                 }
               ],
               "target": {
@@ -26316,7 +26246,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Gets an array of attachments for the item."
+                  "text": "Gets the item's attachments as an array."
                 },
                 {
                   "kind": "paragraph"
@@ -26344,7 +26274,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -26385,7 +26315,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -26426,7 +26356,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Blocked attachments in Outlook"
+                      "text": " Blocked attachments in Outlook"
                     }
                   ],
                   "targetUrl": "https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519"
@@ -26481,7 +26411,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -26522,7 +26452,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -26550,10 +26480,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -26608,7 +26534,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -26649,7 +26575,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -26677,10 +26603,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -26742,7 +26664,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -26783,7 +26705,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -26811,10 +26733,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -26862,7 +26780,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -26903,7 +26821,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -26931,10 +26849,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -26982,7 +26896,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -27023,7 +26937,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -27082,7 +26996,7 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB OR An"
+                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB OR An "
                     },
                     {
                       "kind": "api-link",
@@ -27153,10 +27067,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -27173,7 +27083,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -27214,7 +27124,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -27242,10 +27152,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -27269,7 +27175,7 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB. OR An"
+                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB. OR An "
                     },
                     {
                       "kind": "api-link",
@@ -27356,7 +27262,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -27397,7 +27303,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -27425,10 +27331,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -27496,7 +27398,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -27537,7 +27439,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -27565,10 +27467,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -27592,7 +27490,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Gets the entities found in the selected item."
+                  "text": "Gets the entities found in the selected item's body."
                 },
                 {
                   "kind": "paragraph"
@@ -27627,7 +27525,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -27668,7 +27566,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -27696,10 +27594,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -27718,7 +27612,7 @@
                 "description": [
                   {
                     "kind": "text",
-                    "text": "If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. If no entities of the specified type are present on the item, the method returns an empty array. Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter."
+                    "text": "If the value passed in entityType is not a valid member of the EntityType enumeration, the method returns null. If no entities of the specified type are present in the item's body, the method returns an empty array. Otherwise, the type of the objects in the returned array depends on the type of entity requested in the entityType parameter."
                   }
                 ]
               },
@@ -27740,7 +27634,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Gets an array of all the entities of the specified entity type found in the selected item."
+                  "text": "Gets an array of all the entities of the specified entity type found in the selected item's body."
                 },
                 {
                   "kind": "paragraph"
@@ -27775,7 +27669,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -27816,7 +27710,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -28378,10 +28272,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -28464,7 +28354,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -28505,7 +28395,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -28533,10 +28423,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -28613,7 +28499,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -28654,7 +28540,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -28682,10 +28568,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -28775,7 +28657,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -28816,7 +28698,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -28844,10 +28726,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -28905,7 +28783,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -28946,7 +28824,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -28974,10 +28852,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -29054,7 +28928,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -29095,7 +28969,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -29123,10 +28997,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -29173,7 +29043,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -29214,7 +29084,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -29242,10 +29112,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -29300,7 +29166,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -29341,7 +29207,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -29616,7 +29482,21 @@
                 },
                 {
                   "kind": "text",
-                  "text": "Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more details, see Use the Outlook REST APIs from an Outlook add-in."
+                  "text": "Note: The identifier returned by the itemId property is the same as the Exchange Web Services item identifier. The itemId property is not identical to the Outlook Entry ID or the ID used by the Outlook REST API. Before making REST API calls using this value, it should be converted using Office.context.mailbox.convertToRestId. For more details, see "
+                },
+                {
+                  "kind": "web-link",
+                  "elements": [
+                    {
+                      "kind": "text",
+                      "text": " Use the Outlook REST APIs from an Outlook add-in"
+                    }
+                  ],
+                  "targetUrl": "https://docs.microsoft.com/outlook/add-ins/use-rest-api#get-the-item-id"
+                },
+                {
+                  "kind": "text",
+                  "text": "."
                 },
                 {
                   "kind": "paragraph"
@@ -29644,7 +29524,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -29685,7 +29565,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -29713,10 +29593,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -29771,7 +29647,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -29812,7 +29688,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -29840,10 +29716,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -29854,7 +29726,7 @@
             },
             "loadCustomPropertiesAsync": {
               "kind": "method",
-              "signature": "loadCustomPropertiesAsync(callback: (result: AsyncResult) => void, userContext?: any): void;",
+              "signature": "loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -29868,12 +29740,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<Office.CustomProperties>) => void"
                 },
                 "userContext": {
                   "name": "userContext",
@@ -29934,7 +29806,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -29975,7 +29847,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -30003,10 +29875,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -30060,7 +29928,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -30101,7 +29969,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -30129,10 +29997,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -30180,7 +30044,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -30221,7 +30085,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -30249,10 +30113,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -30314,7 +30174,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -30355,7 +30215,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -30383,10 +30243,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -30448,7 +30304,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -30489,7 +30345,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -30517,10 +30373,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -30575,7 +30427,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -30616,7 +30468,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -30644,10 +30496,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -30679,10 +30527,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -30699,7 +30543,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -30740,7 +30584,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -30768,10 +30612,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -30905,10 +30745,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -30925,7 +30761,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -30966,7 +30802,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -30994,10 +30830,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -31005,7 +30837,7 @@
           "members": {
             "addAsync": {
               "kind": "method",
-              "signature": "addAsync(key: string, JSONmessage: NotificationMessageDetails, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "addAsync(key: string, JSONmessage: NotificationMessageDetails, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -31055,12 +30887,19 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. [Api set: Mailbox 1.3]"
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
+                    },
+                    {
+                      "kind": "paragraph"
+                    },
+                    {
+                      "kind": "text",
+                      "text": "[Api set: Mailbox 1.3]"
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -31079,10 +30918,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -31099,7 +30934,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -31140,7 +30975,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -31180,22 +31015,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addAsync(key: string, JSONmessage: NotificationMessageDetails): void;`"
+                  "kind": "code",
+                  "text": "addAsync(key: string, JSONmessage: NotificationMessageDetails): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addAsync(key: string, JSONmessage: NotificationMessageDetails, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "addAsync(key: string, JSONmessage: NotificationMessageDetails, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addAsync(key: string, JSONmessage: NotificationMessageDetails, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "addAsync(key: string, JSONmessage: NotificationMessageDetails, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -31205,7 +31043,7 @@
             },
             "getAllAsync": {
               "kind": "method",
-              "signature": "getAllAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "getAllAsync(options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<Office.NotificationMessageDetails[]>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -31231,12 +31069,21 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. The "
+                    },
+                    {
+                      "kind": "code",
+                      "text": "value",
+                      "highlighter": "plain"
+                    },
+                    {
+                      "kind": "text",
+                      "text": " property of the result is an array of NotificationMessageDetails objects."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<Office.NotificationMessageDetails[]>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -31255,10 +31102,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -31275,7 +31118,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -31316,7 +31159,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -31350,14 +31193,15 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has this signature:"
+                  "text": "In addition to this signature, this method also has the following signature:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`getAllAsync(callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "getAllAsync(callback: (result: AsyncResult<Office.NotificationMessageDetails[]>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -31367,7 +31211,7 @@
             },
             "removeAsync": {
               "kind": "method",
-              "signature": "removeAsync(key: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "removeAsync(key: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -31405,12 +31249,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -31429,10 +31273,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -31449,7 +31289,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -31490,7 +31330,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -31524,28 +31364,31 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has these signatures:"
+                  "text": "In addition to this signature, this method also has the following signatures:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAsync(key: string): void;`"
+                  "kind": "code",
+                  "text": "removeAsync(key: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAsync(key: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "removeAsync(key: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAsync(key: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "removeAsync(key: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -31555,7 +31398,7 @@
             },
             "replaceAsync": {
               "kind": "method",
-              "signature": "replaceAsync(key: string, JSONmessage: NotificationMessageDetails, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "replaceAsync(key: string, JSONmessage: NotificationMessageDetails, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -31605,12 +31448,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -31636,10 +31479,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -31656,7 +31495,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -31697,7 +31536,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -31731,28 +31570,31 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has these signatures:"
+                  "text": "In addition to this signature, this method also has the following signatures:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`replaceAsync(key: string, JSONmessage: NotificationMessageDetails): void;`"
+                  "kind": "code",
+                  "text": "replaceAsync(key: string, JSONmessage: NotificationMessageDetails): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`replaceAsync(key: string, JSONmessage: NotificationMessageDetails, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "replaceAsync(key: string, JSONmessage: NotificationMessageDetails, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`replaceAsync(key: string, JSONmessage: NotificationMessageDetails, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "replaceAsync(key: string, JSONmessage: NotificationMessageDetails, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -31790,10 +31632,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -31810,7 +31648,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -31851,7 +31689,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -31879,10 +31717,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -31967,10 +31801,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -31987,7 +31817,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -32028,7 +31858,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -32056,10 +31886,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -32067,7 +31893,7 @@
           "members": {
             "addAsync": {
               "kind": "method",
-              "signature": "addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -32105,12 +31931,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If adding the recipients fails, the asyncResult.error property will contain an error code."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. If adding the recipients fails, the asyncResult.error property will contain an error code."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -32157,10 +31983,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -32177,7 +31999,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -32218,7 +32040,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -32287,28 +32109,31 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has these signatures:"
+                  "text": "In addition to this signature, this method also has the following signatures:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addAsync(recipients: (string | EmailUser | EmailAddressDetails)[]): void;`"
+                  "kind": "code",
+                  "text": "addAsync(recipients: (string | EmailUser | EmailAddressDetails)[]): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -32318,7 +32143,7 @@
             },
             "getAsync": {
               "kind": "method",
-              "signature": "getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;",
+              "signature": "getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult<Office.EmailAddressDetails[]>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -32344,12 +32169,21 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. The "
+                    },
+                    {
+                      "kind": "code",
+                      "text": "value",
+                      "highlighter": "plain"
+                    },
+                    {
+                      "kind": "text",
+                      "text": " property of the result is an array of EmailAddressDetails objects."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<Office.EmailAddressDetails[]>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -32363,7 +32197,7 @@
                 },
                 {
                   "kind": "text",
-                  "text": "When the call completes, the asyncResult.value property will contain an array of"
+                  "text": "When the call completes, the asyncResult.value property will contain an array of "
                 },
                 {
                   "kind": "api-link",
@@ -32394,10 +32228,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -32414,7 +32244,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -32455,7 +32285,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -32489,14 +32319,15 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has this signature:"
+                  "text": "In addition to this signature, this method also has the following signature:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`getAsync(callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "getAsync(callback: (result: AsyncResult<Office.EmailAddressDetails[]>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -32506,7 +32337,7 @@
             },
             "setAsync": {
               "kind": "method",
-              "signature": "setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -32544,12 +32375,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If setting the recipients fails the asyncResult.error property will contain a code that indicates any error that occurred while adding the data."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. If setting the recipients fails the asyncResult.error property will contain a code that indicates any error that occurred while adding the data."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -32641,10 +32472,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -32661,7 +32488,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -32702,7 +32529,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -32771,28 +32598,31 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has these signatures:"
+                  "text": "In addition to this signature, this method also has the following signatures:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(recipients: (string | EmailUser | EmailAddressDetails)[]): void;`"
+                  "kind": "code",
+                  "text": "setAsync(recipients: (string | EmailUser | EmailAddressDetails)[]): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -32983,16 +32813,16 @@
             },
             "callback": {
               "kind": "property",
-              "signature": "callback?: (result: AsyncResult) => void;",
+              "signature": "callback?: (result: AsyncResult<any>) => void;",
               "isOptional": true,
               "isReadOnly": false,
               "isStatic": false,
-              "type": "(result: AsyncResult) => void",
+              "type": "(result: AsyncResult<any>) => void",
               "deprecatedMessage": [],
               "summary": [
                 {
                   "kind": "text",
-                  "text": "When the reply display call completes, the function passed in the callback parameter is called with a single parameter, asyncResult, which is an AsyncResult object."
+                  "text": "When the reply display call completes, the function passed in the callback parameter is called with a single parameter, asyncResult, which is an Office.AsyncResult object."
                 }
               ],
               "remarks": [],
@@ -33041,7 +32871,7 @@
             },
             {
               "kind": "text",
-              "text": "While the Outlook add-in API limits access to these settings to only the add-in that created them, these settings should not be considered secure storage. They can be accessed by Exchange Web Services or Extended MAPI. They should not be used to store sensitive information such as user credentials or security tokens."
+              "text": "While the Outlook Add-in API limits access to these settings to only the add-in that created them, these settings should not be considered secure storage. They can be accessed by Exchange Web Services or Extended MAPI. They should not be used to store sensitive information such as user credentials or security tokens."
             },
             {
               "kind": "paragraph"
@@ -33074,10 +32904,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -33094,7 +32920,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -33135,7 +32961,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -33163,10 +32989,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -33217,10 +33039,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -33237,7 +33055,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -33278,7 +33096,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -33306,10 +33124,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -33357,10 +33171,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -33377,7 +33187,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -33418,7 +33228,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -33446,10 +33256,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -33459,7 +33265,7 @@
             },
             "saveAsync": {
               "kind": "method",
-              "signature": "saveAsync(callback?: (result: AsyncResult) => void): void;",
+              "signature": "saveAsync(callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -33473,12 +33279,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional? When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -33504,10 +33310,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -33524,7 +33326,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -33565,7 +33367,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -33593,10 +33395,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -33677,10 +33475,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -33697,7 +33491,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -33738,7 +33532,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -33766,10 +33560,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -33835,10 +33625,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -33855,7 +33641,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -33896,7 +33682,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -33924,10 +33710,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -33935,7 +33717,7 @@
           "members": {
             "getAsync": {
               "kind": "method",
-              "signature": "getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;",
+              "signature": "getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult<string>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -33961,12 +33743,21 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. The "
+                    },
+                    {
+                      "kind": "code",
+                      "text": "value",
+                      "highlighter": "plain"
+                    },
+                    {
+                      "kind": "text",
+                      "text": " property of the result is the subject of the item."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<string>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -33992,10 +33783,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -34012,7 +33799,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -34053,7 +33840,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -34087,14 +33874,15 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has this signature:"
+                  "text": "In addition to this signature, this method also has the following signature:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`getAsync(callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "getAsync(callback: (result: AsyncResult<string>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -34104,7 +33892,7 @@
             },
             "setAsync": {
               "kind": "method",
-              "signature": "setAsync(subject: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "setAsync(subject: string, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -34142,12 +33930,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If setting the subject fails, the asyncResult.error property will contain an error code."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. If setting the subject fails, the asyncResult.error property will contain an error code."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -34173,10 +33961,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -34193,7 +33977,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -34234,7 +34018,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -34303,28 +34087,31 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has these signatures:"
+                  "text": "In addition to this signature, this method also has the following signatures:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(subject: string): void;`"
+                  "kind": "code",
+                  "text": "setAsync(subject: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(subject: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "setAsync(subject: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(subject: string, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "setAsync(subject: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -34350,7 +34137,26 @@
             },
             {
               "kind": "text",
-              "text": "The list of tasks suggested in an email message is returned in the taskSuggestions property of the [Entities]Entities object that is returned when the getEntities or getEntitiesByType method is called on the active item."
+              "text": "The list of tasks suggested in an email message is returned in the taskSuggestions property of the "
+            },
+            {
+              "kind": "api-link",
+              "elements": [
+                {
+                  "kind": "text",
+                  "text": " Entities"
+                }
+              ],
+              "target": {
+                "scopeName": "",
+                "packageName": "Outlook_1_6",
+                "exportName": "Office",
+                "memberName": "Entities"
+              }
+            },
+            {
+              "kind": "text",
+              "text": " object that is returned when the getEntities or getEntitiesByType method is called on the active item."
             },
             {
               "kind": "paragraph"
@@ -34361,10 +34167,6 @@
             }
           ],
           "remarks": [
-            {
-              "kind": "text",
-              "text": ""
-            },
             {
               "kind": "html-tag",
               "token": "<table>"
@@ -34382,7 +34184,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -34423,7 +34225,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -34451,10 +34253,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -34525,10 +34323,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -34545,7 +34339,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -34586,7 +34380,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -34614,10 +34408,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -34625,7 +34415,7 @@
           "members": {
             "getAsync": {
               "kind": "method",
-              "signature": "getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult) => void): void;",
+              "signature": "getAsync(options: Office.AsyncContextOptions, callback: (result: AsyncResult<Date>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -34651,12 +34441,21 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. The "
+                    },
+                    {
+                      "kind": "code",
+                      "text": "value",
+                      "highlighter": "plain"
+                    },
+                    {
+                      "kind": "text",
+                      "text": " property of the result is a Date object."
                     }
                   ],
                   "isOptional": false,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<Date>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -34682,10 +34481,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -34702,7 +34497,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -34743,7 +34538,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -34777,14 +34572,15 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has this signature:"
+                  "text": "In addition to this signature, this method also has the following signature:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`getAsync(callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "getAsync(callback: (result: AsyncResult<Date>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -34794,7 +34590,7 @@
             },
             "setAsync": {
               "kind": "method",
-              "signature": "setAsync(dateTime: Date, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult) => void): void;",
+              "signature": "setAsync(dateTime: Date, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -34832,12 +34628,12 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. If setting the date and time fails, the asyncResult.error property will contain an error code."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. If setting the date and time fails, the asyncResult.error property will contain an error code."
                     }
                   ],
                   "isOptional": true,
                   "isSpread": false,
-                  "type": "(result: AsyncResult) => void"
+                  "type": "(result: AsyncResult<void>) => void"
                 }
               },
               "deprecatedMessage": [],
@@ -34870,10 +34666,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -34890,7 +34682,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -34931,7 +34723,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -35000,28 +34792,31 @@
                 },
                 {
                   "kind": "text",
-                  "text": "In addition to the main signature, this method also has these signatures:"
+                  "text": "In addition to this signature, this method also has the following signatures:"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(dateTime: Date): void;`"
+                  "kind": "code",
+                  "text": "setAsync(dateTime: Date): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(dateTime: Date, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "setAsync(dateTime: Date, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(dateTime: Date, callback: (result: AsyncResult) => void): void;`"
+                  "kind": "code",
+                  "text": "setAsync(dateTime: Date, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -35052,10 +34847,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -35072,7 +34863,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -35113,7 +34904,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -35141,10 +34932,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -35196,7 +34983,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -35237,7 +35024,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -35527,10 +35314,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -35562,10 +35345,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -35582,7 +35361,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -35623,7 +35402,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -35651,10 +35430,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -35686,10 +35461,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -35706,7 +35477,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -35747,7 +35518,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -35775,10 +35546,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -35810,10 +35577,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -35830,7 +35593,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -35871,7 +35634,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -35899,10 +35662,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,

--- a/generate-docs/json/Outlook_1_7.api.json
+++ b/generate-docs/json/Outlook_1_7.api.json
@@ -69,7 +69,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Office.context.mailbox.item"
+                  "text": " Office.context.mailbox.item"
                 }
               ],
               "target": {
@@ -88,7 +88,16 @@
             },
             {
               "kind": "text",
-              "text": "Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information."
+              "text": "Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of "
+            },
+            {
+              "kind": "code",
+              "text": "Office.context.mailbox.item",
+              "highlighter": "plain"
+            },
+            {
+              "kind": "text",
+              "text": ". Refer to the Object Model pages for more information."
             }
           ],
           "remarks": [],
@@ -185,10 +194,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -205,7 +210,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -246,7 +251,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -377,30 +382,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addFileAttachmentAsync(uri: string, attachmentName: string): void;`"
+                  "kind": "code",
+                  "text": "addFileAttachmentAsync(uri: string, attachmentName: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addFileAttachmentAsync(uri: string, attachmentName: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "addFileAttachmentAsync(uri: string, attachmentName: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult"
-                },
-                {
-                  "kind": "html-tag",
-                  "token": "<string>"
-                },
-                {
-                  "kind": "text",
-                  "text": ") => void): void;`"
+                  "kind": "code",
+                  "text": "addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -479,7 +479,34 @@
                 },
                 {
                   "kind": "text",
-                  "text": "Currently the supported event types are `Office.EventType.AppointmentTimeChanged`, `Office.EventType.RecipientsChanged`, and `Office.EventType.RecurrenceChanged`."
+                  "text": "Currently the supported event types are "
+                },
+                {
+                  "kind": "code",
+                  "text": "Office.EventType.AppointmentTimeChanged",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": ", "
+                },
+                {
+                  "kind": "code",
+                  "text": "Office.EventType.RecipientsChanged",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": ", and "
+                },
+                {
+                  "kind": "code",
+                  "text": "Office.EventType.RecurrenceChanged",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": "."
                 },
                 {
                   "kind": "paragraph"
@@ -507,7 +534,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -548,7 +575,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -588,16 +615,9 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addHandlerAsync(eventType:EventType, handler: any, callback?: (result: AsyncResult"
-                },
-                {
-                  "kind": "html-tag",
-                  "token": "<void>"
-                },
-                {
-                  "kind": "text",
-                  "text": ") => void): void;`"
+                  "kind": "code",
+                  "text": "addHandlerAsync(eventType:EventType, handler: any, callback?: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -702,10 +722,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -722,7 +738,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -763,7 +779,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -838,30 +854,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addItemAttachmentAsync(itemId: any, attachmentName: string): void;`"
+                  "kind": "code",
+                  "text": "addItemAttachmentAsync(itemId: any, attachmentName: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult"
-                },
-                {
-                  "kind": "html-tag",
-                  "token": "<string>"
-                },
-                {
-                  "kind": "text",
-                  "text": ") => void): void;`"
+                  "kind": "code",
+                  "text": "addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -908,7 +919,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -949,7 +960,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -977,10 +988,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -1053,7 +1060,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -1094,7 +1101,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -1122,10 +1129,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -1172,7 +1175,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -1213,7 +1216,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -1241,10 +1244,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -1292,7 +1291,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -1333,7 +1332,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -1448,7 +1447,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -1489,7 +1488,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -1517,10 +1516,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -1623,7 +1618,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -1664,7 +1659,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -1692,10 +1687,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -1749,7 +1740,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -1790,7 +1781,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -1818,10 +1809,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -1912,7 +1899,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -1953,7 +1940,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -1981,10 +1968,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -2050,7 +2033,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -2091,7 +2074,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -2119,10 +2102,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -2170,7 +2149,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -2211,7 +2190,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -2239,10 +2218,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -2309,7 +2284,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -2350,7 +2325,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -2378,10 +2353,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -2415,7 +2386,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Organizer"
+                      "text": " Organizer"
                     }
                   ],
                   "target": {
@@ -2455,7 +2426,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -2496,7 +2467,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -2524,10 +2495,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -2554,7 +2521,16 @@
                 },
                 {
                   "kind": "text",
-                  "text": "The recurrence property returns a recurrence object for recurring appointments or meetings requests if an item is a series or an instance in a series. `null` is returned for single appointments and meeting requests of single appointments."
+                  "text": "The recurrence property returns a recurrence object for recurring appointments or meetings requests if an item is a series or an instance in a series. "
+                },
+                {
+                  "kind": "code",
+                  "text": "null",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": " is returned for single appointments and meeting requests of single appointments."
                 },
                 {
                   "kind": "paragraph"
@@ -2596,7 +2572,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -2637,7 +2613,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -2665,10 +2641,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -2736,7 +2708,7 @@
                 },
                 {
                   "kind": "text",
-                  "text": "The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window."
+                  "text": "The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to continue in a separate window."
                 },
                 {
                   "kind": "paragraph"
@@ -2764,7 +2736,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -2805,7 +2777,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -2880,30 +2852,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAttachmentAsync(attachmentIndex: string): void;`"
+                  "kind": "code",
+                  "text": "removeAttachmentAsync(attachmentIndex: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult"
-                },
-                {
-                  "kind": "html-tag",
-                  "token": "<void>"
-                },
-                {
-                  "kind": "text",
-                  "text": ") => void): void;`"
+                  "kind": "code",
+                  "text": "removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -2927,7 +2894,7 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "The event that should invoke the handler."
+                      "text": "The event that should revoke the handler."
                     }
                   ],
                   "isOptional": false,
@@ -2982,7 +2949,34 @@
                 },
                 {
                   "kind": "text",
-                  "text": "Currently the supported event types are `Office.EventType.AppointmentTimeChanged`, `Office.EventType.RecipientsChanged`, and `Office.EventType.RecurrenceChanged`."
+                  "text": "Currently the supported event types are "
+                },
+                {
+                  "kind": "code",
+                  "text": "Office.EventType.AppointmentTimeChanged",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": ", "
+                },
+                {
+                  "kind": "code",
+                  "text": "Office.EventType.RecipientsChanged",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": ", and "
+                },
+                {
+                  "kind": "code",
+                  "text": "Office.EventType.RecurrenceChanged",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": "."
                 },
                 {
                   "kind": "paragraph"
@@ -3010,7 +3004,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -3051,7 +3045,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -3091,16 +3085,9 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeHandlerAsync(eventType:EventType, handler: any, callback?: (result: AsyncResult"
-                },
-                {
-                  "kind": "html-tag",
-                  "token": "<void>"
-                },
-                {
-                  "kind": "text",
-                  "text": ") => void): void;`"
+                  "kind": "code",
+                  "text": "removeHandlerAsync(eventType:EventType, handler: any, callback?: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -3166,7 +3153,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -3207,7 +3194,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -3235,10 +3222,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -3357,7 +3340,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -3398,7 +3381,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -3473,30 +3456,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`saveAsync(): void;`"
+                  "kind": "code",
+                  "text": "saveAsync(): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`saveAsync(options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "saveAsync(options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`saveAsync(callback: (result: AsyncResult"
-                },
-                {
-                  "kind": "html-tag",
-                  "token": "<void>"
-                },
-                {
-                  "kind": "text",
-                  "text": ") => void): void;`"
+                  "kind": "code",
+                  "text": "saveAsync(callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -3536,7 +3514,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Use the Outlook REST APIs from an Outlook add-in"
+                      "text": " Use the Outlook REST APIs from an Outlook add-in"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/use-rest-api"
@@ -3578,7 +3556,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -3619,7 +3597,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -3647,10 +3625,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -3746,7 +3720,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -3787,7 +3761,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -3862,30 +3836,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string, callback: (result: AsyncResult"
-                },
-                {
-                  "kind": "html-tag",
-                  "token": "<void>"
-                },
-                {
-                  "kind": "text",
-                  "text": ") => void): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -3965,7 +3934,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -4006,7 +3975,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -4034,10 +4003,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -4099,7 +4064,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -4140,7 +4105,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -4168,10 +4133,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -4203,10 +4164,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -4223,7 +4180,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -4264,7 +4221,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -4292,10 +4249,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -4340,7 +4293,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -4381,7 +4334,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -4409,10 +4362,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -4502,7 +4451,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -4543,7 +4492,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -4571,10 +4520,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -4650,7 +4595,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -4692,7 +4637,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -4720,10 +4665,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -4799,7 +4740,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -4840,7 +4781,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -4868,10 +4809,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -4947,7 +4884,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -4988,7 +4925,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -5016,10 +4953,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -5125,7 +5058,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -5166,7 +5099,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -5194,10 +5127,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -5280,7 +5209,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -5321,7 +5250,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -5349,10 +5278,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -5379,7 +5304,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Office.context.mailbox.item"
+                  "text": " Office.context.mailbox.item"
                 }
               ],
               "target": {
@@ -5476,7 +5401,34 @@
                 },
                 {
                   "kind": "text",
-                  "text": "Currently the supported event types are `Office.EventType.AppointmentTimeChanged`, `Office.EventType.RecipientsChanged`, and `Office.EventType.RecurrenceChanged`."
+                  "text": "Currently the supported event types are "
+                },
+                {
+                  "kind": "code",
+                  "text": "Office.EventType.AppointmentTimeChanged",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": ", "
+                },
+                {
+                  "kind": "code",
+                  "text": "Office.EventType.RecipientsChanged",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": ", and "
+                },
+                {
+                  "kind": "code",
+                  "text": "Office.EventType.RecurrenceChanged",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": "."
                 },
                 {
                   "kind": "paragraph"
@@ -5504,7 +5456,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -5545,7 +5497,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -5585,16 +5537,9 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addHandlerAsync(eventType: Office.EventType, handler: any, callback?: (result: AsyncResult"
-                },
-                {
-                  "kind": "html-tag",
-                  "token": "<void>"
-                },
-                {
-                  "kind": "text",
-                  "text": ") => void): void;`"
+                  "kind": "code",
+                  "text": "addHandlerAsync(eventType: Office.EventType, handler: any, callback?: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -5613,7 +5558,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Gets an array of attachments for the item."
+                  "text": "Gets the item's attachments as an array."
                 },
                 {
                   "kind": "paragraph"
@@ -5641,7 +5586,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -5682,7 +5627,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -5723,7 +5668,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Blocked attachments in Outlook"
+                      "text": " Blocked attachments in Outlook"
                     }
                   ],
                   "targetUrl": "https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519"
@@ -5778,7 +5723,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -5819,7 +5764,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -5847,10 +5792,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -5898,7 +5839,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -5939,7 +5880,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -5967,10 +5908,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -6018,7 +5955,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -6059,7 +5996,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -6118,7 +6055,7 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB OR An"
+                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB OR An "
                     },
                     {
                       "kind": "api-link",
@@ -6189,10 +6126,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -6209,7 +6142,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -6250,7 +6183,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -6278,10 +6211,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -6305,7 +6234,7 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB. OR An"
+                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB. OR An "
                     },
                     {
                       "kind": "api-link",
@@ -6392,7 +6321,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -6433,7 +6362,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -6461,10 +6390,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -6525,7 +6450,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -6566,7 +6491,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -6594,10 +6519,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -6656,7 +6577,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -6697,7 +6618,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -6725,10 +6646,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -6788,10 +6705,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -6808,7 +6721,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -6849,7 +6762,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -7411,10 +7324,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -7497,7 +7406,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -7538,7 +7447,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -7566,10 +7475,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -7646,7 +7551,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -7687,7 +7592,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -7715,10 +7620,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -7808,7 +7709,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -7849,7 +7750,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -7877,10 +7778,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -7938,7 +7835,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -7979,7 +7876,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -8007,10 +7904,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -8087,7 +7980,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -8128,7 +8021,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -8156,10 +8049,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -8213,7 +8102,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -8254,7 +8143,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -8536,7 +8425,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Use the Outlook REST APIs from an Outlook add-in"
+                      "text": " Use the Outlook REST APIs from an Outlook add-in"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/use-rest-api#get-the-item-id"
@@ -8571,7 +8460,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -8612,7 +8501,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -8640,10 +8529,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -8698,7 +8583,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -8739,7 +8624,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -8767,10 +8652,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -8861,7 +8742,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -8902,7 +8783,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -8930,10 +8811,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -8987,7 +8864,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -9028,7 +8905,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -9056,10 +8933,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -9114,7 +8987,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -9155,7 +9028,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -9183,10 +9056,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -9234,7 +9103,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -9275,7 +9144,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -9303,10 +9172,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -9380,7 +9245,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -9421,7 +9286,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -9449,10 +9314,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -9500,7 +9361,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -9541,7 +9402,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -9569,10 +9430,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -9599,7 +9456,16 @@
                 },
                 {
                   "kind": "text",
-                  "text": "The recurrence property returns a recurrence object for recurring appointments or meetings requests if an item is a series or an instance in a series. `null` is returned for single appointments and meeting requests of single appointments."
+                  "text": "The recurrence property returns a recurrence object for recurring appointments or meetings requests if an item is a series or an instance in a series. "
+                },
+                {
+                  "kind": "code",
+                  "text": "null",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": " is returned for single appointments and meeting requests of single appointments."
                 },
                 {
                   "kind": "paragraph"
@@ -9641,7 +9507,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -9682,7 +9548,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -9710,10 +9576,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -9738,7 +9600,7 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "The event that should invoke the handler."
+                      "text": "The event that should revoke the handler."
                     }
                   ],
                   "isOptional": false,
@@ -9793,7 +9655,34 @@
                 },
                 {
                   "kind": "text",
-                  "text": "Currently the supported event types are `Office.EventType.AppointmentTimeChanged`, `Office.EventType.RecipientsChanged`, and `Office.EventType.RecurrenceChanged`."
+                  "text": "Currently the supported event types are "
+                },
+                {
+                  "kind": "code",
+                  "text": "Office.EventType.AppointmentTimeChanged",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": ", "
+                },
+                {
+                  "kind": "code",
+                  "text": "Office.EventType.RecipientsChanged",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": ", and "
+                },
+                {
+                  "kind": "code",
+                  "text": "Office.EventType.RecurrenceChanged",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": "."
                 },
                 {
                   "kind": "paragraph"
@@ -9821,7 +9710,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -9862,7 +9751,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -9902,16 +9791,9 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeHandlerAsync(eventType:EventType, handler: any, callback?: (result: AsyncResult"
-                },
-                {
-                  "kind": "html-tag",
-                  "token": "<void>"
-                },
-                {
-                  "kind": "text",
-                  "text": ") => void): void;`"
+                  "kind": "code",
+                  "text": "removeHandlerAsync(eventType:EventType, handler: any, callback?: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -9984,7 +9866,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -10025,7 +9907,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -10053,10 +9935,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -10097,7 +9975,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Use the Outlook REST APIs from an Outlook add-in"
+                      "text": " Use the Outlook REST APIs from an Outlook add-in"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/use-rest-api"
@@ -10139,7 +10017,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -10180,7 +10058,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -10208,10 +10086,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -10266,7 +10140,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -10307,7 +10181,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -10335,10 +10209,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -10400,7 +10270,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -10441,7 +10311,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -10469,10 +10339,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -10511,10 +10377,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -10531,7 +10393,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -10572,7 +10434,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -10600,10 +10462,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -10758,10 +10616,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -10778,7 +10632,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -10819,7 +10673,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -10847,10 +10701,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -10929,10 +10779,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -10949,7 +10795,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -10990,7 +10836,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -11030,8 +10876,9 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`getAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult<Office.Body>) => void): void;`"
+                  "kind": "code",
+                  "text": "getAsync(coerciontype: Office.CoercionType, callback: (result: AsyncResult<Office.Body>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -11091,10 +10938,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -11111,7 +10954,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -11152,7 +10995,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -11180,10 +11023,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -11277,10 +11116,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -11297,7 +11132,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -11338,7 +11173,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -11413,30 +11248,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`prependAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`"
+                  "kind": "code",
+                  "text": "prependAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`prependAsync(data: string, callback: (result: AsyncResult"
-                },
-                {
-                  "kind": "html-tag",
-                  "token": "<void>"
-                },
-                {
-                  "kind": "text",
-                  "text": ") => void): void;`"
+                  "kind": "code",
+                  "text": "prependAsync(data: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`prependAsync(data: string): void;`"
+                  "kind": "code",
+                  "text": "prependAsync(data: string): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -11530,10 +11360,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -11550,7 +11376,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -11591,7 +11417,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -11694,30 +11520,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`"
+                  "kind": "code",
+                  "text": "setAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(data: string, callback: (result: AsyncResult"
-                },
-                {
-                  "kind": "html-tag",
-                  "token": "<void>"
-                },
-                {
-                  "kind": "text",
-                  "text": ") => void): void;`"
+                  "kind": "code",
+                  "text": "setAsync(data: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(data: string): void;`"
+                  "kind": "code",
+                  "text": "setAsync(data: string): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -11811,10 +11632,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -11831,7 +11648,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -11872,7 +11689,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -11975,30 +11792,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string, callback: (result: AsyncResult"
-                },
-                {
-                  "kind": "html-tag",
-                  "token": "<void>"
-                },
-                {
-                  "kind": "text",
-                  "text": ") => void): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -12084,10 +11896,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -12104,7 +11912,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -12145,7 +11953,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -12173,10 +11981,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -12338,10 +12142,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -12358,7 +12158,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -12399,7 +12199,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -12427,10 +12227,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -12481,10 +12277,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -12501,7 +12293,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -12542,7 +12334,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -12570,10 +12362,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -12597,7 +12385,14 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "The name of the property to be removed. [Api set: Mailbox 1.0]"
+                      "text": "The name of the property to be removed."
+                    },
+                    {
+                      "kind": "paragraph"
+                    },
+                    {
+                      "kind": "text",
+                      "text": "[Api set: Mailbox 1.0]"
                     }
                   ],
                   "isOptional": false,
@@ -12621,10 +12416,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -12641,7 +12432,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -12682,7 +12473,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -12710,10 +12501,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -12749,7 +12536,14 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. Any state data that is passed to the callback method. [Api set: Mailbox 1.0]"
+                      "text": "Optional. Any state data that is passed to the callback method."
+                    },
+                    {
+                      "kind": "paragraph"
+                    },
+                    {
+                      "kind": "text",
+                      "text": "[Api set: Mailbox 1.0]"
                     }
                   ],
                   "isOptional": true,
@@ -12780,10 +12574,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -12800,7 +12590,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -12841,7 +12631,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -12869,10 +12659,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -12946,10 +12732,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -12966,7 +12748,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -13007,7 +12789,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -13035,10 +12817,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -13069,10 +12847,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -13089,7 +12863,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -13130,7 +12904,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -13158,10 +12932,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -13197,10 +12967,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -13217,7 +12983,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -13258,7 +13024,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -13286,10 +13052,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -13328,10 +13090,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -13348,7 +13106,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -13389,7 +13147,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -13417,10 +13175,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -13494,10 +13248,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -13514,7 +13264,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -13555,7 +13305,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -13583,10 +13333,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -13618,10 +13364,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -13638,7 +13380,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -13679,7 +13421,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -13707,10 +13449,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -13823,10 +13561,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -13843,7 +13577,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -13884,7 +13618,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -13912,10 +13646,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -14028,10 +13758,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -14048,7 +13774,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -14089,7 +13815,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -14117,10 +13843,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -14296,10 +14018,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -14316,7 +14034,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -14357,7 +14075,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -14385,10 +14103,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -14422,7 +14136,16 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter, asyncResult, which is an Office.AsyncResult object. The `value` property of the result is message's from value, as an EmailAddressDetails object."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter, asyncResult, which is an Office.AsyncResult object. The "
+                    },
+                    {
+                      "kind": "code",
+                      "text": "value",
+                      "highlighter": "plain"
+                    },
+                    {
+                      "kind": "text",
+                      "text": " property of the result is message's from value, as an EmailAddressDetails object."
                     }
                   ],
                   "isOptional": false,
@@ -14479,10 +14202,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -14499,7 +14218,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -14540,7 +14259,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -14580,8 +14299,9 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`getAsync(callback?: (result: AsyncResult<Office.EmailAddressDetails>) => void): void;`"
+                  "kind": "code",
+                  "text": "getAsync(callback?: (result: AsyncResult<Office.EmailAddressDetails>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -14600,7 +14320,16 @@
           "summary": [
             {
               "kind": "text",
-              "text": "The item namespace is used to access the currently selected message, meeting request, or appointment. You can determine the type of the item by using the `itemType` property."
+              "text": "The item namespace is used to access the currently selected message, meeting request, or appointment. You can determine the type of the item by using the "
+            },
+            {
+              "kind": "code",
+              "text": "itemType",
+              "highlighter": "plain"
+            },
+            {
+              "kind": "text",
+              "text": " property."
             },
             {
               "kind": "paragraph"
@@ -14611,10 +14340,6 @@
             }
           ],
           "remarks": [
-            {
-              "kind": "text",
-              "text": ""
-            },
             {
               "kind": "html-tag",
               "token": "<table>"
@@ -14632,7 +14357,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -14673,7 +14398,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -14701,10 +14426,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -14781,7 +14502,34 @@
                 },
                 {
                   "kind": "text",
-                  "text": "Currently the supported event types are `Office.EventType.AppointmentTimeChanged`, `Office.EventType.RecipientsChanged`, and `Office.EventType.RecurrenceChanged`."
+                  "text": "Currently the supported event types are "
+                },
+                {
+                  "kind": "code",
+                  "text": "Office.EventType.AppointmentTimeChanged",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": ", "
+                },
+                {
+                  "kind": "code",
+                  "text": "Office.EventType.RecipientsChanged",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": ", and "
+                },
+                {
+                  "kind": "code",
+                  "text": "Office.EventType.RecurrenceChanged",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": "."
                 },
                 {
                   "kind": "paragraph"
@@ -14809,7 +14557,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -14850,7 +14598,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -14890,16 +14638,9 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addHandlerAsync(eventType: Office.EventType, handler: any, callback?: (result: AsyncResult"
-                },
-                {
-                  "kind": "html-tag",
-                  "token": "<void>"
-                },
-                {
-                  "kind": "text",
-                  "text": ") => void): void;`"
+                  "kind": "code",
+                  "text": "addHandlerAsync(eventType: Office.EventType, handler: any, callback?: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -14946,7 +14687,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -14987,7 +14728,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -15015,10 +14756,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -15066,7 +14803,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -15107,7 +14844,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -15135,10 +14872,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -15186,7 +14919,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -15227,7 +14960,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -15316,7 +15049,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -15357,7 +15090,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -15385,10 +15118,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -15479,7 +15208,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -15520,7 +15249,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -15548,10 +15277,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -15598,7 +15323,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -15639,7 +15364,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -15667,10 +15392,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -15697,7 +15418,25 @@
                 },
                 {
                   "kind": "text",
-                  "text": "The recurrence property returns a recurrence object for recurring appointments or meetings requests if an item is a series or an instance in a series. `null` is returned for single appointments and meeting requests of single appointments. `undefined` is returned for messages that are not meeting requests."
+                  "text": "The recurrence property returns a recurrence object for recurring appointments or meetings requests if an item is a series or an instance in a series. "
+                },
+                {
+                  "kind": "code",
+                  "text": "null",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": " is returned for single appointments and meeting requests of single appointments. "
+                },
+                {
+                  "kind": "code",
+                  "text": "undefined",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": " is returned for messages that are not meeting requests."
                 },
                 {
                   "kind": "paragraph"
@@ -15739,7 +15478,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -15780,7 +15519,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -15808,10 +15547,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -15836,7 +15571,7 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "The event that should invoke the handler."
+                      "text": "The event that should revoke the handler."
                     }
                   ],
                   "isOptional": false,
@@ -15891,7 +15626,34 @@
                 },
                 {
                   "kind": "text",
-                  "text": "Currently the supported event types are `Office.EventType.AppointmentTimeChanged`, `Office.EventType.RecipientsChanged`, and `Office.EventType.RecurrenceChanged`."
+                  "text": "Currently the supported event types are "
+                },
+                {
+                  "kind": "code",
+                  "text": "Office.EventType.AppointmentTimeChanged",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": ", "
+                },
+                {
+                  "kind": "code",
+                  "text": "Office.EventType.RecipientsChanged",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": ", and "
+                },
+                {
+                  "kind": "code",
+                  "text": "Office.EventType.RecurrenceChanged",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": "."
                 },
                 {
                   "kind": "paragraph"
@@ -15919,7 +15681,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -15960,7 +15722,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -16000,16 +15762,9 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeHandlerAsync(eventType: Office.EventType, handler: any, callback?: (result: AsyncResult"
-                },
-                {
-                  "kind": "html-tag",
-                  "token": "<void>"
-                },
-                {
-                  "kind": "text",
-                  "text": ") => void): void;`"
+                  "kind": "code",
+                  "text": "removeHandlerAsync(eventType: Office.EventType, handler: any, callback?: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -16049,7 +15804,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Use the Outlook REST APIs from an Outlook add-in"
+                      "text": " Use the Outlook REST APIs from an Outlook add-in"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/use-rest-api"
@@ -16091,7 +15846,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -16132,7 +15887,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -16160,10 +15915,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -16190,7 +15941,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Office.context.mailbox.item"
+                  "text": " Office.context.mailbox.item"
                 }
               ],
               "target": {
@@ -16209,7 +15960,16 @@
             },
             {
               "kind": "text",
-              "text": "Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information."
+              "text": "Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of "
+            },
+            {
+              "kind": "code",
+              "text": "Office.context.mailbox.item",
+              "highlighter": "plain"
+            },
+            {
+              "kind": "text",
+              "text": ". Refer to the Object Model pages for more information."
             }
           ],
           "remarks": [],
@@ -16306,10 +16066,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -16326,7 +16082,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -16367,7 +16123,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -16490,30 +16246,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addFileAttachmentAsync(uri: string, attachmentName: string): void;`"
+                  "kind": "code",
+                  "text": "addFileAttachmentAsync(uri: string, attachmentName: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addFileAttachmentAsync(uri: string, attachmentName: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "addFileAttachmentAsync(uri: string, attachmentName: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult"
-                },
-                {
-                  "kind": "html-tag",
-                  "token": "<string>"
-                },
-                {
-                  "kind": "text",
-                  "text": ") => void): void;`"
+                  "kind": "code",
+                  "text": "addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -16618,10 +16369,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -16638,7 +16385,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -16679,7 +16426,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -16754,30 +16501,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addItemAttachmentAsync(itemId: any, attachmentName: string): void;`"
+                  "kind": "code",
+                  "text": "addItemAttachmentAsync(itemId: any, attachmentName: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult"
-                },
-                {
-                  "kind": "html-tag",
-                  "token": "<string>"
-                },
-                {
-                  "kind": "text",
-                  "text": ") => void): void;`"
+                  "kind": "code",
+                  "text": "addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -16849,7 +16591,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -16890,7 +16632,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -16918,10 +16660,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -17011,7 +16749,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -17052,7 +16790,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -17080,10 +16818,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -17150,7 +16884,7 @@
                 },
                 {
                   "kind": "text",
-                  "text": "The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window."
+                  "text": "The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to continue in a separate window."
                 },
                 {
                   "kind": "paragraph"
@@ -17178,7 +16912,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -17219,7 +16953,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -17294,30 +17028,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAttachmentAsync(attachmentIndex: string): void;`"
+                  "kind": "code",
+                  "text": "removeAttachmentAsync(attachmentIndex: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult"
-                },
-                {
-                  "kind": "html-tag",
-                  "token": "<void>"
-                },
-                {
-                  "kind": "text",
-                  "text": ") => void): void;`"
+                  "kind": "code",
+                  "text": "removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -17435,7 +17164,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -17476,7 +17205,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -17551,30 +17280,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`saveAsync(): void;`"
+                  "kind": "code",
+                  "text": "saveAsync(): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`saveAsync(options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "saveAsync(options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`saveAsync(callback: (result: AsyncResult"
-                },
-                {
-                  "kind": "html-tag",
-                  "token": "<void>"
-                },
-                {
-                  "kind": "text",
-                  "text": ") => void): void;`"
+                  "kind": "code",
+                  "text": "saveAsync(callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -17669,7 +17393,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -17710,7 +17434,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -17785,30 +17509,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string, callback: (result: AsyncResult"
-                },
-                {
-                  "kind": "html-tag",
-                  "token": "<void>"
-                },
-                {
-                  "kind": "text",
-                  "text": ") => void): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -17869,7 +17588,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -17910,7 +17629,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -17938,10 +17657,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -17968,7 +17683,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Office.context.mailbox.item"
+                  "text": " Office.context.mailbox.item"
                 }
               ],
               "target": {
@@ -17987,7 +17702,16 @@
             },
             {
               "kind": "text",
-              "text": "Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information."
+              "text": "Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of "
+            },
+            {
+              "kind": "code",
+              "text": "Office.context.mailbox.item",
+              "highlighter": "plain"
+            },
+            {
+              "kind": "text",
+              "text": ". Refer to the Object Model pages for more information."
             }
           ],
           "remarks": [],
@@ -18005,7 +17729,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Gets an array of attachments for the item."
+                  "text": "Gets the item's attachments as an array."
                 },
                 {
                   "kind": "paragraph"
@@ -18016,10 +17740,6 @@
                 }
               ],
               "remarks": [
-                {
-                  "kind": "text",
-                  "text": ""
-                },
                 {
                   "kind": "html-tag",
                   "token": "<table>"
@@ -18037,7 +17757,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -18078,7 +17798,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -18119,7 +17839,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Blocked attachments in Outlook"
+                      "text": " Blocked attachments in Outlook"
                     }
                   ],
                   "targetUrl": "https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519"
@@ -18151,7 +17871,7 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB OR An"
+                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB OR An "
                     },
                     {
                       "kind": "api-link",
@@ -18222,10 +17942,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -18242,7 +17958,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -18283,7 +17999,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -18311,10 +18027,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -18338,7 +18050,7 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB. OR An"
+                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB. OR An "
                     },
                     {
                       "kind": "api-link",
@@ -18425,7 +18137,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -18466,7 +18178,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -18494,10 +18206,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -18555,7 +18263,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -18596,7 +18304,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -18624,10 +18332,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -18687,10 +18391,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -18707,7 +18407,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -18748,7 +18448,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -19310,10 +19010,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -19396,7 +19092,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -19437,7 +19133,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -19465,10 +19161,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -19545,7 +19237,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -19586,7 +19278,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -19614,10 +19306,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -19707,7 +19395,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -19748,7 +19436,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -19776,10 +19464,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -19837,7 +19521,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -19878,7 +19562,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -19906,10 +19590,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -19986,7 +19666,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -20027,7 +19707,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -20055,10 +19735,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -20112,7 +19788,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -20153,7 +19829,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -20395,10 +20071,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -20439,7 +20111,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Use the Outlook REST APIs from an Outlook add-in"
+                      "text": " Use the Outlook REST APIs from an Outlook add-in"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/use-rest-api#get-the-item-id"
@@ -20474,7 +20146,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -20515,7 +20187,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -20543,10 +20215,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -20601,7 +20269,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -20642,7 +20310,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -20670,10 +20338,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -20735,7 +20399,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -20776,7 +20440,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -20804,10 +20468,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -20855,7 +20515,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -20896,7 +20556,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -20924,10 +20584,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -21124,10 +20780,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -21144,7 +20796,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -21185,7 +20837,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -21213,10 +20865,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -21250,7 +20898,14 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. [Api set: Mailbox 1.1]"
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
+                    },
+                    {
+                      "kind": "paragraph"
+                    },
+                    {
+                      "kind": "text",
+                      "text": "[Api set: Mailbox 1.1]"
                     }
                   ],
                   "isOptional": true,
@@ -21274,10 +20929,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -21294,7 +20945,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -21335,7 +20986,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -21375,16 +21026,9 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`getAsync(callback: (result: AsyncResult"
-                },
-                {
-                  "kind": "html-tag",
-                  "token": "<string>"
-                },
-                {
-                  "kind": "text",
-                  "text": ") => void): void;`"
+                  "kind": "code",
+                  "text": "getAsync(callback: (result: AsyncResult<string>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -21432,7 +21076,14 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. If setting the location fails, the asyncResult.error property will contain an error code. [Api set: Mailbox 1.1]"
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. If setting the location fails, the asyncResult.error property will contain an error code."
+                    },
+                    {
+                      "kind": "paragraph"
+                    },
+                    {
+                      "kind": "text",
+                      "text": "[Api set: Mailbox 1.1]"
                     }
                   ],
                   "isOptional": true,
@@ -21456,10 +21107,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -21476,7 +21123,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -21517,7 +21164,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -21592,30 +21239,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(location: string): void;`"
+                  "kind": "code",
+                  "text": "setAsync(location: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(location: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "setAsync(location: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(location: string, callback: (result: AsyncResult"
-                },
-                {
-                  "kind": "html-tag",
-                  "token": "<void>"
-                },
-                {
-                  "kind": "text",
-                  "text": ") => void): void;`"
+                  "kind": "code",
+                  "text": "setAsync(location: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -21674,10 +21316,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -21694,7 +21332,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -21735,7 +21373,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -21763,10 +21401,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -21843,7 +21477,16 @@
                 },
                 {
                   "kind": "text",
-                  "text": "Currently, the supported event types are `Office.EventType.ItemChanged` and `Office.EventType.OfficeThemeChanged`."
+                  "text": "Currently, the only supported event type is "
+                },
+                {
+                  "kind": "code",
+                  "text": "Office.EventType.ItemChanged",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": "."
                 },
                 {
                   "kind": "paragraph"
@@ -21871,7 +21514,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -21912,7 +21555,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -21940,10 +21583,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -22033,7 +21672,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -22074,7 +21713,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -22102,10 +21741,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -22183,7 +21818,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -22224,7 +21859,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -22252,10 +21887,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -22338,7 +21969,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -22379,7 +22010,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -22420,7 +22051,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Outlook Mail API"
+                      "text": " Outlook Mail API"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/previous-versions/office/office-365-api/api/version-2.0/mail-rest-operations"
@@ -22434,7 +22065,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Microsoft Graph"
+                      "text": " Microsoft Graph"
                     }
                   ],
                   "targetUrl": "http://graph.microsoft.io/"
@@ -22517,7 +22148,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -22558,7 +22189,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -22586,10 +22217,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -22674,10 +22301,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -22694,7 +22317,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -22735,7 +22358,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -22763,10 +22386,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -22866,7 +22485,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -22907,7 +22526,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -22935,10 +22554,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -23037,7 +22652,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -23078,7 +22693,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -23106,10 +22721,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -23208,7 +22819,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -23249,7 +22860,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -23277,10 +22888,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -23304,7 +22911,14 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "A dictionary containing all values to be filled in for the user in the new form. All parameters are optional. toRecipients: An array of strings containing the email addresses or an array containing an"
+                      "text": "A dictionary containing all values to be filled in for the user in the new form. All parameters are optional."
+                    },
+                    {
+                      "kind": "paragraph"
+                    },
+                    {
+                      "kind": "text",
+                      "text": "toRecipients: An array of strings containing the email addresses or an array containing an "
                     },
                     {
                       "kind": "api-link",
@@ -23485,7 +23099,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -23526,7 +23140,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -23554,10 +23168,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -23618,7 +23228,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -23659,7 +23269,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -23700,7 +23310,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "get attachments from the selected item"
+                      "text": " get attachments from the selected item"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/get-attachments-of-an-outlook-item"
@@ -23847,7 +23457,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -23888,7 +23498,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -23928,31 +23538,17 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`getCallbackTokenAsync(callback: (result: AsyncResult"
-                },
-                {
-                  "kind": "html-tag",
-                  "token": "<string>"
-                },
-                {
-                  "kind": "text",
-                  "text": ") => void): void;`"
+                  "kind": "code",
+                  "text": "getCallbackTokenAsync(callback: (result: AsyncResult<string>) => void): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`getCallbackTokenAsync(callback: (result: AsyncResult"
-                },
-                {
-                  "kind": "html-tag",
-                  "token": "<string>"
-                },
-                {
-                  "kind": "text",
-                  "text": ") => void, userContext?: any): void;`"
+                  "kind": "code",
+                  "text": "getCallbackTokenAsync(callback: (result: AsyncResult<string>) => void, userContext?: any): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -24035,7 +23631,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -24076,7 +23672,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -24117,7 +23713,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "authenticate the add-in and user with a third-party system"
+                      "text": " authenticate the add-in and user with a third-party system"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/authentication"
@@ -24143,7 +23739,57 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "The mailbox item. Depending on the context in which the add-in opened, the item may be of any number of types. If you want to see IntelliSense for only a specific type, you should cast this item to one of the following: `ItemCompose`, `ItemRead`, `MessageCompose`, `MessageRead`, `AppointmentCompose`, `AppointmentRead`"
+                  "text": "The mailbox item. Depending on the context in which the add-in opened, the item may be of any number of types. If you want to see IntelliSense for only a specific type, you should cast this item to one of the following: "
+                },
+                {
+                  "kind": "code",
+                  "text": "ItemCompose",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": ", "
+                },
+                {
+                  "kind": "code",
+                  "text": "ItemRead",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": ", "
+                },
+                {
+                  "kind": "code",
+                  "text": "MessageCompose",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": ", "
+                },
+                {
+                  "kind": "code",
+                  "text": "MessageRead",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": ", "
+                },
+                {
+                  "kind": "code",
+                  "text": "AppointmentCompose",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": ", "
+                },
+                {
+                  "kind": "code",
+                  "text": "AppointmentRead",
+                  "highlighter": "plain"
                 }
               ],
               "remarks": [],
@@ -24181,7 +23827,16 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. The `value` property of the result is the XML of the EWS request provided as a string. If the result exceeds 1 MB in size, an error message is returned instead."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. The "
+                    },
+                    {
+                      "kind": "code",
+                      "text": "value",
+                      "highlighter": "plain"
+                    },
+                    {
+                      "kind": "text",
+                      "text": " property of the result is the XML of the EWS request provided as a string. If the result exceeds 1 MB in size, an error message is returned instead."
                     }
                   ],
                   "isOptional": false,
@@ -24247,7 +23902,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Specify permissions for mail add-in access to the user's mailbox"
+                      "text": " Specify permissions for mail add-in access to the user's mailbox"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -24309,8 +23964,9 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`<?xml version=\"1.0\" encoding=\"iso-8859-1\"?>`"
+                  "kind": "code",
+                  "text": "<?xml version=\"1.0\" encoding=\"iso-8859-1\"?>",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
@@ -24345,7 +24001,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -24386,7 +24042,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -24414,10 +24070,190 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
+                }
+              ],
+              "isBeta": false,
+              "isSealed": false,
+              "isVirtual": false,
+              "isOverride": false
+            },
+            "removeHandlerAsync": {
+              "kind": "method",
+              "signature": "removeHandlerAsync(eventType: Office.EventType, handler: (type: EventType) => void, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
+              "accessModifier": "",
+              "isOptional": false,
+              "isStatic": false,
+              "returnValue": {
+                "type": "void",
+                "description": []
+              },
+              "parameters": {
+                "eventType": {
+                  "name": "eventType",
+                  "description": [
+                    {
+                      "kind": "text",
+                      "text": "The event that should revoke the handler."
+                    }
+                  ],
+                  "isOptional": false,
+                  "isSpread": false,
+                  "type": "Office.EventType"
+                },
+                "handler": {
+                  "name": "handler",
+                  "description": [
+                    {
+                      "kind": "text",
+                      "text": "The function to handle the event. The function must accept a single parameter, which is an object literal. The type property on the parameter will match the eventType parameter passed to addHandlerAsync."
+                    }
+                  ],
+                  "isOptional": false,
+                  "isSpread": false,
+                  "type": "(type: EventType) => void"
+                },
+                "options": {
+                  "name": "options",
+                  "description": [
+                    {
+                      "kind": "text",
+                      "text": "Optional. Provides an option for preserving context data of any type, unchanged, for use in a callback."
+                    }
+                  ],
+                  "isOptional": true,
+                  "isSpread": false,
+                  "type": "Office.AsyncContextOptions"
+                },
+                "callback": {
+                  "name": "callback",
+                  "description": [
+                    {
+                      "kind": "text",
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
+                    }
+                  ],
+                  "isOptional": true,
+                  "isSpread": false,
+                  "type": "(result: AsyncResult<void>) => void"
+                }
+              },
+              "deprecatedMessage": [],
+              "summary": [
+                {
+                  "kind": "text",
+                  "text": "Removes an event handler for a supported event."
+                },
+                {
+                  "kind": "paragraph"
                 },
                 {
                   "kind": "text",
-                  "text": ""
+                  "text": "Currently, the only supported event type is "
+                },
+                {
+                  "kind": "code",
+                  "text": "Office.EventType.ItemChanged",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": "."
+                },
+                {
+                  "kind": "paragraph"
+                },
+                {
+                  "kind": "text",
+                  "text": "[Api set: Mailbox 1.5]"
+                }
+              ],
+              "remarks": [
+                {
+                  "kind": "html-tag",
+                  "token": "<table>"
+                },
+                {
+                  "kind": "html-tag",
+                  "token": "<tr>"
+                },
+                {
+                  "kind": "html-tag",
+                  "token": "<td>"
+                },
+                {
+                  "kind": "web-link",
+                  "elements": [
+                    {
+                      "kind": "text",
+                      "text": " Minimum permission level"
+                    }
+                  ],
+                  "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
+                },
+                {
+                  "kind": "html-tag",
+                  "token": "</td>"
+                },
+                {
+                  "kind": "html-tag",
+                  "token": "<td>"
+                },
+                {
+                  "kind": "text",
+                  "text": "ReadItem"
+                },
+                {
+                  "kind": "html-tag",
+                  "token": "</td>"
+                },
+                {
+                  "kind": "html-tag",
+                  "token": "</tr>"
+                },
+                {
+                  "kind": "paragraph"
+                },
+                {
+                  "kind": "html-tag",
+                  "token": "<tr>"
+                },
+                {
+                  "kind": "html-tag",
+                  "token": "<td>"
+                },
+                {
+                  "kind": "web-link",
+                  "elements": [
+                    {
+                      "kind": "text",
+                      "text": " Applicable Outlook mode"
+                    }
+                  ],
+                  "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
+                },
+                {
+                  "kind": "html-tag",
+                  "token": "</td>"
+                },
+                {
+                  "kind": "html-tag",
+                  "token": "<td>"
+                },
+                {
+                  "kind": "text",
+                  "text": "Compose or read"
+                },
+                {
+                  "kind": "html-tag",
+                  "token": "</td>"
+                },
+                {
+                  "kind": "html-tag",
+                  "token": "</tr>"
+                },
+                {
+                  "kind": "html-tag",
+                  "token": "</table>"
                 }
               ],
               "isBeta": false,
@@ -24478,7 +24314,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -24519,7 +24355,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -24560,7 +24396,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "REST API"
+                      "text": " REST API"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/rest/"
@@ -24587,7 +24423,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Information about the user associated with the mailbox. This includes their account type, display name, email adddress, and time zone."
+                  "text": "Information about the user associated with the mailbox. This includes their account type, display name, email address, and time zone."
                 },
                 {
                   "kind": "paragraph"
@@ -24610,10 +24446,6 @@
                     "exportName": "Office",
                     "memberName": "UserProfile"
                   }
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "remarks": [],
@@ -24691,10 +24523,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -24715,7 +24543,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -24747,10 +24575,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false
@@ -24905,10 +24729,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -24929,7 +24749,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -24961,10 +24781,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false
@@ -25080,10 +24896,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -25104,7 +24916,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -25136,10 +24948,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false
@@ -25203,10 +25011,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -25227,7 +25031,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -25259,10 +25063,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false
@@ -25313,10 +25113,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -25337,7 +25133,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -25369,10 +25165,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false
@@ -25553,10 +25345,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -25577,7 +25365,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -25609,10 +25397,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false
@@ -25742,10 +25526,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -25766,7 +25546,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -25798,10 +25578,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false
@@ -27594,10 +27370,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -27618,7 +27390,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -27650,10 +27422,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false
@@ -27743,10 +27511,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -27767,7 +27531,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -27799,10 +27563,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false
@@ -27892,10 +27652,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -27916,7 +27672,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -27948,10 +27704,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false
@@ -28015,10 +27767,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -28039,7 +27787,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -28071,10 +27819,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false
@@ -28164,10 +27908,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -28188,7 +27928,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -28220,10 +27960,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false
@@ -28265,10 +28001,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -28285,7 +28017,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -28326,7 +28058,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -28354,10 +28086,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -28526,7 +28254,16 @@
             },
             {
               "kind": "text",
-              "text": "Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information."
+              "text": "Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of "
+            },
+            {
+              "kind": "code",
+              "text": "Office.context.mailbox.item",
+              "highlighter": "plain"
+            },
+            {
+              "kind": "text",
+              "text": ". Refer to the Object Model pages for more information."
             }
           ],
           "remarks": [],
@@ -28586,7 +28323,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -28627,7 +28364,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -28655,10 +28392,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -28685,7 +28418,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Office.context.mailbox.item"
+                  "text": " Office.context.mailbox.item"
                 }
               ],
               "target": {
@@ -28704,7 +28437,16 @@
             },
             {
               "kind": "text",
-              "text": "Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of `Office.context.mailbox.item`. Refer to the Object Model pages for more information."
+              "text": "Important: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of "
+            },
+            {
+              "kind": "code",
+              "text": "Office.context.mailbox.item",
+              "highlighter": "plain"
+            },
+            {
+              "kind": "text",
+              "text": ". Refer to the Object Model pages for more information."
             }
           ],
           "remarks": [],
@@ -28801,10 +28543,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -28821,7 +28559,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -28862,7 +28600,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -28993,30 +28731,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addFileAttachmentAsync(uri: string, attachmentName: string): void;`"
+                  "kind": "code",
+                  "text": "addFileAttachmentAsync(uri: string, attachmentName: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addFileAttachmentAsync(uri: string, attachmentName: string, options: AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "addFileAttachmentAsync(uri: string, attachmentName: string, options: AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult"
-                },
-                {
-                  "kind": "html-tag",
-                  "token": "<string>"
-                },
-                {
-                  "kind": "text",
-                  "text": ") => void): void;`"
+                  "kind": "code",
+                  "text": "addFileAttachmentAsync(uri: string, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -29095,7 +28828,34 @@
                 },
                 {
                   "kind": "text",
-                  "text": "Currently the supported event types are `Office.EventType.AppointmentTimeChanged`, `Office.EventType.RecipientsChanged`, and `Office.EventType.RecurrenceChanged`."
+                  "text": "Currently the supported event types are "
+                },
+                {
+                  "kind": "code",
+                  "text": "Office.EventType.AppointmentTimeChanged",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": ", "
+                },
+                {
+                  "kind": "code",
+                  "text": "Office.EventType.RecipientsChanged",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": ", and "
+                },
+                {
+                  "kind": "code",
+                  "text": "Office.EventType.RecurrenceChanged",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": "."
                 },
                 {
                   "kind": "paragraph"
@@ -29123,7 +28883,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -29164,7 +28924,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -29204,16 +28964,9 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addHandlerAsync(eventType:EventType, handler: any, callback?: (result: AsyncResult"
-                },
-                {
-                  "kind": "html-tag",
-                  "token": "<void>"
-                },
-                {
-                  "kind": "text",
-                  "text": ") => void): void;`"
+                  "kind": "code",
+                  "text": "addHandlerAsync(eventType:EventType, handler: any, callback?: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -29318,10 +29071,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -29338,7 +29087,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -29379,7 +29128,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -29454,30 +29203,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addItemAttachmentAsync(itemId: any, attachmentName: string): void;`"
+                  "kind": "code",
+                  "text": "addItemAttachmentAsync(itemId: any, attachmentName: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "addItemAttachmentAsync(itemId: any, attachmentName: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult"
-                },
-                {
-                  "kind": "html-tag",
-                  "token": "<string>"
-                },
-                {
-                  "kind": "text",
-                  "text": ") => void): void;`"
+                  "kind": "code",
+                  "text": "addItemAttachmentAsync(itemId: any, attachmentName: string, callback: (result: AsyncResult<string>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -29524,7 +29268,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -29565,7 +29309,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -29593,10 +29337,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -29644,7 +29384,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -29685,7 +29425,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -29713,10 +29453,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -29790,7 +29526,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -29831,7 +29567,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -29859,10 +29595,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -29935,7 +29667,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -29976,7 +29708,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -30004,10 +29736,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -30068,7 +29796,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -30109,7 +29837,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -30137,10 +29865,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -30188,7 +29912,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -30229,7 +29953,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -30257,10 +29981,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -30308,7 +30028,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -30349,7 +30069,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -30445,7 +30165,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -30486,7 +30206,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -30514,10 +30234,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -30608,7 +30324,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -30649,7 +30365,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -30677,10 +30393,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -30734,7 +30446,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -30775,7 +30487,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -30803,10 +30515,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -30897,7 +30605,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -30938,7 +30646,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -30966,10 +30674,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -31016,7 +30720,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -31057,7 +30761,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -31085,10 +30789,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -31115,7 +30815,25 @@
                 },
                 {
                   "kind": "text",
-                  "text": "The recurrence property returns a recurrence object for recurring appointments or meetings requests if an item is a series or an instance in a series. `null` is returned for single appointments and meeting requests of single appointments. `undefined` is returned for messages that are not meeting requests."
+                  "text": "The recurrence property returns a recurrence object for recurring appointments or meetings requests if an item is a series or an instance in a series. "
+                },
+                {
+                  "kind": "code",
+                  "text": "null",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": " is returned for single appointments and meeting requests of single appointments. "
+                },
+                {
+                  "kind": "code",
+                  "text": "undefined",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": " is returned for messages that are not meeting requests."
                 },
                 {
                   "kind": "paragraph"
@@ -31157,7 +30875,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -31198,7 +30916,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -31226,10 +30944,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -31297,7 +31011,7 @@
                 },
                 {
                   "kind": "text",
-                  "text": "The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing in an inline form and subsequently pops out the inline form to continue in a separate window."
+                  "text": "The removeAttachmentAsync method removes the attachment with the specified identifier from the item. As a best practice, you should use the attachment identifier to remove an attachment only if the same mail app has added that attachment in the same session. In Outlook Web App and OWA for Devices, the attachment identifier is valid only within the same session. A session is over when the user closes the app, or if the user starts composing an inline form then subsequently pops out the form to continue in a separate window."
                 },
                 {
                   "kind": "paragraph"
@@ -31325,7 +31039,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -31366,7 +31080,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -31441,30 +31155,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAttachmentAsync(attachmentIndex: string): void;`"
+                  "kind": "code",
+                  "text": "removeAttachmentAsync(attachmentIndex: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "removeAttachmentAsync(attachmentIndex: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult"
-                },
-                {
-                  "kind": "html-tag",
-                  "token": "<void>"
-                },
-                {
-                  "kind": "text",
-                  "text": ") => void): void;`"
+                  "kind": "code",
+                  "text": "removeAttachmentAsync(attachmentIndex: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -31488,7 +31197,7 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "The event that should invoke the handler."
+                      "text": "The event that should revoke the handler."
                     }
                   ],
                   "isOptional": false,
@@ -31543,7 +31252,34 @@
                 },
                 {
                   "kind": "text",
-                  "text": "Currently the supported event types are `Office.EventType.AppointmentTimeChanged`, `Office.EventType.RecipientsChanged`, and `Office.EventType.RecurrenceChanged`."
+                  "text": "Currently the supported event types are "
+                },
+                {
+                  "kind": "code",
+                  "text": "Office.EventType.AppointmentTimeChanged",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": ", "
+                },
+                {
+                  "kind": "code",
+                  "text": "Office.EventType.RecipientsChanged",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": ", and "
+                },
+                {
+                  "kind": "code",
+                  "text": "Office.EventType.RecurrenceChanged",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": "."
                 },
                 {
                   "kind": "paragraph"
@@ -31571,7 +31307,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -31612,7 +31348,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -31652,16 +31388,9 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeHandlerAsync(eventType:EventType, handler: any, callback?: (result: AsyncResult"
-                },
-                {
-                  "kind": "html-tag",
-                  "token": "<void>"
-                },
-                {
-                  "kind": "text",
-                  "text": ") => void): void;`"
+                  "kind": "code",
+                  "text": "removeHandlerAsync(eventType:EventType, handler: any, callback?: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -31779,7 +31508,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -31820,7 +31549,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -31895,30 +31624,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`saveAsync(): void;`"
+                  "kind": "code",
+                  "text": "saveAsync(): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`saveAsync(options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "saveAsync(options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`saveAsync(callback: (result: AsyncResult"
-                },
-                {
-                  "kind": "html-tag",
-                  "token": "<void>"
-                },
-                {
-                  "kind": "text",
-                  "text": ") => void): void;`"
+                  "kind": "code",
+                  "text": "saveAsync(callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -31958,7 +31682,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Use the Outlook REST APIs from an Outlook add-in"
+                      "text": " Use the Outlook REST APIs from an Outlook add-in"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/use-rest-api"
@@ -32000,7 +31724,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -32041,7 +31765,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -32069,10 +31793,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -32168,7 +31888,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -32209,7 +31929,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -32284,30 +32004,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string, options: Office.AsyncContextOptions & CoercionTypeOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setSelectedDataAsync(data: string, callback: (result: AsyncResult"
-                },
-                {
-                  "kind": "html-tag",
-                  "token": "<void>"
-                },
-                {
-                  "kind": "text",
-                  "text": ") => void): void;`"
+                  "kind": "code",
+                  "text": "setSelectedDataAsync(data: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -32368,7 +32083,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -32409,7 +32124,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -32437,10 +32152,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -32495,7 +32206,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -32536,7 +32247,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -32564,10 +32275,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -32594,7 +32301,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Office.context.mailbox.item"
+                  "text": " Office.context.mailbox.item"
                 }
               ],
               "target": {
@@ -32691,7 +32398,34 @@
                 },
                 {
                   "kind": "text",
-                  "text": "Currently the supported event types are `Office.EventType.AppointmentTimeChanged`, `Office.EventType.RecipientsChanged`, and `Office.EventType.RecurrenceChanged`."
+                  "text": "Currently the supported event types are "
+                },
+                {
+                  "kind": "code",
+                  "text": "Office.EventType.AppointmentTimeChanged",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": ", "
+                },
+                {
+                  "kind": "code",
+                  "text": "Office.EventType.RecipientsChanged",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": ", and "
+                },
+                {
+                  "kind": "code",
+                  "text": "Office.EventType.RecurrenceChanged",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": "."
                 },
                 {
                   "kind": "paragraph"
@@ -32719,7 +32453,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -32760,7 +32494,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -32800,16 +32534,9 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addHandlerAsync(eventType:EventType, handler: any, callback?: (result: AsyncResult"
-                },
-                {
-                  "kind": "html-tag",
-                  "token": "<void>"
-                },
-                {
-                  "kind": "text",
-                  "text": ") => void): void;`"
+                  "kind": "code",
+                  "text": "addHandlerAsync(eventType:EventType, handler: any, callback?: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -32828,7 +32555,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Gets an array of attachments for the item."
+                  "text": "Gets the item's attachments as an array."
                 },
                 {
                   "kind": "paragraph"
@@ -32856,7 +32583,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -32897,7 +32624,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -32938,7 +32665,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Blocked attachments in Outlook"
+                      "text": " Blocked attachments in Outlook"
                     }
                   ],
                   "targetUrl": "https://support.office.com/article/Blocked-attachments-in-Outlook-434752E1-02D3-4E90-9124-8B81E49A8519"
@@ -32993,7 +32720,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -33034,7 +32761,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -33062,10 +32789,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -33120,7 +32843,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -33161,7 +32884,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -33189,10 +32912,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -33254,7 +32973,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -33295,7 +33014,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -33323,10 +33042,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -33374,7 +33089,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -33415,7 +33130,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -33443,10 +33158,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -33494,7 +33205,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -33535,7 +33246,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -33594,7 +33305,7 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB OR An"
+                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB OR An "
                     },
                     {
                       "kind": "api-link",
@@ -33665,10 +33376,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -33685,7 +33392,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -33726,7 +33433,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -33754,10 +33461,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -33781,7 +33484,7 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB. OR An"
+                      "text": "A string that contains text and HTML and that represents the body of the reply form. The string is limited to 32 KB. OR An "
                     },
                     {
                       "kind": "api-link",
@@ -33868,7 +33571,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -33909,7 +33612,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -33937,10 +33640,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -34008,7 +33707,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -34049,7 +33748,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -34077,10 +33776,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -34139,7 +33834,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -34180,7 +33875,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -34208,10 +33903,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -34287,7 +33978,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -34328,7 +34019,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -34890,10 +34581,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -34976,7 +34663,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -35017,7 +34704,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -35045,10 +34732,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -35125,7 +34808,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -35166,7 +34849,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -35194,10 +34877,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -35287,7 +34966,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -35328,7 +35007,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -35356,10 +35035,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -35417,7 +35092,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -35458,7 +35133,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -35486,10 +35161,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -35566,7 +35237,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -35607,7 +35278,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -35635,10 +35306,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -35685,7 +35352,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -35726,7 +35393,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -35754,10 +35421,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -35812,7 +35475,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -35853,7 +35516,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -36135,7 +35798,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Use the Outlook REST APIs from an Outlook add-in"
+                      "text": " Use the Outlook REST APIs from an Outlook add-in"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/use-rest-api#get-the-item-id"
@@ -36170,7 +35833,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -36211,7 +35874,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -36239,10 +35902,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -36297,7 +35956,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -36338,7 +35997,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -36366,10 +36025,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -36460,7 +36115,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -36501,7 +36156,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -36529,10 +36184,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -36586,7 +36237,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -36627,7 +36278,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -36655,10 +36306,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -36706,7 +36353,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -36747,7 +36394,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -36775,10 +36422,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -36805,7 +36448,25 @@
                 },
                 {
                   "kind": "text",
-                  "text": "The recurrence property returns a recurrence object for recurring appointments or meetings requests if an item is a series or an instance in a series. `null` is returned for single appointments and meeting requests of single appointments. `undefined` is returned for messages that are not meeting requests."
+                  "text": "The recurrence property returns a recurrence object for recurring appointments or meetings requests if an item is a series or an instance in a series. "
+                },
+                {
+                  "kind": "code",
+                  "text": "null",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": " is returned for single appointments and meeting requests of single appointments. "
+                },
+                {
+                  "kind": "code",
+                  "text": "undefined",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": " is returned for messages that are not meeting requests."
                 },
                 {
                   "kind": "paragraph"
@@ -36847,7 +36508,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -36888,7 +36549,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -36916,10 +36577,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -36944,7 +36601,7 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "The event that should invoke the handler."
+                      "text": "The event that should revoke the handler."
                     }
                   ],
                   "isOptional": false,
@@ -36999,7 +36656,34 @@
                 },
                 {
                   "kind": "text",
-                  "text": "Currently the supported event types are `Office.EventType.AppointmentTimeChanged`, `Office.EventType.RecipientsChanged`, and `Office.EventType.RecurrenceChanged`."
+                  "text": "Currently the supported event types are "
+                },
+                {
+                  "kind": "code",
+                  "text": "Office.EventType.AppointmentTimeChanged",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": ", "
+                },
+                {
+                  "kind": "code",
+                  "text": "Office.EventType.RecipientsChanged",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": ", and "
+                },
+                {
+                  "kind": "code",
+                  "text": "Office.EventType.RecurrenceChanged",
+                  "highlighter": "plain"
+                },
+                {
+                  "kind": "text",
+                  "text": "."
                 },
                 {
                   "kind": "paragraph"
@@ -37027,7 +36711,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -37068,7 +36752,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -37108,16 +36792,9 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeHandlerAsync(eventType:EventType, handler: any, callback?: (result: AsyncResult"
-                },
-                {
-                  "kind": "html-tag",
-                  "token": "<void>"
-                },
-                {
-                  "kind": "text",
-                  "text": ") => void): void;`"
+                  "kind": "code",
+                  "text": "removeHandlerAsync(eventType:EventType, handler: any, callback?: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -37178,7 +36855,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -37219,7 +36896,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -37247,10 +36924,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -37291,7 +36964,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Use the Outlook REST APIs from an Outlook add-in"
+                      "text": " Use the Outlook REST APIs from an Outlook add-in"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/use-rest-api"
@@ -37333,7 +37006,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -37374,7 +37047,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -37402,10 +37075,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -37467,7 +37136,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -37508,7 +37177,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -37536,10 +37205,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -37594,7 +37259,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -37635,7 +37300,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -37663,10 +37328,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -37698,10 +37359,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -37718,7 +37375,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -37759,7 +37416,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -37787,10 +37444,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -37924,10 +37577,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -37944,7 +37593,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -37985,7 +37634,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -38013,10 +37662,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -38074,7 +37719,14 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. [Api set: Mailbox 1.3]"
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult."
+                    },
+                    {
+                      "kind": "paragraph"
+                    },
+                    {
+                      "kind": "text",
+                      "text": "[Api set: Mailbox 1.3]"
                     }
                   ],
                   "isOptional": true,
@@ -38098,10 +37750,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -38118,7 +37766,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -38159,7 +37807,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -38199,30 +37847,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addAsync(key: string, JSONmessage: NotificationMessageDetails): void;`"
+                  "kind": "code",
+                  "text": "addAsync(key: string, JSONmessage: NotificationMessageDetails): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addAsync(key: string, JSONmessage: NotificationMessageDetails, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "addAsync(key: string, JSONmessage: NotificationMessageDetails, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addAsync(key: string, JSONmessage: NotificationMessageDetails, callback: (result: AsyncResult"
-                },
-                {
-                  "kind": "html-tag",
-                  "token": "<void>"
-                },
-                {
-                  "kind": "text",
-                  "text": ") => void): void;`"
+                  "kind": "code",
+                  "text": "addAsync(key: string, JSONmessage: NotificationMessageDetails, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -38258,7 +37901,16 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. The `value` property of the result is an array of NotificationMessageDetails objects."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. The "
+                    },
+                    {
+                      "kind": "code",
+                      "text": "value",
+                      "highlighter": "plain"
+                    },
+                    {
+                      "kind": "text",
+                      "text": " property of the result is an array of NotificationMessageDetails objects."
                     }
                   ],
                   "isOptional": true,
@@ -38282,10 +37934,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -38302,7 +37950,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -38343,7 +37991,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -38383,8 +38031,9 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`getAllAsync(callback: (result: AsyncResult<Office.NotificationMessageDetails[]>) => void): void;`"
+                  "kind": "code",
+                  "text": "getAllAsync(callback: (result: AsyncResult<Office.NotificationMessageDetails[]>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -38456,10 +38105,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -38476,7 +38121,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -38517,7 +38162,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -38557,30 +38202,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAsync(key: string): void;`"
+                  "kind": "code",
+                  "text": "removeAsync(key: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAsync(key: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "removeAsync(key: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`removeAsync(key: string, callback: (result: AsyncResult"
-                },
-                {
-                  "kind": "html-tag",
-                  "token": "<void>"
-                },
-                {
-                  "kind": "text",
-                  "text": ") => void): void;`"
+                  "kind": "code",
+                  "text": "removeAsync(key: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -38671,10 +38311,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -38691,7 +38327,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -38732,7 +38368,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -38772,30 +38408,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`replaceAsync(key: string, JSONmessage: NotificationMessageDetails): void;`"
+                  "kind": "code",
+                  "text": "replaceAsync(key: string, JSONmessage: NotificationMessageDetails): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`replaceAsync(key: string, JSONmessage: NotificationMessageDetails, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "replaceAsync(key: string, JSONmessage: NotificationMessageDetails, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`replaceAsync(key: string, JSONmessage: NotificationMessageDetails, callback: (result: AsyncResult"
-                },
-                {
-                  "kind": "html-tag",
-                  "token": "<void>"
-                },
-                {
-                  "kind": "text",
-                  "text": ") => void): void;`"
+                  "kind": "code",
+                  "text": "replaceAsync(key: string, JSONmessage: NotificationMessageDetails, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -38826,10 +38457,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -38846,7 +38473,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -38887,7 +38514,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -38915,10 +38542,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -38952,7 +38575,16 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter, asyncResult, which is an AsyncResult object. The `value` property of the result is message's organizer value, as an EmailAddressDetails object."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter, asyncResult, which is an AsyncResult object. The "
+                    },
+                    {
+                      "kind": "code",
+                      "text": "value",
+                      "highlighter": "plain"
+                    },
+                    {
+                      "kind": "text",
+                      "text": " property of the result is message's organizer value, as an EmailAddressDetails object."
                     }
                   ],
                   "isOptional": true,
@@ -38995,10 +38627,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -39015,7 +38643,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -39056,7 +38684,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -39084,10 +38712,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -39125,10 +38749,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -39145,7 +38765,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -39186,7 +38806,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -39214,10 +38834,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -39302,10 +38918,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -39322,7 +38934,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -39363,7 +38975,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -39391,10 +39003,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -39492,10 +39100,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -39512,7 +39116,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -39553,7 +39157,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -39628,30 +39232,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addAsync(recipients: (string | EmailUser | EmailAddressDetails)[]): void;`"
+                  "kind": "code",
+                  "text": "addAsync(recipients: (string | EmailUser | EmailAddressDetails)[]): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult"
-                },
-                {
-                  "kind": "html-tag",
-                  "token": "<void>"
-                },
-                {
-                  "kind": "text",
-                  "text": ") => void): void;`"
+                  "kind": "code",
+                  "text": "addAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -39687,7 +39286,16 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. The `value` property of the result is an array of EmailAddressDetails objects."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. The "
+                    },
+                    {
+                      "kind": "code",
+                      "text": "value",
+                      "highlighter": "plain"
+                    },
+                    {
+                      "kind": "text",
+                      "text": " property of the result is an array of EmailAddressDetails objects."
                     }
                   ],
                   "isOptional": false,
@@ -39737,10 +39345,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -39757,7 +39361,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -39798,7 +39402,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -39838,8 +39442,9 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`getAsync(callback: (result: AsyncResult<Office.EmailAddressDetails[]>) => void): void;`"
+                  "kind": "code",
+                  "text": "getAsync(callback: (result: AsyncResult<Office.EmailAddressDetails[]>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -39984,10 +39589,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -40004,7 +39605,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -40045,7 +39646,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -40120,30 +39721,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(recipients: (string | EmailUser | EmailAddressDetails)[]): void;`"
+                  "kind": "code",
+                  "text": "setAsync(recipients: (string | EmailUser | EmailAddressDetails)[]): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult"
-                },
-                {
-                  "kind": "html-tag",
-                  "token": "<void>"
-                },
-                {
-                  "kind": "text",
-                  "text": ") => void): void;`"
+                  "kind": "code",
+                  "text": "setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -40190,7 +39786,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -40231,7 +39827,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -40729,10 +40325,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -40766,7 +40358,16 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter, asyncResult, which is an Office.AsyncResult object. The `value` property of the result is a Recurrence object."
+                      "text": "Optional. When the method completes, the function passed in the callback parameter is called with a single parameter, asyncResult, which is an Office.AsyncResult object. The "
+                    },
+                    {
+                      "kind": "code",
+                      "text": "value",
+                      "highlighter": "plain"
+                    },
+                    {
+                      "kind": "text",
+                      "text": " property of the result is a Recurrence object."
                     }
                   ],
                   "isOptional": true,
@@ -40813,7 +40414,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -40854,7 +40455,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -40894,8 +40495,9 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`getAsync(callback?: (result: AsyncResult<Office.Recurrence>) => void): void;`"
+                  "kind": "code",
+                  "text": "getAsync(callback?: (result: AsyncResult<Office.Recurrence>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -40942,7 +40544,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -40983,7 +40585,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -41011,10 +40613,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -41062,7 +40660,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -41103,7 +40701,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -41131,10 +40729,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -41182,7 +40776,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -41223,7 +40817,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -41251,10 +40845,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -41321,7 +40911,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -41362,7 +40952,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -41390,10 +40980,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -41489,7 +41075,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -41530,7 +41116,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -41605,16 +41191,9 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(recurrencePattern: Recurrence, callback?: (result: AsyncResult"
-                },
-                {
-                  "kind": "html-tag",
-                  "token": "<void>"
-                },
-                {
-                  "kind": "text",
-                  "text": ") => void): void;`"
+                  "kind": "code",
+                  "text": "setAsync(recurrencePattern: Recurrence, callback?: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -41661,7 +41240,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -41702,7 +41281,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -41730,10 +41309,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -41925,7 +41500,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -41966,7 +41541,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -41994,10 +41569,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -42319,10 +41890,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -42339,7 +41906,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -42380,7 +41947,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -42408,10 +41975,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -42462,10 +42025,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -42482,7 +42041,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -42523,7 +42082,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -42551,10 +42110,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -42602,10 +42157,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -42622,7 +42173,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -42663,7 +42214,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -42691,10 +42242,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -42749,10 +42296,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -42769,7 +42312,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -42810,7 +42353,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -42838,10 +42381,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -42922,10 +42461,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -42942,7 +42477,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -42983,7 +42518,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -43011,10 +42546,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -43045,10 +42576,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -43065,7 +42592,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -43106,7 +42633,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -43134,10 +42661,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -43170,10 +42693,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -43190,7 +42709,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -43231,7 +42750,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -43259,10 +42778,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -43292,7 +42807,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "ISO 8601"
+                      "text": " ISO 8601"
                     }
                   ],
                   "targetUrl": "https://www.iso.org/iso-8601-date-and-time-format.html"
@@ -43311,10 +42826,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -43331,7 +42842,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -43372,7 +42883,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -43400,10 +42911,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -43433,7 +42940,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "ISO 8601"
+                      "text": " ISO 8601"
                     }
                   ],
                   "targetUrl": "https://www.iso.org/iso-8601-date-and-time-format.html"
@@ -43452,10 +42959,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -43472,7 +42975,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -43513,7 +43016,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -43541,10 +43044,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -43574,7 +43073,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "ISO 8601"
+                      "text": " ISO 8601"
                     }
                   ],
                   "targetUrl": "https://www.iso.org/iso-8601-date-and-time-format.html"
@@ -43593,10 +43092,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -43613,7 +43108,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -43654,7 +43149,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -43682,10 +43177,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -43715,7 +43206,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "ISO 8601"
+                      "text": " ISO 8601"
                     }
                   ],
                   "targetUrl": "https://www.iso.org/iso-8601-date-and-time-format.html"
@@ -43734,10 +43225,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -43754,7 +43241,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -43795,7 +43282,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -43823,10 +43310,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -43874,10 +43357,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -43894,7 +43373,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -43935,7 +43414,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -43963,10 +43442,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -44038,10 +43513,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -44058,7 +43529,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -44099,7 +43570,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -44174,15 +43645,20 @@
                   "kind": "paragraph"
                 },
                 {
+                  "kind": "code",
+                  "text": "setEndDate(date: string): void;",
+                  "highlighter": "plain"
+                },
+                {
                   "kind": "text",
-                  "text": "`setEndDate(date: string): void;` (Where date is the end date of the recurring appointment series represented in the "
+                  "text": " (Where date is the end date of the recurring appointment series represented in the "
                 },
                 {
                   "kind": "web-link",
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "ISO 8601"
+                      "text": " ISO 8601"
                     }
                   ],
                   "targetUrl": "https://www.iso.org/iso-8601-date-and-time-format.html"
@@ -44261,10 +43737,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -44281,7 +43753,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -44322,7 +43794,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -44397,15 +43869,20 @@
                   "kind": "paragraph"
                 },
                 {
+                  "kind": "code",
+                  "text": "setStartDate(date: string): void;",
+                  "highlighter": "plain"
+                },
+                {
                   "kind": "text",
-                  "text": "`setStartDate(date: string): void;` (Where date is the start date of the recurring appointment series represented in the "
+                  "text": " (Where date is the start date of the recurring appointment series represented in the "
                 },
                 {
                   "kind": "web-link",
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "ISO 8601"
+                      "text": " ISO 8601"
                     }
                   ],
                   "targetUrl": "https://www.iso.org/iso-8601-date-and-time-format.html"
@@ -44472,10 +43949,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -44492,7 +43965,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -44533,7 +44006,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -44608,8 +44081,13 @@
                   "kind": "paragraph"
                 },
                 {
+                  "kind": "code",
+                  "text": "setStartTime(time: string): void;",
+                  "highlighter": "plain"
+                },
+                {
                   "kind": "text",
-                  "text": "`setStartTime(time: string): void;` (Where time is the start time of all instances represented by standard datetime string format: \"THH:mm:ss:mmm\")."
+                  "text": " (Where time is the start time of all instances represented by standard datetime string format: \"THH:mm:ss:mmm\")."
                 }
               ],
               "isBeta": false,
@@ -44675,10 +44153,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -44695,7 +44169,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -44736,7 +44210,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -44764,10 +44238,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -44801,7 +44271,16 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. The `value` property of the result is the subject of the item."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. The "
+                    },
+                    {
+                      "kind": "code",
+                      "text": "value",
+                      "highlighter": "plain"
+                    },
+                    {
+                      "kind": "text",
+                      "text": " property of the result is the subject of the item."
                     }
                   ],
                   "isOptional": false,
@@ -44832,10 +44311,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -44852,7 +44327,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -44893,7 +44368,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -44933,16 +44408,9 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`getAsync(callback: (result: AsyncResult"
-                },
-                {
-                  "kind": "html-tag",
-                  "token": "<string>"
-                },
-                {
-                  "kind": "text",
-                  "text": ") => void): void;`"
+                  "kind": "code",
+                  "text": "getAsync(callback: (result: AsyncResult<string>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -45021,10 +44489,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -45041,7 +44505,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -45082,7 +44546,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -45157,30 +44621,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(subject: string): void;`"
+                  "kind": "code",
+                  "text": "setAsync(subject: string): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(subject: string, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "setAsync(subject: string, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(subject: string, callback: (result: AsyncResult"
-                },
-                {
-                  "kind": "html-tag",
-                  "token": "<void>"
-                },
-                {
-                  "kind": "text",
-                  "text": ") => void): void;`"
+                  "kind": "code",
+                  "text": "setAsync(subject: string, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -45213,7 +44672,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Entities"
+                  "text": " Entities"
                 }
               ],
               "target": {
@@ -45237,10 +44696,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -45257,7 +44712,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -45298,7 +44753,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -45326,10 +44781,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -45400,10 +44851,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -45420,7 +44867,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -45461,7 +44908,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -45489,10 +44936,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -45526,7 +44969,16 @@
                   "description": [
                     {
                       "kind": "text",
-                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. The `value` property of the result is a Date object."
+                      "text": "When the method completes, the function passed in the callback parameter is called with a single parameter of type AsyncResult. The "
+                    },
+                    {
+                      "kind": "code",
+                      "text": "value",
+                      "highlighter": "plain"
+                    },
+                    {
+                      "kind": "text",
+                      "text": " property of the result is a Date object."
                     }
                   ],
                   "isOptional": false,
@@ -45557,10 +45009,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -45577,7 +45025,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -45618,7 +45066,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -45658,16 +45106,9 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`getAsync(callback: (result: AsyncResult"
-                },
-                {
-                  "kind": "html-tag",
-                  "token": "<Date>"
-                },
-                {
-                  "kind": "text",
-                  "text": ") => void): void;`"
+                  "kind": "code",
+                  "text": "getAsync(callback: (result: AsyncResult<Date>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -45753,10 +45194,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -45773,7 +45210,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -45814,7 +45251,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -45889,30 +45326,25 @@
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(dateTime: Date): void;`"
+                  "kind": "code",
+                  "text": "setAsync(dateTime: Date): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(dateTime: Date, options: Office.AsyncContextOptions): void;`"
+                  "kind": "code",
+                  "text": "setAsync(dateTime: Date, options: Office.AsyncContextOptions): void;",
+                  "highlighter": "plain"
                 },
                 {
                   "kind": "paragraph"
                 },
                 {
-                  "kind": "text",
-                  "text": "`setAsync(dateTime: Date, callback: (result: AsyncResult"
-                },
-                {
-                  "kind": "html-tag",
-                  "token": "<void>"
-                },
-                {
-                  "kind": "text",
-                  "text": ") => void): void;`"
+                  "kind": "code",
+                  "text": "setAsync(dateTime: Date, callback: (result: AsyncResult<void>) => void): void;",
+                  "highlighter": "plain"
                 }
               ],
               "isBeta": false,
@@ -45943,10 +45375,6 @@
           ],
           "remarks": [
             {
-              "kind": "text",
-              "text": ""
-            },
-            {
               "kind": "html-tag",
               "token": "<table>"
             },
@@ -45963,7 +45391,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Minimum permission level"
+                  "text": " Minimum permission level"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -46004,7 +45432,7 @@
               "elements": [
                 {
                   "kind": "text",
-                  "text": "Applicable Outlook mode"
+                  "text": " Applicable Outlook mode"
                 }
               ],
               "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -46032,10 +45460,6 @@
             {
               "kind": "html-tag",
               "token": "</table>"
-            },
-            {
-              "kind": "text",
-              "text": ""
             }
           ],
           "isBeta": false,
@@ -46087,7 +45511,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -46128,7 +45552,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -46418,10 +45842,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -46453,10 +45873,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -46473,7 +45889,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -46514,7 +45930,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -46542,10 +45958,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -46577,10 +45989,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -46597,7 +46005,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -46638,7 +46046,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -46666,10 +46074,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,
@@ -46701,10 +46105,6 @@
               ],
               "remarks": [
                 {
-                  "kind": "text",
-                  "text": ""
-                },
-                {
                   "kind": "html-tag",
                   "token": "<table>"
                 },
@@ -46721,7 +46121,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Minimum permission level"
+                      "text": " Minimum permission level"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions"
@@ -46762,7 +46162,7 @@
                   "elements": [
                     {
                       "kind": "text",
-                      "text": "Applicable Outlook mode"
+                      "text": " Applicable Outlook mode"
                     }
                   ],
                   "targetUrl": "https://docs.microsoft.com/outlook/add-ins/#extension-points"
@@ -46790,10 +46190,6 @@
                 {
                   "kind": "html-tag",
                   "token": "</table>"
-                },
-                {
-                  "kind": "text",
-                  "text": ""
                 }
               ],
               "isBeta": false,


### PR DESCRIPTION
These are changes (mainly cleanup) to the primary Outlook documentation which had not been pushed to the legacy docs.