### PR TITLE
Streamlining WhatsNew experience

### DIFF
--- a/generate-docs/tools/.gitignore
+++ b/generate-docs/tools/.gitignore
@@ -1,4 +1,6 @@
+node_modules
+tool-inputs
+tool-outputs
 *.js
 *.js.map
-*.d.ts
-*.md
+package-lock.json

--- a/generate-docs/tools/WhatsNew.ts
+++ b/generate-docs/tools/WhatsNew.ts
@@ -1,7 +1,6 @@
-// usage: node WhatsNew "Old d.ts" "New d.ts" "link prefix"
-// example: node WhatsNew excel-1_7.d.ts excel-1_8.d.ts javascript/api/excel/excel.
-
 import { readFileSync } from "fs";
+import { promptFromList } from '../scripts/simple-prompts';
+import { fetchAndThrowOnError, DtsBuilder} from '../scripts/util';
 import * as fsx from "fs-extra";
 import * as ts from "typescript";
 
@@ -319,33 +318,88 @@ function parseDTSFieldItem(
 let topClass: ClassStruct = null;
 let lastItem: ClassStruct | FieldStruct = null;
 
-(() => {
+tryCatch(async () => {
+    // Get file locations
+    const officeJSUrl = await promptFromList({
+        message: "Which d.ts file should be used as the RELEASE version?",
+        choices: [
+            { name: "DefinitelyTyped", value: "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/master/types/office-js/index.d.ts" },
+            { name: "Local file [generate-docs\\tools\\tool-inputs\\release.d.ts]", value: "" }
+        ]
+    });
+
+    if (officeJSUrl.length > 0) {
+        fsx.writeFileSync("./tool-inputs/release.d.ts", await fetchAndThrowOnError(officeJSUrl, "text"));
+    }
+
+    const officeJSPreviewUrl = await promptFromList({
+        message: "Which d.ts file should be used as the PREVIEW version?",
+        choices: [
+            { name: "DefinitelyTyped", value: "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/master/types/office-js-preview/index.d.ts" },
+            { name: "Local file [generate-docs\\tools\\tool-inputs\\preview.d.ts]", value: "" }
+        ]
+    });
+
+    if (officeJSPreviewUrl.length > 0) {
+        fsx.writeFileSync("./tool-inputs/preview.d.ts", await fetchAndThrowOnError(officeJSPreviewUrl, "text"));
+    }
+
+    // read whole files
+    let wholeRelease = fsx.readFileSync("./tool-inputs/release.d.ts").toString();
+    let wholePreview = fsx.readFileSync("./tool-inputs/preview.d.ts").toString();
+
+    const hostName = await promptFromList({
+        message: "Which host is being generated?",
+        choices: [
+            { name: "Excel", value: "excel" },
+            { name: "OneNote", value: "onenote" },
+            { name: "Outlook", value: "outlook" },
+            { name: "Visio", value: "visio" },
+            { name: "Word", value: "word" }
+        ]
+    });
+    const releaseHostFileName: string = './tool-inputs/' + hostName + '-release.d.ts';
+    const previewHostFileName: string = './tool-inputs/' + hostName + '-preview.d.ts';
+
+    const dtsBuilder = new DtsBuilder();
+    fsx.writeFileSync(
+        './tool-inputs/' + hostName + '-release.d.ts',
+        dtsBuilder.extractDtsSection(wholeRelease, "Begin Excel APIs", "End Excel APIs")
+    );
+    fsx.writeFileSync(
+        './tool-inputs/' + hostName + '-preview.d.ts',
+        dtsBuilder.extractDtsSection(wholePreview, "Begin Excel APIs", "End Excel APIs")
+    );
 
     const releaseAPI: APISet = new APISet();
-    const betaAPI: APISet = new APISet();
+    const previewAPI: APISet = new APISet();
 
-    // read files
-    const fileNames: string[] = process.argv.slice(2);
     const releaseFile: ts.SourceFile = ts.createSourceFile(
         "Release",
-        fixDTS(readFileSync(fileNames[0]).toString()),
+        fixDTS(readFileSync(releaseHostFileName).toString()),
         ts.ScriptTarget.ES2015,
         true);
-    const betaFile: ts.SourceFile = ts.createSourceFile(
+    const previewFile: ts.SourceFile = ts.createSourceFile(
         "Preview",
-        fixDTS(readFileSync(fileNames[1]).toString()),
+        fixDTS(readFileSync(previewHostFileName).toString()),
         ts.ScriptTarget.ES2015,
         true);
+
     parseDTS(releaseFile, releaseAPI);
-    parseDTS(betaFile, betaAPI);
+    parseDTS(previewFile, previewAPI);
 
-    fsx.writeFileSync("Release.d.ts", releaseAPI.getAsDTS());
-    fsx.writeFileSync("Beta.d.ts", betaAPI.getAsDTS());
+    const diffAPI: APISet = previewAPI.diff(releaseAPI);
 
+    const relativePath: string = "javascript/api/" + hostName + "/" + hostName + ".";
+    fsx.writeFileSync("./tool-outputs/WhatsNew.d.ts", diffAPI.getAsDTS());
+    fsx.writeFileSync("./tool-outputs/WhatsNew.md", diffAPI.getAsMarkdown(relativePath));
+});
 
-    const diffAPI: APISet = betaAPI.diff(releaseAPI);
-
-    const relativePath: string = process.argv[4];
-    fsx.writeFileSync("WhatsNew.d.ts", diffAPI.getAsDTS());
-    fsx.writeFileSync("WhatsNew.md", diffAPI.getAsMarkdown(relativePath));
-})();
+async function tryCatch(call: () => Promise<void>) {
+    try {
+        await call();
+    } catch (e) {
+        console.error(e);
+        process.exit(1);
+    }
+}

--- a/generate-docs/tools/package.json
+++ b/generate-docs/tools/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "tools",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "start": "tsc -p tsconfig.json --watch",
+    "lint": "tslint --project tsconfig.json"
+  },
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "@types/fs-extra": "3.0.1",
+    "@types/inquirer": "0.0.34",
+    "@types/js-yaml": "3.5.29",
+    "@types/lodash": "4.14.64",
+    "@types/node": "7.0.5",
+    "del": "2.2.2",
+    "ts-lint": "4.5.1",
+    "ts-node": "2.1.0",
+    "typescript": "2.6.2"
+  },
+  "dependencies": {
+    "fs-extra": "3.0.1",
+    "inquirer": "3.1.0",
+    "js-yaml": "3.7.0",
+    "lodash": "4.17.5",
+    "isomorphic-fetch": "2.2.1"
+  }
+}

--- a/generate-docs/tools/tsconfig.json
+++ b/generate-docs/tools/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+      "module": "commonjs",
+      "target": "es6",
+      "sourceMap": true,
+      "typeRoots": [
+          "node_modules/**"
+      ],
+      "strict": false,
+      "noUnusedLocals": true
+  },
+  "exclude": [
+      "node_modules/**",
+      "tool-inputs/**",
+      "tool-outputs/**"
+  ]
+}


### PR DESCRIPTION
This changes the WhatsNew tool to have a similar compilation pattern as the rest of the repo. It also now pulls directly from DefinitelyTyped (or a local file) and automatically reduces the scope to the selected host.

I've also confirmed the output hasn't been affected by this change.