### PR TITLE
Update docfx to use dfm engine

### DIFF
--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -1,5 +1,6 @@
 { 
   "build": {
+    "markdownEngineName": "dfm",
     "content": [
       {
         "files": [


### PR DESCRIPTION
This should restore the links in Outlook (and elsewhere).

[Staging site link](https://review.docs.microsoft.com/en-us/javascript/api/outlook/office.diagnostics?view=office-js&branch=jmazzotta-patch-2)