### PR TITLE
A tool to remove an API set from a d.ts file

### DIFF
--- a/generate-docs/tools/VersionRemover.ts
+++ b/generate-docs/tools/VersionRemover.ts
@@ -1,0 +1,23 @@
+import * as fsx from "fs-extra";
+
+let wholeDTS = fsx.readFileSync(process.argv[2]).toString();
+let indexOfApiSetTag = wholeDTS.indexOf("Api set: " + process.argv[3]);
+while (indexOfApiSetTag >= 0) {
+    let commentStart = wholeDTS.lastIndexOf("/**", indexOfApiSetTag);
+    let commentEnd = wholeDTS.indexOf("*/", indexOfApiSetTag) + 1;
+    let declarationString = wholeDTS.substring(commentEnd + 1, wholeDTS.indexOf("\n", commentEnd + 2));
+    let endPosition;
+    if (declarationString.indexOf("class") >= 0 || declarationString.indexOf("enum") >= 0 || declarationString.indexOf("interface") >= 0) {
+        endPosition = wholeDTS.indexOf("}\n", commentEnd);
+    } else {
+        endPosition = wholeDTS.indexOf(";", commentEnd);
+    }
+
+    if (endPosition === -1) {
+        endPosition = commentEnd;
+    }
+    wholeDTS = wholeDTS.substring(0, commentStart) + wholeDTS.substring(endPosition + 1);
+    indexOfApiSetTag = wholeDTS.indexOf("Api set: " + process.argv[3]);
+}
+
+fsx.writeFileSync(process.argv[4], wholeDTS);

--- a/generate-docs/tools/VersionRemover.ts
+++ b/generate-docs/tools/VersionRemover.ts
@@ -1,3 +1,5 @@
+// usage: node VersionRemover [source d.ts] [API set name] [output file name]
+// example: node VersionRemover excel.d.ts "ExcelApi 1.8" excel_1_7.d.ts
 import * as fsx from "fs-extra";
 
 let wholeDTS = fsx.readFileSync(process.argv[2]).toString();


### PR DESCRIPTION
I developed this little tool while working on the preview doc sets, but I think it has value outside of that (particularly with versioning on the horizon). The tool goes through a d.ts file and removes any classes, enums, interfaces, or fields with the specified API set.