### PR TITLE
Removing old cast snippet and forcing SL snippet addition

### DIFF
--- a/docs/code-snippets/office-snippets.yaml
+++ b/docs/code-snippets/office-snippets.yaml
@@ -638,13 +638,6 @@ Office.Bindings.releaseByIdAsync_1:
     function write(message){ 
         document.getElementById('message').innerText += message;  
     }
-Office.cast.item:
-  - |-
-    // The following example uses the toMessageCompose method to cast the Office.context.mailbox.item
-    // property so that it will only show IntelliSense for the Message object in compose mode.
-    // After the cast, the message variable will only display IntelliSense for methods and properties
-    // that can be used in compose mode.
-    var message = Office.cast.item.toMessageCompose(Office.context.mailbox.item);
 Office.Context.contentLanguage:
   - |-
     function sayHelloWithContentLanguage() {

--- a/generate-docs/json/snippets.yaml
+++ b/generate-docs/json/snippets.yaml
@@ -3445,21 +3445,6 @@ Office.Bindings.releaseByIdAsync_1:
     function write(message){ 
         document.getElementById('message').innerText += message;  
     }
-Office.cast.item:
-  - >-
-    // The following example uses the toMessageCompose method to cast the
-    Office.context.mailbox.item
-
-    // property so that it will only show IntelliSense for the Message object in
-    compose mode.
-
-    // After the cast, the message variable will only display IntelliSense for
-    methods and properties
-
-    // that can be used in compose mode.
-
-    var message =
-    Office.cast.item.toMessageCompose(Office.context.mailbox.item);
 Office.Context.contentLanguage:
   - |-
     function sayHelloWithContentLanguage() {

--- a/generate-docs/script-inputs/local-repo-snippets.yaml
+++ b/generate-docs/script-inputs/local-repo-snippets.yaml
@@ -3077,13 +3077,6 @@ Office.Bindings.releaseByIdAsync_1:
     function write(message){ 
         document.getElementById('message').innerText += message;  
     }
-Office.cast.item:
-  - |-
-    // The following example uses the toMessageCompose method to cast the Office.context.mailbox.item
-    // property so that it will only show IntelliSense for the Message object in compose mode.
-    // After the cast, the message variable will only display IntelliSense for methods and properties
-    // that can be used in compose mode.
-    var message = Office.cast.item.toMessageCompose(Office.context.mailbox.item);
 Office.Context.contentLanguage:
   - |-
     function sayHelloWithContentLanguage() {

--- a/generate-docs/scripts/preprocessor.ts
+++ b/generate-docs/scripts/preprocessor.ts
@@ -53,15 +53,6 @@ tryCatch(async () => {
         ]
     });
 
-    console.log('\n');
-    const includeScriptLabSnippets = await promptFromList({
-        message: `Do you want to include Script Lab code snippets in the generated docs?`,
-        choices: [
-            { name: "Yes", value: "y" },
-            { name: "No", value: "n" }
-        ]
-    });
-
     console.log("\nStarting preprocessor script...");
 
     // ----
@@ -177,10 +168,8 @@ tryCatch(async () => {
 
     console.log("\nCreating snippets file...");
 
-    if (includeScriptLabSnippets === "y") {
-        console.log("\nReading from: https://raw.githubusercontent.com/OfficeDev/office-js-snippets/master/snippet-extractor-output/snippets.yaml");
-        fsx.writeFileSync("../script-inputs/script-lab-snippets.yaml", await fetchAndThrowOnError("https://raw.githubusercontent.com/OfficeDev/office-js-snippets/master/snippet-extractor-output/snippets.yaml", "text"));
-    }
+    console.log("\nReading from: https://raw.githubusercontent.com/OfficeDev/office-js-snippets/master/snippet-extractor-output/snippets.yaml");
+    fsx.writeFileSync("../script-inputs/script-lab-snippets.yaml", await fetchAndThrowOnError("https://raw.githubusercontent.com/OfficeDev/office-js-snippets/master/snippet-extractor-output/snippets.yaml", "text"));
 
     console.log("\nReading from files: " + path.resolve("../../docs/code-snippets"));
 
@@ -197,17 +186,14 @@ tryCatch(async () => {
     // Parse the YAML into an object/hash set.
     let snippets: Object = yaml.load(localCodeSnippetsString);
 
-    // If including Script Lab snippets, add them to the set. If a duplicate key exists, merge the Script Lab example(s)
-    // into the item with the existing key.
-    if (includeScriptLabSnippets === "y") {
-        let scriptLabSnippets: Object = yaml.load(fsx.readFileSync(`../script-inputs/script-lab-snippets.yaml`).toString());
-        for (const key of Object.keys(scriptLabSnippets)) {
-            if (snippets[key]) {
-                console.log("Combining local and Script Lab snippets for: " + key);
-                snippets[key] = snippets[key].concat(scriptLabSnippets[key]);
-            } else {
-                snippets[key] = scriptLabSnippets[key];
-            }
+    // If a duplicate key exists, merge the Script Lab example(s) into the item with the existing key.
+    let scriptLabSnippets: Object = yaml.load(fsx.readFileSync(`../script-inputs/script-lab-snippets.yaml`).toString());
+    for (const key of Object.keys(scriptLabSnippets)) {
+        if (snippets[key]) {
+            console.log("Combining local and Script Lab snippets for: " + key);
+            snippets[key] = snippets[key].concat(scriptLabSnippets[key]);
+        } else {
+            snippets[key] = scriptLabSnippets[key];
         }
     }
 


### PR DESCRIPTION
I don't believe we'll ever not include the Script Lab snippets at this point, so I removed the option from the build script.