### PR TITLE
insertText second parameter should be uppercase

### DIFF
--- a/docs/code-snippets/word-snippets.yaml
+++ b/docs/code-snippets/word-snippets.yaml
@@ -713,7 +713,7 @@ Word.ContentControl.tag:
         myContentControl.tag = 'Customer-Address';
         myContentControl.title = ' has t';
         myContentControl.style = 'Heading 2';
-        myContentControl.insertText('One Microsoft Way, Redmond, WA 98052', 'replace');
+        myContentControl.insertText('One Microsoft Way, Redmond, WA 98052', 'Replace');
         myContentControl.cannotEdit = true;
         
         // Queue a command to load the id property for the content control you created.
@@ -2032,7 +2032,7 @@ Word.Range.insertContentControl:
         myContentControl.tag = "Customer-Address";
         myContentControl.title = "Enter Customer Address Here:";
         myContentControl.style = "Normal";
-        myContentControl.insertText("One Microsoft Way, Redmond, WA 98052", 'replace');
+        myContentControl.insertText("One Microsoft Way, Redmond, WA 98052", 'Replace');
         myContentControl.cannotEdit = true;
     
         // Synchronize the document state by executing the queued commands,

--- a/docs/docs-ref-autogen/word/word.contentcontrol.yml
+++ b/docs/docs-ref-autogen/word/word.contentcontrol.yml
@@ -1981,7 +1981,7 @@ items:
               myContentControl.tag = 'Customer-Address';
               myContentControl.title = ' has t';
               myContentControl.style = 'Heading 2';
-              myContentControl.insertText('One Microsoft Way, Redmond, WA 98052', 'replace');
+              myContentControl.insertText('One Microsoft Way, Redmond, WA 98052', 'Replace');
               myContentControl.cannotEdit = true;
               
               // Queue a command to load the id property for the content control you created.


### PR DESCRIPTION
According to the specs (and the rest of the document) the options are:
The value can be 'Replace', 'Start', or 'End'.

Replace should be the 'enum' Replace vs replace used in the example. Fixed this to Uppercase (Scriptlab will otherwise give an error)