### PR TITLE
[tools] (WhatsNew) Linking fields

### DIFF
--- a/generate-docs/tools/WhatsNew.ts
+++ b/generate-docs/tools/WhatsNew.ts
@@ -163,7 +163,8 @@ class APISet {
                 const className = clas.getClassName();
                 output += "### [" + className + "](/"
                     + relativePath + className.toLowerCase() + ")\n\n";
-                output += "|What's new|Description|\n|:---|:---|\n";
+                output += extractFirstSentenceFromComment(clas.comment);
+                output += "\n\n|Fields|Description|\n|:---|:---|\n";
                 clas.fields.forEach((field) => {
                     // remove unnecessary parts of the declaration string
                     let newItemText = field.declarationString.replace(/;/g, "");
@@ -172,14 +173,7 @@ class APISet {
                     let tableLine = "|[" + newItemText + "]("
                         + buildFieldLink(relativePath, className, field) + ")|";
 
-                    const firstSentenceIndex = field.comment.indexOf("* ") + 2;
-                    let endIndex = field.comment.indexOf("\n", firstSentenceIndex);
-                    if (endIndex === -1) {
-                        // this is necessary if the comment is a single line (as in collections)
-                        endIndex = field.comment.indexOf("\*/");
-                    }
-
-                    tableLine += field.comment.substring(firstSentenceIndex, endIndex).trim();
+                    tableLine += extractFirstSentenceFromComment(field.comment);
                     output += tableLine + "|\n";
                 });
                 output += "\n";
@@ -187,6 +181,8 @@ class APISet {
         });
         return output;
     }
+
+
 
     public sort(): void {
         this.api.forEach((element) => {
@@ -201,6 +197,17 @@ class APISet {
             }
         });
     }
+}
+
+function extractFirstSentenceFromComment(commentText) {
+    const firstSentenceIndex = commentText.indexOf("* ") + 2;
+    let endIndex = commentText.indexOf("\n", firstSentenceIndex);
+    if (endIndex === -1) {
+        // this is necessary if the comment is a single line (as in collections)
+        endIndex = commentText.indexOf("\*/");
+    }
+
+    return commentText.substring(firstSentenceIndex, endIndex).trim();
 }
 
 function buildFieldLink(relativePath: string, className: string, field: FieldStruct) {

--- a/generate-docs/tools/WhatsNew.ts
+++ b/generate-docs/tools/WhatsNew.ts
@@ -156,22 +156,20 @@ class APISet {
     public getAsMarkdown(relativePath: string): string {
         this.sort();
         // table header
-        let output: string = "|Object|What's new|Description|\n|---|---|---|\n";
+        let output: string = "";
         this.api.forEach((clas) => {
             // ignore enums
             if (clas.type !== ClassType.Enum) {
                 const className = clas.getClassName();
-                output += "|[" + className + "](/"
-                    + relativePath + className.toLowerCase() + ")|";
-                let firstItem = true;
+                output += "### [" + className + "](/"
+                    + relativePath + className.toLowerCase() + ")\n\n";
+                output += "|What's new|Description|\n|:---|:---|\n";
                 clas.fields.forEach((field) => {
                     // remove unnecessary parts of the declaration string
                     let newItemText = field.declarationString.replace(/;/g, "");
                     newItemText = newItemText.substring(0, newItemText.lastIndexOf(":")).replace("readonly ", "");
-                    newItemText = newItemText.replace("|", "\\|");
-                    let tableLine = firstItem ? "" : "||";
-                    firstItem = false;
-                    tableLine += "[" + newItemText + "]("
+                    newItemText = newItemText.replace(/\|/g, "\\|");
+                    let tableLine = "|[" + newItemText + "]("
                         + buildFieldLink(relativePath, className, field) + ")|";
 
                     const firstSentenceIndex = field.comment.indexOf("* ") + 2;
@@ -184,6 +182,7 @@ class APISet {
                     tableLine += field.comment.substring(firstSentenceIndex, endIndex).trim();
                     output += tableLine + "|\n";
                 });
+                output += "\n";
             }
         });
         return output;

--- a/generate-docs/tools/WhatsNew.ts
+++ b/generate-docs/tools/WhatsNew.ts
@@ -22,11 +22,13 @@ class FieldStruct {
     public declarationString: string;
     public comment: string;
     public type: FieldType;
+    public name: string;
 
-    constructor(decString: string, commentString: string, fieldType: FieldType) {
+    constructor(decString: string, commentString: string, fieldType: FieldType, fieldName: string) {
         this.declarationString = decString;
         this.comment = commentString;
         this.type = fieldType;
+        this.name = fieldName;
     }
 }
 
@@ -140,7 +142,11 @@ class APISet {
             output.push(clas.declarationString + " {");
             clas.fields.forEach((field) => {
                 output.push("    " + field.comment);
-                output.push("    " + field.declarationString);
+                if (field.type === FieldType.Enum) {
+                    output.push("    " + field.declarationString + ",");
+                } else {
+                    output.push("    " + field.declarationString);
+                }
             });
             output.push("}");
         });
@@ -150,38 +156,33 @@ class APISet {
     public getAsMarkdown(relativePath: string): string {
         this.sort();
         // table header
-        let output: string = "|Object|What's new|Description|\n";
-        output += "|:----|:----|:----|\n";
+        let output: string = "|Object|What's new|Description|\n|---|---|---|\n";
         this.api.forEach((clas) => {
             // ignore enums
             if (clas.type !== ClassType.Enum) {
+                const className = clas.getClassName();
+                output += "|[" + className + "](/"
+                    + relativePath + className.toLowerCase() + ")|";
+                let firstItem = true;
                 clas.fields.forEach((field) => {
-                    const className: string = clas.getClassName();
-                    let tableLine: string = "|[" + className + "](/" + relativePath + className.toLowerCase() + ")|";
                     // remove unnecessary parts of the declaration string
-                    let newItemText: string = field.declarationString.replace(/;/g, "");
-                    switch (field.type) {
-                        case FieldType.Property:
-                            newItemText = newItemText.substring(0, newItemText.indexOf(":")).replace("readonly ", "")
-                             + " (property)";
-                            break;
-                        case FieldType.Event:
-                            newItemText = newItemText.substring(0, newItemText.indexOf(":")).replace("readonly ", "")
-                            + " (event)";
-                            break;
-                    }
+                    let newItemText = field.declarationString.replace(/;/g, "");
+                    newItemText = newItemText.substring(0, newItemText.lastIndexOf(":")).replace("readonly ", "");
+                    newItemText = newItemText.replace("|", "\\|");
+                    let tableLine = firstItem ? "" : "||";
+                    firstItem = false;
+                    tableLine += "[" + newItemText + "]("
+                        + buildFieldLink(relativePath, className, field) + ")|";
 
-                    tableLine += newItemText + "|";
-
-                    const firstSentenceIndex: number = field.comment.indexOf("* ") + 2;
-                    let endIndex: number = field.comment.indexOf("\n", firstSentenceIndex);
+                    const firstSentenceIndex = field.comment.indexOf("* ") + 2;
+                    let endIndex = field.comment.indexOf("\n", firstSentenceIndex);
                     if (endIndex === -1) {
                         // this is necessary if the comment is a single line (as in collections)
                         endIndex = field.comment.indexOf("\*/");
                     }
 
-                    tableLine += field.comment.substring(firstSentenceIndex, endIndex).trim() + "|";
-                    output += tableLine + "\n";
+                    tableLine += field.comment.substring(firstSentenceIndex, endIndex).trim();
+                    output += tableLine + "|\n";
                 });
             }
         });
@@ -201,6 +202,38 @@ class APISet {
             }
         });
     }
+}
+
+function buildFieldLink(relativePath: string, className: string, field: FieldStruct) {
+    switch (field.type) {
+        case FieldType.Method:
+            let parameterLink: string = "";
+            let paramIndex = field.declarationString.indexOf(":");
+            while (paramIndex > 0 && paramIndex < field.declarationString.indexOf(")")) {
+                const wordStartIndex = Math.max(
+                    field.declarationString.lastIndexOf("(", paramIndex),
+                    field.declarationString.lastIndexOf(" ", paramIndex)) + 1;
+                parameterLink += "-" + field.declarationString.substring(wordStartIndex, paramIndex) + "-";
+                paramIndex = field.declarationString.indexOf(":", paramIndex + 1);
+            }
+            return relativePath + className.toLowerCase() + "#" + field.name + parameterLink;
+        default:
+            return relativePath + className.toLowerCase() + "#" + field.name;
+    }
+}
+
+function fixDTS(definitions: string): string {
+    // remove undesirable content, like load, set, data classes, and toJSON
+    return definitions
+        .replace(/\s*load\(option\?: (Excel|Word|OneNote|Visio)\.Interfaces\.\S*LoadOptions.*\): \S*?;/gm, '')
+        .replace(/\*\s*?`load\(option\?: string \| string\[\]\): (Excel|Word|OneNote|Visio)\..*?` - Where option is a comma-delimited string or an array of strings that specify the properties to load\./g, '')
+        .replace(/interface .*?LoadOptions \{[^}]*?}/gm, '')
+        .replace(/interface .*?Data \{[^}]*?}/gm, '')
+        .replace(/load\(option\?\: string \| string\[\]\)\: .*\;/gm, '')
+        .replace(/toJSON\(\)\:.*\;/gm, '')
+        .replace(/\/\*\* Sets multiple properties.*\s*\*\s*\*.@remarks\s*\*\s*\* This method has the following additional signature:\s*\*\s*\* \`set\(properties:.*\s*\*\s*\* @param.*\s*\*.*\s*\*\/\s*set\(properties:.*\s*\/\*\* Sets multiple properties.*\s*set\(properties:.*;/gm, '')
+        .replace(/context\: RequestContext\;/gm, "")
+        .replace(/\/\*\* The request context associated with the object\. This connects the add\-in\'s process to the Office host application\'s process\. \*\//gm, "");
 }
 
 function parseDTS(node: ts.Node, allClasses: APISet): void {
@@ -226,8 +259,11 @@ function parseDTS(node: ts.Node, allClasses: APISet): void {
         case ts.SyntaxKind.MethodSignature:
             parseDTSFieldItem(node as ts.MethodSignature, FieldType.Method);
             break;
+        case ts.SyntaxKind.MethodDeclaration:
+            parseDTSFieldItem(node as ts.MethodDeclaration, FieldType.Method);
+            break;
         default:
-            // the compiler parses comments after the class/field, thereof this connects to the previous item
+            // the compiler parses comments after the class/field, therefore this connects to the previous item
             if (node.getText().indexOf("/**") >= 0 &&
                 node.getText().indexOf("*/") >= 0 &&
                 lastItem !== null &&
@@ -250,17 +286,19 @@ function parseDTSTopLevelItem(
     node: ts.InterfaceDeclaration | ts.ClassDeclaration | ts.EnumDeclaration,
     allClasses: APISet,
     type: ClassType): void {
+    //console.log("Creating " + node.name.text);
     topClass = new ClassStruct("export " + type.toLowerCase() + " " + node.name.text, "", type);
     allClasses.addClass(topClass);
     lastItem = topClass;
 }
 
 function parseDTSFieldItem(
-    node: ts.PropertySignature | ts.PropertyDeclaration | ts.EnumMember | ts.MethodSignature,
+    node: ts.PropertySignature | ts.PropertyDeclaration | ts.EnumMember | ts.MethodSignature | ts.MethodDeclaration,
     type: FieldType): void {
-    // checking for and ignoring mid-method parameters for load()
     if (node.getText().indexOf("expand?") < 0 && node.getText().indexOf("select?") < 0) {
-        const newField: FieldStruct = new FieldStruct(node.getText(), "", type);
+        // checking for and ignoring mid-method parameters for load()
+        const newField: FieldStruct = new FieldStruct(node.getText(), "", type, node.name.getText());
+        //console.log("Adding " + newField.name + " to " + topClass.getClassName());
         topClass.fields.push(newField);
         lastItem = newField;
     }
@@ -278,18 +316,21 @@ let lastItem: ClassStruct | FieldStruct = null;
     // read files
     const fileNames: string[] = process.argv.slice(2);
     const releaseFile: ts.SourceFile = ts.createSourceFile(
-        fileNames[0],
-        readFileSync(fileNames[0]).toString(),
+        "Release",
+        fixDTS(readFileSync(fileNames[0]).toString()),
         ts.ScriptTarget.ES2015,
         true);
     const betaFile: ts.SourceFile = ts.createSourceFile(
-        fileNames[1],
-        readFileSync(fileNames[1]).toString(),
+        "Preview",
+        fixDTS(readFileSync(fileNames[1]).toString()),
         ts.ScriptTarget.ES2015,
         true);
-
     parseDTS(releaseFile, releaseAPI);
     parseDTS(betaFile, betaAPI);
+
+    fsx.writeFileSync("Release.d.ts", releaseAPI.getAsDTS());
+    fsx.writeFileSync("Beta.d.ts", betaAPI.getAsDTS());
+
 
     const diffAPI: APISet = betaAPI.diff(releaseAPI);
 

--- a/generate-docs/tools/WhatsNew.ts
+++ b/generate-docs/tools/WhatsNew.ts
@@ -222,9 +222,9 @@ function buildFieldLink(relativePath: string, className: string, field: FieldStr
                 parameterLink += "-" + field.declarationString.substring(wordStartIndex, paramIndex) + "-";
                 paramIndex = field.declarationString.indexOf(":", paramIndex + 1);
             }
-            return relativePath + className.toLowerCase() + "#" + field.name + parameterLink;
+            return "/" + relativePath + className.toLowerCase() + "#" + field.name + parameterLink;
         default:
-            return relativePath + className.toLowerCase() + "#" + field.name;
+            return "/" + relativePath + className.toLowerCase() + "#" + field.name;
     }
 }
 

--- a/generate-docs/tools/tslint.json
+++ b/generate-docs/tools/tslint.json
@@ -1,11 +1,62 @@
 {
-    "defaultSeverity": "warning",
-    "extends": [
-        "tslint:recommended"
-    ],
-    "jsRules": {},
     "rules": {
-        "max-classes-per-file": false
-    },
-    "rulesDirectory": []
+        "no-reference": true,
+        "only-arrow-functions": [
+            true,
+            "allow-declarations",
+            "allow-named-functions"
+        ],
+        "no-namespace": [
+            true,
+            "allow-declarations"
+        ],
+        "class-name": true,
+        "curly": true,
+        "eofline": true,
+        "forin": true,
+        "indent": [
+            true,
+            "spaces"
+        ],
+        "label-position": true,
+        "no-arg": true,
+        "no-var-keyword": true,
+        "no-console": [
+            true,
+            "time",
+            "timeEnd"
+        ],
+        "no-construct": true,
+        "no-debugger": true,
+        "no-duplicate-variable": true,
+        "no-empty": false,
+        "no-eval": true,
+        "no-trailing-whitespace": true,
+        "no-unused-expression": true,
+        "no-use-before-declare": true,
+        "one-line": [
+            true,
+            "check-open-brace",
+            "check-whitespace"
+        ],
+        "radix": true,
+        "semicolon": [
+            true,
+            "always",
+            "ignore-interfaces"
+        ],
+        "triple-equals": [
+            true,
+            "allow-null-check"
+        ],
+        "variable-name": false,
+        "whitespace": [
+            true,
+            "check-branch",
+            "check-decl",
+            "check-operator",
+            "check-separator",
+            "check-type"
+        ]
+    }
 }


### PR DESCRIPTION
This update improves the tool to link fields to their entries in the reference docs. It also improves the field tables, removes *LoadOptions, and fixes bugs around unioned types.

[Here's a sample docs build](https://review.docs.microsoft.com/en-us/office/dev/add-ins/reference/requirement-sets/excel-api-requirement-sets?branch=AlexJ-WhatsNew#whats-in-the-excel-javascript-api-preview).