### PR TITLE
Updating docs and pulling in Common API preview

### DIFF
--- a/docs/docs-ref-autogen/excel/excel.shape.yml
+++ b/docs/docs-ref-autogen/excel/excel.shape.yml
@@ -768,6 +768,19 @@ items:
       return:
         type:
           - boolean
+        description: |-
+
+          #### Examples
+
+          ```typescript
+          await Excel.run(async (context) => {
+              const sheet = context.workbook.worksheets.getItem("Shapes");
+              const shape = sheet.shapes.getItem("Octagon")
+              shape.lockAspectRatio = true;
+              shape.scaleHeight(1.25, Excel.ShapeScaleType.currentSize);
+              await context.sync();
+          });
+          ```
   - uid: excel.Excel.Shape.name
     summary: >-
       Represents the name of the shape.
@@ -921,8 +934,8 @@ items:
           await Excel.run(async (context) => {
               const sheet = context.workbook.worksheets.getItem("Shapes");
               const shape = sheet.shapes.getItem("Octagon")
+              shape.lockAspectRatio = true;
               shape.scaleHeight(1.25, Excel.ShapeScaleType.currentSize);
-              shape.scaleWidth(1.25, Excel.ShapeScaleType.currentSize);
               await context.sync();
           });
           ```
@@ -1003,19 +1016,7 @@ items:
       return:
         type:
           - void
-        description: |-
-
-          #### Examples
-
-          ```typescript
-          await Excel.run(async (context) => {
-              const sheet = context.workbook.worksheets.getItem("Shapes");
-              const shape = sheet.shapes.getItem("Octagon")
-              shape.scaleHeight(1.25, Excel.ShapeScaleType.currentSize);
-              shape.scaleWidth(1.25, Excel.ShapeScaleType.currentSize);
-              await context.sync();
-          });
-          ```
+        description: ''
       parameters:
         - id: scaleFactor
           description: Specifies the ratio between the width of the shape after you resize it and the current or original width.

--- a/docs/docs-ref-autogen/office.yml
+++ b/docs/docs-ref-autogen/office.yml
@@ -16,6 +16,8 @@ items:
       - office.Office.AsyncContextOptions
       - office.Office.AsyncResult
       - office.Office.AsyncResultStatus
+      - office.Office.Auth
+      - office.Office.AuthOptions
       - office.Office.Binding
       - office.Office.BindingDataChangedEventArgs
       - office.Office.Bindings
@@ -368,6 +370,10 @@ references:
     name: Office.AsyncResult
   - uid: office.Office.AsyncResultStatus
     name: Office.AsyncResultStatus
+  - uid: office.Office.Auth
+    name: Office.Auth
+  - uid: office.Office.AuthOptions
+    name: Office.AuthOptions
   - uid: office.Office.Binding
     name: Office.Binding
   - uid: office.Office.BindingDataChangedEventArgs

--- a/docs/docs-ref-autogen/office/office.auth.yml
+++ b/docs/docs-ref-autogen/office/office.auth.yml
@@ -1,0 +1,119 @@
+### YamlMime:UniversalReference
+items:
+  - uid: office.Office.Auth
+    summary: >-
+      The Office Auth namespace, Office.context.auth, provides a method that allows the Office host to obtain an access
+      token to the add-in's web application. Indirectly, this also enables the add-in to access the signed-in user's
+      Microsoft Graph data without requiring the user to sign in a second time.
+    isPreview: true
+    name: Office.Auth
+    fullName: Office.Auth
+    langs:
+      - typeScript
+    type: interface
+    package: office
+    children:
+      - office.Office.Auth.getAccessTokenAsync
+      - office.Office.Auth.getAccessTokenAsync_1
+  - uid: office.Office.Auth.getAccessTokenAsync
+    summary: >-
+      Calls the Azure Active Directory V 2.0 endpoint to get an access token to your add-in's web application. Enables
+      add-ins to identify users. Server side code can use this token to access Microsoft Graph for the add-in's web
+      application by using the ["on behalf of" OAuth
+      flow](https://docs.microsoft.com/azure/active-directory/develop/active-directory-v2-protocols-oauth-on-behalf-of)<!--
+      -->.
+
+
+      Important: In Outlook, this API is not supported if the add-in is loaded in an Outlook.com or Gmail mailbox.
+    remarks: >-
+      <table><tr><td>Hosts</td><td>Excel, OneNote, Outlook, PowerPoint, Word</td></tr>
+
+
+      <tr><td>Requirement
+      sets</td><td>[IdentityAPI](https://docs.microsoft.com/office/dev/add-ins/develop/specify-office-hosts-and-api-requirements)</td></tr></table>
+
+
+      This API requires a single sign-on configuration that bridges the add-in to an Azure application. Office users
+      sign-in with Organizational Accounts and Microsoft Accounts. Microsoft Azure returns tokens intended for both user
+      account types to access resources in the Microsoft Graph.
+
+      #### Examples
+
+
+      ```javascript
+
+      Office.context.auth.getAccessTokenAsync(function(result) {
+          if (result.status === "succeeded") {
+              var token = result.value;
+              // ...
+          } else {
+              console.log("Error obtaining token", result.error);
+          }
+      });
+
+      ```
+    isPreview: true
+    name: 'getAccessTokenAsync(options, callback)'
+    fullName: 'getAccessTokenAsync(options, callback)'
+    langs:
+      - typeScript
+    type: method
+    syntax:
+      content: 'getAccessTokenAsync(options?: AuthOptions, callback?: (result: AsyncResult<string>) => void): void;'
+      return:
+        type:
+          - void
+        description: ''
+      parameters:
+        - id: options
+          description: Optional. Accepts an AuthOptions object to define sign-on behaviors.
+          type:
+            - office.Office.AuthOptions
+        - id: callback
+          description: >-
+            Optional. Accepts a callback method that can use parse the token for the user's ID or use the token in the
+            "on behalf of" flow to get access to Microsoft Graph. If AsyncResult.status is "succeeded", then
+            AsyncResult.value is the raw AAD v. 2.0-formatted access token.
+          type:
+            - '(result: AsyncResult<string>) => void'
+  - uid: office.Office.Auth.getAccessTokenAsync_1
+    summary: >-
+      Calls the Azure Active Directory V 2.0 endpoint to get an access token to your add-in's web application. Enables
+      add-ins to identify users. Server side code can use this token to access Microsoft Graph for the add-in's web
+      application by using the ["on behalf of" OAuth
+      flow](https://docs.microsoft.com/azure/active-directory/develop/active-directory-v2-protocols-oauth-on-behalf-of)<!--
+      -->.
+
+
+      Important: In Outlook, this API is not supported if the add-in is loaded in an Outlook.com or Gmail mailbox.
+    remarks: >-
+      <table><tr><td>Hosts</td><td>Excel, OneNote, Outlook, PowerPoint, Word</td></tr>
+
+
+      <tr><td>Requirement
+      sets</td><td>[IdentityAPI](https://docs.microsoft.com/office/dev/add-ins/develop/specify-office-hosts-and-api-requirements)</td></tr></table>
+
+
+      This API requires a single sign-on configuration that bridges the add-in to an Azure application. Office users
+      sign-in with Organizational Accounts and Microsoft Accounts. Microsoft Azure returns tokens intended for both user
+      account types to access resources in the Microsoft Graph.
+    isPreview: true
+    name: getAccessTokenAsync(callback)
+    fullName: getAccessTokenAsync(callback)
+    langs:
+      - typeScript
+    type: method
+    syntax:
+      content: 'getAccessTokenAsync(callback?: (result: AsyncResult<string>) => void): void;'
+      return:
+        type:
+          - void
+        description: ''
+      parameters:
+        - id: callback
+          description: >-
+            Optional. Accepts a callback method that can use parse the token for the user's ID or use the token in the
+            "on behalf of" flow to get access to Microsoft Graph. If AsyncResult.status is "succeeded", then
+            AsyncResult.value is the raw AAD v. 2.0-formatted access token.
+          type:
+            - '(result: AsyncResult<string>) => void'

--- a/docs/docs-ref-autogen/office/office.authoptions.yml
+++ b/docs/docs-ref-autogen/office/office.authoptions.yml
@@ -1,0 +1,75 @@
+### YamlMime:UniversalReference
+items:
+  - uid: office.Office.AuthOptions
+    summary: >-
+      Provides options for the user experience when Office obtains an access token to the add-in from AAD v. 2.0 with
+      the getAccessTokenAsync method.
+    name: Office.AuthOptions
+    fullName: Office.AuthOptions
+    langs:
+      - typeScript
+    type: interface
+    package: office
+    children:
+      - office.Office.AuthOptions.asyncContext
+      - office.Office.AuthOptions.authChallenge
+      - office.Office.AuthOptions.forceAddAccount
+      - office.Office.AuthOptions.forceConsent
+  - uid: office.Office.AuthOptions.asyncContext
+    summary: >-
+      A user-defined item of any type that is returned, unchanged, in the asyncContext property of the AsyncResult
+      object that is passed to a callback.
+    name: asyncContext
+    fullName: asyncContext
+    langs:
+      - typeScript
+    type: property
+    syntax:
+      content: 'asyncContext?: any'
+      return:
+        type:
+          - any
+  - uid: office.Office.AuthOptions.authChallenge
+    summary: >-
+      Causes Office to prompt the user to provide the additional factor when the tenancy being targeted by Microsoft
+      Graph requires multifactor authentication. The string value identifies the type of additional factor that is
+      required. In most cases, you won't know at development time whether the user's tenant requires an additional
+      factor or what the string should be. So this option would be used in a "second try" call of getAccessTokenAsync
+      after Microsoft Graph has sent an error requesting the additional factor and containing the string that should be
+      used with the authChallenge option.
+    name: authChallenge
+    fullName: authChallenge
+    langs:
+      - typeScript
+    type: property
+    syntax:
+      content: 'authChallenge?: string'
+      return:
+        type:
+          - string
+  - uid: office.Office.AuthOptions.forceAddAccount
+    summary: 'Prompts the user to add their Office account (or to switch to it, if it is already added).'
+    name: forceAddAccount
+    fullName: forceAddAccount
+    langs:
+      - typeScript
+    type: property
+    syntax:
+      content: 'forceAddAccount?: boolean,'
+      return:
+        type:
+          - boolean
+  - uid: office.Office.AuthOptions.forceConsent
+    summary: >-
+      Causes Office to display the add-in consent experience. Useful if the add-in's Azure permissions have changed or
+      if the user's consent has been revoked.
+    name: forceConsent
+    fullName: forceConsent
+    langs:
+      - typeScript
+    type: property
+    syntax:
+      content: 'forceConsent?: boolean,'
+      return:
+        type:
+          - boolean

--- a/docs/docs-ref-autogen/office/office.context.yml
+++ b/docs/docs-ref-autogen/office/office.context.yml
@@ -12,6 +12,7 @@ items:
     type: interface
     package: office
     children:
+      - office.Office.Context.auth
       - office.Office.Context.commerceAllowed
       - office.Office.Context.contentLanguage
       - office.Office.Context.diagnostics
@@ -26,6 +27,19 @@ items:
       - office.Office.Context.roamingSettings
       - office.Office.Context.touchEnabled
       - office.Office.Context.ui
+  - uid: office.Office.Context.auth
+    summary: Provides information and access to the signed-in user.
+    isPreview: true
+    name: auth
+    fullName: auth
+    langs:
+      - typeScript
+    type: property
+    syntax:
+      content: 'auth: Auth;'
+      return:
+        type:
+          - office.Office.Auth
   - uid: office.Office.Context.commerceAllowed
     summary: 'True, if the current platform allows the add-in to display a UI for selling or upgrading; otherwise returns False.'
     remarks: >-

--- a/docs/docs-ref-autogen/office/office.document.yml
+++ b/docs/docs-ref-autogen/office/office.document.yml
@@ -4150,7 +4150,9 @@ items:
             "calculated columns" feature of Excel, which automatically duplicates formulas within a column. To work
             around this when you want to write `data` that contains formulas to a selected table, try specifying the
             data as an array of arrays (instead of a TableData object), and specify the coercionType as
-            Microsoft.Office.Matrix or "matrix".
+            Microsoft.Office.Matrix or "matrix". However, this technique will block the "calculated columns" feature
+            only when one of the following conditions is met: (1) you are writing to all the cells of the column, or (2)
+            there are already at least two different formulas in the column.
           type:
             - 'string | TableData | any[][]'
         - id: options
@@ -4297,7 +4299,9 @@ items:
             "calculated columns" feature of Excel, which automatically duplicates formulas within a column. To work
             around this when you want to write `data` that contains formulas to a selected table, try specifying the
             data as an array of arrays (instead of a TableData object), and specify the coercionType as
-            Microsoft.Office.Matrix or "matrix".
+            Microsoft.Office.Matrix or "matrix". However, this technique will block the "calculated columns" feature
+            only when one of the following conditions is met: (1) you are writing to all the cells of the column, or (2)
+            there are already at least two different formulas in the column.
           type:
             - 'string | TableData | any[][]'
         - id: callback

--- a/docs/docs-ref-autogen/toc.yml
+++ b/docs/docs-ref-autogen/toc.yml
@@ -2160,6 +2160,10 @@ items:
                 uid: office.Office.AsyncContextOptions
               - name: AsyncResult
                 uid: office.Office.AsyncResult
+              - name: Auth
+                uid: office.Office.Auth
+              - name: AuthOptions
+                uid: office.Office.AuthOptions
               - name: Binding
                 uid: office.Office.Binding
               - name: BindingDataChangedEventArgs

--- a/generate-docs/api-extractor-inputs-office/office.d.ts
+++ b/generate-docs/api-extractor-inputs-office/office.d.ts
@@ -650,6 +650,12 @@ export declare namespace Office {
      */     
     export interface Context {
         /**
+         * Provides information and access to the signed-in user.
+         * 
+         * @beta
+         */
+        auth: Auth;
+        /**
         * True, if the current platform allows the add-in to display a UI for selling or upgrading; otherwise returns False.
         * 
         * @remarks
@@ -1247,6 +1253,84 @@ export declare namespace Office {
          * `false` - The dialog will not be shown and the developer must handle pop-ups (by providing a user interface artifact to trigger the navigation).
          */
         promptBeforeOpen?: boolean;
+        /**
+         * A user-defined item of any type that is returned, unchanged, in the asyncContext property of the AsyncResult object that is passed to a callback.
+         */
+        asyncContext?: any
+    }
+
+    /**
+     * The Office Auth namespace, Office.context.auth, provides a method that allows the Office host to obtain an access token to the add-in's web application. 
+     * Indirectly, this also enables the add-in to access the signed-in user's Microsoft Graph data without requiring the user to sign in a second time.
+     * 
+     * @beta
+     */
+    export interface Auth {
+        /**
+         * Calls the Azure Active Directory V 2.0 endpoint to get an access token to your add-in's web application. Enables  add-ins to identify users. 
+         * Server side code can use this token to access Microsoft Graph for the add-in's web application by using the 
+         * {@link https://docs.microsoft.com/azure/active-directory/develop/active-directory-v2-protocols-oauth-on-behalf-of | "on behalf of" OAuth flow}.
+         * 
+         * Important: In Outlook, this API is not supported if the add-in is loaded in an Outlook.com or Gmail mailbox.
+         *
+         * @remarks
+         * <table><tr><td>Hosts</td><td>Excel, OneNote, Outlook, PowerPoint, Word</td></tr>
+         *
+         * <tr><td>Requirement sets</td><td>{@link https://docs.microsoft.com/office/dev/add-ins/develop/specify-office-hosts-and-api-requirements | IdentityAPI}</td></tr></table>
+         *
+         * This API requires a single sign-on configuration that bridges the add-in to an Azure application. Office users sign-in with Organizational 
+         * Accounts and Microsoft Accounts. Microsoft Azure returns tokens intended for both user account types to access resources in the Microsoft Graph.
+         *
+         * @param options - Optional. Accepts an AuthOptions object to define sign-on behaviors.
+         * @param callback - Optional. Accepts a callback method that can use parse the token for the user's ID or use the token in the "on behalf of" flow to get access to Microsoft Graph.
+         *                   If AsyncResult.status is "succeeded", then AsyncResult.value is the raw AAD v. 2.0-formatted access token.
+         * 
+         * @beta
+         */
+        getAccessTokenAsync(options?: AuthOptions, callback?: (result: AsyncResult<string>) => void): void;
+        /**
+         * Calls the Azure Active Directory V 2.0 endpoint to get an access token to your add-in's web application. Enables  add-ins to identify users. 
+         * Server side code can use this token to access Microsoft Graph for the add-in's web application by using the 
+         * {@link https://docs.microsoft.com/azure/active-directory/develop/active-directory-v2-protocols-oauth-on-behalf-of | "on behalf of" OAuth flow}.
+         * 
+         * Important: In Outlook, this API is not supported if the add-in is loaded in an Outlook.com or Gmail mailbox.
+         *
+         * @remarks
+         * <table><tr><td>Hosts</td><td>Excel, OneNote, Outlook, PowerPoint, Word</td></tr>
+         *
+         * <tr><td>Requirement sets</td><td>{@link https://docs.microsoft.com/office/dev/add-ins/develop/specify-office-hosts-and-api-requirements | IdentityAPI}</td></tr></table>
+         *
+         * This API requires a single sign-on configuration that bridges the add-in to an Azure application. Office users sign-in with Organizational 
+         * Accounts and Microsoft Accounts. Microsoft Azure returns tokens intended for both user account types to access resources in the Microsoft Graph.
+         *
+         * @param callback - Optional. Accepts a callback method that can use parse the token for the user's ID or use the token in the "on behalf of" flow to get access to Microsoft Graph.
+         *                   If AsyncResult.status is "succeeded", then AsyncResult.value is the raw AAD v. 2.0-formatted access token.
+         * 
+         * @beta
+         */
+        getAccessTokenAsync(callback?: (result: AsyncResult<string>) => void): void;
+    }
+    /**
+     * Provides options for the user experience when Office obtains an access token to the add-in from AAD v. 2.0 with the getAccessTokenAsync method.
+     */
+    export interface AuthOptions {
+        /**
+         * Causes Office to display the add-in consent experience. Useful if the add-in's Azure permissions have changed or if the user's consent has
+         * been revoked.
+         */
+        forceConsent?: boolean,
+        /**
+         * Prompts the user to add their Office account (or to switch to it, if it is already added).
+         */
+        forceAddAccount?: boolean,
+        /**
+         * Causes Office to prompt the user to provide the additional factor when the tenancy being targeted by Microsoft Graph requires multifactor
+         * authentication. The string value identifies the type of additional factor that is required. In most cases, you won't know at development
+         * time whether the user's tenant requires an additional factor or what the string should be. So this option would be used in a "second try"
+         * call of getAccessTokenAsync after Microsoft Graph has sent an error requesting the additional factor and containing the string that should
+         * be used with the authChallenge option.
+         */
+        authChallenge?: string
         /**
          * A user-defined item of any type that is returned, unchanged, in the asyncContext property of the AsyncResult object that is passed to a callback.
          */
@@ -4709,7 +4793,9 @@ export declare namespace Office {
          * In Excel, if you specify formulas in the TableData object you pass for the data parameter, you might not get the results you expect due to 
          * the "calculated columns" feature of Excel, which automatically duplicates formulas within a column. To work around this when you want to 
          * write `data` that contains formulas to a selected table, try specifying the data as an array of arrays (instead of a TableData object), and 
-         * specify the coercionType as Microsoft.Office.Matrix or "matrix".
+         * specify the coercionType as Microsoft.Office.Matrix or "matrix". However, this technique will block the "calculated columns" feature only 
+         * when one of the following conditions is met: (1) you are writing to all the cells of the column, or (2) there are already at least two 
+         * different formulas in the column.
          * 
          * @param options - Provides options for how to insert data to the selection.
          * @param callback - Optional. A function that is invoked when the callback returns, whose only parameter is of type {@link Office.AsyncResult}.
@@ -4893,7 +4979,9 @@ export declare namespace Office {
          * In Excel, if you specify formulas in the TableData object you pass for the data parameter, you might not get the results you expect due to 
          * the "calculated columns" feature of Excel, which automatically duplicates formulas within a column. To work around this when you want to 
          * write `data` that contains formulas to a selected table, try specifying the data as an array of arrays (instead of a TableData object), and 
-         * specify the coercionType as Microsoft.Office.Matrix or "matrix".
+         * specify the coercionType as Microsoft.Office.Matrix or "matrix". However, this technique will block the "calculated columns" feature only 
+         * when one of the following conditions is met: (1) you are writing to all the cells of the column, or (2) there are already at least two 
+         * different formulas in the column.
          * 
          * @param callback - Optional. A function that is invoked when the callback returns, whose only parameter is of type {@link Office.AsyncResult}.
          *                  The AsyncResult.value property always returns undefined because there is no object or data to retrieve.

--- a/generate-docs/json/office.api.json
+++ b/generate-docs/json/office.api.json
@@ -882,6 +882,327 @@
             },
             {
               "kind": "Interface",
+              "canonicalReference": "(Auth:interface)",
+              "docComment": "/**\n * The Office Auth namespace, Office.context.auth, provides a method that allows the Office host to obtain an access token to the add-in's web application. Indirectly, this also enables the add-in to access the signed-in user's Microsoft Graph data without requiring the user to sign in a second time.\n *\n * @beta\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "export interface "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Auth"
+                },
+                {
+                  "kind": "Content",
+                  "text": " "
+                }
+              ],
+              "releaseTag": "Beta",
+              "name": "Auth",
+              "members": [
+                {
+                  "kind": "MethodSignature",
+                  "canonicalReference": "(getAccessTokenAsync:0)",
+                  "docComment": "/**\n * Calls the Azure Active Directory V 2.0 endpoint to get an access token to your add-in's web application. Enables add-ins to identify users. Server side code can use this token to access Microsoft Graph for the add-in's web application by using the {@link https://docs.microsoft.com/azure/active-directory/develop/active-directory-v2-protocols-oauth-on-behalf-of | \"on behalf of\" OAuth flow}.\n *\n * Important: In Outlook, this API is not supported if the add-in is loaded in an Outlook.com or Gmail mailbox.\n *\n * @remarks\n *\n * <table><tr><td>Hosts</td><td>Excel, OneNote, Outlook, PowerPoint, Word</td></tr>\n *\n * <tr><td>Requirement sets</td><td>{@link https://docs.microsoft.com/office/dev/add-ins/develop/specify-office-hosts-and-api-requirements | IdentityAPI}</td></tr></table>\n *\n * This API requires a single sign-on configuration that bridges the add-in to an Azure application. Office users sign-in with Organizational Accounts and Microsoft Accounts. Microsoft Azure returns tokens intended for both user account types to access resources in the Microsoft Graph.\n *\n * @param options - Optional. Accepts an AuthOptions object to define sign-on behaviors.\n *\n * @param callback - Optional. Accepts a callback method that can use parse the token for the user's ID or use the token in the \"on behalf of\" flow to get access to Microsoft Graph. If AsyncResult.status is \"succeeded\", then AsyncResult.value is the raw AAD v. 2.0-formatted access token.\n *\n * @beta\n */\n",
+                  "excerptTokens": [
+                    {
+                      "kind": "Reference",
+                      "text": "getAccessTokenAsync"
+                    },
+                    {
+                      "kind": "Content",
+                      "text": "("
+                    },
+                    {
+                      "kind": "Reference",
+                      "text": "options"
+                    },
+                    {
+                      "kind": "Content",
+                      "text": "?: "
+                    },
+                    {
+                      "kind": "Reference",
+                      "text": "AuthOptions"
+                    },
+                    {
+                      "kind": "Content",
+                      "text": ", "
+                    },
+                    {
+                      "kind": "Reference",
+                      "text": "callback"
+                    },
+                    {
+                      "kind": "Content",
+                      "text": "?: "
+                    },
+                    {
+                      "kind": "Content",
+                      "text": "("
+                    },
+                    {
+                      "kind": "Reference",
+                      "text": "result"
+                    },
+                    {
+                      "kind": "Content",
+                      "text": ": "
+                    },
+                    {
+                      "kind": "Reference",
+                      "text": "AsyncResult"
+                    },
+                    {
+                      "kind": "Content",
+                      "text": "<string>) => void"
+                    },
+                    {
+                      "kind": "Content",
+                      "text": "): "
+                    },
+                    {
+                      "kind": "Content",
+                      "text": "void"
+                    },
+                    {
+                      "kind": "Content",
+                      "text": ";"
+                    }
+                  ],
+                  "returnTypeTokenRange": {
+                    "startIndex": 14,
+                    "endIndex": 15
+                  },
+                  "releaseTag": "Beta",
+                  "overloadIndex": 0,
+                  "parameters": [
+                    {
+                      "parameterName": "options",
+                      "parameterTypeTokenRange": {
+                        "startIndex": 4,
+                        "endIndex": 5
+                      }
+                    },
+                    {
+                      "parameterName": "callback",
+                      "parameterTypeTokenRange": {
+                        "startIndex": 8,
+                        "endIndex": 13
+                      }
+                    }
+                  ],
+                  "name": "getAccessTokenAsync"
+                },
+                {
+                  "kind": "MethodSignature",
+                  "canonicalReference": "(getAccessTokenAsync:1)",
+                  "docComment": "/**\n * Calls the Azure Active Directory V 2.0 endpoint to get an access token to your add-in's web application. Enables add-ins to identify users. Server side code can use this token to access Microsoft Graph for the add-in's web application by using the {@link https://docs.microsoft.com/azure/active-directory/develop/active-directory-v2-protocols-oauth-on-behalf-of | \"on behalf of\" OAuth flow}.\n *\n * Important: In Outlook, this API is not supported if the add-in is loaded in an Outlook.com or Gmail mailbox.\n *\n * @remarks\n *\n * <table><tr><td>Hosts</td><td>Excel, OneNote, Outlook, PowerPoint, Word</td></tr>\n *\n * <tr><td>Requirement sets</td><td>{@link https://docs.microsoft.com/office/dev/add-ins/develop/specify-office-hosts-and-api-requirements | IdentityAPI}</td></tr></table>\n *\n * This API requires a single sign-on configuration that bridges the add-in to an Azure application. Office users sign-in with Organizational Accounts and Microsoft Accounts. Microsoft Azure returns tokens intended for both user account types to access resources in the Microsoft Graph.\n *\n * @param callback - Optional. Accepts a callback method that can use parse the token for the user's ID or use the token in the \"on behalf of\" flow to get access to Microsoft Graph. If AsyncResult.status is \"succeeded\", then AsyncResult.value is the raw AAD v. 2.0-formatted access token.\n *\n * @beta\n */\n",
+                  "excerptTokens": [
+                    {
+                      "kind": "Reference",
+                      "text": "getAccessTokenAsync"
+                    },
+                    {
+                      "kind": "Content",
+                      "text": "("
+                    },
+                    {
+                      "kind": "Reference",
+                      "text": "callback"
+                    },
+                    {
+                      "kind": "Content",
+                      "text": "?: "
+                    },
+                    {
+                      "kind": "Content",
+                      "text": "("
+                    },
+                    {
+                      "kind": "Reference",
+                      "text": "result"
+                    },
+                    {
+                      "kind": "Content",
+                      "text": ": "
+                    },
+                    {
+                      "kind": "Reference",
+                      "text": "AsyncResult"
+                    },
+                    {
+                      "kind": "Content",
+                      "text": "<string>) => void"
+                    },
+                    {
+                      "kind": "Content",
+                      "text": "): "
+                    },
+                    {
+                      "kind": "Content",
+                      "text": "void"
+                    },
+                    {
+                      "kind": "Content",
+                      "text": ";"
+                    }
+                  ],
+                  "returnTypeTokenRange": {
+                    "startIndex": 10,
+                    "endIndex": 11
+                  },
+                  "releaseTag": "Beta",
+                  "overloadIndex": 1,
+                  "parameters": [
+                    {
+                      "parameterName": "callback",
+                      "parameterTypeTokenRange": {
+                        "startIndex": 4,
+                        "endIndex": 9
+                      }
+                    }
+                  ],
+                  "name": "getAccessTokenAsync"
+                }
+              ],
+              "extendsTokenRanges": []
+            },
+            {
+              "kind": "Interface",
+              "canonicalReference": "(AuthOptions:interface)",
+              "docComment": "/**\n * Provides options for the user experience when Office obtains an access token to the add-in from AAD v. 2.0 with the getAccessTokenAsync method.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "export interface "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "AuthOptions"
+                },
+                {
+                  "kind": "Content",
+                  "text": " "
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "AuthOptions",
+              "members": [
+                {
+                  "kind": "PropertySignature",
+                  "canonicalReference": "asyncContext",
+                  "docComment": "/**\n * A user-defined item of any type that is returned, unchanged, in the asyncContext property of the AsyncResult object that is passed to a callback.\n */\n",
+                  "excerptTokens": [
+                    {
+                      "kind": "Reference",
+                      "text": "asyncContext"
+                    },
+                    {
+                      "kind": "Content",
+                      "text": "?: "
+                    },
+                    {
+                      "kind": "Content",
+                      "text": "any"
+                    }
+                  ],
+                  "releaseTag": "Public",
+                  "name": "asyncContext",
+                  "propertyTypeTokenRange": {
+                    "startIndex": 2,
+                    "endIndex": 3
+                  }
+                },
+                {
+                  "kind": "PropertySignature",
+                  "canonicalReference": "authChallenge",
+                  "docComment": "/**\n * Causes Office to prompt the user to provide the additional factor when the tenancy being targeted by Microsoft Graph requires multifactor authentication. The string value identifies the type of additional factor that is required. In most cases, you won't know at development time whether the user's tenant requires an additional factor or what the string should be. So this option would be used in a \"second try\" call of getAccessTokenAsync after Microsoft Graph has sent an error requesting the additional factor and containing the string that should be used with the authChallenge option.\n */\n",
+                  "excerptTokens": [
+                    {
+                      "kind": "Reference",
+                      "text": "authChallenge"
+                    },
+                    {
+                      "kind": "Content",
+                      "text": "?: "
+                    },
+                    {
+                      "kind": "Content",
+                      "text": "string"
+                    }
+                  ],
+                  "releaseTag": "Public",
+                  "name": "authChallenge",
+                  "propertyTypeTokenRange": {
+                    "startIndex": 2,
+                    "endIndex": 3
+                  }
+                },
+                {
+                  "kind": "PropertySignature",
+                  "canonicalReference": "forceAddAccount",
+                  "docComment": "/**\n * Prompts the user to add their Office account (or to switch to it, if it is already added).\n */\n",
+                  "excerptTokens": [
+                    {
+                      "kind": "Reference",
+                      "text": "forceAddAccount"
+                    },
+                    {
+                      "kind": "Content",
+                      "text": "?: "
+                    },
+                    {
+                      "kind": "Content",
+                      "text": "boolean"
+                    },
+                    {
+                      "kind": "Content",
+                      "text": ","
+                    }
+                  ],
+                  "releaseTag": "Public",
+                  "name": "forceAddAccount",
+                  "propertyTypeTokenRange": {
+                    "startIndex": 2,
+                    "endIndex": 3
+                  }
+                },
+                {
+                  "kind": "PropertySignature",
+                  "canonicalReference": "forceConsent",
+                  "docComment": "/**\n * Causes Office to display the add-in consent experience. Useful if the add-in's Azure permissions have changed or if the user's consent has been revoked.\n */\n",
+                  "excerptTokens": [
+                    {
+                      "kind": "Reference",
+                      "text": "forceConsent"
+                    },
+                    {
+                      "kind": "Content",
+                      "text": "?: "
+                    },
+                    {
+                      "kind": "Content",
+                      "text": "boolean"
+                    },
+                    {
+                      "kind": "Content",
+                      "text": ","
+                    }
+                  ],
+                  "releaseTag": "Public",
+                  "name": "forceConsent",
+                  "propertyTypeTokenRange": {
+                    "startIndex": 2,
+                    "endIndex": 3
+                  }
+                }
+              ],
+              "extendsTokenRanges": []
+            },
+            {
+              "kind": "Interface",
               "canonicalReference": "(Binding:interface)",
               "docComment": "/**\n * Represents a binding to a section of the document.\n *\n * @remarks\n *\n * <table><tr><td>Requirement Sets</td><td>MatrixBindings, TableBindings, TextBindings</td></tr></table>\n *\n * The Binding object exposes the functionality possessed by all bindings regardless of type.\n *\n * The Binding object is never called directly. It is the abstract parent class of the objects that represent each type of binding: {@link Office.MatrixBinding}, {@link Office.TableBinding}, or {@link Office.TextBinding}. All three of these objects inherit the getDataAsync and setDataAsync methods from the Binding object that enable to you interact with the data in the binding. They also inherit the id and type properties for querying those property values. Additionally, the MatrixBinding and TableBinding objects expose additional methods for matrix- and table-specific features, such as counting the number of rows and columns.\n *\n * **Support details**\n *\n * A capital Y in the following matrix indicates that this interface is supported in the corresponding Office host application. An empty cell indicates that the Office host application doesn't support this interface.\n *\n * For more information about Office host application and server requirements, see {@link https://docs.microsoft.com/office/dev/add-ins/concepts/requirements-for-running-office-add-ins | Requirements for running Office Add-ins}.\n *\n * *Supported hosts, by platform* <table> <tr><th> </th><th> Office for Windows desktop </th><th> Office Online (in browser) </th><th> Office for iPad </th><th> Office for Mac </th></tr> <tr><td><strong> Access </strong></td><td> </td><td> Y </td><td> </td><td> </td></tr> <tr><td><strong> Excel </strong></td><td> Y </td><td> Y </td><td> Y </td><td> Y </td></tr> <tr><td><strong> Word </strong></td><td> Y </td><td> Y </td><td> Y </td><td> Y </td></tr> </table>\n */\n",
               "excerptTokens": [
@@ -3904,6 +4225,35 @@
               "releaseTag": "Public",
               "name": "Context",
               "members": [
+                {
+                  "kind": "PropertySignature",
+                  "canonicalReference": "auth",
+                  "docComment": "/**\n * Provides information and access to the signed-in user.\n *\n * @beta\n */\n",
+                  "excerptTokens": [
+                    {
+                      "kind": "Reference",
+                      "text": "auth"
+                    },
+                    {
+                      "kind": "Content",
+                      "text": ": "
+                    },
+                    {
+                      "kind": "Reference",
+                      "text": "Auth"
+                    },
+                    {
+                      "kind": "Content",
+                      "text": ";"
+                    }
+                  ],
+                  "releaseTag": "Beta",
+                  "name": "auth",
+                  "propertyTypeTokenRange": {
+                    "startIndex": 2,
+                    "endIndex": 3
+                  }
+                },
                 {
                   "kind": "PropertySignature",
                   "canonicalReference": "commerceAllowed",
@@ -13643,7 +13993,7 @@
                 {
                   "kind": "MethodSignature",
                   "canonicalReference": "(setSelectedDataAsync:0)",
-                  "docComment": "/**\n * Writes the specified data into the current selection.\n *\n * @remarks\n *\n * <table><tr><td>Requirement Sets</td><td>Selection</td></tr></table>\n *\n * **Application-specific behaviors**\n *\n * The following application-specific actions apply when writing data to a selection.\n *\n * <table> <tr> <td>Word</td> <td>If there is no selection and the insertion point is at a valid location, the specified `data` is inserted at the insertion point</td> <td>If `data` is a string, the specified text is inserted.</td> </tr> <tr> <td></td> <td></td> <td>If `data` is an array of arrays (\"matrix\") or a TableData object, a new Word table is inserted.</td> </tr> <tr> <td></td> <td></td> <td>If `data` is HTML, the specified HTML is inserted. (**Important**: If any of the HTML you insert is invalid, Word won't raise an error. Word will insert as much of the HTML as it can and omits any invalid data).</td> </tr> <tr> <td></td> <td></td> <td>If `data` is Office Open XML, the specified XML is inserted.</td> </tr> <tr> <td></td> <td></td> <td>If `data` is a base64 encoded image stream, the specified image is inserted.</td> </tr> <tr> <td></td> <td>If there is a selection</td> <td>It will be replaced with the specified `data` following the same rules as above.</td> </tr> <tr> <td></td> <td>Insert images</td> <td>Inserted images are placed inline. The imageLeft and imageTop parameters are ignored. The image aspect ratio is always locked. If only one of the imageWidth and imageHeight parameter is given, the other value will be automatically scaled to keep the original aspect ratio.</td> </tr>\n *\n * <tr> <td>Excel</td> <td>If a single cell is selected</td> <td>If `data` is a string, the specified text is inserted as the value of the current cell.</td> </tr> <tr> <td></td> <td></td> <td>If `data` is an array of arrays (\"matrix\"), the specified set of rows and columns are inserted, if no other data in surrounding cells will be overwritten.</td> </tr> <tr> <td></td> <td></td> <td>If `data` is a TableData object, a new Excel table with the specified set of rows and headers is inserted, if no other data in surrounding cells will be overwritten.</td> </tr> <tr> <td></td> <td>If multiple cells are selected</td> <td>If the shape does not match the shape of `data`, an error is returned.</td> </tr> <tr> <td></td> <td></td> <td>If the shape of the selection exactly matches the shape of `data`, the values of the selected cells are updated based on the values in `data`.</td> </tr> <tr> <td></td> <td>Insert images</td> <td>Inserted images are floating. The position imageLeft and imageTop parameters are relative to currently selected cell(s). Negative imageLeft and imageTop values are allowed and possibly readjusted by Excel to position the image inside a worksheet. Image aspect ratio is locked unless both imageWidth and imageHeight parameters are provided. If only one of the imageWidth and imageHeight parameter is given, the other value will be automatically scaled to keep the original aspect ratio.</td> </tr> <tr> <td></td> <td>All other cases</td> <td>An error is returned.</td> </tr>\n *\n * <tr> <td>Excel Online</td> <td>In addition to the behaviors described for Excel above, these limits apply when writing data in Excel Online</td> <td>The total number of cells you can write to a worksheet with the `data` parameter can't exceed 20,000 in a single call to this method.</td> </tr> <tr> <td></td> <td></td> <td>The number of formatting groups passed to the `cellFormat` parameter can't exceed 100. A single formatting group consists of a set of formatting applied to a specified range of cells.</td> </tr>\n *\n * <tr> <td>PowerPoint</td> <td>Insert image</td> <td>Inserted images are floating. The position imageLeft and imageTop parameters are optional but if provided, both should be present. If a single value is provided, it will be ignored. Negative imageLeft and imageTop values are allowed and can position an image outside of a slide. If no optional parameter is given and slide has a placeholder, the image will replace the placeholder in the slide. Image aspect ratio will be locked unless both imageWidth and imageHeight parameters are provided. If only one of the imageWidth and imageHeight parameter is given, the other value will be automatically scaled to keep the original aspect ratio.</td> </tr> </table>\n *\n * The possible values for the {@link Office.CoercionType} parameter vary by the host.\n *\n * <table> <tr> <th>Host</th> <th>Supported coercionType</th> </tr> <tr> <td>Excel, PowerPoint, Project, and Word</td> <td>`Office.CoercionType.Text` (string)</td> </tr> <tr> <td>Excel and Word</td> <td>`Office.CoercionType.Matrix` (array of arrays)</td> </tr> <tr> <td>Access, Excel, and Word</td> <td>`Office.CoercionType.Table` (TableData object)</td> </tr> <tr> <td>Word</td> <td>`Office.CoercionType.Html`</td> </tr> <tr> <td>Word</td> <td>`Office.CoercionType.Ooxml` (Office Open XML)</td> </tr> <tr> <td>PowerPoint and PowerPoint Online</td> <td>`Office.CoercionType.SlideRange`</td> </tr> <tr> <td>Excel, PowerPoint, and Word</td> <td>`Office.CoercionType.XmlSvg`</td> </tr> </table>\n *\n * **Support details**\n *\n * A capital Y in the following matrix indicates that this method is supported in the corresponding Office host application. An empty cell indicates that the Office host application doesn't support this method.\n *\n * For more information about Office host application and server requirements, see {@link https://docs.microsoft.com/office/dev/add-ins/concepts/requirements-for-running-office-add-ins | Requirements for running Office Add-ins}.\n *\n * *Supported hosts, by platform* <table> <tr><th> </th><th> Office for Windows desktop </th><th> Office Online (in browser) </th><th> Office for iPad </th><th> Office for Mac </th></tr> <tr><td><strong> Excel </strong></td><td> Y </td><td> Y </td><td> Y </td><td> Y </td></tr> <tr><td><strong> PowerPoint </strong></td><td> Y </td><td> Y </td><td> Y </td><td> Y </td></tr> <tr><td><strong> Project </strong></td><td> Y </td><td> </td><td> </td><td> </td></tr> <tr><td><strong> Word </strong></td><td> Y </td><td> Y </td><td> Y </td><td> Y </td></tr> </table>\n *\n * @param data - The data to be set. Either a string or {@link Office.CoercionType} value, 2d array or TableData object.\n *\n * If the value passed for `data` is:\n *\n * - A string: Plain text or anything that can be coerced to a string will be inserted. In Excel, you can also specify data as a valid formula to add that formula to the selected cell. For example, setting data to \"=SUM(A1:A5)\" will total the values in the specified range. However, when you set a formula on the bound cell, after doing so, you can't read the added formula (or any pre-existing formula) from the bound cell. If you call the Document.getSelectedDataAsync method on the selected cell to read its data, the method can return only the data displayed in the cell (the formula's result).\n *\n * - An array of arrays (\"matrix\"): Tabular data without headers will be inserted. For example, to write data to three rows in two columns, you can pass an array like this: [[\"R1C1\", \"R1C2\"], [\"R2C1\", \"R2C2\"], [\"R3C1\", \"R3C2\"]]. To write a single column of three rows, pass an array like this: [[\"R1C1\"], [\"R2C1\"], [\"R3C1\"]]\n *\n * In Excel, you can also specify data as an array of arrays that contains valid formulas to add them to the selected cells. For example if no other data will be overwritten, setting data to [[\"=SUM(A1:A5)\",\"=AVERAGE(A1:A5)\"]] will add those two formulas to the selection. Just as when setting a formula on a single cell as \"text\", you can't read the added formulas (or any pre-existing formulas) after they have been set - you can only read the formulas' results.\n *\n * - A TableData object: A table with headers will be inserted. In Excel, if you specify formulas in the TableData object you pass for the data parameter, you might not get the results you expect due to the \"calculated columns\" feature of Excel, which automatically duplicates formulas within a column. To work around this when you want to write `data` that contains formulas to a selected table, try specifying the data as an array of arrays (instead of a TableData object), and specify the coercionType as Microsoft.Office.Matrix or \"matrix\".\n *\n * @param options - Provides options for how to insert data to the selection.\n *\n * @param callback - Optional. A function that is invoked when the callback returns, whose only parameter is of type {@link Office.AsyncResult}. The AsyncResult.value property always returns undefined because there is no object or data to retrieve.\n */\n",
+                  "docComment": "/**\n * Writes the specified data into the current selection.\n *\n * @remarks\n *\n * <table><tr><td>Requirement Sets</td><td>Selection</td></tr></table>\n *\n * **Application-specific behaviors**\n *\n * The following application-specific actions apply when writing data to a selection.\n *\n * <table> <tr> <td>Word</td> <td>If there is no selection and the insertion point is at a valid location, the specified `data` is inserted at the insertion point</td> <td>If `data` is a string, the specified text is inserted.</td> </tr> <tr> <td></td> <td></td> <td>If `data` is an array of arrays (\"matrix\") or a TableData object, a new Word table is inserted.</td> </tr> <tr> <td></td> <td></td> <td>If `data` is HTML, the specified HTML is inserted. (**Important**: If any of the HTML you insert is invalid, Word won't raise an error. Word will insert as much of the HTML as it can and omits any invalid data).</td> </tr> <tr> <td></td> <td></td> <td>If `data` is Office Open XML, the specified XML is inserted.</td> </tr> <tr> <td></td> <td></td> <td>If `data` is a base64 encoded image stream, the specified image is inserted.</td> </tr> <tr> <td></td> <td>If there is a selection</td> <td>It will be replaced with the specified `data` following the same rules as above.</td> </tr> <tr> <td></td> <td>Insert images</td> <td>Inserted images are placed inline. The imageLeft and imageTop parameters are ignored. The image aspect ratio is always locked. If only one of the imageWidth and imageHeight parameter is given, the other value will be automatically scaled to keep the original aspect ratio.</td> </tr>\n *\n * <tr> <td>Excel</td> <td>If a single cell is selected</td> <td>If `data` is a string, the specified text is inserted as the value of the current cell.</td> </tr> <tr> <td></td> <td></td> <td>If `data` is an array of arrays (\"matrix\"), the specified set of rows and columns are inserted, if no other data in surrounding cells will be overwritten.</td> </tr> <tr> <td></td> <td></td> <td>If `data` is a TableData object, a new Excel table with the specified set of rows and headers is inserted, if no other data in surrounding cells will be overwritten.</td> </tr> <tr> <td></td> <td>If multiple cells are selected</td> <td>If the shape does not match the shape of `data`, an error is returned.</td> </tr> <tr> <td></td> <td></td> <td>If the shape of the selection exactly matches the shape of `data`, the values of the selected cells are updated based on the values in `data`.</td> </tr> <tr> <td></td> <td>Insert images</td> <td>Inserted images are floating. The position imageLeft and imageTop parameters are relative to currently selected cell(s). Negative imageLeft and imageTop values are allowed and possibly readjusted by Excel to position the image inside a worksheet. Image aspect ratio is locked unless both imageWidth and imageHeight parameters are provided. If only one of the imageWidth and imageHeight parameter is given, the other value will be automatically scaled to keep the original aspect ratio.</td> </tr> <tr> <td></td> <td>All other cases</td> <td>An error is returned.</td> </tr>\n *\n * <tr> <td>Excel Online</td> <td>In addition to the behaviors described for Excel above, these limits apply when writing data in Excel Online</td> <td>The total number of cells you can write to a worksheet with the `data` parameter can't exceed 20,000 in a single call to this method.</td> </tr> <tr> <td></td> <td></td> <td>The number of formatting groups passed to the `cellFormat` parameter can't exceed 100. A single formatting group consists of a set of formatting applied to a specified range of cells.</td> </tr>\n *\n * <tr> <td>PowerPoint</td> <td>Insert image</td> <td>Inserted images are floating. The position imageLeft and imageTop parameters are optional but if provided, both should be present. If a single value is provided, it will be ignored. Negative imageLeft and imageTop values are allowed and can position an image outside of a slide. If no optional parameter is given and slide has a placeholder, the image will replace the placeholder in the slide. Image aspect ratio will be locked unless both imageWidth and imageHeight parameters are provided. If only one of the imageWidth and imageHeight parameter is given, the other value will be automatically scaled to keep the original aspect ratio.</td> </tr> </table>\n *\n * The possible values for the {@link Office.CoercionType} parameter vary by the host.\n *\n * <table> <tr> <th>Host</th> <th>Supported coercionType</th> </tr> <tr> <td>Excel, PowerPoint, Project, and Word</td> <td>`Office.CoercionType.Text` (string)</td> </tr> <tr> <td>Excel and Word</td> <td>`Office.CoercionType.Matrix` (array of arrays)</td> </tr> <tr> <td>Access, Excel, and Word</td> <td>`Office.CoercionType.Table` (TableData object)</td> </tr> <tr> <td>Word</td> <td>`Office.CoercionType.Html`</td> </tr> <tr> <td>Word</td> <td>`Office.CoercionType.Ooxml` (Office Open XML)</td> </tr> <tr> <td>PowerPoint and PowerPoint Online</td> <td>`Office.CoercionType.SlideRange`</td> </tr> <tr> <td>Excel, PowerPoint, and Word</td> <td>`Office.CoercionType.XmlSvg`</td> </tr> </table>\n *\n * **Support details**\n *\n * A capital Y in the following matrix indicates that this method is supported in the corresponding Office host application. An empty cell indicates that the Office host application doesn't support this method.\n *\n * For more information about Office host application and server requirements, see {@link https://docs.microsoft.com/office/dev/add-ins/concepts/requirements-for-running-office-add-ins | Requirements for running Office Add-ins}.\n *\n * *Supported hosts, by platform* <table> <tr><th> </th><th> Office for Windows desktop </th><th> Office Online (in browser) </th><th> Office for iPad </th><th> Office for Mac </th></tr> <tr><td><strong> Excel </strong></td><td> Y </td><td> Y </td><td> Y </td><td> Y </td></tr> <tr><td><strong> PowerPoint </strong></td><td> Y </td><td> Y </td><td> Y </td><td> Y </td></tr> <tr><td><strong> Project </strong></td><td> Y </td><td> </td><td> </td><td> </td></tr> <tr><td><strong> Word </strong></td><td> Y </td><td> Y </td><td> Y </td><td> Y </td></tr> </table>\n *\n * @param data - The data to be set. Either a string or {@link Office.CoercionType} value, 2d array or TableData object.\n *\n * If the value passed for `data` is:\n *\n * - A string: Plain text or anything that can be coerced to a string will be inserted. In Excel, you can also specify data as a valid formula to add that formula to the selected cell. For example, setting data to \"=SUM(A1:A5)\" will total the values in the specified range. However, when you set a formula on the bound cell, after doing so, you can't read the added formula (or any pre-existing formula) from the bound cell. If you call the Document.getSelectedDataAsync method on the selected cell to read its data, the method can return only the data displayed in the cell (the formula's result).\n *\n * - An array of arrays (\"matrix\"): Tabular data without headers will be inserted. For example, to write data to three rows in two columns, you can pass an array like this: [[\"R1C1\", \"R1C2\"], [\"R2C1\", \"R2C2\"], [\"R3C1\", \"R3C2\"]]. To write a single column of three rows, pass an array like this: [[\"R1C1\"], [\"R2C1\"], [\"R3C1\"]]\n *\n * In Excel, you can also specify data as an array of arrays that contains valid formulas to add them to the selected cells. For example if no other data will be overwritten, setting data to [[\"=SUM(A1:A5)\",\"=AVERAGE(A1:A5)\"]] will add those two formulas to the selection. Just as when setting a formula on a single cell as \"text\", you can't read the added formulas (or any pre-existing formulas) after they have been set - you can only read the formulas' results.\n *\n * - A TableData object: A table with headers will be inserted. In Excel, if you specify formulas in the TableData object you pass for the data parameter, you might not get the results you expect due to the \"calculated columns\" feature of Excel, which automatically duplicates formulas within a column. To work around this when you want to write `data` that contains formulas to a selected table, try specifying the data as an array of arrays (instead of a TableData object), and specify the coercionType as Microsoft.Office.Matrix or \"matrix\". However, this technique will block the \"calculated columns\" feature only when one of the following conditions is met: (1) you are writing to all the cells of the column, or (2) there are already at least two different formulas in the column.\n *\n * @param options - Provides options for how to insert data to the selection.\n *\n * @param callback - Optional. A function that is invoked when the callback returns, whose only parameter is of type {@link Office.AsyncResult}. The AsyncResult.value property always returns undefined because there is no object or data to retrieve.\n */\n",
                   "excerptTokens": [
                     {
                       "kind": "Reference",
@@ -13768,7 +14118,7 @@
                 {
                   "kind": "MethodSignature",
                   "canonicalReference": "(setSelectedDataAsync:1)",
-                  "docComment": "/**\n * Writes the specified data into the current selection.\n *\n * @remarks\n *\n * <table><tr><td>Requirement Sets</td><td>Selection</td></tr></table>\n *\n * **Application-specific behaviors**\n *\n * The following application-specific actions apply when writing data to a selection.\n *\n * <table> <tr> <td>Word</td> <td>If there is no selection and the insertion point is at a valid location, the specified `data` is inserted at the insertion point</td> <td>If `data` is a string, the specified text is inserted.</td> </tr> <tr> <td></td> <td></td> <td>If `data` is an array of arrays (\"matrix\") or a TableData object, a new Word table is inserted.</td> </tr> <tr> <td></td> <td></td> <td>If `data` is HTML, the specified HTML is inserted. (**Important**: If any of the HTML you insert is invalid, Word won't raise an error. Word will insert as much of the HTML as it can and omits any invalid data).</td> </tr> <tr> <td></td> <td></td> <td>If `data` is Office Open XML, the specified XML is inserted.</td> </tr> <tr> <td></td> <td></td> <td>If `data` is a base64 encoded image stream, the specified image is inserted.</td></tr></td> </tr> <tr> <td></td> <td>If there is a selection</td> <td>It will be replaced with the specified `data` following the same rules as above.</td> </tr> <tr> <td></td> <td>Insert images</td> <td>Inserted images are placed inline. The imageLeft and imageTop parameters are ignored. The image aspect ratio is always locked. If only one of the imageWidth and imageHeight parameter is given, the other value will be automatically scaled to keep the original aspect ratio.</td> </tr>\n *\n * <tr> <td>Excel</td> <td>If a single cell is selected</td> <td>If `data` is a string, the specified text is inserted as the value of the current cell.</td> </tr> <tr> <td></td> <td></td> <td>If `data` is an array of arrays (\"matrix\"), the specified set of rows and columns are inserted, if no other data in surrounding cells will be overwritten.</td> </tr> <tr> <td></td> <td></td> <td>If `data` is a TableData object, a new Excel table with the specified set of rows and headers is inserted, if no other data in surrounding cells will be overwritten.</td> </tr> <tr> <td></td> <td>If multiple cells are selected</td><td>If the shape does not match the shape of `data`, an error is returned.</td> </tr> <tr> <td></td> <td></td> <td>If the shape of the selection exactly matches the shape of `data`, the values of the selected cells are updated based on the values in `data`.</td> </tr> <tr> <td></td> <td>Insert images</td> <td>Inserted images are floating. The position imageLeft and imageTop parameters are relative to currently selected cell(s). Negative imageLeft and imageTop values are allowed and possibly readjusted by Excel to position the image inside a worksheet. Image aspect ratio is locked unless both imageWidth and imageHeight parameters are provided. If only one of the imageWidth and imageHeight parameter is given, the other value will be automatically scaled to keep the original aspect ratio.</td> </tr> <tr> <td></td> <td>All other cases</td> <td>An error is returned.</td> </tr>\n *\n * <tr> <td>Excel Online</td> <td>In addition to the behaviors described for Excel above, these limits apply when writing data in Excel Online</td> <td>The total number of cells you can write to a worksheet with the `data` parameter can't exceed 20,000 in a single call to this method.</td> </tr> <tr> <td></td> <td></td> <td>The number of formatting groups passed to the `cellFormat` parameter can't exceed 100. A single formatting group consists of a set of formatting applied to a specified range of cells.</td> </tr>\n *\n * <tr> <td>PowerPoint</td> <td>Insert image</td> <td>Inserted images are floating. The position imageLeft and imageTop parameters are optional but if provided, both should be present. If a single value is provided, it will be ignored. Negative imageLeft and imageTop values are allowed and can position an image outside of a slide. If no optional parameter is given and slide has a placeholder, the image will replace the placeholder in the slide. Image aspect ratio will be locked unless both imageWidth and imageHeight parameters are provided. If only one of the imageWidth and imageHeight parameter is given, the other value will be automatically scaled to keep the original aspect ratio.</td> </tr> </table>\n *\n * The possible values for the {@link Office.CoercionType} parameter vary by the host.\n *\n * <table> <tr> <th>Host</th> <th>Supported coercionType</th> </tr> <tr> <td>Excel, PowerPoint, Project, and Word</td> <td>`Office.CoercionType.Text` (string)</td> </tr> <tr> <td>Excel and Word</td> <td>`Office.CoercionType.Matrix` (array of arrays)</td> </tr> <tr> <td>Access, Excel, and Word</td> <td>`Office.CoercionType.Table` (TableData object)</td> </tr> <tr> <td>Word</td> <td>`Office.CoercionType.Html`</td> </tr> <tr> <td>Word</td> <td>`Office.CoercionType.Ooxml` (Office Open XML)</td> </tr> <tr> <td>PowerPoint and PowerPoint Online</td> <td>`Office.CoercionType.SlideRange`</td> </tr> <tr> <td>Excel, PowerPoint, and Word</td> <td>`Office.CoercionType.XmlSvg`</td> </tr> </table>\n *\n * **Support details**\n *\n * A capital Y in the following matrix indicates that this method is supported in the corresponding Office host application. An empty cell indicates that the Office host application doesn't support this method.\n *\n * For more information about Office host application and server requirements, see {@link https://docs.microsoft.com/office/dev/add-ins/concepts/requirements-for-running-office-add-ins | Requirements for running Office Add-ins}.\n *\n * *Supported hosts, by platform* <table> <tr><th> </th><th> Office for Windows desktop </th><th> Office Online (in browser) </th><th> Office for iPad </th><th> Office for Mac </th></tr> <tr><td><strong> Excel </strong></td><td> Y </td><td> Y </td><td> Y </td><td> Y </td></tr> <tr><td><strong> PowerPoint </strong></td><td> Y </td><td> Y </td><td> Y </td><td> Y </td></tr> <tr><td><strong> Project </strong></td><td> Y </td><td> </td><td> </td><td> </td></tr> <tr><td><strong> Word </strong></td><td> Y </td><td> Y </td><td> Y </td><td> Y </td></tr> </table>\n *\n * @param data - The data to be set. Either a string or {@link Office.CoercionType} value, 2d array or TableData object.\n *\n * If the value passed for `data` is:\n *\n * - A string: Plain text or anything that can be coerced to a string will be inserted. In Excel, you can also specify data as a valid formula to add that formula to the selected cell. For example, setting data to \"=SUM(A1:A5)\" will total the values in the specified range. However, when you set a formula on the bound cell, after doing so, you can't read the added formula (or any pre-existing formula) from the bound cell. If you call the Document.getSelectedDataAsync method on the selected cell to read its data, the method can return only the data displayed in the cell (the formula's result).\n *\n * - An array of arrays (\"matrix\"): Tabular data without headers will be inserted. For example, to write data to three rows in two columns, you can pass an array like this: [[\"R1C1\", \"R1C2\"], [\"R2C1\", \"R2C2\"], [\"R3C1\", \"R3C2\"]]. To write a single column of three rows, pass an array like this: [[\"R1C1\"], [\"R2C1\"], [\"R3C1\"]]\n *\n * In Excel, you can also specify data as an array of arrays that contains valid formulas to add them to the selected cells. For example if no other data will be overwritten, setting data to [[\"=SUM(A1:A5)\",\"=AVERAGE(A1:A5)\"]] will add those two formulas to the selection. Just as when setting a formula on a single cell as \"text\", you can't read the added formulas (or any pre-existing formulas) after they have been set - you can only read the formulas' results.\n *\n * - A TableData object: A table with headers will be inserted. In Excel, if you specify formulas in the TableData object you pass for the data parameter, you might not get the results you expect due to the \"calculated columns\" feature of Excel, which automatically duplicates formulas within a column. To work around this when you want to write `data` that contains formulas to a selected table, try specifying the data as an array of arrays (instead of a TableData object), and specify the coercionType as Microsoft.Office.Matrix or \"matrix\".\n *\n * @param callback - Optional. A function that is invoked when the callback returns, whose only parameter is of type {@link Office.AsyncResult}. The AsyncResult.value property always returns undefined because there is no object or data to retrieve.\n */\n",
+                  "docComment": "/**\n * Writes the specified data into the current selection.\n *\n * @remarks\n *\n * <table><tr><td>Requirement Sets</td><td>Selection</td></tr></table>\n *\n * **Application-specific behaviors**\n *\n * The following application-specific actions apply when writing data to a selection.\n *\n * <table> <tr> <td>Word</td> <td>If there is no selection and the insertion point is at a valid location, the specified `data` is inserted at the insertion point</td> <td>If `data` is a string, the specified text is inserted.</td> </tr> <tr> <td></td> <td></td> <td>If `data` is an array of arrays (\"matrix\") or a TableData object, a new Word table is inserted.</td> </tr> <tr> <td></td> <td></td> <td>If `data` is HTML, the specified HTML is inserted. (**Important**: If any of the HTML you insert is invalid, Word won't raise an error. Word will insert as much of the HTML as it can and omits any invalid data).</td> </tr> <tr> <td></td> <td></td> <td>If `data` is Office Open XML, the specified XML is inserted.</td> </tr> <tr> <td></td> <td></td> <td>If `data` is a base64 encoded image stream, the specified image is inserted.</td></tr></td> </tr> <tr> <td></td> <td>If there is a selection</td> <td>It will be replaced with the specified `data` following the same rules as above.</td> </tr> <tr> <td></td> <td>Insert images</td> <td>Inserted images are placed inline. The imageLeft and imageTop parameters are ignored. The image aspect ratio is always locked. If only one of the imageWidth and imageHeight parameter is given, the other value will be automatically scaled to keep the original aspect ratio.</td> </tr>\n *\n * <tr> <td>Excel</td> <td>If a single cell is selected</td> <td>If `data` is a string, the specified text is inserted as the value of the current cell.</td> </tr> <tr> <td></td> <td></td> <td>If `data` is an array of arrays (\"matrix\"), the specified set of rows and columns are inserted, if no other data in surrounding cells will be overwritten.</td> </tr> <tr> <td></td> <td></td> <td>If `data` is a TableData object, a new Excel table with the specified set of rows and headers is inserted, if no other data in surrounding cells will be overwritten.</td> </tr> <tr> <td></td> <td>If multiple cells are selected</td><td>If the shape does not match the shape of `data`, an error is returned.</td> </tr> <tr> <td></td> <td></td> <td>If the shape of the selection exactly matches the shape of `data`, the values of the selected cells are updated based on the values in `data`.</td> </tr> <tr> <td></td> <td>Insert images</td> <td>Inserted images are floating. The position imageLeft and imageTop parameters are relative to currently selected cell(s). Negative imageLeft and imageTop values are allowed and possibly readjusted by Excel to position the image inside a worksheet. Image aspect ratio is locked unless both imageWidth and imageHeight parameters are provided. If only one of the imageWidth and imageHeight parameter is given, the other value will be automatically scaled to keep the original aspect ratio.</td> </tr> <tr> <td></td> <td>All other cases</td> <td>An error is returned.</td> </tr>\n *\n * <tr> <td>Excel Online</td> <td>In addition to the behaviors described for Excel above, these limits apply when writing data in Excel Online</td> <td>The total number of cells you can write to a worksheet with the `data` parameter can't exceed 20,000 in a single call to this method.</td> </tr> <tr> <td></td> <td></td> <td>The number of formatting groups passed to the `cellFormat` parameter can't exceed 100. A single formatting group consists of a set of formatting applied to a specified range of cells.</td> </tr>\n *\n * <tr> <td>PowerPoint</td> <td>Insert image</td> <td>Inserted images are floating. The position imageLeft and imageTop parameters are optional but if provided, both should be present. If a single value is provided, it will be ignored. Negative imageLeft and imageTop values are allowed and can position an image outside of a slide. If no optional parameter is given and slide has a placeholder, the image will replace the placeholder in the slide. Image aspect ratio will be locked unless both imageWidth and imageHeight parameters are provided. If only one of the imageWidth and imageHeight parameter is given, the other value will be automatically scaled to keep the original aspect ratio.</td> </tr> </table>\n *\n * The possible values for the {@link Office.CoercionType} parameter vary by the host.\n *\n * <table> <tr> <th>Host</th> <th>Supported coercionType</th> </tr> <tr> <td>Excel, PowerPoint, Project, and Word</td> <td>`Office.CoercionType.Text` (string)</td> </tr> <tr> <td>Excel and Word</td> <td>`Office.CoercionType.Matrix` (array of arrays)</td> </tr> <tr> <td>Access, Excel, and Word</td> <td>`Office.CoercionType.Table` (TableData object)</td> </tr> <tr> <td>Word</td> <td>`Office.CoercionType.Html`</td> </tr> <tr> <td>Word</td> <td>`Office.CoercionType.Ooxml` (Office Open XML)</td> </tr> <tr> <td>PowerPoint and PowerPoint Online</td> <td>`Office.CoercionType.SlideRange`</td> </tr> <tr> <td>Excel, PowerPoint, and Word</td> <td>`Office.CoercionType.XmlSvg`</td> </tr> </table>\n *\n * **Support details**\n *\n * A capital Y in the following matrix indicates that this method is supported in the corresponding Office host application. An empty cell indicates that the Office host application doesn't support this method.\n *\n * For more information about Office host application and server requirements, see {@link https://docs.microsoft.com/office/dev/add-ins/concepts/requirements-for-running-office-add-ins | Requirements for running Office Add-ins}.\n *\n * *Supported hosts, by platform* <table> <tr><th> </th><th> Office for Windows desktop </th><th> Office Online (in browser) </th><th> Office for iPad </th><th> Office for Mac </th></tr> <tr><td><strong> Excel </strong></td><td> Y </td><td> Y </td><td> Y </td><td> Y </td></tr> <tr><td><strong> PowerPoint </strong></td><td> Y </td><td> Y </td><td> Y </td><td> Y </td></tr> <tr><td><strong> Project </strong></td><td> Y </td><td> </td><td> </td><td> </td></tr> <tr><td><strong> Word </strong></td><td> Y </td><td> Y </td><td> Y </td><td> Y </td></tr> </table>\n *\n * @param data - The data to be set. Either a string or {@link Office.CoercionType} value, 2d array or TableData object.\n *\n * If the value passed for `data` is:\n *\n * - A string: Plain text or anything that can be coerced to a string will be inserted. In Excel, you can also specify data as a valid formula to add that formula to the selected cell. For example, setting data to \"=SUM(A1:A5)\" will total the values in the specified range. However, when you set a formula on the bound cell, after doing so, you can't read the added formula (or any pre-existing formula) from the bound cell. If you call the Document.getSelectedDataAsync method on the selected cell to read its data, the method can return only the data displayed in the cell (the formula's result).\n *\n * - An array of arrays (\"matrix\"): Tabular data without headers will be inserted. For example, to write data to three rows in two columns, you can pass an array like this: [[\"R1C1\", \"R1C2\"], [\"R2C1\", \"R2C2\"], [\"R3C1\", \"R3C2\"]]. To write a single column of three rows, pass an array like this: [[\"R1C1\"], [\"R2C1\"], [\"R3C1\"]]\n *\n * In Excel, you can also specify data as an array of arrays that contains valid formulas to add them to the selected cells. For example if no other data will be overwritten, setting data to [[\"=SUM(A1:A5)\",\"=AVERAGE(A1:A5)\"]] will add those two formulas to the selection. Just as when setting a formula on a single cell as \"text\", you can't read the added formulas (or any pre-existing formulas) after they have been set - you can only read the formulas' results.\n *\n * - A TableData object: A table with headers will be inserted. In Excel, if you specify formulas in the TableData object you pass for the data parameter, you might not get the results you expect due to the \"calculated columns\" feature of Excel, which automatically duplicates formulas within a column. To work around this when you want to write `data` that contains formulas to a selected table, try specifying the data as an array of arrays (instead of a TableData object), and specify the coercionType as Microsoft.Office.Matrix or \"matrix\". However, this technique will block the \"calculated columns\" feature only when one of the following conditions is met: (1) you are writing to all the cells of the column, or (2) there are already at least two different formulas in the column.\n *\n * @param callback - Optional. A function that is invoked when the callback returns, whose only parameter is of type {@link Office.AsyncResult}. The AsyncResult.value property always returns undefined because there is no object or data to retrieve.\n */\n",
                   "excerptTokens": [
                     {
                       "kind": "Reference",

--- a/generate-docs/json/snippets.yaml
+++ b/generate-docs/json/snippets.yaml
@@ -17245,17 +17245,17 @@ Excel.Shape.scaleHeight:
     await Excel.run(async (context) => {
         const sheet = context.workbook.worksheets.getItem("Shapes");
         const shape = sheet.shapes.getItem("Octagon")
+        shape.lockAspectRatio = true;
         shape.scaleHeight(1.25, Excel.ShapeScaleType.currentSize);
-        shape.scaleWidth(1.25, Excel.ShapeScaleType.currentSize);
         await context.sync();
     });
-Excel.Shape.scaleWidth:
+Excel.Shape.lockAspectRatio:
   - |-
     await Excel.run(async (context) => {
         const sheet = context.workbook.worksheets.getItem("Shapes");
         const shape = sheet.shapes.getItem("Octagon")
+        shape.lockAspectRatio = true;
         shape.scaleHeight(1.25, Excel.ShapeScaleType.currentSize);
-        shape.scaleWidth(1.25, Excel.ShapeScaleType.currentSize);
         await context.sync();
     });
 Excel.Shape.setZOrder:

--- a/generate-docs/script-inputs/office.d.ts
+++ b/generate-docs/script-inputs/office.d.ts
@@ -4720,7 +4720,9 @@ declare namespace Office {
          * In Excel, if you specify formulas in the TableData object you pass for the data parameter, you might not get the results you expect due to 
          * the "calculated columns" feature of Excel, which automatically duplicates formulas within a column. To work around this when you want to 
          * write `data` that contains formulas to a selected table, try specifying the data as an array of arrays (instead of a TableData object), and 
-         * specify the coercionType as Microsoft.Office.Matrix or "matrix".
+         * specify the coercionType as Microsoft.Office.Matrix or "matrix". However, this technique will block the "calculated columns" feature only 
+         * when one of the following conditions is met: (1) you are writing to all the cells of the column, or (2) there are already at least two 
+         * different formulas in the column.
          * 
          * @param options Provides options for how to insert data to the selection.
          * @param callback Optional. A function that is invoked when the callback returns, whose only parameter is of type {@link Office.AsyncResult}.
@@ -4904,7 +4906,9 @@ declare namespace Office {
          * In Excel, if you specify formulas in the TableData object you pass for the data parameter, you might not get the results you expect due to 
          * the "calculated columns" feature of Excel, which automatically duplicates formulas within a column. To work around this when you want to 
          * write `data` that contains formulas to a selected table, try specifying the data as an array of arrays (instead of a TableData object), and 
-         * specify the coercionType as Microsoft.Office.Matrix or "matrix".
+         * specify the coercionType as Microsoft.Office.Matrix or "matrix". However, this technique will block the "calculated columns" feature only 
+         * when one of the following conditions is met: (1) you are writing to all the cells of the column, or (2) there are already at least two 
+         * different formulas in the column.
          * 
          * @param callback Optional. A function that is invoked when the callback returns, whose only parameter is of type {@link Office.AsyncResult}.
          *                  The AsyncResult.value property always returns undefined because there is no object or data to retrieve.

--- a/generate-docs/script-inputs/office_preview.d.ts
+++ b/generate-docs/script-inputs/office_preview.d.ts
@@ -661,6 +661,12 @@ declare namespace Office {
      */     
     interface Context {
         /**
+         * Provides information and access to the signed-in user.
+         * 
+         * @beta
+         */
+        auth: Auth;
+        /**
         * True, if the current platform allows the add-in to display a UI for selling or upgrading; otherwise returns False.
         * 
         * @remarks
@@ -1258,6 +1264,84 @@ declare namespace Office {
          * `false` - The dialog will not be shown and the developer must handle pop-ups (by providing a user interface artifact to trigger the navigation).
          */
         promptBeforeOpen?: boolean;
+        /**
+         * A user-defined item of any type that is returned, unchanged, in the asyncContext property of the AsyncResult object that is passed to a callback.
+         */
+        asyncContext?: any
+    }
+
+    /**
+     * The Office Auth namespace, Office.context.auth, provides a method that allows the Office host to obtain an access token to the add-in's web application. 
+     * Indirectly, this also enables the add-in to access the signed-in user's Microsoft Graph data without requiring the user to sign in a second time.
+     * 
+     * @beta
+     */
+    interface Auth {
+        /**
+         * Calls the Azure Active Directory V 2.0 endpoint to get an access token to your add-in's web application. Enables  add-ins to identify users. 
+         * Server side code can use this token to access Microsoft Graph for the add-in's web application by using the 
+         * {@link https://docs.microsoft.com/azure/active-directory/develop/active-directory-v2-protocols-oauth-on-behalf-of | "on behalf of" OAuth flow}.
+         * 
+         * Important: In Outlook, this API is not supported if the add-in is loaded in an Outlook.com or Gmail mailbox.
+         *
+         * @remarks
+         * <table><tr><td>Hosts</td><td>Excel, OneNote, Outlook, PowerPoint, Word</td></tr>
+         *
+         * <tr><td>Requirement sets</td><td>{@link https://docs.microsoft.com/office/dev/add-ins/develop/specify-office-hosts-and-api-requirements | IdentityAPI}</td></tr></table>
+         *
+         * This API requires a single sign-on configuration that bridges the add-in to an Azure application. Office users sign-in with Organizational 
+         * Accounts and Microsoft Accounts. Microsoft Azure returns tokens intended for both user account types to access resources in the Microsoft Graph.
+         *
+         * @param options - Optional. Accepts an AuthOptions object to define sign-on behaviors.
+         * @param callback - Optional. Accepts a callback method that can use parse the token for the user's ID or use the token in the "on behalf of" flow to get access to Microsoft Graph.
+         *                   If AsyncResult.status is "succeeded", then AsyncResult.value is the raw AAD v. 2.0-formatted access token.
+         * 
+         * @beta
+         */
+        getAccessTokenAsync(options?: AuthOptions, callback?: (result: AsyncResult<string>) => void): void;
+        /**
+         * Calls the Azure Active Directory V 2.0 endpoint to get an access token to your add-in's web application. Enables  add-ins to identify users. 
+         * Server side code can use this token to access Microsoft Graph for the add-in's web application by using the 
+         * {@link https://docs.microsoft.com/azure/active-directory/develop/active-directory-v2-protocols-oauth-on-behalf-of | "on behalf of" OAuth flow}.
+         * 
+         * Important: In Outlook, this API is not supported if the add-in is loaded in an Outlook.com or Gmail mailbox.
+         *
+         * @remarks
+         * <table><tr><td>Hosts</td><td>Excel, OneNote, Outlook, PowerPoint, Word</td></tr>
+         *
+         * <tr><td>Requirement sets</td><td>{@link https://docs.microsoft.com/office/dev/add-ins/develop/specify-office-hosts-and-api-requirements | IdentityAPI}</td></tr></table>
+         *
+         * This API requires a single sign-on configuration that bridges the add-in to an Azure application. Office users sign-in with Organizational 
+         * Accounts and Microsoft Accounts. Microsoft Azure returns tokens intended for both user account types to access resources in the Microsoft Graph.
+         *
+         * @param callback - Optional. Accepts a callback method that can use parse the token for the user's ID or use the token in the "on behalf of" flow to get access to Microsoft Graph.
+         *                   If AsyncResult.status is "succeeded", then AsyncResult.value is the raw AAD v. 2.0-formatted access token.
+         * 
+         * @beta
+         */
+        getAccessTokenAsync(callback?: (result: AsyncResult<string>) => void): void;
+    }
+    /**
+     * Provides options for the user experience when Office obtains an access token to the add-in from AAD v. 2.0 with the getAccessTokenAsync method.
+     */
+    interface AuthOptions {
+        /**
+         * Causes Office to display the add-in consent experience. Useful if the add-in's Azure permissions have changed or if the user's consent has
+         * been revoked.
+         */
+        forceConsent?: boolean,
+        /**
+         * Prompts the user to add their Office account (or to switch to it, if it is already added).
+         */
+        forceAddAccount?: boolean,
+        /**
+         * Causes Office to prompt the user to provide the additional factor when the tenancy being targeted by Microsoft Graph requires multifactor
+         * authentication. The string value identifies the type of additional factor that is required. In most cases, you won't know at development
+         * time whether the user's tenant requires an additional factor or what the string should be. So this option would be used in a "second try"
+         * call of getAccessTokenAsync after Microsoft Graph has sent an error requesting the additional factor and containing the string that should
+         * be used with the authChallenge option.
+         */
+        authChallenge?: string
         /**
          * A user-defined item of any type that is returned, unchanged, in the asyncContext property of the AsyncResult object that is passed to a callback.
          */
@@ -4720,7 +4804,9 @@ declare namespace Office {
          * In Excel, if you specify formulas in the TableData object you pass for the data parameter, you might not get the results you expect due to 
          * the "calculated columns" feature of Excel, which automatically duplicates formulas within a column. To work around this when you want to 
          * write `data` that contains formulas to a selected table, try specifying the data as an array of arrays (instead of a TableData object), and 
-         * specify the coercionType as Microsoft.Office.Matrix or "matrix".
+         * specify the coercionType as Microsoft.Office.Matrix or "matrix". However, this technique will block the "calculated columns" feature only 
+         * when one of the following conditions is met: (1) you are writing to all the cells of the column, or (2) there are already at least two 
+         * different formulas in the column.
          * 
          * @param options Provides options for how to insert data to the selection.
          * @param callback Optional. A function that is invoked when the callback returns, whose only parameter is of type {@link Office.AsyncResult}.
@@ -4904,7 +4990,9 @@ declare namespace Office {
          * In Excel, if you specify formulas in the TableData object you pass for the data parameter, you might not get the results you expect due to 
          * the "calculated columns" feature of Excel, which automatically duplicates formulas within a column. To work around this when you want to 
          * write `data` that contains formulas to a selected table, try specifying the data as an array of arrays (instead of a TableData object), and 
-         * specify the coercionType as Microsoft.Office.Matrix or "matrix".
+         * specify the coercionType as Microsoft.Office.Matrix or "matrix". However, this technique will block the "calculated columns" feature only 
+         * when one of the following conditions is met: (1) you are writing to all the cells of the column, or (2) there are already at least two 
+         * different formulas in the column.
          * 
          * @param callback Optional. A function that is invoked when the callback returns, whose only parameter is of type {@link Office.AsyncResult}.
          *                  The AsyncResult.value property always returns undefined because there is no object or data to retrieve.

--- a/generate-docs/script-inputs/script-lab-snippets.yaml
+++ b/generate-docs/script-inputs/script-lab-snippets.yaml
@@ -2169,17 +2169,17 @@ Excel.Shape.scaleHeight:
     await Excel.run(async (context) => {
         const sheet = context.workbook.worksheets.getItem("Shapes");
         const shape = sheet.shapes.getItem("Octagon")
+        shape.lockAspectRatio = true;
         shape.scaleHeight(1.25, Excel.ShapeScaleType.currentSize);
-        shape.scaleWidth(1.25, Excel.ShapeScaleType.currentSize);
         await context.sync();
     });
-Excel.Shape.scaleWidth:
+Excel.Shape.lockAspectRatio:
   - |-
     await Excel.run(async (context) => {
         const sheet = context.workbook.worksheets.getItem("Shapes");
         const shape = sheet.shapes.getItem("Octagon")
+        shape.lockAspectRatio = true;
         shape.scaleHeight(1.25, Excel.ShapeScaleType.currentSize);
-        shape.scaleWidth(1.25, Excel.ShapeScaleType.currentSize);
         await context.sync();
     });
 Excel.Shape.setZOrder:

--- a/generate-docs/scripts/preprocessor.ts
+++ b/generate-docs/scripts/preprocessor.ts
@@ -87,7 +87,7 @@ tryCatch(async () => {
     console.log("create file: office.d.ts");
     fsx.writeFileSync(
         '../api-extractor-inputs-office/office.d.ts',
-        handleCommonImports(dtsBuilder.extractDtsSection(releaseDefinitions, "Begin Office namespace", "End Office namespace") +
+        handleCommonImports(dtsBuilder.extractDtsSection(previewDefinitions, "Begin Office namespace", "End Office namespace") +
         '\n' +
         '\n' +
         dtsBuilder.extractDtsSection(releaseDefinitions, "Begin OfficeExtension runtime", "End OfficeExtension runtime"), "Common API")


### PR DESCRIPTION
This switches the Common API source to office-js-preview, instead of office-js. It also gets the latest from Definitely Typed and office-js-snippets.