### PR TITLE
Suppress inaccurate warnings from API Extractor

### DIFF
--- a/generate-docs/api-extractor-inputs-custom-functions-runtime/api-extractor.json
+++ b/generate-docs/api-extractor-inputs-custom-functions-runtime/api-extractor.json
@@ -17,5 +17,19 @@
         "logLevel": "none"
       }
     },
+    "tsdocMessageReporting": {
+      "tsdoc-escape-right-brace": {
+        "logLevel": "none"
+      },
+      "tsdoc-escape-greater-than": {
+        "logLevel": "none"
+      },
+      "tsdoc-malformed-inline-tag": {
+        "logLevel": "none"
+      },
+      "tsdoc-unnecessary-backslash": {
+        "logLevel": "none"
+      }
+    }
   }
 }

--- a/generate-docs/api-extractor-inputs-excel-release/api-extractor.json
+++ b/generate-docs/api-extractor-inputs-excel-release/api-extractor.json
@@ -15,7 +15,24 @@
     "extractorMessageReporting": {
       "ae-missing-release-tag": {
         "logLevel": "none"
+      },
+      "ae-forgotten-export": {
+        "logLevel": "none"
       }
     },
+    "tsdocMessageReporting": {
+      "tsdoc-escape-right-brace": {
+        "logLevel": "none"
+      },
+      "tsdoc-escape-greater-than": {
+        "logLevel": "none"
+      },
+      "tsdoc-malformed-inline-tag": {
+        "logLevel": "none"
+      },
+      "tsdoc-unnecessary-backslash": {
+        "logLevel": "none"
+      }
+    }
   }
 }

--- a/generate-docs/api-extractor-inputs-excel/api-extractor.json
+++ b/generate-docs/api-extractor-inputs-excel/api-extractor.json
@@ -15,7 +15,24 @@
     "extractorMessageReporting": {
       "ae-missing-release-tag": {
         "logLevel": "none"
+      },
+      "ae-forgotten-export": {
+        "logLevel": "none"
       }
     },
+    "tsdocMessageReporting": {
+      "tsdoc-escape-right-brace": {
+        "logLevel": "none"
+      },
+      "tsdoc-escape-greater-than": {
+        "logLevel": "none"
+      },
+      "tsdoc-malformed-inline-tag": {
+        "logLevel": "none"
+      },
+      "tsdoc-unnecessary-backslash": {
+        "logLevel": "none"
+      }
+    }
   }
 }

--- a/generate-docs/api-extractor-inputs-office-runtime/api-extractor.json
+++ b/generate-docs/api-extractor-inputs-office-runtime/api-extractor.json
@@ -17,5 +17,19 @@
         "logLevel": "none"
       }
     },
+    "tsdocMessageReporting": {
+      "tsdoc-escape-right-brace": {
+        "logLevel": "none"
+      },
+      "tsdoc-escape-greater-than": {
+        "logLevel": "none"
+      },
+      "tsdoc-malformed-inline-tag": {
+        "logLevel": "none"
+      },
+      "tsdoc-unnecessary-backslash": {
+        "logLevel": "none"
+      }
+    }
   }
 }

--- a/generate-docs/api-extractor-inputs-office/api-extractor.json
+++ b/generate-docs/api-extractor-inputs-office/api-extractor.json
@@ -15,7 +15,13 @@
     "extractorMessageReporting": {
       "ae-missing-release-tag": {
         "logLevel": "none"
+      },
+      "ae-forgotten-export": {
+        "logLevel": "none"
+      },
+      "ae-unresolved-link": {
+        "logLevel": "none"
       }
-    },
+    }
   }
 }

--- a/generate-docs/api-extractor-inputs-office/api-extractor.json
+++ b/generate-docs/api-extractor-inputs-office/api-extractor.json
@@ -22,6 +22,20 @@
       "ae-unresolved-link": {
         "logLevel": "none"
       }
+    },
+    "tsdocMessageReporting": {
+      "tsdoc-escape-right-brace": {
+        "logLevel": "none"
+      },
+      "tsdoc-escape-greater-than": {
+        "logLevel": "none"
+      },
+      "tsdoc-malformed-inline-tag": {
+        "logLevel": "none"
+      },
+      "tsdoc-unnecessary-backslash": {
+        "logLevel": "none"
+      }
     }
   }
 }

--- a/generate-docs/api-extractor-inputs-onenote/api-extractor.json
+++ b/generate-docs/api-extractor-inputs-onenote/api-extractor.json
@@ -15,7 +15,18 @@
     "extractorMessageReporting": {
       "ae-missing-release-tag": {
         "logLevel": "none"
+      },
+      "ae-forgotten-export": {
+        "logLevel": "none"
       }
     },
+    "tsdocMessageReporting": {
+      "tsdoc-escape-right-brace": {
+        "logLevel": "none"
+      },
+      "tsdoc-malformed-inline-tag": {
+        "logLevel": "none"
+      }
+    }
   }
 }

--- a/generate-docs/api-extractor-inputs-onenote/api-extractor.json
+++ b/generate-docs/api-extractor-inputs-onenote/api-extractor.json
@@ -24,7 +24,13 @@
       "tsdoc-escape-right-brace": {
         "logLevel": "none"
       },
+      "tsdoc-escape-greater-than": {
+        "logLevel": "none"
+      },
       "tsdoc-malformed-inline-tag": {
+        "logLevel": "none"
+      },
+      "tsdoc-unnecessary-backslash": {
         "logLevel": "none"
       }
     }

--- a/generate-docs/api-extractor-inputs-outlook-legacy/Outlook_1_1/api-extractor.json
+++ b/generate-docs/api-extractor-inputs-outlook-legacy/Outlook_1_1/api-extractor.json
@@ -19,6 +19,20 @@
       "ae-forgotten-export": {
         "logLevel": "none"
       }
+    },
+    "tsdocMessageReporting": {
+      "tsdoc-escape-right-brace": {
+        "logLevel": "none"
+      },
+      "tsdoc-escape-greater-than": {
+        "logLevel": "none"
+      },
+      "tsdoc-malformed-inline-tag": {
+        "logLevel": "none"
+      },
+      "tsdoc-unnecessary-backslash": {
+        "logLevel": "none"
+      }
     }
   }
 }

--- a/generate-docs/api-extractor-inputs-outlook-legacy/Outlook_1_1/api-extractor.json
+++ b/generate-docs/api-extractor-inputs-outlook-legacy/Outlook_1_1/api-extractor.json
@@ -15,7 +15,10 @@
     "extractorMessageReporting": {
       "ae-missing-release-tag": {
         "logLevel": "none"
+      }, 
+      "ae-forgotten-export": {
+        "logLevel": "none"
       }
-    },
+    }
   }
 }

--- a/generate-docs/api-extractor-inputs-outlook-legacy/Outlook_1_2/api-extractor.json
+++ b/generate-docs/api-extractor-inputs-outlook-legacy/Outlook_1_2/api-extractor.json
@@ -19,6 +19,20 @@
       "ae-forgotten-export": {
         "logLevel": "none"
       }
+    },
+    "tsdocMessageReporting": {
+      "tsdoc-escape-right-brace": {
+        "logLevel": "none"
+      },
+      "tsdoc-escape-greater-than": {
+        "logLevel": "none"
+      },
+      "tsdoc-malformed-inline-tag": {
+        "logLevel": "none"
+      },
+      "tsdoc-unnecessary-backslash": {
+        "logLevel": "none"
+      }
     }
   }
 }

--- a/generate-docs/api-extractor-inputs-outlook-legacy/Outlook_1_2/api-extractor.json
+++ b/generate-docs/api-extractor-inputs-outlook-legacy/Outlook_1_2/api-extractor.json
@@ -15,7 +15,10 @@
     "extractorMessageReporting": {
       "ae-missing-release-tag": {
         "logLevel": "none"
+      }, 
+      "ae-forgotten-export": {
+        "logLevel": "none"
       }
-    },
+    }
   }
 }

--- a/generate-docs/api-extractor-inputs-outlook-legacy/Outlook_1_3/api-extractor.json
+++ b/generate-docs/api-extractor-inputs-outlook-legacy/Outlook_1_3/api-extractor.json
@@ -19,6 +19,20 @@
       "ae-forgotten-export": {
         "logLevel": "none"
       }
+    },
+    "tsdocMessageReporting": {
+      "tsdoc-escape-right-brace": {
+        "logLevel": "none"
+      },
+      "tsdoc-escape-greater-than": {
+        "logLevel": "none"
+      },
+      "tsdoc-malformed-inline-tag": {
+        "logLevel": "none"
+      },
+      "tsdoc-unnecessary-backslash": {
+        "logLevel": "none"
+      }
     }
   }
 }

--- a/generate-docs/api-extractor-inputs-outlook-legacy/Outlook_1_3/api-extractor.json
+++ b/generate-docs/api-extractor-inputs-outlook-legacy/Outlook_1_3/api-extractor.json
@@ -15,7 +15,10 @@
     "extractorMessageReporting": {
       "ae-missing-release-tag": {
         "logLevel": "none"
+      }, 
+      "ae-forgotten-export": {
+        "logLevel": "none"
       }
-    },
+    }
   }
 }

--- a/generate-docs/api-extractor-inputs-outlook-legacy/Outlook_1_4/api-extractor.json
+++ b/generate-docs/api-extractor-inputs-outlook-legacy/Outlook_1_4/api-extractor.json
@@ -19,6 +19,20 @@
       "ae-forgotten-export": {
         "logLevel": "none"
       }
+    },
+    "tsdocMessageReporting": {
+      "tsdoc-escape-right-brace": {
+        "logLevel": "none"
+      },
+      "tsdoc-escape-greater-than": {
+        "logLevel": "none"
+      },
+      "tsdoc-malformed-inline-tag": {
+        "logLevel": "none"
+      },
+      "tsdoc-unnecessary-backslash": {
+        "logLevel": "none"
+      }
     }
   }
 }

--- a/generate-docs/api-extractor-inputs-outlook-legacy/Outlook_1_4/api-extractor.json
+++ b/generate-docs/api-extractor-inputs-outlook-legacy/Outlook_1_4/api-extractor.json
@@ -15,7 +15,10 @@
     "extractorMessageReporting": {
       "ae-missing-release-tag": {
         "logLevel": "none"
+      }, 
+      "ae-forgotten-export": {
+        "logLevel": "none"
       }
-    },
+    }
   }
 }

--- a/generate-docs/api-extractor-inputs-outlook-legacy/Outlook_1_5/api-extractor.json
+++ b/generate-docs/api-extractor-inputs-outlook-legacy/Outlook_1_5/api-extractor.json
@@ -19,6 +19,20 @@
       "ae-forgotten-export": {
         "logLevel": "none"
       }
+    },
+    "tsdocMessageReporting": {
+      "tsdoc-escape-right-brace": {
+        "logLevel": "none"
+      },
+      "tsdoc-escape-greater-than": {
+        "logLevel": "none"
+      },
+      "tsdoc-malformed-inline-tag": {
+        "logLevel": "none"
+      },
+      "tsdoc-unnecessary-backslash": {
+        "logLevel": "none"
+      }
     }
   }
 }

--- a/generate-docs/api-extractor-inputs-outlook-legacy/Outlook_1_5/api-extractor.json
+++ b/generate-docs/api-extractor-inputs-outlook-legacy/Outlook_1_5/api-extractor.json
@@ -15,7 +15,10 @@
     "extractorMessageReporting": {
       "ae-missing-release-tag": {
         "logLevel": "none"
+      }, 
+      "ae-forgotten-export": {
+        "logLevel": "none"
       }
-    },
+    }
   }
 }

--- a/generate-docs/api-extractor-inputs-outlook-legacy/Outlook_1_6/api-extractor.json
+++ b/generate-docs/api-extractor-inputs-outlook-legacy/Outlook_1_6/api-extractor.json
@@ -19,6 +19,20 @@
       "ae-forgotten-export": {
         "logLevel": "none"
       }
+    },
+    "tsdocMessageReporting": {
+      "tsdoc-escape-right-brace": {
+        "logLevel": "none"
+      },
+      "tsdoc-escape-greater-than": {
+        "logLevel": "none"
+      },
+      "tsdoc-malformed-inline-tag": {
+        "logLevel": "none"
+      },
+      "tsdoc-unnecessary-backslash": {
+        "logLevel": "none"
+      }
     }
   }
 }

--- a/generate-docs/api-extractor-inputs-outlook-legacy/Outlook_1_6/api-extractor.json
+++ b/generate-docs/api-extractor-inputs-outlook-legacy/Outlook_1_6/api-extractor.json
@@ -15,7 +15,10 @@
     "extractorMessageReporting": {
       "ae-missing-release-tag": {
         "logLevel": "none"
+      }, 
+      "ae-forgotten-export": {
+        "logLevel": "none"
       }
-    },
+    }
   }
 }

--- a/generate-docs/api-extractor-inputs-outlook-legacy/Outlook_1_7/api-extractor.json
+++ b/generate-docs/api-extractor-inputs-outlook-legacy/Outlook_1_7/api-extractor.json
@@ -19,6 +19,20 @@
       "ae-forgotten-export": {
         "logLevel": "none"
       }
+    },
+    "tsdocMessageReporting": {
+      "tsdoc-escape-right-brace": {
+        "logLevel": "none"
+      },
+      "tsdoc-escape-greater-than": {
+        "logLevel": "none"
+      },
+      "tsdoc-malformed-inline-tag": {
+        "logLevel": "none"
+      },
+      "tsdoc-unnecessary-backslash": {
+        "logLevel": "none"
+      }
     }
   }
 }

--- a/generate-docs/api-extractor-inputs-outlook-legacy/Outlook_1_7/api-extractor.json
+++ b/generate-docs/api-extractor-inputs-outlook-legacy/Outlook_1_7/api-extractor.json
@@ -15,7 +15,10 @@
     "extractorMessageReporting": {
       "ae-missing-release-tag": {
         "logLevel": "none"
+      }, 
+      "ae-forgotten-export": {
+        "logLevel": "none"
       }
-    },
+    }
   }
 }

--- a/generate-docs/api-extractor-inputs-outlook/api-extractor.json
+++ b/generate-docs/api-extractor-inputs-outlook/api-extractor.json
@@ -19,6 +19,20 @@
       "ae-forgotten-export": {
         "logLevel": "none"
       }
+    },
+    "tsdocMessageReporting": {
+      "tsdoc-escape-right-brace": {
+        "logLevel": "none"
+      },
+      "tsdoc-escape-greater-than": {
+        "logLevel": "none"
+      },
+      "tsdoc-malformed-inline-tag": {
+        "logLevel": "none"
+      },
+      "tsdoc-unnecessary-backslash": {
+        "logLevel": "none"
+      }
     }
   }
 }

--- a/generate-docs/api-extractor-inputs-outlook/api-extractor.json
+++ b/generate-docs/api-extractor-inputs-outlook/api-extractor.json
@@ -15,7 +15,10 @@
     "extractorMessageReporting": {
       "ae-missing-release-tag": {
         "logLevel": "none"
+      }, 
+      "ae-forgotten-export": {
+        "logLevel": "none"
       }
-    },
+    }
   }
 }

--- a/generate-docs/api-extractor-inputs-powerpoint/api-extractor.json
+++ b/generate-docs/api-extractor-inputs-powerpoint/api-extractor.json
@@ -16,6 +16,20 @@
       "ae-missing-release-tag": {
         "logLevel": "none"
       }
+    },
+    "tsdocMessageReporting": {
+      "tsdoc-escape-right-brace": {
+        "logLevel": "none"
+      },
+      "tsdoc-escape-greater-than": {
+        "logLevel": "none"
+      },
+      "tsdoc-malformed-inline-tag": {
+        "logLevel": "none"
+      },
+      "tsdoc-unnecessary-backslash": {
+        "logLevel": "none"
+      }
     }
   }
 }

--- a/generate-docs/api-extractor-inputs-powerpoint/api-extractor.json
+++ b/generate-docs/api-extractor-inputs-powerpoint/api-extractor.json
@@ -16,6 +16,6 @@
       "ae-missing-release-tag": {
         "logLevel": "none"
       }
-    },
+    }
   }
 }

--- a/generate-docs/api-extractor-inputs-visio/api-extractor.json
+++ b/generate-docs/api-extractor-inputs-visio/api-extractor.json
@@ -15,7 +15,18 @@
     "extractorMessageReporting": {
       "ae-missing-release-tag": {
         "logLevel": "none"
+      },
+      "ae-forgotten-export": {
+        "logLevel": "none"
       }
     },
+    "tsdocMessageReporting": {
+      "tsdoc-escape-right-brace": {
+        "logLevel": "none"
+      },
+      "tsdoc-malformed-inline-tag": {
+        "logLevel": "none"
+      }
+    }
   }
 }

--- a/generate-docs/api-extractor-inputs-visio/api-extractor.json
+++ b/generate-docs/api-extractor-inputs-visio/api-extractor.json
@@ -24,7 +24,13 @@
       "tsdoc-escape-right-brace": {
         "logLevel": "none"
       },
+      "tsdoc-escape-greater-than": {
+        "logLevel": "none"
+      },
       "tsdoc-malformed-inline-tag": {
+        "logLevel": "none"
+      },
+      "tsdoc-unnecessary-backslash": {
         "logLevel": "none"
       }
     }

--- a/generate-docs/api-extractor-inputs-word/api-extractor.json
+++ b/generate-docs/api-extractor-inputs-word/api-extractor.json
@@ -15,7 +15,27 @@
     "extractorMessageReporting": {
       "ae-missing-release-tag": {
         "logLevel": "none"
-      }
+      },
+      "ae-forgotten-export": {
+        "logLevel": "none"
+      },
+	  "ae-unresolved-link": {
+	    "logLevel": "none"
+	  }
     },
+    "tsdocMessageReporting": {
+      "tsdoc-escape-right-brace": {
+        "logLevel": "none"
+      },
+      "tsdoc-escape-greater-than": {
+        "logLevel": "none"
+      },
+      "tsdoc-malformed-inline-tag": {
+        "logLevel": "none"
+      },
+      "tsdoc-unnecessary-backslash": {
+        "logLevel": "none"
+      }
+    }
   }
 }

--- a/generate-docs/json/snippets.yaml
+++ b/generate-docs/json/snippets.yaml
@@ -17169,19 +17169,6 @@ Excel.Range.style:
 
         await context.sync();
     });
-Excel.RangeAreas.format:
-  - |-
-    await Excel.run(async (context) => {
-
-        const sheet = context.workbook.worksheets.getActiveWorksheet();
-        const usedRange = sheet.getUsedRange();
-
-        // Find the ranges with formulas
-        const formulaRanges = usedRange.getSpecialCells("Formulas");
-        formulaRanges.format.fill.color = "lightgreen";
-
-        await context.sync();
-    });
 Excel.RangeFormat.textOrientation:
   - |-
     await Excel.run(async (context) => {
@@ -18261,6 +18248,19 @@ Excel.WorksheetFreezePanes.unfreeze:
     await Excel.run(async (context) => {
         const sheet = context.workbook.worksheets.getItem("Sample");
         sheet.freezePanes.unfreeze();
+
+        await context.sync();
+    });
+Excel.RangeAreas.format:
+  - |-
+    await Excel.run(async (context) => {
+
+        const sheet = context.workbook.worksheets.getActiveWorksheet();
+        const usedRange = sheet.getUsedRange();
+
+        // Find the ranges with formulas
+        const formulaRanges = usedRange.getSpecialCells("Formulas");
+        formulaRanges.format.fill.color = "lightgreen";
 
         await context.sync();
     });

--- a/generate-docs/package.json
+++ b/generate-docs/package.json
@@ -2,7 +2,7 @@
   "name": "generate-docs",
   "version": "1.0.0",
   "dependencies": {
-    "@microsoft/api-extractor": "7.1.0",
-    "@microsoft/api-documenter": "7.1.1"
+    "@microsoft/api-extractor": "^7.1.0",
+    "@microsoft/api-documenter": "^7.1.1"
   }
 }

--- a/generate-docs/script-inputs/script-lab-snippets.yaml
+++ b/generate-docs/script-inputs/script-lab-snippets.yaml
@@ -1876,19 +1876,6 @@ Excel.Range.style:
 
         await context.sync();
     });
-Excel.RangeAreas.format:
-  - |-
-    await Excel.run(async (context) => {
-
-        const sheet = context.workbook.worksheets.getActiveWorksheet();
-        const usedRange = sheet.getUsedRange();
-
-        // Find the ranges with formulas
-        const formulaRanges = usedRange.getSpecialCells("Formulas");
-        formulaRanges.format.fill.color = "lightgreen";
-
-        await context.sync();
-    });
 Excel.RangeFormat.textOrientation:
   - |-
     await Excel.run(async (context) => {
@@ -3008,6 +2995,19 @@ Excel.WorksheetProtection.unprotect:
     await Excel.run(async (context) => {
         let activeSheet = context.workbook.worksheets.getActiveWorksheet();
         activeSheet.protection.unprotect(password);
+    });
+Excel.RangeAreas.format:
+  - |-
+    await Excel.run(async (context) => {
+
+        const sheet = context.workbook.worksheets.getActiveWorksheet();
+        const usedRange = sheet.getUsedRange();
+
+        // Find the ranges with formulas
+        const formulaRanges = usedRange.getSpecialCells("Formulas");
+        formulaRanges.format.fill.color = "lightgreen";
+
+        await context.sync();
     });
 Word.InlinePicture.getBase64ImageSrc:
   - |-


### PR DESCRIPTION
These warnings come about because of our file splitting. There's also some TSDOC warnings that don't have an effect on the end documentation.