### PR TITLE
Switching to MarkDig parser

### DIFF
--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -1,6 +1,5 @@
 { 
   "build": {
-    "markdownEngineName": "dfm",
     "content": [
       {
         "files": [


### PR DESCRIPTION
[Staging site](https://review.docs.microsoft.com/en-us/javascript/api/office?view=office-js&branch=AlexJ-MD).

This changes the OPS build to use the current MarkDig parsing engine, instead of the obsolete one. All the HTML/Markdown conflicts should be resolved and this shouldn't cause any visual changes.