### PR TITLE
Have Outlook release use office-js instead of office-js-preview

### DIFF
--- a/generate-docs/json/outlook_1_7/Outlook.api.json
+++ b/generate-docs/json/outlook_1_7/Outlook.api.json
@@ -39,7 +39,7 @@
             {
               "kind": "Interface",
               "canonicalReference": "(Appointment:interface)",
-              "docComment": "/**\n * The subclass of {@link Office.Item} dealing with appointments.\n *\n * **Important**: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of Office.context.mailbox.item. Refer to the {@link https://docs.microsoft.com/office/dev/add-ins/reference/objectmodel/preview-requirement-set/office.context.mailbox.item | Object Model} page for more information.\n */\n",
+              "docComment": "/**\n * The subclass of {@link Office.Item} dealing with appointments.\n *\n * **Important**: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of Office.context.mailbox.item. Refer to the {@link https://docs.microsoft.com/office/dev/add-ins/reference/objectmodel/requirement-set-1.7/office.context.mailbox.item | Object Model} page for more information.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -75,7 +75,7 @@
             {
               "kind": "Interface",
               "canonicalReference": "(AppointmentCompose:interface)",
-              "docComment": "/**\n * The appointment organizer mode of {@link Office.Item | Office.context.mailbox.item}.\n *\n * **Important**: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of Office.context.mailbox.item. Refer to the {@link https://docs.microsoft.com/office/dev/add-ins/reference/objectmodel/preview-requirement-set/office.context.mailbox.item | Object Model} page for more information.\n */\n",
+              "docComment": "/**\n * The appointment organizer mode of {@link Office.Item | Office.context.mailbox.item}.\n *\n * **Important**: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of Office.context.mailbox.item. Refer to the {@link https://docs.microsoft.com/office/dev/add-ins/reference/objectmodel/requirement-set-1.7/office.context.mailbox.item | Object Model} page for more information.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -2215,7 +2215,7 @@
                 {
                   "kind": "MethodSignature",
                   "canonicalReference": "(setSelectedDataAsync:2)",
-                  "docComment": "/**\n * Asynchronously inserts data into the body or subject of a message.\n *\n * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. After insertion, the cursor is placed at the end of the inserted content.\n *\n * [Api set: Mailbox 1.2]\n *\n * @remarks\n *\n * **{@link https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions | Minimum permission level}**: ReadWriteItem\n *\n * **{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}**: Appointment Organizer\n *\n * **Errors**:\n *\n * - InvalidAttachmentId: The attachment identifier does not exist.S\n *\n * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.\n *\n * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult.\n */\n",
+                  "docComment": "/**\n * Asynchronously inserts data into the body or subject of a message.\n *\n * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. After insertion, the cursor is placed at the end of the inserted content.\n *\n * [Api set: Mailbox 1.2]\n *\n * @remarks\n *\n * **{@link https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions | Minimum permission level}**: ReadWriteItem\n *\n * **{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}**: Appointment Organizer\n *\n * **Errors**:\n *\n * - InvalidAttachmentId: The attachment identifier does not exist.\n *\n * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.\n *\n * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult.\n */\n",
                   "excerptTokens": [
                     {
                       "kind": "Reference",
@@ -2961,7 +2961,7 @@
             {
               "kind": "Interface",
               "canonicalReference": "(AppointmentRead:interface)",
-              "docComment": "/**\n * The appointment attendee mode of {@link Office.Item | Office.context.mailbox.item}.\n *\n * **Important**: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of Office.context.mailbox.item. Refer to the {@link https://docs.microsoft.com/office/dev/add-ins/reference/objectmodel/preview-requirement-set/office.context.mailbox.item | Object Model} page for more information.\n */\n",
+              "docComment": "/**\n * The appointment attendee mode of {@link Office.Item | Office.context.mailbox.item}.\n *\n * **Important**: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of Office.context.mailbox.item. Refer to the {@link https://docs.microsoft.com/office/dev/add-ins/reference/objectmodel/requirement-set-1.7/office.context.mailbox.item | Object Model} page for more information.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -7994,7 +7994,7 @@
                 {
                   "kind": "MethodSignature",
                   "canonicalReference": "(loadCustomPropertiesAsync:0)",
-                  "docComment": "/**\n * Asynchronously loads custom properties for this add-in on the selected item.\n *\n * Custom properties are stored as key/value pairs on a per-app, per-item basis. This method returns a CustomProperties object in the callback, which provides methods to access the custom properties specific to the current item and the current add-in. Custom properties are not encrypted on the item, so this should not be used as secure storage.\n *\n * The custom properties are provided as a CustomProperties object in the asyncResult.value property. This object can be used to get, set, and remove custom properties from the item and save changes to the custom property set back to the server.\n *\n * [Api set: Mailbox 1.0]\n *\n * @remarks\n *\n * **{@link https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions | Minimum permission level}**: ReadItem\n *\n * **{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}**: Compose or Read </table> *\n *\n * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult.\n *\n * @param userContext - Optional. Developers can provide any object they wish to access in the callback function. This object can be accessed by the asyncResult.asyncContext property in the callback function.\n */\n",
+                  "docComment": "/**\n * Asynchronously loads custom properties for this add-in on the selected item.\n *\n * Custom properties are stored as key/value pairs on a per-app, per-item basis. This method returns a CustomProperties object in the callback, which provides methods to access the custom properties specific to the current item and the current add-in. Custom properties are not encrypted on the item, so this should not be used as secure storage.\n *\n * The custom properties are provided as a CustomProperties object in the asyncResult.value property. This object can be used to get, set, and remove custom properties from the item and save changes to the custom property set back to the server.\n *\n * [Api set: Mailbox 1.0]\n *\n * @remarks\n *\n * **{@link https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions | Minimum permission level}**: ReadItem\n *\n * **{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}**: Compose or Read\n *\n * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult.\n *\n * @param userContext - Optional. Developers can provide any object they wish to access in the callback function. This object can be accessed by the asyncResult.asyncContext property in the callback function.\n */\n",
                   "excerptTokens": [
                     {
                       "kind": "Reference",
@@ -8494,7 +8494,7 @@
             {
               "kind": "Interface",
               "canonicalReference": "(ItemCompose:interface)",
-              "docComment": "/**\n * The compose mode of {@link Office.Item | Office.context.mailbox.item}.\n *\n * **Important**: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of Office.context.mailbox.item. Refer to the {@link https://docs.microsoft.com/office/dev/add-ins/reference/objectmodel/preview-requirement-set/office.context.mailbox.item | Object Model} page for more information.\n */\n",
+              "docComment": "/**\n * The compose mode of {@link Office.Item | Office.context.mailbox.item}.\n *\n * **Important**: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of Office.context.mailbox.item. Refer to the {@link https://docs.microsoft.com/office/dev/add-ins/reference/objectmodel/requirement-set-1.7/office.context.mailbox.item | Object Model} page for more information.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -10091,7 +10091,7 @@
             {
               "kind": "Interface",
               "canonicalReference": "(ItemRead:interface)",
-              "docComment": "/**\n * The read mode of {@link Office.Item | Office.context.mailbox.item}.\n *\n * **Important**: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of Office.context.mailbox.item. Refer to the {@link https://docs.microsoft.com/office/dev/add-ins/reference/objectmodel/preview-requirement-set/office.context.mailbox.item | Object Model} page for more information.\n */\n",
+              "docComment": "/**\n * The read mode of {@link Office.Item | Office.context.mailbox.item}.\n *\n * **Important**: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of Office.context.mailbox.item. Refer to the {@link https://docs.microsoft.com/office/dev/add-ins/reference/objectmodel/requirement-set-1.7/office.context.mailbox.item | Object Model} page for more information.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -12564,7 +12564,7 @@
                 {
                   "kind": "MethodSignature",
                   "canonicalReference": "(getCallbackTokenAsync:2)",
-                  "docComment": "/**\n * Gets a string that contains a token used to get an attachment or item from an Exchange Server.\n *\n * The getCallbackTokenAsync method makes an asynchronous call to get an opaque token from the Exchange Server that hosts the user's mailbox. The lifetime of the callback token is 5 minutes.\n *\n * The token is returned as a string in the `asyncResult.value` property.\n *\n * You can pass the token and an attachment identifier or item identifier to a third-party system. The third-party system uses the token as a bearer authorization token to call the Exchange Web Services (EWS) GetAttachment or GetItem operation to return an attachment or item. For example, you can create a remote service to get attachments from the selected item.\n *\n * Your app must have the ReadItem permission specified in its manifest to call the getCallbackTokenAsync method in read mode.\n *\n * In compose mode you must call the saveAsync method to get an item identifier to pass to the getCallbackTokenAsync method. Your app must have ReadWriteItem permissions to call the saveAsync method.\n *\n * [Api set: Mailbox 1.0]\n *\n * @remarks\n *\n * **{@link https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions | Minimum permission level}**: ReadItem\n *\n * **{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}**: Compose or Read\n *\n * **Errors**:\n *\n * - HTTPRequestFailure: The request has failed. Please look at the diagnostics object for the HTTP error code.\n *\n * - InternalServerError: The Exchange server returned an error. Please look at the diagnostics object for more information.\n *\n * - NetworkError: The user is no longer connected to the network. Please check your network connection and try again.\n *\n * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. The token is returned as a string in the `asyncResult.value` property. If there was an error, the `asyncResult.error` and `asyncResult.diagnostics` properties may provide additional information.\n *\n * @param userContext - Optional. Any state data that is passed to the asynchronous method.\n */\n",
+                  "docComment": "/**\n * Gets a string that contains a token used to get an attachment or item from an Exchange Server.\n *\n * The getCallbackTokenAsync method makes an asynchronous call to get an opaque token from the Exchange Server that hosts the user's mailbox. The lifetime of the callback token is 5 minutes.\n *\n * The token is returned as a string in the `asyncResult.value` property.\n *\n * You can pass the token and an attachment identifier or item identifier to a third-party system. The third-party system uses the token as a bearer authorization token to call the Exchange Web Services (EWS) GetAttachment or GetItem operation to return an attachment or item. For example, you can create a remote service to get attachments from the selected item.\n *\n * Your app must have the ReadItem permission specified in its manifest to call the getCallbackTokenAsync method in read mode.\n *\n * In compose mode you must call the saveAsync method to get an item identifier to pass to the getCallbackTokenAsync method. Your app must have ReadWriteItem permissions to call the saveAsync method.\n *\n * [Api set: Mailbox 1.0]\n *\n * @remarks\n *\n * **Errors**:\n *\n * - HTTPRequestFailure: The request has failed. Please look at the diagnostics object for the HTTP error code.\n *\n * - InternalServerError: The Exchange server returned an error. Please look at the diagnostics object for more information.\n *\n * - NetworkError: The user is no longer connected to the network. Please check your network connection and try again.\n *\n * **{@link https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions | Minimum permission level}**: ReadItem\n *\n * **{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}**: Compose or Read\n *\n * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. The token is returned as a string in the `asyncResult.value` property. If there was an error, the `asyncResult.error` and `asyncResult.diagnostics` properties may provide additional information.\n *\n * @param userContext - Optional. Any state data that is passed to the asynchronous method.\n */\n",
                   "excerptTokens": [
                     {
                       "kind": "Reference",
@@ -14036,7 +14036,7 @@
                 {
                   "kind": "Enum",
                   "canonicalReference": "(ItemType:enum)",
-                  "docComment": "/**\n * Specifies an item's type.\n *\n * [Api set: Mailbox 1.0]\n *\n * @remarks\n *\n * **{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}**: Compose or\n */\n",
+                  "docComment": "/**\n * Specifies an item's type.\n *\n * [Api set: Mailbox 1.0]\n *\n * @remarks\n *\n * **{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}**: Compose or Read\n */\n",
                   "excerptTokens": [
                     {
                       "kind": "Content",
@@ -18822,7 +18822,7 @@
             {
               "kind": "Interface",
               "canonicalReference": "(Message:interface)",
-              "docComment": "/**\n * A subclass of {@link Office.Item} for messages.\n *\n * **Important**: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of Office.context.mailbox.item. Refer to the {@link https://docs.microsoft.com/office/dev/add-ins/reference/objectmodel/preview-requirement-set/office.context.mailbox.item | Object Model} page for more information.\n */\n",
+              "docComment": "/**\n * A subclass of {@link Office.Item} for messages.\n *\n * **Important**: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of Office.context.mailbox.item. Refer to the {@link https://docs.microsoft.com/office/dev/add-ins/reference/objectmodel/requirement-set-1.7/office.context.mailbox.item | Object Model} page for more information.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -18888,7 +18888,7 @@
             {
               "kind": "Interface",
               "canonicalReference": "(MessageCompose:interface)",
-              "docComment": "/**\n * The message compose mode of {@link Office.Item | Office.context.mailbox.item}.\n *\n * **Important**: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of Office.context.mailbox.item. Refer to the {@link https://docs.microsoft.com/office/dev/add-ins/reference/objectmodel/preview-requirement-set/office.context.mailbox.item | Object Model} page for more information.\n */\n",
+              "docComment": "/**\n * The message compose mode of {@link Office.Item | Office.context.mailbox.item}.\n *\n * **Important**: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of Office.context.mailbox.item. Refer to the {@link https://docs.microsoft.com/office/dev/add-ins/reference/objectmodel/requirement-set-1.7/office.context.mailbox.item | Object Model} page for more information.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -21444,7 +21444,7 @@
             {
               "kind": "Interface",
               "canonicalReference": "(MessageRead:interface)",
-              "docComment": "/**\n * The message read mode of {@link Office.Item | Office.context.mailbox.item}.\n *\n * **Important**: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of Office.context.mailbox.item. Refer to the {@link https://docs.microsoft.com/office/dev/add-ins/reference/objectmodel/preview-requirement-set/office.context.mailbox.item | Object Model} page for more information.\n */\n",
+              "docComment": "/**\n * The message read mode of {@link Office.Item | Office.context.mailbox.item}.\n *\n * **Important**: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of Office.context.mailbox.item. Refer to the {@link https://docs.microsoft.com/office/dev/add-ins/reference/objectmodel/requirement-set-1.7/office.context.mailbox.item | Object Model} page for more information.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -23311,7 +23311,7 @@
                 {
                   "kind": "PropertySignature",
                   "canonicalReference": "icon",
-                  "docComment": "/**\n * A reference to an icon that is defined in the manifest in the Resources section. It appears in the infobar area. It is only applicable if the type is InformationalMessage. Specifying this parameter for an unsupported type results in an exception.\n *\n * **Note**: At present, the custom icon is displayed in Outlook on Windows only and not on other platforms (e.g., Mac).\n */\n",
+                  "docComment": "/**\n * A reference to an icon that is defined in the manifest in the Resources section. It appears in the infobar area. It is only applicable if the type is InformationalMessage. Specifying this parameter for an unsupported type results in an exception.\n *\n * **Note**: At present, the custom icon is displayed in Outlook on Windows only and not on other clients (e.g., Mac, web browser).\n */\n",
                   "excerptTokens": [
                     {
                       "kind": "Reference",

--- a/generate-docs/json/outlook_1_7/Outlook.api.json
+++ b/generate-docs/json/outlook_1_7/Outlook.api.json
@@ -39,7 +39,7 @@
             {
               "kind": "Interface",
               "canonicalReference": "(Appointment:interface)",
-              "docComment": "/**\n * The subclass of {@link Office.Item} dealing with appointments.\n *\n * **Important**: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of Office.context.mailbox.item. Refer to the {@link https://docs.microsoft.com/office/dev/add-ins/reference/objectmodel/requirement-set-1.7/office.context.mailbox.item | Object Model} page for more information.\n */\n",
+              "docComment": "/**\n * The subclass of {@link Office.Item} dealing with appointments.\n *\n * **Important**: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of Office.context.mailbox.item. Refer to the {@link https://docs.microsoft.com/office/dev/add-ins/reference/objectmodel/preview-requirement-set/office.context.mailbox.item | Object Model} page for more information.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -75,7 +75,7 @@
             {
               "kind": "Interface",
               "canonicalReference": "(AppointmentCompose:interface)",
-              "docComment": "/**\n * The appointment organizer mode of {@link Office.Item | Office.context.mailbox.item}.\n *\n * **Important**: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of Office.context.mailbox.item. Refer to the {@link https://docs.microsoft.com/office/dev/add-ins/reference/objectmodel/requirement-set-1.7/office.context.mailbox.item | Object Model} page for more information.\n */\n",
+              "docComment": "/**\n * The appointment organizer mode of {@link Office.Item | Office.context.mailbox.item}.\n *\n * **Important**: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of Office.context.mailbox.item. Refer to the {@link https://docs.microsoft.com/office/dev/add-ins/reference/objectmodel/preview-requirement-set/office.context.mailbox.item | Object Model} page for more information.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -2215,7 +2215,7 @@
                 {
                   "kind": "MethodSignature",
                   "canonicalReference": "(setSelectedDataAsync:2)",
-                  "docComment": "/**\n * Asynchronously inserts data into the body or subject of a message.\n *\n * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. After insertion, the cursor is placed at the end of the inserted content.\n *\n * [Api set: Mailbox 1.2]\n *\n * @remarks\n *\n * **{@link https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions | Minimum permission level}**: ReadWriteItem\n *\n * **{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}**: Appointment Organizer\n *\n * **Errors**:\n *\n * - InvalidAttachmentId: The attachment identifier does not exist.\n *\n * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.\n *\n * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult.\n */\n",
+                  "docComment": "/**\n * Asynchronously inserts data into the body or subject of a message.\n *\n * The setSelectedDataAsync method inserts the specified string at the cursor location in the subject or body of the item, or, if text is selected in the editor, it replaces the selected text. If the cursor is not in the body or subject field, an error is returned. After insertion, the cursor is placed at the end of the inserted content.\n *\n * [Api set: Mailbox 1.2]\n *\n * @remarks\n *\n * **{@link https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions | Minimum permission level}**: ReadWriteItem\n *\n * **{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}**: Appointment Organizer\n *\n * **Errors**:\n *\n * - InvalidAttachmentId: The attachment identifier does not exist.S\n *\n * @param data - The data to be inserted. Data is not to exceed 1,000,000 characters. If more than 1,000,000 characters are passed in, an ArgumentOutOfRange exception is thrown.\n *\n * @param callback - Optional. When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult.\n */\n",
                   "excerptTokens": [
                     {
                       "kind": "Reference",
@@ -2961,7 +2961,7 @@
             {
               "kind": "Interface",
               "canonicalReference": "(AppointmentRead:interface)",
-              "docComment": "/**\n * The appointment attendee mode of {@link Office.Item | Office.context.mailbox.item}.\n *\n * **Important**: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of Office.context.mailbox.item. Refer to the {@link https://docs.microsoft.com/office/dev/add-ins/reference/objectmodel/requirement-set-1.7/office.context.mailbox.item | Object Model} page for more information.\n */\n",
+              "docComment": "/**\n * The appointment attendee mode of {@link Office.Item | Office.context.mailbox.item}.\n *\n * **Important**: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of Office.context.mailbox.item. Refer to the {@link https://docs.microsoft.com/office/dev/add-ins/reference/objectmodel/preview-requirement-set/office.context.mailbox.item | Object Model} page for more information.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -7994,7 +7994,7 @@
                 {
                   "kind": "MethodSignature",
                   "canonicalReference": "(loadCustomPropertiesAsync:0)",
-                  "docComment": "/**\n * Asynchronously loads custom properties for this add-in on the selected item.\n *\n * Custom properties are stored as key/value pairs on a per-app, per-item basis. This method returns a CustomProperties object in the callback, which provides methods to access the custom properties specific to the current item and the current add-in. Custom properties are not encrypted on the item, so this should not be used as secure storage.\n *\n * The custom properties are provided as a CustomProperties object in the asyncResult.value property. This object can be used to get, set, and remove custom properties from the item and save changes to the custom property set back to the server.\n *\n * [Api set: Mailbox 1.0]\n *\n * @remarks\n *\n * **{@link https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions | Minimum permission level}**: ReadItem\n *\n * **{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}**: Compose or Read\n *\n * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult.\n *\n * @param userContext - Optional. Developers can provide any object they wish to access in the callback function. This object can be accessed by the asyncResult.asyncContext property in the callback function.\n */\n",
+                  "docComment": "/**\n * Asynchronously loads custom properties for this add-in on the selected item.\n *\n * Custom properties are stored as key/value pairs on a per-app, per-item basis. This method returns a CustomProperties object in the callback, which provides methods to access the custom properties specific to the current item and the current add-in. Custom properties are not encrypted on the item, so this should not be used as secure storage.\n *\n * The custom properties are provided as a CustomProperties object in the asyncResult.value property. This object can be used to get, set, and remove custom properties from the item and save changes to the custom property set back to the server.\n *\n * [Api set: Mailbox 1.0]\n *\n * @remarks\n *\n * **{@link https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions | Minimum permission level}**: ReadItem\n *\n * **{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}**: Compose or Read </table> *\n *\n * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult.\n *\n * @param userContext - Optional. Developers can provide any object they wish to access in the callback function. This object can be accessed by the asyncResult.asyncContext property in the callback function.\n */\n",
                   "excerptTokens": [
                     {
                       "kind": "Reference",
@@ -8494,7 +8494,7 @@
             {
               "kind": "Interface",
               "canonicalReference": "(ItemCompose:interface)",
-              "docComment": "/**\n * The compose mode of {@link Office.Item | Office.context.mailbox.item}.\n *\n * **Important**: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of Office.context.mailbox.item. Refer to the {@link https://docs.microsoft.com/office/dev/add-ins/reference/objectmodel/requirement-set-1.7/office.context.mailbox.item | Object Model} page for more information.\n */\n",
+              "docComment": "/**\n * The compose mode of {@link Office.Item | Office.context.mailbox.item}.\n *\n * **Important**: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of Office.context.mailbox.item. Refer to the {@link https://docs.microsoft.com/office/dev/add-ins/reference/objectmodel/preview-requirement-set/office.context.mailbox.item | Object Model} page for more information.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -10091,7 +10091,7 @@
             {
               "kind": "Interface",
               "canonicalReference": "(ItemRead:interface)",
-              "docComment": "/**\n * The read mode of {@link Office.Item | Office.context.mailbox.item}.\n *\n * **Important**: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of Office.context.mailbox.item. Refer to the {@link https://docs.microsoft.com/office/dev/add-ins/reference/objectmodel/requirement-set-1.7/office.context.mailbox.item | Object Model} page for more information.\n */\n",
+              "docComment": "/**\n * The read mode of {@link Office.Item | Office.context.mailbox.item}.\n *\n * **Important**: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of Office.context.mailbox.item. Refer to the {@link https://docs.microsoft.com/office/dev/add-ins/reference/objectmodel/preview-requirement-set/office.context.mailbox.item | Object Model} page for more information.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -12564,7 +12564,7 @@
                 {
                   "kind": "MethodSignature",
                   "canonicalReference": "(getCallbackTokenAsync:2)",
-                  "docComment": "/**\n * Gets a string that contains a token used to get an attachment or item from an Exchange Server.\n *\n * The getCallbackTokenAsync method makes an asynchronous call to get an opaque token from the Exchange Server that hosts the user's mailbox. The lifetime of the callback token is 5 minutes.\n *\n * The token is returned as a string in the `asyncResult.value` property.\n *\n * You can pass the token and an attachment identifier or item identifier to a third-party system. The third-party system uses the token as a bearer authorization token to call the Exchange Web Services (EWS) GetAttachment or GetItem operation to return an attachment or item. For example, you can create a remote service to get attachments from the selected item.\n *\n * Your app must have the ReadItem permission specified in its manifest to call the getCallbackTokenAsync method in read mode.\n *\n * In compose mode you must call the saveAsync method to get an item identifier to pass to the getCallbackTokenAsync method. Your app must have ReadWriteItem permissions to call the saveAsync method.\n *\n * [Api set: Mailbox 1.0]\n *\n * @remarks\n *\n * **Errors**:\n *\n * - HTTPRequestFailure: The request has failed. Please look at the diagnostics object for the HTTP error code.\n *\n * - InternalServerError: The Exchange server returned an error. Please look at the diagnostics object for more information.\n *\n * - NetworkError: The user is no longer connected to the network. Please check your network connection and try again.\n *\n * **{@link https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions | Minimum permission level}**: ReadItem\n *\n * **{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}**: Compose or Read\n *\n * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. The token is returned as a string in the `asyncResult.value` property. If there was an error, the `asyncResult.error` and `asyncResult.diagnostics` properties may provide additional information.\n *\n * @param userContext - Optional. Any state data that is passed to the asynchronous method.\n */\n",
+                  "docComment": "/**\n * Gets a string that contains a token used to get an attachment or item from an Exchange Server.\n *\n * The getCallbackTokenAsync method makes an asynchronous call to get an opaque token from the Exchange Server that hosts the user's mailbox. The lifetime of the callback token is 5 minutes.\n *\n * The token is returned as a string in the `asyncResult.value` property.\n *\n * You can pass the token and an attachment identifier or item identifier to a third-party system. The third-party system uses the token as a bearer authorization token to call the Exchange Web Services (EWS) GetAttachment or GetItem operation to return an attachment or item. For example, you can create a remote service to get attachments from the selected item.\n *\n * Your app must have the ReadItem permission specified in its manifest to call the getCallbackTokenAsync method in read mode.\n *\n * In compose mode you must call the saveAsync method to get an item identifier to pass to the getCallbackTokenAsync method. Your app must have ReadWriteItem permissions to call the saveAsync method.\n *\n * [Api set: Mailbox 1.0]\n *\n * @remarks\n *\n * **{@link https://docs.microsoft.com/outlook/add-ins/understanding-outlook-add-in-permissions | Minimum permission level}**: ReadItem\n *\n * **{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}**: Compose or Read\n *\n * **Errors**:\n *\n * - HTTPRequestFailure: The request has failed. Please look at the diagnostics object for the HTTP error code.\n *\n * - InternalServerError: The Exchange server returned an error. Please look at the diagnostics object for more information.\n *\n * - NetworkError: The user is no longer connected to the network. Please check your network connection and try again.\n *\n * @param callback - When the method completes, the function passed in the callback parameter is called with a single parameter of type Office.AsyncResult. The token is returned as a string in the `asyncResult.value` property. If there was an error, the `asyncResult.error` and `asyncResult.diagnostics` properties may provide additional information.\n *\n * @param userContext - Optional. Any state data that is passed to the asynchronous method.\n */\n",
                   "excerptTokens": [
                     {
                       "kind": "Reference",
@@ -14036,7 +14036,7 @@
                 {
                   "kind": "Enum",
                   "canonicalReference": "(ItemType:enum)",
-                  "docComment": "/**\n * Specifies an item's type.\n *\n * [Api set: Mailbox 1.0]\n *\n * @remarks\n *\n * **{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}**: Compose or Read\n */\n",
+                  "docComment": "/**\n * Specifies an item's type.\n *\n * [Api set: Mailbox 1.0]\n *\n * @remarks\n *\n * **{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}**: Compose or\n */\n",
                   "excerptTokens": [
                     {
                       "kind": "Content",
@@ -18822,7 +18822,7 @@
             {
               "kind": "Interface",
               "canonicalReference": "(Message:interface)",
-              "docComment": "/**\n * A subclass of {@link Office.Item} for messages.\n *\n * **Important**: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of Office.context.mailbox.item. Refer to the {@link https://docs.microsoft.com/office/dev/add-ins/reference/objectmodel/requirement-set-1.7/office.context.mailbox.item | Object Model} page for more information.\n */\n",
+              "docComment": "/**\n * A subclass of {@link Office.Item} for messages.\n *\n * **Important**: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of Office.context.mailbox.item. Refer to the {@link https://docs.microsoft.com/office/dev/add-ins/reference/objectmodel/preview-requirement-set/office.context.mailbox.item | Object Model} page for more information.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -18888,7 +18888,7 @@
             {
               "kind": "Interface",
               "canonicalReference": "(MessageCompose:interface)",
-              "docComment": "/**\n * The message compose mode of {@link Office.Item | Office.context.mailbox.item}.\n *\n * **Important**: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of Office.context.mailbox.item. Refer to the {@link https://docs.microsoft.com/office/dev/add-ins/reference/objectmodel/requirement-set-1.7/office.context.mailbox.item | Object Model} page for more information.\n */\n",
+              "docComment": "/**\n * The message compose mode of {@link Office.Item | Office.context.mailbox.item}.\n *\n * **Important**: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of Office.context.mailbox.item. Refer to the {@link https://docs.microsoft.com/office/dev/add-ins/reference/objectmodel/preview-requirement-set/office.context.mailbox.item | Object Model} page for more information.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -21444,7 +21444,7 @@
             {
               "kind": "Interface",
               "canonicalReference": "(MessageRead:interface)",
-              "docComment": "/**\n * The message read mode of {@link Office.Item | Office.context.mailbox.item}.\n *\n * **Important**: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of Office.context.mailbox.item. Refer to the {@link https://docs.microsoft.com/office/dev/add-ins/reference/objectmodel/requirement-set-1.7/office.context.mailbox.item | Object Model} page for more information.\n */\n",
+              "docComment": "/**\n * The message read mode of {@link Office.Item | Office.context.mailbox.item}.\n *\n * **Important**: This is an internal Outlook object, not directly exposed through existing interfaces. You should treat this as a mode of Office.context.mailbox.item. Refer to the {@link https://docs.microsoft.com/office/dev/add-ins/reference/objectmodel/preview-requirement-set/office.context.mailbox.item | Object Model} page for more information.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -23311,7 +23311,7 @@
                 {
                   "kind": "PropertySignature",
                   "canonicalReference": "icon",
-                  "docComment": "/**\n * A reference to an icon that is defined in the manifest in the Resources section. It appears in the infobar area. It is only applicable if the type is InformationalMessage. Specifying this parameter for an unsupported type results in an exception.\n *\n * **Note**: At present, the custom icon is displayed in Outlook on Windows only and not on other clients (e.g., Mac, web browser).\n */\n",
+                  "docComment": "/**\n * A reference to an icon that is defined in the manifest in the Resources section. It appears in the infobar area. It is only applicable if the type is InformationalMessage. Specifying this parameter for an unsupported type results in an exception.\n *\n * **Note**: At present, the custom icon is displayed in Outlook on Windows only and not on other platforms (e.g., Mac).\n */\n",
                   "excerptTokens": [
                     {
                       "kind": "Reference",

--- a/generate-docs/scripts/preprocessor.ts
+++ b/generate-docs/scripts/preprocessor.ts
@@ -102,10 +102,22 @@ tryCatch(async () => {
         handleCommonImports(handleLiteralParameterOverloads(dtsBuilder.extractDtsSection(releaseDefinitions, "Begin OneNote APIs", "End OneNote APIs")), "Other")
     );
 
-    console.log("create file: outlook.d.ts");
+    console.log("create file: outlook.d.ts (preview)");
     fsx.writeFileSync(
         '../api-extractor-inputs-outlook/outlook.d.ts',
         handleCommonImports(dtsBuilder.extractDtsSection(previewDefinitions, "Begin Exchange APIs", "End Exchange APIs"), "Outlook")
+    );
+
+    console.log("create file: outlook.d.ts (release)");
+    fsx.writeFileSync(
+        '../api-extractor-inputs-outlook-release/Outlook_1_7/outlook.d.ts',
+        handleCommonImports(dtsBuilder.extractDtsSection(releaseDefinitions, "Begin Exchange APIs", "End Exchange APIs"), "Outlook", true)
+    );
+
+    console.log("create file: powerpoint.d.ts");
+    fsx.writeFileSync(
+        '../api-extractor-inputs-powerpoint/powerpoint.d.ts',
+        handleCommonImports(dtsBuilder.extractDtsSection(releaseDefinitions, "Begin PowerPoint APIs", "End PowerPoint APIs"), "Other")
     );
 
     console.log("create file: powerpoint.d.ts");
@@ -258,7 +270,7 @@ function applyRegularExpressions (definitionsIn) {
 function handleCommonImports(hostDts: string, hostName: "Common API" | "Outlook" | "Other", isVersioned?: boolean): string {
     const commonApiNamespaceImport = "import \{ OfficeExtension \} from \"" + (isVersioned ? "../" : "") + "../api-extractor-inputs-office/office\"\n";
     const outlookApiNamespaceImport = "import \{ Office as Outlook\} from \"" + (isVersioned ? "../" : "") + "../api-extractor-inputs-outlook/outlook\"\n";
-    const commonApiNamespaceImportForOutlook = "import \{Office as CommonAPI\} from \"../api-extractor-inputs-office/office\"\n";
+    const commonApiNamespaceImportForOutlook = "import \{Office as CommonAPI\} from \"" + (isVersioned ? "../" : "") + "../api-extractor-inputs-office/office\"\n";
     if (hostName === "Outlook") {
         hostDts = hostDts.replace(/: Office\./g, ": CommonAPI.").replace(/\<Office\./g, "<CommonAPI.");
         return commonApiNamespaceImportForOutlook + hostDts;

--- a/generate-docs/scripts/preprocessor.ts
+++ b/generate-docs/scripts/preprocessor.ts
@@ -110,7 +110,7 @@ tryCatch(async () => {
 
     console.log("create file: outlook.d.ts (release)");
     fsx.writeFileSync(
-        '../api-extractor-inputs-outlook-release/Outlook_1_7/outlook.d.ts',
+        '../api-extractor-inputs-outlook-release/outlook_1_7/outlook.d.ts',
         handleCommonImports(dtsBuilder.extractDtsSection(releaseDefinitions, "Begin Exchange APIs", "End Exchange APIs"), "Outlook", true)
     );
 

--- a/generate-docs/scripts/preprocessor.ts
+++ b/generate-docs/scripts/preprocessor.ts
@@ -120,12 +120,6 @@ tryCatch(async () => {
         handleCommonImports(dtsBuilder.extractDtsSection(releaseDefinitions, "Begin PowerPoint APIs", "End PowerPoint APIs"), "Other")
     );
 
-    console.log("create file: powerpoint.d.ts");
-    fsx.writeFileSync(
-        '../api-extractor-inputs-powerpoint/powerpoint.d.ts',
-        handleCommonImports(dtsBuilder.extractDtsSection(releaseDefinitions, "Begin PowerPoint APIs", "End PowerPoint APIs"), "Other")
-    );
-
     console.log("create file: visio.d.ts");
     fsx.writeFileSync(
         '../api-extractor-inputs-visio/visio.d.ts',


### PR DESCRIPTION
Now that Outlook's preview content is out of DefinitelyTyped/office-js, the preprocessor can generate different docs based on preview and release.

Note that this PR is dependent on https://github.com/DefinitelyTyped/DefinitelyTyped/pull/37564 for the upstream content changes.