### PR TITLE
Adding Excel event snippet examples

### DIFF
--- a/docs/code-snippets/excel-snippets.yaml
+++ b/docs/code-snippets/excel-snippets.yaml
@@ -337,6 +337,30 @@ Excel.ChartAxisTitle.load:
                 console.log("Debug info: " + JSON.stringify(error.debugInfo));
             }
     });
+Excel.Chart.onActivated:
+  - |-
+    Excel.run(function (context){
+        var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+        pieChart.onActivated.add(function (event) {
+            return Excel.run((context) => {
+                console.log("The pie chart is the active chart. ID: " + event.chartId);
+                return context.sync();
+            });
+        });
+        return context.sync();
+    });
+Excel.Chart.onDeactivated:
+  - |-
+    Excel.run(function (context){
+        var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+        pieChart.onDeactivated.add(function (event) {
+            return Excel.run((context) => {
+                console.log("The pie chart is NOT active.");
+                return context.sync();
+            });
+        });
+        return context.sync();
+    });
 Excel.ChartCollection.add:
   - |-
     // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
@@ -439,6 +463,54 @@ Excel.ChartCollection.load:
         if (error instanceof OfficeExtension.Error) {
             console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
+    });
+Excel.ChartCollection.onActivated:
+  - |-
+    Excel.run(function (context){
+        context.workbook.worksheets.getActiveWorksheet()
+            .charts.onActivated.add(function (event) {
+            return Excel.run((context) => {
+                console.log("The ID of the active chart is: " + event.chartId)
+                return context.sync();
+            });
+        });
+        return context.sync();
+    });
+Excel.ChartCollection.onAdded:
+  - |-
+    Excel.run(function (context){
+        context.workbook.worksheets.getActiveWorksheet()
+            .charts.onAdded.add(function (event) {
+            return Excel.run((context) => {
+                console.log("A chart has been added with ID: " + event.chartId);
+                return context.sync();
+            });
+        });
+        return context.sync();
+    });
+Excel.ChartCollection.onDeactivated:
+  - |-
+    Excel.run(function (context){
+        context.workbook.worksheets.getActiveWorksheet()
+            .charts.onDeactivated.add(function (event) {
+            return Excel.run((context) => {
+                console.log("The chart with this ID was deactivated: " + event.chartId);
+                return context.sync();
+            });
+        });
+        return context.sync();
+    });
+Excel.ChartCollection.onDeleted:
+  - |-
+    Excel.run(function (context){
+        context.workbook.worksheets.getActiveWorksheet()
+            .charts.onDeleted.add(function (event) {
+            return Excel.run((context) => {
+                console.log("The chart with this ID was deleted: " + event.chartId);
+                return context.sync();
+            });
+        });
+        return context.sync();
     });
 Excel.ChartDataLabels.load:
   - |-
@@ -2251,6 +2323,54 @@ Excel.Worksheet.load:
         if (error instanceof OfficeExtension.Error) {
             console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
+    });
+Excel.Worksheet.onActivated:
+  - |-
+    Excel.run(function (context) {
+        var sheet = context.workbook.worksheets.getItem("Sample");
+        sheet.onActivated.add(function (event) {
+            return Excel.run((context) => {
+                console.log("The activated worksheet ID is: " + event.worksheetId);
+                return context.sync();
+            });
+        });
+        return context.sync();
+    });
+Excel.Worksheet.onCalculated:
+  - |-
+    Excel.run(function (context) {
+        var sheet = context.workbook.worksheets.getItem("Sample");
+        sheet.onCalculated.add(function (event) {
+            return Excel.run((context) => {
+                console.log("The worksheet has recalculated.");
+                return context.sync();
+            });
+        });
+        return context.sync();
+    });
+Excel.Worksheet.onDeactivated:
+  - |-
+    Excel.run(function (context) {
+        var sheet = context.workbook.worksheets.getItem("Sample");
+        sheet.onDeactivated.add(function (event) {
+            return Excel.run((context) => {
+                console.log("The deactivated worksheet is: " + event.worksheetId);
+                return context.sync();
+            });
+        });
+        return context.sync();
+    });
+Excel.Worksheet.onSelectionChanged:
+  - |-
+    Excel.run(function (context) {
+        var sheet = context.workbook.worksheets.getItem("Sample");
+        sheet.onSelectionChanged.add(function (event) {
+            return Excel.run((context) => {
+                console.log("The selected range has changed to: " + event.address);
+                return context.sync();
+            });
+        });
+        return context.sync();
     });
 Excel.WorksheetCollection.add:
   - |-

--- a/docs/docs-ref-autogen/excel/excel.chart.yml
+++ b/docs/docs-ref-autogen/excel/excel.chart.yml
@@ -434,6 +434,22 @@ items:
       return:
         type:
           - OfficeExtension.EventHandlers<Excel.ChartActivatedEventArgs>
+        description: |-
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context){
+              var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+              pieChart.onActivated.add(function (event) {
+                  return Excel.run((context) => {
+                      console.log("The pie chart is the active chart. ID: " + event.chartId);
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
   - uid: excel.Excel.Chart.onDeactivated
     summary: |-
       Occurs when the chart is deactivated.
@@ -449,6 +465,22 @@ items:
       return:
         type:
           - OfficeExtension.EventHandlers<Excel.ChartDeactivatedEventArgs>
+        description: |-
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context){
+              var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+              pieChart.onDeactivated.add(function (event) {
+                  return Excel.run((context) => {
+                      console.log("The pie chart is NOT active.");
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
   - uid: excel.Excel.Chart.plotArea
     summary: |-
       Represents the plotArea for the chart.

--- a/docs/docs-ref-autogen/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel/excel.chartcollection.yml
@@ -355,6 +355,22 @@ items:
       return:
         type:
           - OfficeExtension.EventHandlers<Excel.ChartActivatedEventArgs>
+        description: |-
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context){
+              context.workbook.worksheets.getActiveWorksheet()
+                  .charts.onActivated.add(function (event) {
+                  return Excel.run((context) => {
+                      console.log("The ID of the active chart is: " + event.chartId)
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
   - uid: excel.Excel.ChartCollection.onAdded
     summary: |-
       Occurs when a new chart is added to the worksheet.
@@ -370,6 +386,22 @@ items:
       return:
         type:
           - OfficeExtension.EventHandlers<Excel.ChartAddedEventArgs>
+        description: |-
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context){
+              context.workbook.worksheets.getActiveWorksheet()
+                  .charts.onAdded.add(function (event) {
+                  return Excel.run((context) => {
+                      console.log("A chart has been added with ID: " + event.chartId);
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
   - uid: excel.Excel.ChartCollection.onDeactivated
     summary: |-
       Occurs when a chart is deactivated.
@@ -385,6 +417,22 @@ items:
       return:
         type:
           - OfficeExtension.EventHandlers<Excel.ChartDeactivatedEventArgs>
+        description: |-
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context){
+              context.workbook.worksheets.getActiveWorksheet()
+                  .charts.onDeactivated.add(function (event) {
+                  return Excel.run((context) => {
+                      console.log("The chart with this ID was deactivated: " + event.chartId);
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
   - uid: excel.Excel.ChartCollection.onDeleted
     summary: |-
       Occurs when a chart is deleted.
@@ -400,6 +448,22 @@ items:
       return:
         type:
           - OfficeExtension.EventHandlers<Excel.ChartDeletedEventArgs>
+        description: |-
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context){
+              context.workbook.worksheets.getActiveWorksheet()
+                  .charts.onDeleted.add(function (event) {
+                  return Excel.run((context) => {
+                      console.log("The chart with this ID was deleted: " + event.chartId);
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
   - uid: excel.Excel.ChartCollection.toJSON
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to

--- a/docs/docs-ref-autogen/excel/excel.worksheet.yml
+++ b/docs/docs-ref-autogen/excel/excel.worksheet.yml
@@ -716,6 +716,22 @@ items:
       return:
         type:
           - OfficeExtension.EventHandlers<Excel.WorksheetActivatedEventArgs>
+        description: |-
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context) {
+              var sheet = context.workbook.worksheets.getItem("Sample");
+              sheet.onActivated.add(function (event) {
+                  return Excel.run((context) => {
+                      console.log("The activated worksheet ID is: " + event.worksheetId);
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
   - uid: excel.Excel.Worksheet.onCalculated
     summary: |-
       Occurs when the worksheet is calculated.
@@ -731,6 +747,22 @@ items:
       return:
         type:
           - OfficeExtension.EventHandlers<Excel.WorksheetCalculatedEventArgs>
+        description: |-
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context) {
+              var sheet = context.workbook.worksheets.getItem("Sample");
+              sheet.onCalculated.add(function (event) {
+                  return Excel.run((context) => {
+                      console.log("The worksheet has recalculated.");
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
   - uid: excel.Excel.Worksheet.onChanged
     summary: |-
       Occurs when data changed on a specific worksheet.
@@ -774,6 +806,22 @@ items:
       return:
         type:
           - OfficeExtension.EventHandlers<Excel.WorksheetDeactivatedEventArgs>
+        description: |-
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context) {
+              var sheet = context.workbook.worksheets.getItem("Sample");
+              sheet.onDeactivated.add(function (event) {
+                  return Excel.run((context) => {
+                      console.log("The deactivated worksheet is: " + event.worksheetId);
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
   - uid: excel.Excel.Worksheet.onSelectionChanged
     summary: |-
       Occurs when the selection changes on a specific worksheet.
@@ -789,6 +837,22 @@ items:
       return:
         type:
           - OfficeExtension.EventHandlers<Excel.WorksheetSelectionChangedEventArgs>
+        description: |-
+
+          #### Examples
+
+          ```javascript
+          Excel.run(function (context) {
+              var sheet = context.workbook.worksheets.getItem("Sample");
+              sheet.onSelectionChanged.add(function (event) {
+                  return Excel.run((context) => {
+                      console.log("The selected range has changed to: " + event.address);
+                      return context.sync();
+                  });
+              });
+              return context.sync();
+          });
+          ```
   - uid: excel.Excel.Worksheet.pivotTables
     summary: |-
       Collection of PivotTables that are part of the worksheet. Read-only.

--- a/docs/docs-ref-autogen/outlook/office.appointmentcompose.yml
+++ b/docs/docs-ref-autogen/outlook/office.appointmentcompose.yml
@@ -1129,7 +1129,7 @@ items:
             - '(result: AsyncResult<void>) => void'
   - uid: outlook.Office.AppointmentCompose.removeHandlerAsync
     summary: >-
-      Removes an event handler for a supported event.
+      Removes the event handlers for a supported event type.
 
 
       Currently the supported event types are `Office.EventType.AppointmentTimeChanged`<!-- -->,
@@ -1151,16 +1151,14 @@ items:
       In addition to this signature, the method also has the following signature:
 
 
-      `removeHandlerAsync(eventType:EventType, handler: any, callback?: (result: AsyncResult<void>) => void): void;`
-    name: 'removeHandlerAsync(eventType, handler, options, callback)'
+      `removeHandlerAsync(eventType:EventType, callback?: (result: AsyncResult<void>) => void): void;`
+    name: 'removeHandlerAsync(eventType, options, callback)'
     fullName: removeHandlerAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: >-
-        removeHandlerAsync(eventType:EventType, handler: any, options?: any, callback?: (result: AsyncResult<void>) =>
-        void): void;
+      content: 'removeHandlerAsync(eventType:EventType, options?: any, callback?: (result: AsyncResult<void>) => void): void;'
       return:
         type:
           - void
@@ -1170,12 +1168,6 @@ items:
           description: The event that should revoke the handler.
           type:
             - EventType
-        - id: handler
-          description: >-
-            The function to handle the event. The function must accept a single parameter, which is an object literal.
-            The type property on the parameter will match the eventType parameter passed to removeHandlerAsync.
-          type:
-            - any
         - id: options
           description: >-
             Optional. An object literal that contains one or more of the following properties. asyncContext: Developers

--- a/docs/docs-ref-autogen/outlook/office.appointmentread.yml
+++ b/docs/docs-ref-autogen/outlook/office.appointmentread.yml
@@ -1330,7 +1330,7 @@ items:
           - Recurrence
   - uid: outlook.Office.AppointmentRead.removeHandlerAsync
     summary: >-
-      Removes an event handler for a supported event.
+      Removes the event handlers for a supported event type.
 
 
       Currently the supported event types are `Office.EventType.AppointmentTimeChanged`<!-- -->,
@@ -1351,16 +1351,14 @@ items:
       In addition to this signature, the method also has the following signature:
 
 
-      `removeHandlerAsync(eventType:EventType, handler: any, callback?: (result: AsyncResult<void>) => void): void;`
-    name: 'removeHandlerAsync(eventType, handler, options, callback)'
+      `removeHandlerAsync(eventType:EventType, callback?: (result: AsyncResult<void>) => void): void;`
+    name: 'removeHandlerAsync(eventType, options, callback)'
     fullName: removeHandlerAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: >-
-        removeHandlerAsync(eventType:EventType, handler: any, options?: any, callback?: (result: AsyncResult<void>) =>
-        void): void;
+      content: 'removeHandlerAsync(eventType:EventType, options?: any, callback?: (result: AsyncResult<void>) => void): void;'
       return:
         type:
           - void
@@ -1370,12 +1368,6 @@ items:
           description: The event that should revoke the handler.
           type:
             - EventType
-        - id: handler
-          description: >-
-            The function to handle the event. The function must accept a single parameter, which is an object literal.
-            The type property on the parameter will match the eventType parameter passed to removeHandlerAsync.
-          type:
-            - any
         - id: options
           description: >-
             Optional. An object literal that contains one or more of the following properties. asyncContext: Developers

--- a/docs/docs-ref-autogen/outlook/office.item.yml
+++ b/docs/docs-ref-autogen/outlook/office.item.yml
@@ -609,7 +609,7 @@ items:
           - outlook.Office.Recurrence
   - uid: outlook.Office.Item.removeHandlerAsync
     summary: >-
-      Removes an event handler for a supported event.
+      Removes the event handlers for a supported event type.
 
 
       Currently the supported event types are `Office.EventType.AppointmentTimeChanged`<!-- -->,
@@ -630,17 +630,16 @@ items:
       In addition to this signature, the method also has the following signature:
 
 
-      `removeHandlerAsync(eventType: Office.EventType, handler: any, callback?: (result: AsyncResult<void>) => void):
-      void;`
-    name: 'removeHandlerAsync(eventType, handler, options, callback)'
+      `removeHandlerAsync(eventType: Office.EventType, callback?: (result: AsyncResult<void>) => void): void;`
+    name: 'removeHandlerAsync(eventType, options, callback)'
     fullName: removeHandlerAsync
     langs:
       - typeScript
     type: method
     syntax:
       content: >-
-        removeHandlerAsync(eventType: Office.EventType, handler: any, options?: any, callback?: (result:
-        AsyncResult<void>) => void): void;
+        removeHandlerAsync(eventType: Office.EventType, options?: any, callback?: (result: AsyncResult<void>) => void):
+        void;
       return:
         type:
           - void
@@ -650,12 +649,6 @@ items:
           description: The event that should revoke the handler.
           type:
             - Office.EventType
-        - id: handler
-          description: >-
-            The function to handle the event. The function must accept a single parameter, which is an object literal.
-            The type property on the parameter will match the eventType parameter passed to removeHandlerAsync.
-          type:
-            - any
         - id: options
           description: >-
             Optional. An object literal that contains one or more of the following properties. asyncContext: Developers

--- a/docs/docs-ref-autogen/outlook/office.mailbox.yml
+++ b/docs/docs-ref-autogen/outlook/office.mailbox.yml
@@ -1006,7 +1006,7 @@ items:
             - any
   - uid: outlook.Office.Mailbox.removeHandlerAsync
     summary: >-
-      Removes an event handler for a supported event.
+      Removes the event handlers for a supported event type.
 
 
       Currently, the only supported event type is `Office.EventType.ItemChanged`<!-- -->. In Preview,
@@ -1021,15 +1021,15 @@ items:
 
       <tr><td>[Applicable Outlook mode](https://docs.microsoft.com/outlook/add-ins/#extension-points)</td><td>Compose or
       read</td></tr></table>
-    name: 'removeHandlerAsync(eventType, handler, options, callback)'
+    name: 'removeHandlerAsync(eventType, options, callback)'
     fullName: removeHandlerAsync
     langs:
       - typeScript
     type: method
     syntax:
       content: >-
-        removeHandlerAsync(eventType: Office.EventType, handler: (type: EventType) => void, options?:
-        Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
+        removeHandlerAsync(eventType: Office.EventType, options?: Office.AsyncContextOptions, callback?: (result:
+        AsyncResult<void>) => void): void;
       return:
         type:
           - void
@@ -1039,12 +1039,6 @@ items:
           description: The event that should revoke the handler.
           type:
             - Office.EventType
-        - id: handler
-          description: >-
-            The function to handle the event. The function must accept a single parameter, which is an object literal.
-            The type property on the parameter will match the eventType parameter passed to addHandlerAsync.
-          type:
-            - '(type: EventType) => void'
         - id: options
           description: 'Optional. Provides an option for preserving context data of any type, unchanged, for use in a callback.'
           type:

--- a/docs/docs-ref-autogen/outlook/office.messagecompose.yml
+++ b/docs/docs-ref-autogen/outlook/office.messagecompose.yml
@@ -1143,7 +1143,7 @@ items:
             - '(result: AsyncResult<void>) => void'
   - uid: outlook.Office.MessageCompose.removeHandlerAsync
     summary: >-
-      Removes an event handler for a supported event.
+      Removes the event handlers for a supported event type.
 
 
       Currently the supported event types are `Office.EventType.AppointmentTimeChanged`<!-- -->,
@@ -1164,16 +1164,14 @@ items:
       In addition to this signature, the method also has the following signature:
 
 
-      `removeHandlerAsync(eventType:EventType, handler: any, callback?: (result: AsyncResult<void>) => void): void;`
-    name: 'removeHandlerAsync(eventType, handler, options, callback)'
+      `removeHandlerAsync(eventType:EventType, callback?: (result: AsyncResult<void>) => void): void;`
+    name: 'removeHandlerAsync(eventType, options, callback)'
     fullName: removeHandlerAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: >-
-        removeHandlerAsync(eventType:EventType, handler: any, options?: any, callback?: (result: AsyncResult<void>) =>
-        void): void;
+      content: 'removeHandlerAsync(eventType:EventType, options?: any, callback?: (result: AsyncResult<void>) => void): void;'
       return:
         type:
           - void
@@ -1183,12 +1181,6 @@ items:
           description: The event that should revoke the handler.
           type:
             - EventType
-        - id: handler
-          description: >-
-            The function to handle the event. The function must accept a single parameter, which is an object literal.
-            The type property on the parameter will match the eventType parameter passed to removeHandlerAsync.
-          type:
-            - any
         - id: options
           description: >-
             Optional. An object literal that contains one or more of the following properties. asyncContext: Developers

--- a/docs/docs-ref-autogen/outlook/office.messageread.yml
+++ b/docs/docs-ref-autogen/outlook/office.messageread.yml
@@ -1340,7 +1340,7 @@ items:
           - Recurrence
   - uid: outlook.Office.MessageRead.removeHandlerAsync
     summary: >-
-      Removes an event handler for a supported event.
+      Removes the event handlers for a supported event type.
 
 
       Currently the supported event types are `Office.EventType.AppointmentTimeChanged`<!-- -->,
@@ -1361,16 +1361,14 @@ items:
       In addition to this signature, the method also has the following signature:
 
 
-      `removeHandlerAsync(eventType:EventType, handler: any, callback?: (result: AsyncResult<void>) => void): void;`
-    name: 'removeHandlerAsync(eventType, handler, options, callback)'
+      `removeHandlerAsync(eventType:EventType, callback?: (result: AsyncResult<void>) => void): void;`
+    name: 'removeHandlerAsync(eventType, options, callback)'
     fullName: removeHandlerAsync
     langs:
       - typeScript
     type: method
     syntax:
-      content: >-
-        removeHandlerAsync(eventType:EventType, handler: any, options?: any, callback?: (result: AsyncResult<void>) =>
-        void): void;
+      content: 'removeHandlerAsync(eventType:EventType, options?: any, callback?: (result: AsyncResult<void>) => void): void;'
       return:
         type:
           - void
@@ -1380,12 +1378,6 @@ items:
           description: The event that should revoke the handler.
           type:
             - EventType
-        - id: handler
-          description: >-
-            The function to handle the event. The function must accept a single parameter, which is an object literal.
-            The type property on the parameter will match the eventType parameter passed to removeHandlerAsync.
-          type:
-            - any
         - id: options
           description: >-
             Optional. An object literal that contains one or more of the following properties. asyncContext: Developers

--- a/generate-docs/api-extractor-inputs-office/office.d.ts
+++ b/generate-docs/api-extractor-inputs-office/office.d.ts
@@ -3,16 +3,6 @@
 ////////////////////////////////////////////////////////////////
 
 export declare namespace Office {
-    /**
-    * Provides a container for APIs that are still in Preview, not released for use in production add-ins.
-    */
-    var Preview: {
-        /**
-         * Initializes the use of custom JavaScript functions in Excel.
-         */
-        startCustomFunctions(): Promise<void>;
-    }
-
     /** A Promise object. Promises can be chained via ".then", and errors can be caught via ".catch". 
      * When a browser-provided native Promise implementation is available, Office.Promise will switch to use the native Promise instead.
      */

--- a/generate-docs/api-extractor-inputs-outlook/outlook.d.ts
+++ b/generate-docs/api-extractor-inputs-outlook/outlook.d.ts
@@ -2983,7 +2983,7 @@ export declare namespace Office {
          */
         removeAttachmentAsync(attachmentId: string, callback: (result: AsyncResult<void>) => void): void;
        /**
-        * Removes an event handler for a supported event.
+        * Removes the event handlers for a supported event type.
         * 
         * Currently the supported event types are `Office.EventType.AppointmentTimeChanged`, `Office.EventType.RecipientsChanged`, and 
         * `Office.EventType.RecurrenceChanged`. In Preview, `Office.EventType.AttachmentsChanged` is also supported.
@@ -2998,19 +2998,17 @@ export declare namespace Office {
         * 
         * In addition to this signature, the method also has the following signature:
         * 
-        * `removeHandlerAsync(eventType:EventType, handler: any, callback?: (result: AsyncResult<void>) => void): void;`
+        * `removeHandlerAsync(eventType:EventType, callback?: (result: AsyncResult<void>) => void): void;`
         * 
         * @param eventType - The event that should revoke the handler.
-        * @param handler - The function to handle the event. The function must accept a single parameter, which is an object literal. 
-        *                The type property on the parameter will match the eventType parameter passed to removeHandlerAsync.
         * @param options - Optional. An object literal that contains one or more of the following properties.
         *        asyncContext: Developers can provide any object they wish to access in the callback method.
         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter, 
         *                 asyncResult, which is an Office.AsyncResult object.
         */
-       removeHandlerAsync(eventType:EventType, handler: any, options?: any, callback?: (result: AsyncResult<void>) => void): void;
+       removeHandlerAsync(eventType:EventType, options?: any, callback?: (result: AsyncResult<void>) => void): void;
        /**
-        * Removes an event handler for a supported event.
+        * Removes the event handlers for a supported event type.
         * 
         * Currently the supported event types are `Office.EventType.AppointmentTimeChanged`, `Office.EventType.RecipientsChanged`, and 
         * `Office.EventType.RecurrenceChanged`. In Preview, `Office.EventType.AttachmentsChanged` is also supported.
@@ -3024,12 +3022,10 @@ export declare namespace Office {
         * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Appointment Organizer</td></tr></table>
         * 
         * @param eventType - The event that should revoke the handler.
-        * @param handler - The function to handle the event. The function must accept a single parameter, which is an object literal. 
-        *                The type property on the parameter will match the eventType parameter passed to removeHandlerAsync.
         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter, 
         *                 asyncResult, which is an Office.AsyncResult object.
         */
-       removeHandlerAsync(eventType:EventType, handler: any, callback?: (result: AsyncResult<void>) => void): void;
+       removeHandlerAsync(eventType:EventType, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Asynchronously saves an item.
          *
@@ -3980,7 +3976,7 @@ export declare namespace Office {
        loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any): void;
 
        /**
-        * Removes an event handler for a supported event.
+        * Removes the event handlers for a supported event type.
         * 
         * Currently the supported event types are `Office.EventType.AppointmentTimeChanged`, `Office.EventType.RecipientsChanged`, and 
         * `Office.EventType.RecurrenceChanged`. In Preview, `Office.EventType.AttachmentsChanged` is also supported.
@@ -3995,19 +3991,17 @@ export declare namespace Office {
         * 
         * In addition to this signature, the method also has the following signature:
         * 
-        * `removeHandlerAsync(eventType:EventType, handler: any, callback?: (result: AsyncResult<void>) => void): void;`
+        * `removeHandlerAsync(eventType:EventType, callback?: (result: AsyncResult<void>) => void): void;`
         * 
         * @param eventType - The event that should revoke the handler.
-        * @param handler - The function to handle the event. The function must accept a single parameter, which is an object literal. 
-        *                The type property on the parameter will match the eventType parameter passed to removeHandlerAsync.
         * @param options - Optional. An object literal that contains one or more of the following properties.
         *        asyncContext: Developers can provide any object they wish to access in the callback method.
         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter, 
         *                 asyncResult, which is an Office.AsyncResult object.
         */
-       removeHandlerAsync(eventType:EventType, handler: any, options?: any, callback?: (result: AsyncResult<void>) => void): void;
+       removeHandlerAsync(eventType:EventType, options?: any, callback?: (result: AsyncResult<void>) => void): void;
        /**
-        * Removes an event handler for a supported event.
+        * Removes the event handlers for a supported event type.
         * 
         * Currently the supported event types are `Office.EventType.AppointmentTimeChanged`, `Office.EventType.RecipientsChanged`, and 
         * `Office.EventType.RecurrenceChanged`. In Preview, `Office.EventType.AttachmentsChanged` is also supported.
@@ -4021,12 +4015,10 @@ export declare namespace Office {
         * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Appointment Attendee</td></tr></table>
         * 
         * @param eventType - The event that should revoke the handler.
-        * @param handler - The function to handle the event. The function must accept a single parameter, which is an object literal. 
-        *                The type property on the parameter will match the eventType parameter passed to removeHandlerAsync.
         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter, 
         *                 asyncResult, which is an Office.AsyncResult object.
         */
-       removeHandlerAsync(eventType:EventType, handler: any, callback?: (result: AsyncResult<void>) => void): void; 
+       removeHandlerAsync(eventType:EventType, callback?: (result: AsyncResult<void>) => void): void; 
     }
 
     /**
@@ -4333,7 +4325,7 @@ export declare namespace Office {
        loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any): void;
 
        /**
-        * Removes an event handler for a supported event.
+        * Removes the event handlers for a supported event type.
         * 
         * Currently the supported event types are `Office.EventType.AppointmentTimeChanged`, `Office.EventType.RecipientsChanged`, and 
         * `Office.EventType.RecurrenceChanged`. In Preview, `Office.EventType.AttachmentsChanged` is also supported.
@@ -4348,20 +4340,18 @@ export declare namespace Office {
         * 
         * In addition to this signature, the method also has the following signature:
         * 
-        * `removeHandlerAsync(eventType: Office.EventType, handler: any, callback?: (result: AsyncResult<void>) => void): void;`
+        * `removeHandlerAsync(eventType: Office.EventType, callback?: (result: AsyncResult<void>) => void): void;`
         * 
         * @param eventType - The event that should revoke the handler.
-        * @param handler - The function to handle the event. The function must accept a single parameter, which is an object literal. 
-        *                The type property on the parameter will match the eventType parameter passed to removeHandlerAsync.
         * @param options - Optional. An object literal that contains one or more of the following properties.
         *        asyncContext: Developers can provide any object they wish to access in the callback method.
         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter, 
         *                 asyncResult, which is an Office.AsyncResult object.
         */
-       removeHandlerAsync(eventType: Office.EventType, handler: any, options?: any, callback?: (result: AsyncResult<void>) => void): void;
+       removeHandlerAsync(eventType: Office.EventType, options?: any, callback?: (result: AsyncResult<void>) => void): void;
 
        /**
-        * Removes an event handler for a supported event.
+        * Removes the event handlers for a supported event type.
         * 
         * Currently the supported event types are `Office.EventType.AppointmentTimeChanged`, `Office.EventType.RecipientsChanged`, and 
         * `Office.EventType.RecurrenceChanged`. In Preview, `Office.EventType.AttachmentsChanged` is also supported.
@@ -4375,12 +4365,10 @@ export declare namespace Office {
         * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
         * 
         * @param eventType - The event that should revoke the handler.
-        * @param handler - The function to handle the event. The function must accept a single parameter, which is an object literal. 
-        *                The type property on the parameter will match the eventType parameter passed to removeHandlerAsync.
         * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter, 
         *                 asyncResult, which is an Office.AsyncResult object.
         */
-       removeHandlerAsync(eventType: Office.EventType, handler: any, callback?: (result: AsyncResult<void>) => void): void;
+       removeHandlerAsync(eventType: Office.EventType, callback?: (result: AsyncResult<void>) => void): void;
     }
     /**
      * The compose mode of {@link Office.Item | Office.context.mailbox.item}.
@@ -6388,7 +6376,7 @@ export declare namespace Office {
          */
         removeAttachmentAsync(attachmentId: string, callback: (result: AsyncResult<void>) => void): void;
         /**
-         * Removes an event handler for a supported event.
+         * Removes the event handlers for a supported event type.
          * 
          * Currently the supported event types are `Office.EventType.AppointmentTimeChanged`, `Office.EventType.RecipientsChanged`, and 
          * `Office.EventType.RecurrenceChanged`. In Preview, `Office.EventType.AttachmentsChanged` is also supported.
@@ -6403,19 +6391,17 @@ export declare namespace Office {
          * 
          * In addition to this signature, the method also has the following signature:
          * 
-         * `removeHandlerAsync(eventType:EventType, handler: any, callback?: (result: AsyncResult<void>) => void): void;`
+         * `removeHandlerAsync(eventType:EventType, callback?: (result: AsyncResult<void>) => void): void;`
          * 
          * @param eventType - The event that should revoke the handler.
-         * @param handler - The function to handle the event. The function must accept a single parameter, which is an object literal. 
-         *                The type property on the parameter will match the eventType parameter passed to removeHandlerAsync.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
          * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter, 
          *                 asyncResult, which is an Office.AsyncResult object.
          */
-        removeHandlerAsync(eventType:EventType, handler: any, options?: any, callback?: (result: AsyncResult<void>) => void): void;
+        removeHandlerAsync(eventType:EventType, options?: any, callback?: (result: AsyncResult<void>) => void): void;
         /**
-         * Removes an event handler for a supported event.
+         * Removes the event handlers for a supported event type.
          * 
          * Currently the supported event types are `Office.EventType.AppointmentTimeChanged`, `Office.EventType.RecipientsChanged`, and 
          * `Office.EventType.RecurrenceChanged`. In Preview, `Office.EventType.AttachmentsChanged` is also supported.
@@ -6429,12 +6415,10 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Message Compose</td></tr></table>
          * 
          * @param eventType - The event that should revoke the handler.
-         * @param handler - The function to handle the event. The function must accept a single parameter, which is an object literal. 
-         *                The type property on the parameter will match the eventType parameter passed to removeHandlerAsync.
          * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter, 
          *                 asyncResult, which is an Office.AsyncResult object.
          */
-        removeHandlerAsync(eventType:EventType, handler: any, callback?: (result: AsyncResult<void>) => void): void;
+        removeHandlerAsync(eventType:EventType, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Asynchronously saves an item.
          *
@@ -7421,7 +7405,7 @@ export declare namespace Office {
          */
         loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any): void;
         /**
-         * Removes an event handler for a supported event.
+         * Removes the event handlers for a supported event type.
          * 
          * Currently the supported event types are `Office.EventType.AppointmentTimeChanged`, `Office.EventType.RecipientsChanged`, and 
          * `Office.EventType.RecurrenceChanged`. In Preview, `Office.EventType.AttachmentsChanged` is also supported.
@@ -7436,19 +7420,17 @@ export declare namespace Office {
          * 
          * In addition to this signature, the method also has the following signature:
          * 
-         * `removeHandlerAsync(eventType:EventType, handler: any, callback?: (result: AsyncResult<void>) => void): void;`
+         * `removeHandlerAsync(eventType:EventType, callback?: (result: AsyncResult<void>) => void): void;`
          * 
          * @param eventType - The event that should revoke the handler.
-         * @param handler - The function to handle the event. The function must accept a single parameter, which is an object literal. 
-         *                The type property on the parameter will match the eventType parameter passed to removeHandlerAsync.
          * @param options - Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
          * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter, 
          *                 asyncResult, which is an Office.AsyncResult object.
          */
-        removeHandlerAsync(eventType:EventType, handler: any, options?: any, callback?: (result: AsyncResult<void>) => void): void;
+        removeHandlerAsync(eventType:EventType, options?: any, callback?: (result: AsyncResult<void>) => void): void;
         /**
-         * Removes an event handler for a supported event.
+         * Removes the event handlers for a supported event type.
          * 
          * Currently the supported event types are `Office.EventType.AppointmentTimeChanged`, `Office.EventType.RecipientsChanged`, and 
          * `Office.EventType.RecurrenceChanged`. In Preview, `Office.EventType.AttachmentsChanged` is also supported.
@@ -7462,12 +7444,10 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Message Read</td></tr></table>
          * 
          * @param eventType - The event that should revoke the handler.
-         * @param handler - The function to handle the event. The function must accept a single parameter, which is an object literal. 
-         *                The type property on the parameter will match the eventType parameter passed to removeHandlerAsync.
          * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter, 
          *                 asyncResult, which is an Office.AsyncResult object.
          */
-        removeHandlerAsync(eventType:EventType, handler: any, callback?: (result: AsyncResult<void>) => void): void;
+        removeHandlerAsync(eventType:EventType, callback?: (result: AsyncResult<void>) => void): void;
     }
 
     /**
@@ -8169,7 +8149,7 @@ export declare namespace Office {
          */
         makeEwsRequestAsync(data: any, callback: (result: AsyncResult<string>) => void, userContext?: any): void;
         /**
-         * Removes an event handler for a supported event.
+         * Removes the event handlers for a supported event type.
          *
          * Currently, the only supported event type is `Office.EventType.ItemChanged`. In Preview, `Office.EventType.OfficeThemeChanged` is also supported.
          *
@@ -8182,13 +8162,11 @@ export declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          *
          * @param eventType - The event that should revoke the handler.
-         * @param handler - The function to handle the event. The function must accept a single parameter, which is an object literal. 
-         *                The type property on the parameter will match the eventType parameter passed to addHandlerAsync.
          * @param options - Optional. Provides an option for preserving context data of any type, unchanged, for use in a callback.
          * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
          *                 type Office.AsyncResult.
          */
-        removeHandlerAsync(eventType: Office.EventType, handler: (type: EventType) => void, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
+        removeHandlerAsync(eventType: Office.EventType, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
     }
 
     /**

--- a/generate-docs/json/outlook.api.json
+++ b/generate-docs/json/outlook.api.json
@@ -3483,7 +3483,7 @@
             },
             "removeHandlerAsync": {
               "kind": "method",
-              "signature": "removeHandlerAsync(eventType:EventType, handler: any, options?: any, callback?: (result: AsyncResult<void>) => void): void;",
+              "signature": "removeHandlerAsync(eventType:EventType, options?: any, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -3503,18 +3503,6 @@
                   "isOptional": false,
                   "isSpread": false,
                   "type": "EventType"
-                },
-                "handler": {
-                  "name": "handler",
-                  "description": [
-                    {
-                      "kind": "text",
-                      "text": "The function to handle the event. The function must accept a single parameter, which is an object literal. The type property on the parameter will match the eventType parameter passed to removeHandlerAsync."
-                    }
-                  ],
-                  "isOptional": false,
-                  "isSpread": false,
-                  "type": "any"
                 },
                 "options": {
                   "name": "options",
@@ -3545,7 +3533,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Removes an event handler for a supported event."
+                  "text": "Removes the event handlers for a supported event type."
                 },
                 {
                   "kind": "paragraph"
@@ -3698,7 +3686,7 @@
                 },
                 {
                   "kind": "code",
-                  "text": "removeHandlerAsync(eventType:EventType, handler: any, callback?: (result: AsyncResult<void>) => void): void;",
+                  "text": "removeHandlerAsync(eventType:EventType, callback?: (result: AsyncResult<void>) => void): void;",
                   "highlighter": "plain"
                 }
               ],
@@ -10387,7 +10375,7 @@
             },
             "removeHandlerAsync": {
               "kind": "method",
-              "signature": "removeHandlerAsync(eventType:EventType, handler: any, options?: any, callback?: (result: AsyncResult<void>) => void): void;",
+              "signature": "removeHandlerAsync(eventType:EventType, options?: any, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -10407,18 +10395,6 @@
                   "isOptional": false,
                   "isSpread": false,
                   "type": "EventType"
-                },
-                "handler": {
-                  "name": "handler",
-                  "description": [
-                    {
-                      "kind": "text",
-                      "text": "The function to handle the event. The function must accept a single parameter, which is an object literal. The type property on the parameter will match the eventType parameter passed to removeHandlerAsync."
-                    }
-                  ],
-                  "isOptional": false,
-                  "isSpread": false,
-                  "type": "any"
                 },
                 "options": {
                   "name": "options",
@@ -10449,7 +10425,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Removes an event handler for a supported event."
+                  "text": "Removes the event handlers for a supported event type."
                 },
                 {
                   "kind": "paragraph"
@@ -10602,7 +10578,7 @@
                 },
                 {
                   "kind": "code",
-                  "text": "removeHandlerAsync(eventType:EventType, handler: any, callback?: (result: AsyncResult<void>) => void): void;",
+                  "text": "removeHandlerAsync(eventType:EventType, callback?: (result: AsyncResult<void>) => void): void;",
                   "highlighter": "plain"
                 }
               ],
@@ -17758,7 +17734,7 @@
             },
             "removeHandlerAsync": {
               "kind": "method",
-              "signature": "removeHandlerAsync(eventType: Office.EventType, handler: any, options?: any, callback?: (result: AsyncResult<void>) => void): void;",
+              "signature": "removeHandlerAsync(eventType: Office.EventType, options?: any, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -17778,18 +17754,6 @@
                   "isOptional": false,
                   "isSpread": false,
                   "type": "Office.EventType"
-                },
-                "handler": {
-                  "name": "handler",
-                  "description": [
-                    {
-                      "kind": "text",
-                      "text": "The function to handle the event. The function must accept a single parameter, which is an object literal. The type property on the parameter will match the eventType parameter passed to removeHandlerAsync."
-                    }
-                  ],
-                  "isOptional": false,
-                  "isSpread": false,
-                  "type": "any"
                 },
                 "options": {
                   "name": "options",
@@ -17820,7 +17784,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Removes an event handler for a supported event."
+                  "text": "Removes the event handlers for a supported event type."
                 },
                 {
                   "kind": "paragraph"
@@ -17973,7 +17937,7 @@
                 },
                 {
                   "kind": "code",
-                  "text": "removeHandlerAsync(eventType: Office.EventType, handler: any, callback?: (result: AsyncResult<void>) => void): void;",
+                  "text": "removeHandlerAsync(eventType: Office.EventType, callback?: (result: AsyncResult<void>) => void): void;",
                   "highlighter": "plain"
                 }
               ],
@@ -27126,7 +27090,7 @@
             },
             "removeHandlerAsync": {
               "kind": "method",
-              "signature": "removeHandlerAsync(eventType: Office.EventType, handler: (type: EventType) => void, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
+              "signature": "removeHandlerAsync(eventType: Office.EventType, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -27146,18 +27110,6 @@
                   "isOptional": false,
                   "isSpread": false,
                   "type": "Office.EventType"
-                },
-                "handler": {
-                  "name": "handler",
-                  "description": [
-                    {
-                      "kind": "text",
-                      "text": "The function to handle the event. The function must accept a single parameter, which is an object literal. The type property on the parameter will match the eventType parameter passed to addHandlerAsync."
-                    }
-                  ],
-                  "isOptional": false,
-                  "isSpread": false,
-                  "type": "(type: EventType) => void"
                 },
                 "options": {
                   "name": "options",
@@ -27188,7 +27140,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Removes an event handler for a supported event."
+                  "text": "Removes the event handlers for a supported event type."
                 },
                 {
                   "kind": "paragraph"
@@ -35349,7 +35301,7 @@
             },
             "removeHandlerAsync": {
               "kind": "method",
-              "signature": "removeHandlerAsync(eventType:EventType, handler: any, options?: any, callback?: (result: AsyncResult<void>) => void): void;",
+              "signature": "removeHandlerAsync(eventType:EventType, options?: any, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -35369,18 +35321,6 @@
                   "isOptional": false,
                   "isSpread": false,
                   "type": "EventType"
-                },
-                "handler": {
-                  "name": "handler",
-                  "description": [
-                    {
-                      "kind": "text",
-                      "text": "The function to handle the event. The function must accept a single parameter, which is an object literal. The type property on the parameter will match the eventType parameter passed to removeHandlerAsync."
-                    }
-                  ],
-                  "isOptional": false,
-                  "isSpread": false,
-                  "type": "any"
                 },
                 "options": {
                   "name": "options",
@@ -35411,7 +35351,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Removes an event handler for a supported event."
+                  "text": "Removes the event handlers for a supported event type."
                 },
                 {
                   "kind": "paragraph"
@@ -35564,7 +35504,7 @@
                 },
                 {
                   "kind": "code",
-                  "text": "removeHandlerAsync(eventType:EventType, handler: any, callback?: (result: AsyncResult<void>) => void): void;",
+                  "text": "removeHandlerAsync(eventType:EventType, callback?: (result: AsyncResult<void>) => void): void;",
                   "highlighter": "plain"
                 }
               ],
@@ -41074,7 +41014,7 @@
             },
             "removeHandlerAsync": {
               "kind": "method",
-              "signature": "removeHandlerAsync(eventType:EventType, handler: any, options?: any, callback?: (result: AsyncResult<void>) => void): void;",
+              "signature": "removeHandlerAsync(eventType:EventType, options?: any, callback?: (result: AsyncResult<void>) => void): void;",
               "accessModifier": "",
               "isOptional": false,
               "isStatic": false,
@@ -41094,18 +41034,6 @@
                   "isOptional": false,
                   "isSpread": false,
                   "type": "EventType"
-                },
-                "handler": {
-                  "name": "handler",
-                  "description": [
-                    {
-                      "kind": "text",
-                      "text": "The function to handle the event. The function must accept a single parameter, which is an object literal. The type property on the parameter will match the eventType parameter passed to removeHandlerAsync."
-                    }
-                  ],
-                  "isOptional": false,
-                  "isSpread": false,
-                  "type": "any"
                 },
                 "options": {
                   "name": "options",
@@ -41136,7 +41064,7 @@
               "summary": [
                 {
                   "kind": "text",
-                  "text": "Removes an event handler for a supported event."
+                  "text": "Removes the event handlers for a supported event type."
                 },
                 {
                   "kind": "paragraph"
@@ -41289,7 +41217,7 @@
                 },
                 {
                   "kind": "code",
-                  "text": "removeHandlerAsync(eventType:EventType, handler: any, callback?: (result: AsyncResult<void>) => void): void;",
+                  "text": "removeHandlerAsync(eventType:EventType, callback?: (result: AsyncResult<void>) => void): void;",
                   "highlighter": "plain"
                 }
               ],

--- a/generate-docs/json/snippets.yaml
+++ b/generate-docs/json/snippets.yaml
@@ -346,6 +346,30 @@ Excel.ChartAxisTitle.load:
                 console.log("Debug info: " + JSON.stringify(error.debugInfo));
             }
     });
+Excel.Chart.onActivated:
+  - |-
+    Excel.run(function (context){
+        var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+        pieChart.onActivated.add(function (event) {
+            return Excel.run((context) => {
+                console.log("The pie chart is the active chart. ID: " + event.chartId);
+                return context.sync();
+            });
+        });
+        return context.sync();
+    });
+Excel.Chart.onDeactivated:
+  - |-
+    Excel.run(function (context){
+        var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+        pieChart.onDeactivated.add(function (event) {
+            return Excel.run((context) => {
+                console.log("The pie chart is NOT active.");
+                return context.sync();
+            });
+        });
+        return context.sync();
+    });
 Excel.ChartCollection.add:
   - |-
     // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
@@ -448,6 +472,54 @@ Excel.ChartCollection.load:
         if (error instanceof OfficeExtension.Error) {
             console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
+    });
+Excel.ChartCollection.onActivated:
+  - |-
+    Excel.run(function (context){
+        context.workbook.worksheets.getActiveWorksheet()
+            .charts.onActivated.add(function (event) {
+            return Excel.run((context) => {
+                console.log("The ID of the active chart is: " + event.chartId)
+                return context.sync();
+            });
+        });
+        return context.sync();
+    });
+Excel.ChartCollection.onAdded:
+  - |-
+    Excel.run(function (context){
+        context.workbook.worksheets.getActiveWorksheet()
+            .charts.onAdded.add(function (event) {
+            return Excel.run((context) => {
+                console.log("A chart has been added with ID: " + event.chartId);
+                return context.sync();
+            });
+        });
+        return context.sync();
+    });
+Excel.ChartCollection.onDeactivated:
+  - |-
+    Excel.run(function (context){
+        context.workbook.worksheets.getActiveWorksheet()
+            .charts.onDeactivated.add(function (event) {
+            return Excel.run((context) => {
+                console.log("The chart with this ID was deactivated: " + event.chartId);
+                return context.sync();
+            });
+        });
+        return context.sync();
+    });
+Excel.ChartCollection.onDeleted:
+  - |-
+    Excel.run(function (context){
+        context.workbook.worksheets.getActiveWorksheet()
+            .charts.onDeleted.add(function (event) {
+            return Excel.run((context) => {
+                console.log("The chart with this ID was deleted: " + event.chartId);
+                return context.sync();
+            });
+        });
+        return context.sync();
     });
 Excel.ChartDataLabels.load:
   - >-
@@ -2386,6 +2458,54 @@ Excel.Worksheet.load:
         if (error instanceof OfficeExtension.Error) {
             console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
+    });
+Excel.Worksheet.onActivated:
+  - |-
+    Excel.run(function (context) {
+        var sheet = context.workbook.worksheets.getItem("Sample");
+        sheet.onActivated.add(function (event) {
+            return Excel.run((context) => {
+                console.log("The activated worksheet ID is: " + event.worksheetId);
+                return context.sync();
+            });
+        });
+        return context.sync();
+    });
+Excel.Worksheet.onCalculated:
+  - |-
+    Excel.run(function (context) {
+        var sheet = context.workbook.worksheets.getItem("Sample");
+        sheet.onCalculated.add(function (event) {
+            return Excel.run((context) => {
+                console.log("The worksheet has recalculated.");
+                return context.sync();
+            });
+        });
+        return context.sync();
+    });
+Excel.Worksheet.onDeactivated:
+  - |-
+    Excel.run(function (context) {
+        var sheet = context.workbook.worksheets.getItem("Sample");
+        sheet.onDeactivated.add(function (event) {
+            return Excel.run((context) => {
+                console.log("The deactivated worksheet is: " + event.worksheetId);
+                return context.sync();
+            });
+        });
+        return context.sync();
+    });
+Excel.Worksheet.onSelectionChanged:
+  - |-
+    Excel.run(function (context) {
+        var sheet = context.workbook.worksheets.getItem("Sample");
+        sheet.onSelectionChanged.add(function (event) {
+            return Excel.run((context) => {
+                console.log("The selected range has changed to: " + event.address);
+                return context.sync();
+            });
+        });
+        return context.sync();
     });
 Excel.WorksheetCollection.add:
   - |-

--- a/generate-docs/script-inputs/local-repo-snippets.yaml
+++ b/generate-docs/script-inputs/local-repo-snippets.yaml
@@ -337,6 +337,30 @@ Excel.ChartAxisTitle.load:
                 console.log("Debug info: " + JSON.stringify(error.debugInfo));
             }
     });
+Excel.Chart.onActivated:
+  - |-
+    Excel.run(function (context){
+        var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+        pieChart.onActivated.add(function (event) {
+            return Excel.run((context) => {
+                console.log("The pie chart is the active chart. ID: " + event.chartId);
+                return context.sync();
+            });
+        });
+        return context.sync();
+    });
+Excel.Chart.onDeactivated:
+  - |-
+    Excel.run(function (context){
+        var pieChart = context.workbook.worksheets.getActiveWorksheet().charts.getItem("Pie");
+        pieChart.onDeactivated.add(function (event) {
+            return Excel.run((context) => {
+                console.log("The pie chart is NOT active.");
+                return context.sync();
+            });
+        });
+        return context.sync();
+    });
 Excel.ChartCollection.add:
   - |-
     // Add a chart of chartType "ColumnClustered" on worksheet "Charts" 
@@ -439,6 +463,54 @@ Excel.ChartCollection.load:
         if (error instanceof OfficeExtension.Error) {
             console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
+    });
+Excel.ChartCollection.onActivated:
+  - |-
+    Excel.run(function (context){
+        context.workbook.worksheets.getActiveWorksheet()
+            .charts.onActivated.add(function (event) {
+            return Excel.run((context) => {
+                console.log("The ID of the active chart is: " + event.chartId)
+                return context.sync();
+            });
+        });
+        return context.sync();
+    });
+Excel.ChartCollection.onAdded:
+  - |-
+    Excel.run(function (context){
+        context.workbook.worksheets.getActiveWorksheet()
+            .charts.onAdded.add(function (event) {
+            return Excel.run((context) => {
+                console.log("A chart has been added with ID: " + event.chartId);
+                return context.sync();
+            });
+        });
+        return context.sync();
+    });
+Excel.ChartCollection.onDeactivated:
+  - |-
+    Excel.run(function (context){
+        context.workbook.worksheets.getActiveWorksheet()
+            .charts.onDeactivated.add(function (event) {
+            return Excel.run((context) => {
+                console.log("The chart with this ID was deactivated: " + event.chartId);
+                return context.sync();
+            });
+        });
+        return context.sync();
+    });
+Excel.ChartCollection.onDeleted:
+  - |-
+    Excel.run(function (context){
+        context.workbook.worksheets.getActiveWorksheet()
+            .charts.onDeleted.add(function (event) {
+            return Excel.run((context) => {
+                console.log("The chart with this ID was deleted: " + event.chartId);
+                return context.sync();
+            });
+        });
+        return context.sync();
     });
 Excel.ChartDataLabels.load:
   - |-
@@ -2251,6 +2323,54 @@ Excel.Worksheet.load:
         if (error instanceof OfficeExtension.Error) {
             console.log("Debug info: " + JSON.stringify(error.debugInfo));
         }
+    });
+Excel.Worksheet.onActivated:
+  - |-
+    Excel.run(function (context) {
+        var sheet = context.workbook.worksheets.getItem("Sample");
+        sheet.onActivated.add(function (event) {
+            return Excel.run((context) => {
+                console.log("The activated worksheet ID is: " + event.worksheetId);
+                return context.sync();
+            });
+        });
+        return context.sync();
+    });
+Excel.Worksheet.onCalculated:
+  - |-
+    Excel.run(function (context) {
+        var sheet = context.workbook.worksheets.getItem("Sample");
+        sheet.onCalculated.add(function (event) {
+            return Excel.run((context) => {
+                console.log("The worksheet has recalculated.");
+                return context.sync();
+            });
+        });
+        return context.sync();
+    });
+Excel.Worksheet.onDeactivated:
+  - |-
+    Excel.run(function (context) {
+        var sheet = context.workbook.worksheets.getItem("Sample");
+        sheet.onDeactivated.add(function (event) {
+            return Excel.run((context) => {
+                console.log("The deactivated worksheet is: " + event.worksheetId);
+                return context.sync();
+            });
+        });
+        return context.sync();
+    });
+Excel.Worksheet.onSelectionChanged:
+  - |-
+    Excel.run(function (context) {
+        var sheet = context.workbook.worksheets.getItem("Sample");
+        sheet.onSelectionChanged.add(function (event) {
+            return Excel.run((context) => {
+                console.log("The selected range has changed to: " + event.address);
+                return context.sync();
+            });
+        });
+        return context.sync();
     });
 Excel.WorksheetCollection.add:
   - |-

--- a/generate-docs/script-inputs/office.d.ts
+++ b/generate-docs/script-inputs/office.d.ts
@@ -15,16 +15,6 @@ Copyright (c) Microsoft Corporation
 ////////////////////////////////////////////////////////////////
 
 declare namespace Office {
-    /**
-    * Provides a container for APIs that are still in Preview, not released for use in production add-ins.
-    */
-    var Preview: {
-        /**
-         * Initializes the use of custom JavaScript functions in Excel.
-         */
-        startCustomFunctions(): Promise<void>;
-    }
-
     /** A Promise object. Promises can be chained via ".then", and errors can be caught via ".catch". 
      * When a browser-provided native Promise implementation is available, Office.Promise will switch to use the native Promise instead.
      */
@@ -10448,7 +10438,7 @@ declare namespace Office {
          */
         removeAttachmentAsync(attachmentId: string, callback: (result: AsyncResult<void>) => void): void;
        /**
-        * Removes an event handler for a supported event.
+        * Removes the event handlers for a supported event type.
         * 
         * Currently the supported event types are `Office.EventType.AppointmentTimeChanged`, `Office.EventType.RecipientsChanged`, and 
         * `Office.EventType.RecurrenceChanged`. In Preview, `Office.EventType.AttachmentsChanged` is also supported.
@@ -10463,19 +10453,17 @@ declare namespace Office {
         * 
         * In addition to this signature, the method also has the following signature:
         * 
-        * `removeHandlerAsync(eventType:EventType, handler: any, callback?: (result: AsyncResult<void>) => void): void;`
+        * `removeHandlerAsync(eventType:EventType, callback?: (result: AsyncResult<void>) => void): void;`
         * 
         * @param eventType The event that should revoke the handler.
-        * @param handler The function to handle the event. The function must accept a single parameter, which is an object literal. 
-        *                The type property on the parameter will match the eventType parameter passed to removeHandlerAsync.
         * @param options Optional. An object literal that contains one or more of the following properties.
         *        asyncContext: Developers can provide any object they wish to access in the callback method.
         * @param callback Optional. When the method completes, the function passed in the callback parameter is called with a single parameter, 
         *                 asyncResult, which is an Office.AsyncResult object.
         */
-       removeHandlerAsync(eventType:EventType, handler: any, options?: any, callback?: (result: AsyncResult<void>) => void): void;
+       removeHandlerAsync(eventType:EventType, options?: any, callback?: (result: AsyncResult<void>) => void): void;
        /**
-        * Removes an event handler for a supported event.
+        * Removes the event handlers for a supported event type.
         * 
         * Currently the supported event types are `Office.EventType.AppointmentTimeChanged`, `Office.EventType.RecipientsChanged`, and 
         * `Office.EventType.RecurrenceChanged`. In Preview, `Office.EventType.AttachmentsChanged` is also supported.
@@ -10489,12 +10477,10 @@ declare namespace Office {
         * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Appointment Organizer</td></tr></table>
         * 
         * @param eventType The event that should revoke the handler.
-        * @param handler The function to handle the event. The function must accept a single parameter, which is an object literal. 
-        *                The type property on the parameter will match the eventType parameter passed to removeHandlerAsync.
         * @param callback Optional. When the method completes, the function passed in the callback parameter is called with a single parameter, 
         *                 asyncResult, which is an Office.AsyncResult object.
         */
-       removeHandlerAsync(eventType:EventType, handler: any, callback?: (result: AsyncResult<void>) => void): void;
+       removeHandlerAsync(eventType:EventType, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Asynchronously saves an item.
          *
@@ -11445,7 +11431,7 @@ declare namespace Office {
        loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any): void;
 
        /**
-        * Removes an event handler for a supported event.
+        * Removes the event handlers for a supported event type.
         * 
         * Currently the supported event types are `Office.EventType.AppointmentTimeChanged`, `Office.EventType.RecipientsChanged`, and 
         * `Office.EventType.RecurrenceChanged`. In Preview, `Office.EventType.AttachmentsChanged` is also supported.
@@ -11460,19 +11446,17 @@ declare namespace Office {
         * 
         * In addition to this signature, the method also has the following signature:
         * 
-        * `removeHandlerAsync(eventType:EventType, handler: any, callback?: (result: AsyncResult<void>) => void): void;`
+        * `removeHandlerAsync(eventType:EventType, callback?: (result: AsyncResult<void>) => void): void;`
         * 
         * @param eventType The event that should revoke the handler.
-        * @param handler The function to handle the event. The function must accept a single parameter, which is an object literal. 
-        *                The type property on the parameter will match the eventType parameter passed to removeHandlerAsync.
         * @param options Optional. An object literal that contains one or more of the following properties.
         *        asyncContext: Developers can provide any object they wish to access in the callback method.
         * @param callback Optional. When the method completes, the function passed in the callback parameter is called with a single parameter, 
         *                 asyncResult, which is an Office.AsyncResult object.
         */
-       removeHandlerAsync(eventType:EventType, handler: any, options?: any, callback?: (result: AsyncResult<void>) => void): void;
+       removeHandlerAsync(eventType:EventType, options?: any, callback?: (result: AsyncResult<void>) => void): void;
        /**
-        * Removes an event handler for a supported event.
+        * Removes the event handlers for a supported event type.
         * 
         * Currently the supported event types are `Office.EventType.AppointmentTimeChanged`, `Office.EventType.RecipientsChanged`, and 
         * `Office.EventType.RecurrenceChanged`. In Preview, `Office.EventType.AttachmentsChanged` is also supported.
@@ -11486,12 +11470,10 @@ declare namespace Office {
         * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Appointment Attendee</td></tr></table>
         * 
         * @param eventType The event that should revoke the handler.
-        * @param handler The function to handle the event. The function must accept a single parameter, which is an object literal. 
-        *                The type property on the parameter will match the eventType parameter passed to removeHandlerAsync.
         * @param callback Optional. When the method completes, the function passed in the callback parameter is called with a single parameter, 
         *                 asyncResult, which is an Office.AsyncResult object.
         */
-       removeHandlerAsync(eventType:EventType, handler: any, callback?: (result: AsyncResult<void>) => void): void; 
+       removeHandlerAsync(eventType:EventType, callback?: (result: AsyncResult<void>) => void): void; 
     }
 
     /**
@@ -11798,7 +11780,7 @@ declare namespace Office {
        loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any): void;
 
        /**
-        * Removes an event handler for a supported event.
+        * Removes the event handlers for a supported event type.
         * 
         * Currently the supported event types are `Office.EventType.AppointmentTimeChanged`, `Office.EventType.RecipientsChanged`, and 
         * `Office.EventType.RecurrenceChanged`. In Preview, `Office.EventType.AttachmentsChanged` is also supported.
@@ -11813,20 +11795,18 @@ declare namespace Office {
         * 
         * In addition to this signature, the method also has the following signature:
         * 
-        * `removeHandlerAsync(eventType: Office.EventType, handler: any, callback?: (result: AsyncResult<void>) => void): void;`
+        * `removeHandlerAsync(eventType: Office.EventType, callback?: (result: AsyncResult<void>) => void): void;`
         * 
         * @param eventType The event that should revoke the handler.
-        * @param handler The function to handle the event. The function must accept a single parameter, which is an object literal. 
-        *                The type property on the parameter will match the eventType parameter passed to removeHandlerAsync.
         * @param options Optional. An object literal that contains one or more of the following properties.
         *        asyncContext: Developers can provide any object they wish to access in the callback method.
         * @param callback Optional. When the method completes, the function passed in the callback parameter is called with a single parameter, 
         *                 asyncResult, which is an Office.AsyncResult object.
         */
-       removeHandlerAsync(eventType: Office.EventType, handler: any, options?: any, callback?: (result: AsyncResult<void>) => void): void;
+       removeHandlerAsync(eventType: Office.EventType, options?: any, callback?: (result: AsyncResult<void>) => void): void;
 
        /**
-        * Removes an event handler for a supported event.
+        * Removes the event handlers for a supported event type.
         * 
         * Currently the supported event types are `Office.EventType.AppointmentTimeChanged`, `Office.EventType.RecipientsChanged`, and 
         * `Office.EventType.RecurrenceChanged`. In Preview, `Office.EventType.AttachmentsChanged` is also supported.
@@ -11840,12 +11820,10 @@ declare namespace Office {
         * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
         * 
         * @param eventType The event that should revoke the handler.
-        * @param handler The function to handle the event. The function must accept a single parameter, which is an object literal. 
-        *                The type property on the parameter will match the eventType parameter passed to removeHandlerAsync.
         * @param callback Optional. When the method completes, the function passed in the callback parameter is called with a single parameter, 
         *                 asyncResult, which is an Office.AsyncResult object.
         */
-       removeHandlerAsync(eventType: Office.EventType, handler: any, callback?: (result: AsyncResult<void>) => void): void;
+       removeHandlerAsync(eventType: Office.EventType, callback?: (result: AsyncResult<void>) => void): void;
     }
     /**
      * The compose mode of {@link Office.Item | Office.context.mailbox.item}.
@@ -13853,7 +13831,7 @@ declare namespace Office {
          */
         removeAttachmentAsync(attachmentId: string, callback: (result: AsyncResult<void>) => void): void;
         /**
-         * Removes an event handler for a supported event.
+         * Removes the event handlers for a supported event type.
          * 
          * Currently the supported event types are `Office.EventType.AppointmentTimeChanged`, `Office.EventType.RecipientsChanged`, and 
          * `Office.EventType.RecurrenceChanged`. In Preview, `Office.EventType.AttachmentsChanged` is also supported.
@@ -13868,19 +13846,17 @@ declare namespace Office {
          * 
          * In addition to this signature, the method also has the following signature:
          * 
-         * `removeHandlerAsync(eventType:EventType, handler: any, callback?: (result: AsyncResult<void>) => void): void;`
+         * `removeHandlerAsync(eventType:EventType, callback?: (result: AsyncResult<void>) => void): void;`
          * 
          * @param eventType The event that should revoke the handler.
-         * @param handler The function to handle the event. The function must accept a single parameter, which is an object literal. 
-         *                The type property on the parameter will match the eventType parameter passed to removeHandlerAsync.
          * @param options Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
          * @param callback Optional. When the method completes, the function passed in the callback parameter is called with a single parameter, 
          *                 asyncResult, which is an Office.AsyncResult object.
          */
-        removeHandlerAsync(eventType:EventType, handler: any, options?: any, callback?: (result: AsyncResult<void>) => void): void;
+        removeHandlerAsync(eventType:EventType, options?: any, callback?: (result: AsyncResult<void>) => void): void;
         /**
-         * Removes an event handler for a supported event.
+         * Removes the event handlers for a supported event type.
          * 
          * Currently the supported event types are `Office.EventType.AppointmentTimeChanged`, `Office.EventType.RecipientsChanged`, and 
          * `Office.EventType.RecurrenceChanged`. In Preview, `Office.EventType.AttachmentsChanged` is also supported.
@@ -13894,12 +13870,10 @@ declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Message Compose</td></tr></table>
          * 
          * @param eventType The event that should revoke the handler.
-         * @param handler The function to handle the event. The function must accept a single parameter, which is an object literal. 
-         *                The type property on the parameter will match the eventType parameter passed to removeHandlerAsync.
          * @param callback Optional. When the method completes, the function passed in the callback parameter is called with a single parameter, 
          *                 asyncResult, which is an Office.AsyncResult object.
          */
-        removeHandlerAsync(eventType:EventType, handler: any, callback?: (result: AsyncResult<void>) => void): void;
+        removeHandlerAsync(eventType:EventType, callback?: (result: AsyncResult<void>) => void): void;
         /**
          * Asynchronously saves an item.
          *
@@ -14886,7 +14860,7 @@ declare namespace Office {
          */
         loadCustomPropertiesAsync(callback: (result: AsyncResult<Office.CustomProperties>) => void, userContext?: any): void;
         /**
-         * Removes an event handler for a supported event.
+         * Removes the event handlers for a supported event type.
          * 
          * Currently the supported event types are `Office.EventType.AppointmentTimeChanged`, `Office.EventType.RecipientsChanged`, and 
          * `Office.EventType.RecurrenceChanged`. In Preview, `Office.EventType.AttachmentsChanged` is also supported.
@@ -14901,19 +14875,17 @@ declare namespace Office {
          * 
          * In addition to this signature, the method also has the following signature:
          * 
-         * `removeHandlerAsync(eventType:EventType, handler: any, callback?: (result: AsyncResult<void>) => void): void;`
+         * `removeHandlerAsync(eventType:EventType, callback?: (result: AsyncResult<void>) => void): void;`
          * 
          * @param eventType The event that should revoke the handler.
-         * @param handler The function to handle the event. The function must accept a single parameter, which is an object literal. 
-         *                The type property on the parameter will match the eventType parameter passed to removeHandlerAsync.
          * @param options Optional. An object literal that contains one or more of the following properties.
          *        asyncContext: Developers can provide any object they wish to access in the callback method.
          * @param callback Optional. When the method completes, the function passed in the callback parameter is called with a single parameter, 
          *                 asyncResult, which is an Office.AsyncResult object.
          */
-        removeHandlerAsync(eventType:EventType, handler: any, options?: any, callback?: (result: AsyncResult<void>) => void): void;
+        removeHandlerAsync(eventType:EventType, options?: any, callback?: (result: AsyncResult<void>) => void): void;
         /**
-         * Removes an event handler for a supported event.
+         * Removes the event handlers for a supported event type.
          * 
          * Currently the supported event types are `Office.EventType.AppointmentTimeChanged`, `Office.EventType.RecipientsChanged`, and 
          * `Office.EventType.RecurrenceChanged`. In Preview, `Office.EventType.AttachmentsChanged` is also supported.
@@ -14927,12 +14899,10 @@ declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Message Read</td></tr></table>
          * 
          * @param eventType The event that should revoke the handler.
-         * @param handler The function to handle the event. The function must accept a single parameter, which is an object literal. 
-         *                The type property on the parameter will match the eventType parameter passed to removeHandlerAsync.
          * @param callback Optional. When the method completes, the function passed in the callback parameter is called with a single parameter, 
          *                 asyncResult, which is an Office.AsyncResult object.
          */
-        removeHandlerAsync(eventType:EventType, handler: any, callback?: (result: AsyncResult<void>) => void): void;
+        removeHandlerAsync(eventType:EventType, callback?: (result: AsyncResult<void>) => void): void;
     }
 
     /**
@@ -15634,7 +15604,7 @@ declare namespace Office {
          */
         makeEwsRequestAsync(data: any, callback: (result: AsyncResult<string>) => void, userContext?: any): void;
         /**
-         * Removes an event handler for a supported event.
+         * Removes the event handlers for a supported event type.
          *
          * Currently, the only supported event type is `Office.EventType.ItemChanged`. In Preview, `Office.EventType.OfficeThemeChanged` is also supported.
          *
@@ -15647,13 +15617,11 @@ declare namespace Office {
          * <tr><td>{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}</td><td>Compose or read</td></tr></table>
          *
          * @param eventType The event that should revoke the handler.
-         * @param handler The function to handle the event. The function must accept a single parameter, which is an object literal. 
-         *                The type property on the parameter will match the eventType parameter passed to addHandlerAsync.
          * @param options Optional. Provides an option for preserving context data of any type, unchanged, for use in a callback.
          * @param callback Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of 
          *                 type Office.AsyncResult.
          */
-        removeHandlerAsync(eventType: Office.EventType, handler: (type: EventType) => void, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
+        removeHandlerAsync(eventType: Office.EventType, options?: Office.AsyncContextOptions, callback?: (result: AsyncResult<void>) => void): void;
     }
 
     /**


### PR DESCRIPTION
At the request of the product team, here are a few small snippets showing event usage with Excel objects. This is to compensate for the lack of cross-linking support to EventHandler objects in the return type of those events.