### PR TITLE
[outlook] Autogenerating Outlook legacy version d.ts files

### DIFF
--- a/generate-docs/GenerateDocs.cmd
+++ b/generate-docs/GenerateDocs.cmd
@@ -43,6 +43,13 @@ call node version-remover ..\api-extractor-inputs-excel-release\Excel_1_4\excel.
 call node version-remover ..\api-extractor-inputs-excel-release\Excel_1_3\excel.d.ts "ExcelApi 1.3" ..\api-extractor-inputs-excel-release\Excel_1_2\excel.d.ts
 call node version-remover ..\api-extractor-inputs-excel-release\Excel_1_2\excel.d.ts "ExcelApi 1.2" ..\api-extractor-inputs-excel-release\Excel_1_1\excel.d.ts
 
+call node version-remover ..\api-extractor-inputs-outlook-release\outlook_1_7\outlook.d.ts "Mailbox 1.7" ..\api-extractor-inputs-outlook-release\outlook_1_6\outlook.d.ts
+call node version-remover ..\api-extractor-inputs-outlook-release\outlook_1_6\outlook.d.ts "Mailbox 1.6" ..\api-extractor-inputs-outlook-release\outlook_1_5\outlook.d.ts
+call node version-remover ..\api-extractor-inputs-outlook-release\outlook_1_5\outlook.d.ts "Mailbox 1.5" ..\api-extractor-inputs-outlook-release\outlook_1_4\outlook.d.ts
+call node version-remover ..\api-extractor-inputs-outlook-release\outlook_1_4\outlook.d.ts "Mailbox 1.4" ..\api-extractor-inputs-outlook-release\outlook_1_3\outlook.d.ts
+call node version-remover ..\api-extractor-inputs-outlook-release\outlook_1_3\outlook.d.ts "Mailbox 1.3" ..\api-extractor-inputs-outlook-release\outlook_1_2\outlook.d.ts
+call node version-remover ..\api-extractor-inputs-outlook-release\outlook_1_2\outlook.d.ts "Mailbox 1.2" ..\api-extractor-inputs-outlook-release\outlook_1_1\outlook.d.ts
+
 call node version-remover ..\api-extractor-inputs-word-release\word_1_3\word.d.ts "WordApi 1.3" ..\api-extractor-inputs-word-release\word_1_2\word.d.ts
 call node version-remover ..\api-extractor-inputs-word-release\word_1_2\word.d.ts "WordApi 1.2" ..\api-extractor-inputs-word-release\word_1_1\word.d.ts
 popd
@@ -80,16 +87,22 @@ call ..\node_modules\.bin\api-extractor run
 cd ..\api-extractor-inputs-outlook-release\outlook_1_7
 call ..\..\node_modules\.bin\api-extractor run
 cd ..\outlook_1_6
+call node ..\..\scripts\versioned-dts-cleanup outlook.d.ts Outlook 1.6
 call ..\..\node_modules\.bin\api-extractor run
 cd ..\outlook_1_5
+call node ..\..\scripts\versioned-dts-cleanup outlook.d.ts Outlook 1.5
 call ..\..\node_modules\.bin\api-extractor run
 cd ..\outlook_1_4
+call node ..\..\scripts\versioned-dts-cleanup outlook.d.ts Outlook 1.4
 call ..\..\node_modules\.bin\api-extractor run
 cd ..\outlook_1_3
+call node ..\..\scripts\versioned-dts-cleanup outlook.d.ts Outlook 1.3
 call ..\..\node_modules\.bin\api-extractor run
 cd ..\outlook_1_2
+call node ..\..\scripts\versioned-dts-cleanup outlook.d.ts Outlook 1.2
 call ..\..\node_modules\.bin\api-extractor run
 cd ..\outlook_1_1
+call node ..\..\scripts\versioned-dts-cleanup outlook.d.ts Outlook 1.1
 call ..\..\node_modules\.bin\api-extractor run
 cd ..
 

--- a/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_1/Outlook.d.ts
+++ b/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_1/Outlook.d.ts
@@ -28,6 +28,7 @@ export declare namespace Office {
              */
             Cloud = "cloud"
         }
+        
         /**
          * Specifies an entity's type.
          *
@@ -67,6 +68,7 @@ export declare namespace Office {
              */
             Contact = "contact"
         }
+        
         /**
          * Specifies an item's type.
          *
@@ -86,6 +88,7 @@ export declare namespace Office {
              */
             Appointment = "appointment"
         }
+        
         /**
          * Represents the current view of Outlook on the web.
          */
@@ -131,6 +134,9 @@ export declare namespace Office {
              */
             Other = "other"
         }
+        
+
+        
         /**  
          * Specifies the type of response to a meeting invitation.
          *
@@ -162,6 +168,8 @@ export declare namespace Office {
              */
             Declined = "declined"
         }
+        
+        
     }
     export interface CoercionTypeOptions {
         coercionType?: CommonAPI.CoercionType | string;
@@ -399,6 +407,8 @@ export declare namespace Office {
      * **{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}**: Compose or Read
      */
     export interface Body {
+        
+        
         /**
          * Gets a value that indicates whether the content is in HTML or text format.
          *
@@ -486,6 +496,9 @@ export declare namespace Office {
          *                  Any errors encountered will be provided in the asyncResult.error property.
          */
         prependAsync(data: string, callback?: (asyncResult: CommonAPI.AsyncResult<void>) => void): void;
+        
+        
+
         /**
          * Replaces the selection in the body with the specified text.
          *
@@ -864,6 +877,11 @@ export declare namespace Office {
          */
         urls: string[];
     }
+
+    
+
+    
+
     /**
      * The subclass of {@link Office.Item} dealing with appointments.
      * 
@@ -938,6 +956,7 @@ export declare namespace Office {
          * **{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}**: Appointment Organizer
          */
         location: Location;
+        
         /**
          * Provides access to the optional attendees of an event. The type of object and level of access depends on the mode of the current item. 
          * The optionalAttendees property returns an {@link Office.Recipients} object that provides methods to get or update the optional attendees 
@@ -952,6 +971,8 @@ export declare namespace Office {
          * **{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}**: Appointment Organizer
          */
         optionalAttendees: Recipients;
+        
+        
         /**
          * Provides access to the required attendees of an event. The type of object and level of access depends on the mode of the current item. 
          * The requiredAttendees property returns an {@link Office.Recipients} object that provides methods to get or update the required attendees 
@@ -966,6 +987,7 @@ export declare namespace Office {
          * **{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}**: Appointment Organizer
          */
         requiredAttendees: Recipients;
+        
         /**
          * Gets or sets the date and time that the appointment is to begin.
          *
@@ -1063,6 +1085,8 @@ export declare namespace Office {
          *                 If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
          */
         addFileAttachmentAsync(uri: string, attachmentName: string, callback?: (asyncResult: CommonAPI.AsyncResult<string>) => void): void;
+        
+        
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
@@ -1129,6 +1153,9 @@ export declare namespace Office {
          *                 If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
          */
         addItemAttachmentAsync(itemId: any, attachmentName: string, callback?: (asyncResult: CommonAPI.AsyncResult<string>) => void): void;
+        
+        
+         
         /**
          * Asynchronously loads custom properties for this add-in on the selected item.
          *
@@ -1210,6 +1237,12 @@ export declare namespace Office {
          *                 If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
          */
         removeAttachmentAsync(attachmentId: string, callback?: (asyncResult: CommonAPI.AsyncResult<void>) => void): void;
+       
+       
+        
+        
+        
+        
     }
 
     /**
@@ -1392,6 +1425,7 @@ export declare namespace Office {
          * **{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}**: Appointment Attendee
          */
         normalizedSubject: string;
+        
         /**
          * Provides access to the optional attendees of an event. The type of object and level of access depends on the mode of the current item.
          *
@@ -1419,6 +1453,7 @@ export declare namespace Office {
          * **{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}**: Appointment Attendee
          */
         organizer: EmailAddressDetails;
+        
         /**
          * Provides access to the required attendees of an event. The type of object and level of access depends on the mode of the current item.
          *
@@ -1449,6 +1484,7 @@ export declare namespace Office {
          * **{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}**: Appointment Attendee
          */
         start: Date;
+        
         /**
          * Gets the description that appears in the subject field of an item.
          *
@@ -1466,6 +1502,8 @@ export declare namespace Office {
          */
         subject: string;
 
+        
+        
         /**
          * Displays a reply form that includes the sender and all recipients of the selected message or the organizer and all attendees of the 
          * selected appointment.
@@ -1679,6 +1717,8 @@ export declare namespace Office {
          * @param name - The name of the ItemHasRegularExpressionMatch rule element that defines the filter to match.
          */
         getRegExMatchesByName(name: string): string[];
+        
+        
        /**
         * Asynchronously loads custom properties for this add-in on the selected item.
         *
@@ -1704,6 +1744,9 @@ export declare namespace Office {
         *                    This object can be accessed by the asyncResult.asyncContext property in the callback function.
         */
        loadCustomPropertiesAsync(callback: (asyncResult: CommonAPI.AsyncResult<CustomProperties>) => void, userContext?: any): void;
+
+       
+        
     }
 
     /**
@@ -1747,6 +1790,13 @@ export declare namespace Office {
          */
         itemType: MailboxEnums.ItemType | string;
         
+
+        
+
+        
+
+        
+
        /**
         * Asynchronously loads custom properties for this add-in on the selected item.
         *
@@ -1772,6 +1822,11 @@ export declare namespace Office {
         *                    This object can be accessed by the asyncResult.asyncContext property in the callback function.
         */
        loadCustomPropertiesAsync(callback: (asyncResult: CommonAPI.AsyncResult<CustomProperties>) => void, userContext?: any): void;
+
+
+       
+
+       
     }
     /**
      * The compose mode of {@link Office.Item | Office.context.mailbox.item}.
@@ -1933,6 +1988,10 @@ export declare namespace Office {
          *                 the error.
          */
         addItemAttachmentAsync(itemId: any, attachmentName: string, callback?: (asyncResult: CommonAPI.AsyncResult<string>) => void): void;
+
+        
+        
+        
         /**
          * Removes an attachment from a message or appointment.
          *
@@ -1989,6 +2048,11 @@ export declare namespace Office {
          *                 If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
          */
         removeAttachmentAsync(attachmentId: string, callback?: (asyncResult: CommonAPI.AsyncResult<void>) => void): void;
+
+        
+        
+        
+        
     }
     /**
      * The read mode of {@link Office.Item | Office.context.mailbox.item}.
@@ -2318,6 +2382,8 @@ export declare namespace Office {
          * @param name - The name of the ItemHasRegularExpressionMatch rule element that defines the filter to match.
          */
         getRegExMatchesByName(name: string): string[];
+        
+        
     }
     /**
      * A subclass of {@link Office.Item} for messages.
@@ -2415,6 +2481,7 @@ export declare namespace Office {
          * **{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}**: Message Compose
          */
         conversationId: string;
+        
         /**
          * Gets the type of item that an instance represents.
          *
@@ -2430,6 +2497,8 @@ export declare namespace Office {
          * **{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}**: Message Compose
          */
         itemType: MailboxEnums.ItemType | string;
+        
+        
         /**
          * Gets or sets the description that appears in the subject field of an item.
          *
@@ -2528,6 +2597,8 @@ export declare namespace Office {
          *                 the error.
          */
         addFileAttachmentAsync(uri: string, attachmentName: string, callback?: (asyncResult: CommonAPI.AsyncResult<string>) => void): void;
+        
+        
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
@@ -2596,6 +2667,9 @@ export declare namespace Office {
          *                 the error.
          */
         addItemAttachmentAsync(itemId: any, attachmentName: string, callback?: (asyncResult: CommonAPI.AsyncResult<string>) => void): void;
+        
+        
+        
         /**
          * Asynchronously loads custom properties for this add-in on the selected item.
          *
@@ -2677,6 +2751,12 @@ export declare namespace Office {
          *                 If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
          */
         removeAttachmentAsync(attachmentId: string, callback?: (asyncResult: CommonAPI.AsyncResult<void>) => void): void;
+        
+        
+        
+        
+        
+        
     }
     /**
      * The message read mode of {@link Office.Item | Office.context.mailbox.item}.
@@ -2896,6 +2976,9 @@ export declare namespace Office {
          * **{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}**: Message Read
          */
         normalizedSubject: string;
+        
+        
+        
         /**
          * Gets the email address of the sender of an email message.
          *
@@ -2946,6 +3029,8 @@ export declare namespace Office {
          */
         to: EmailAddressDetails[];
 
+        
+        
         /**
          * Displays a reply form that includes the sender and all recipients of the selected message or the organizer and all attendees of the 
          * selected appointment.
@@ -3160,6 +3245,8 @@ export declare namespace Office {
          * @param name - The name of the ItemHasRegularExpressionMatch rule element that defines the filter to match.
          */
         getRegExMatchesByName(name: string): string[];
+        
+        
         /**
          * Asynchronously loads custom properties for this add-in on the selected item.
          *
@@ -3185,6 +3272,8 @@ export declare namespace Office {
          *                    This object can be accessed by the asyncResult.asyncContext property in the callback function.
          */
         loadCustomPropertiesAsync(callback: (asyncResult: CommonAPI.AsyncResult<CustomProperties>) => void, userContext?: any): void;
+        
+        
     }
 
     /**
@@ -3409,12 +3498,15 @@ export declare namespace Office {
          * `ItemCompose`, `ItemRead`, `MessageCompose`, `MessageRead`, `AppointmentCompose`, `AppointmentRead`
          */
         item: Item & ItemCompose & ItemRead & MessageRead & MessageCompose & AppointmentRead & AppointmentCompose;
+        
         /**
          * Information about the user associated with the mailbox. This includes their account type, display name, email address, and time zone.
          * 
          * More information is under {@link Office.UserProfile}
          */
         userProfile: UserProfile;
+        
+        
         
         /**
          * Gets a dictionary containing time information in local client time.
@@ -3440,6 +3532,7 @@ export declare namespace Office {
          * @param timeValue - A Date object.
          */
         convertToLocalClientTime(timeValue: Date): LocalClientTime;
+        
         /**
          * Gets a Date object from a dictionary containing time information.
          *
@@ -3541,6 +3634,8 @@ export declare namespace Office {
          * @param parameters - An AppointmentForm describing the new appointment. All properties are optional.
          */
         displayNewAppointmentForm(parameters: AppointmentForm): void;
+        
+        
         /**
          * Gets a string that contains a token used to get an attachment or item from an Exchange Server.
          *
@@ -3664,6 +3759,8 @@ export declare namespace Office {
          * @param userContext - Optional. Any state data that is passed to the asynchronous method.
          */
         makeEwsRequestAsync(data: any, callback: (asyncResult: CommonAPI.AsyncResult<string>) => void, userContext?: any): void;
+        
+        
     }
 
     /**
@@ -3710,6 +3807,8 @@ export declare namespace Office {
          */
         subject: string;
     }
+    
+    
     /**
      * Represents a phone number identified in an item. Read mode only.
      *
@@ -3912,6 +4011,12 @@ export declare namespace Office {
         setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (asyncResult: CommonAPI.AsyncResult<void>) => void): void;
     }
 
+    
+
+    
+
+    
+
     /**
      * A file or item attachment. Used when displaying a reply form.
      */
@@ -4056,6 +4161,8 @@ export declare namespace Office {
         set(name: string, value: any): void;
     }
 
+    
+
     /**
      * Provides methods to get and set the subject of an appointment or message in an Outlook add-in.
      *
@@ -4153,6 +4260,7 @@ export declare namespace Office {
          *                 type Office.AsyncResult. If setting the subject fails, the asyncResult.error property will contain an error code.
          */
         setAsync(data: string, callback?: (asyncResult: CommonAPI.AsyncResult<void>) => void): void;
+
     }
     /**
      * Represents a suggested task identified in an item. Read mode only.
@@ -4282,6 +4390,7 @@ export declare namespace Office {
          *                 If setting the date and time fails, the asyncResult.error property will contain an error code.
          */
         setAsync(dateTime: Date, callback?: (asyncResult: CommonAPI.AsyncResult<void>) => void): void;
+
     }
     /**
      * Information about the user associated with the mailbox. This includes their account type, display name, email address, and time zone.
@@ -4295,6 +4404,7 @@ export declare namespace Office {
      * **{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}**: Compose or Read
      */
     export interface UserProfile {
+        
         /**
          * Gets the user's display name.
          *

--- a/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_2/Outlook.d.ts
+++ b/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_2/Outlook.d.ts
@@ -28,6 +28,7 @@ export declare namespace Office {
              */
             Cloud = "cloud"
         }
+        
         /**
          * Specifies an entity's type.
          *
@@ -67,6 +68,7 @@ export declare namespace Office {
              */
             Contact = "contact"
         }
+        
         /**
          * Specifies an item's type.
          *
@@ -86,6 +88,7 @@ export declare namespace Office {
              */
             Appointment = "appointment"
         }
+        
         /**
          * Represents the current view of Outlook on the web.
          */
@@ -131,6 +134,9 @@ export declare namespace Office {
              */
             Other = "other"
         }
+        
+
+        
         /**  
          * Specifies the type of response to a meeting invitation.
          *
@@ -162,6 +168,8 @@ export declare namespace Office {
              */
             Declined = "declined"
         }
+        
+        
     }
     export interface CoercionTypeOptions {
         coercionType?: CommonAPI.CoercionType | string;
@@ -399,6 +407,8 @@ export declare namespace Office {
      * **{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}**: Compose or Read
      */
     export interface Body {
+        
+        
         /**
          * Gets a value that indicates whether the content is in HTML or text format.
          *
@@ -486,6 +496,9 @@ export declare namespace Office {
          *                  Any errors encountered will be provided in the asyncResult.error property.
          */
         prependAsync(data: string, callback?: (asyncResult: CommonAPI.AsyncResult<void>) => void): void;
+        
+        
+
         /**
          * Replaces the selection in the body with the specified text.
          *
@@ -864,6 +877,11 @@ export declare namespace Office {
          */
         urls: string[];
     }
+
+    
+
+    
+
     /**
      * The subclass of {@link Office.Item} dealing with appointments.
      * 
@@ -938,6 +956,7 @@ export declare namespace Office {
          * **{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}**: Appointment Organizer
          */
         location: Location;
+        
         /**
          * Provides access to the optional attendees of an event. The type of object and level of access depends on the mode of the current item. 
          * The optionalAttendees property returns an {@link Office.Recipients} object that provides methods to get or update the optional attendees 
@@ -952,6 +971,8 @@ export declare namespace Office {
          * **{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}**: Appointment Organizer
          */
         optionalAttendees: Recipients;
+        
+        
         /**
          * Provides access to the required attendees of an event. The type of object and level of access depends on the mode of the current item. 
          * The requiredAttendees property returns an {@link Office.Recipients} object that provides methods to get or update the required attendees 
@@ -966,6 +987,7 @@ export declare namespace Office {
          * **{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}**: Appointment Organizer
          */
         requiredAttendees: Recipients;
+        
         /**
          * Gets or sets the date and time that the appointment is to begin.
          *
@@ -1063,6 +1085,8 @@ export declare namespace Office {
          *                 If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
          */
         addFileAttachmentAsync(uri: string, attachmentName: string, callback?: (asyncResult: CommonAPI.AsyncResult<string>) => void): void;
+        
+        
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
@@ -1129,6 +1153,7 @@ export declare namespace Office {
          *                 If adding the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
          */
         addItemAttachmentAsync(itemId: any, attachmentName: string, callback?: (asyncResult: CommonAPI.AsyncResult<string>) => void): void;
+        
         /**
          * Asynchronously returns selected data from the subject or body of a message.
          *
@@ -1263,6 +1288,10 @@ export declare namespace Office {
          *                 If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
          */
         removeAttachmentAsync(attachmentId: string, callback?: (asyncResult: CommonAPI.AsyncResult<void>) => void): void;
+       
+       
+        
+        
         /**
          * Asynchronously inserts data into the body or subject of a message.
          *
@@ -1504,6 +1533,7 @@ export declare namespace Office {
          * **{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}**: Appointment Attendee
          */
         normalizedSubject: string;
+        
         /**
          * Provides access to the optional attendees of an event. The type of object and level of access depends on the mode of the current item.
          *
@@ -1531,6 +1561,7 @@ export declare namespace Office {
          * **{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}**: Appointment Attendee
          */
         organizer: EmailAddressDetails;
+        
         /**
          * Provides access to the required attendees of an event. The type of object and level of access depends on the mode of the current item.
          *
@@ -1561,6 +1592,7 @@ export declare namespace Office {
          * **{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}**: Appointment Attendee
          */
         start: Date;
+        
         /**
          * Gets the description that appears in the subject field of an item.
          *
@@ -1578,6 +1610,8 @@ export declare namespace Office {
          */
         subject: string;
 
+        
+        
         /**
          * Displays a reply form that includes the sender and all recipients of the selected message or the organizer and all attendees of the 
          * selected appointment.
@@ -1791,6 +1825,8 @@ export declare namespace Office {
          * @param name - The name of the ItemHasRegularExpressionMatch rule element that defines the filter to match.
          */
         getRegExMatchesByName(name: string): string[];
+        
+        
        /**
         * Asynchronously loads custom properties for this add-in on the selected item.
         *
@@ -1816,6 +1852,9 @@ export declare namespace Office {
         *                    This object can be accessed by the asyncResult.asyncContext property in the callback function.
         */
        loadCustomPropertiesAsync(callback: (asyncResult: CommonAPI.AsyncResult<CustomProperties>) => void, userContext?: any): void;
+
+       
+        
     }
 
     /**
@@ -1859,6 +1898,13 @@ export declare namespace Office {
          */
         itemType: MailboxEnums.ItemType | string;
         
+
+        
+
+        
+
+        
+
        /**
         * Asynchronously loads custom properties for this add-in on the selected item.
         *
@@ -1884,6 +1930,11 @@ export declare namespace Office {
         *                    This object can be accessed by the asyncResult.asyncContext property in the callback function.
         */
        loadCustomPropertiesAsync(callback: (asyncResult: CommonAPI.AsyncResult<CustomProperties>) => void, userContext?: any): void;
+
+
+       
+
+       
     }
     /**
      * The compose mode of {@link Office.Item | Office.context.mailbox.item}.
@@ -2045,6 +2096,8 @@ export declare namespace Office {
          *                 the error.
          */
         addItemAttachmentAsync(itemId: any, attachmentName: string, callback?: (asyncResult: CommonAPI.AsyncResult<string>) => void): void;
+
+        
         /**
          * Asynchronously returns selected data from the subject or body of a message.
          *
@@ -2155,6 +2208,9 @@ export declare namespace Office {
          *                 If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
          */
         removeAttachmentAsync(attachmentId: string, callback?: (asyncResult: CommonAPI.AsyncResult<void>) => void): void;
+
+        
+        
         /**
          * Asynchronously inserts data into the body or subject of a message.
          *
@@ -2543,6 +2599,8 @@ export declare namespace Office {
          * @param name - The name of the ItemHasRegularExpressionMatch rule element that defines the filter to match.
          */
         getRegExMatchesByName(name: string): string[];
+        
+        
     }
     /**
      * A subclass of {@link Office.Item} for messages.
@@ -2640,6 +2698,7 @@ export declare namespace Office {
          * **{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}**: Message Compose
          */
         conversationId: string;
+        
         /**
          * Gets the type of item that an instance represents.
          *
@@ -2655,6 +2714,7 @@ export declare namespace Office {
          * **{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}**: Message Compose
          */
         itemType: MailboxEnums.ItemType | string;
+        
         
         /**
          * Gets or sets the description that appears in the subject field of an item.
@@ -2754,6 +2814,8 @@ export declare namespace Office {
          *                 the error.
          */
         addFileAttachmentAsync(uri: string, attachmentName: string, callback?: (asyncResult: CommonAPI.AsyncResult<string>) => void): void;
+        
+        
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
@@ -2958,6 +3020,8 @@ export declare namespace Office {
          *                 If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
          */
         removeAttachmentAsync(attachmentId: string, callback?: (asyncResult: CommonAPI.AsyncResult<void>) => void): void;
+        
+        
         
         
         /**
@@ -3238,6 +3302,8 @@ export declare namespace Office {
          */
         normalizedSubject: string;
         
+        
+        
         /**
          * Gets the email address of the sender of an email message.
          *
@@ -3288,6 +3354,8 @@ export declare namespace Office {
          */
         to: EmailAddressDetails[];
 
+        
+        
         /**
          * Displays a reply form that includes the sender and all recipients of the selected message or the organizer and all attendees of the 
          * selected appointment.
@@ -3502,6 +3570,8 @@ export declare namespace Office {
          * @param name - The name of the ItemHasRegularExpressionMatch rule element that defines the filter to match.
          */
         getRegExMatchesByName(name: string): string[];
+        
+        
         /**
          * Asynchronously loads custom properties for this add-in on the selected item.
          *
@@ -3527,6 +3597,8 @@ export declare namespace Office {
          *                    This object can be accessed by the asyncResult.asyncContext property in the callback function.
          */
         loadCustomPropertiesAsync(callback: (asyncResult: CommonAPI.AsyncResult<CustomProperties>) => void, userContext?: any): void;
+        
+        
     }
 
     /**
@@ -3751,12 +3823,15 @@ export declare namespace Office {
          * `ItemCompose`, `ItemRead`, `MessageCompose`, `MessageRead`, `AppointmentCompose`, `AppointmentRead`
          */
         item: Item & ItemCompose & ItemRead & MessageRead & MessageCompose & AppointmentRead & AppointmentCompose;
+        
         /**
          * Information about the user associated with the mailbox. This includes their account type, display name, email address, and time zone.
          * 
          * More information is under {@link Office.UserProfile}
          */
         userProfile: UserProfile;
+        
+        
         
         /**
          * Gets a dictionary containing time information in local client time.
@@ -3782,6 +3857,7 @@ export declare namespace Office {
          * @param timeValue - A Date object.
          */
         convertToLocalClientTime(timeValue: Date): LocalClientTime;
+        
         /**
          * Gets a Date object from a dictionary containing time information.
          *
@@ -3883,6 +3959,8 @@ export declare namespace Office {
          * @param parameters - An AppointmentForm describing the new appointment. All properties are optional.
          */
         displayNewAppointmentForm(parameters: AppointmentForm): void;
+        
+        
         /**
          * Gets a string that contains a token used to get an attachment or item from an Exchange Server.
          *
@@ -4006,6 +4084,8 @@ export declare namespace Office {
          * @param userContext - Optional. Any state data that is passed to the asynchronous method.
          */
         makeEwsRequestAsync(data: any, callback: (asyncResult: CommonAPI.AsyncResult<string>) => void, userContext?: any): void;
+        
+        
     }
 
     /**
@@ -4052,6 +4132,8 @@ export declare namespace Office {
          */
         subject: string;
     }
+    
+    
     /**
      * Represents a phone number identified in an item. Read mode only.
      *
@@ -4254,6 +4336,12 @@ export declare namespace Office {
         setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (asyncResult: CommonAPI.AsyncResult<void>) => void): void;
     }
 
+    
+
+    
+
+    
+
     /**
      * A file or item attachment. Used when displaying a reply form.
      */
@@ -4398,6 +4486,8 @@ export declare namespace Office {
         set(name: string, value: any): void;
     }
 
+    
+
     /**
      * Provides methods to get and set the subject of an appointment or message in an Outlook add-in.
      *
@@ -4495,6 +4585,7 @@ export declare namespace Office {
          *                 type Office.AsyncResult. If setting the subject fails, the asyncResult.error property will contain an error code.
          */
         setAsync(data: string, callback?: (asyncResult: CommonAPI.AsyncResult<void>) => void): void;
+
     }
     /**
      * Represents a suggested task identified in an item. Read mode only.
@@ -4624,6 +4715,7 @@ export declare namespace Office {
          *                 If setting the date and time fails, the asyncResult.error property will contain an error code.
          */
         setAsync(dateTime: Date, callback?: (asyncResult: CommonAPI.AsyncResult<void>) => void): void;
+
     }
     /**
      * Information about the user associated with the mailbox. This includes their account type, display name, email address, and time zone.
@@ -4637,6 +4729,7 @@ export declare namespace Office {
      * **{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}**: Compose or Read
      */
     export interface UserProfile {
+        
         /**
          * Gets the user's display name.
          *

--- a/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_3/Outlook.d.ts
+++ b/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_3/Outlook.d.ts
@@ -28,6 +28,7 @@ export declare namespace Office {
              */
             Cloud = "cloud"
         }
+        
         /**
          * Specifies an entity's type.
          *
@@ -109,6 +110,7 @@ export declare namespace Office {
              */
             Appointment = "appointment"
         }
+        
         /**
          * Represents the current view of Outlook on the web.
          */
@@ -154,6 +156,9 @@ export declare namespace Office {
              */
             Other = "other"
         }
+        
+
+        
         /**  
          * Specifies the type of response to a meeting invitation.
          *
@@ -208,6 +213,7 @@ export declare namespace Office {
              */
             Beta = "beta"
         }
+        
     }
     export interface CoercionTypeOptions {
         coercionType?: CommonAPI.CoercionType | string;
@@ -1018,6 +1024,11 @@ export declare namespace Office {
          */
         urls: string[];
     }
+
+    
+
+    
+
     /**
      * The subclass of {@link Office.Item} dealing with appointments.
      * 
@@ -1118,6 +1129,8 @@ export declare namespace Office {
          * **{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}**: Appointment Organizer
          */
         optionalAttendees: Recipients;
+        
+        
         /**
          * Provides access to the required attendees of an event. The type of object and level of access depends on the mode of the current item. 
          * The requiredAttendees property returns an {@link Office.Recipients} object that provides methods to get or update the required attendees 
@@ -1132,6 +1145,7 @@ export declare namespace Office {
          * **{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}**: Appointment Organizer
          */
         requiredAttendees: Recipients;
+        
         /**
          * Gets or sets the date and time that the appointment is to begin.
          *
@@ -1229,6 +1243,8 @@ export declare namespace Office {
          *                 If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
          */
         addFileAttachmentAsync(uri: string, attachmentName: string, callback?: (asyncResult: CommonAPI.AsyncResult<string>) => void): void;
+        
+        
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
@@ -1449,6 +1465,8 @@ export declare namespace Office {
          *                 If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
          */
         removeAttachmentAsync(attachmentId: string, callback?: (asyncResult: CommonAPI.AsyncResult<void>) => void): void;
+       
+       
         /**
          * Asynchronously saves an item.
          *
@@ -1804,6 +1822,7 @@ export declare namespace Office {
          * **{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}**: Appointment Attendee
          */
         organizer: EmailAddressDetails;
+        
         /**
          * Provides access to the required attendees of an event. The type of object and level of access depends on the mode of the current item.
          *
@@ -1834,6 +1853,7 @@ export declare namespace Office {
          * **{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}**: Appointment Attendee
          */
         start: Date;
+        
         /**
          * Gets the description that appears in the subject field of an item.
          *
@@ -1851,6 +1871,8 @@ export declare namespace Office {
          */
         subject: string;
 
+        
+        
         /**
          * Displays a reply form that includes the sender and all recipients of the selected message or the organizer and all attendees of the 
          * selected appointment.
@@ -2064,6 +2086,8 @@ export declare namespace Office {
          * @param name - The name of the ItemHasRegularExpressionMatch rule element that defines the filter to match.
          */
         getRegExMatchesByName(name: string): string[];
+        
+        
        /**
         * Asynchronously loads custom properties for this add-in on the selected item.
         *
@@ -2089,6 +2113,9 @@ export declare namespace Office {
         *                    This object can be accessed by the asyncResult.asyncContext property in the callback function.
         */
        loadCustomPropertiesAsync(callback: (asyncResult: CommonAPI.AsyncResult<CustomProperties>) => void, userContext?: any): void;
+
+       
+        
     }
 
     /**
@@ -2144,6 +2171,12 @@ export declare namespace Office {
          */
         notificationMessages: NotificationMessages;
 
+        
+
+        
+
+        
+
        /**
         * Asynchronously loads custom properties for this add-in on the selected item.
         *
@@ -2169,6 +2202,11 @@ export declare namespace Office {
         *                    This object can be accessed by the asyncResult.asyncContext property in the callback function.
         */
        loadCustomPropertiesAsync(callback: (asyncResult: CommonAPI.AsyncResult<CustomProperties>) => void, userContext?: any): void;
+
+
+       
+
+       
     }
     /**
      * The compose mode of {@link Office.Item | Office.context.mailbox.item}.
@@ -2930,6 +2968,8 @@ export declare namespace Office {
          * @param name - The name of the ItemHasRegularExpressionMatch rule element that defines the filter to match.
          */
         getRegExMatchesByName(name: string): string[];
+        
+        
     }
     /**
      * A subclass of {@link Office.Item} for messages.
@@ -3027,6 +3067,7 @@ export declare namespace Office {
          * **{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}**: Message Compose
          */
         conversationId: string;
+        
         /**
          * Gets the type of item that an instance represents.
          *
@@ -3054,6 +3095,7 @@ export declare namespace Office {
          * **{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}**: Message Compose
          */
         notificationMessages: NotificationMessages;
+        
         /**
          * Gets or sets the description that appears in the subject field of an item.
          *
@@ -3152,6 +3194,8 @@ export declare namespace Office {
          *                 the error.
          */
         addFileAttachmentAsync(uri: string, attachmentName: string, callback?: (asyncResult: CommonAPI.AsyncResult<string>) => void): void;
+        
+        
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
@@ -3375,6 +3419,8 @@ export declare namespace Office {
          *                 If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
          */
         removeAttachmentAsync(attachmentId: string, callback?: (asyncResult: CommonAPI.AsyncResult<void>) => void): void;
+        
+        
         /**
          * Asynchronously saves an item.
          *
@@ -3742,6 +3788,8 @@ export declare namespace Office {
          * **{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}**: Message Read
          */
         notificationMessages: NotificationMessages;
+        
+        
         /**
          * Gets the email address of the sender of an email message.
          *
@@ -3792,6 +3840,8 @@ export declare namespace Office {
          */
         to: EmailAddressDetails[];
 
+        
+        
         /**
          * Displays a reply form that includes the sender and all recipients of the selected message or the organizer and all attendees of the 
          * selected appointment.
@@ -4006,6 +4056,8 @@ export declare namespace Office {
          * @param name - The name of the ItemHasRegularExpressionMatch rule element that defines the filter to match.
          */
         getRegExMatchesByName(name: string): string[];
+        
+        
         /**
          * Asynchronously loads custom properties for this add-in on the selected item.
          *
@@ -4031,6 +4083,8 @@ export declare namespace Office {
          *                    This object can be accessed by the asyncResult.asyncContext property in the callback function.
          */
         loadCustomPropertiesAsync(callback: (asyncResult: CommonAPI.AsyncResult<CustomProperties>) => void, userContext?: any): void;
+        
+        
     }
 
     /**
@@ -4255,12 +4309,14 @@ export declare namespace Office {
          * `ItemCompose`, `ItemRead`, `MessageCompose`, `MessageRead`, `AppointmentCompose`, `AppointmentRead`
          */
         item: Item & ItemCompose & ItemRead & MessageRead & MessageCompose & AppointmentRead & AppointmentCompose;
+        
         /**
          * Information about the user associated with the mailbox. This includes their account type, display name, email address, and time zone.
          * 
          * More information is under {@link Office.UserProfile}
          */
         userProfile: UserProfile;
+        
         
         /**
          * Converts an item ID formatted for REST into EWS format.
@@ -4428,6 +4484,8 @@ export declare namespace Office {
          * @param parameters - An AppointmentForm describing the new appointment. All properties are optional.
          */
         displayNewAppointmentForm(parameters: AppointmentForm): void;
+        
+        
         /**
          * Gets a string that contains a token used to get an attachment or item from an Exchange Server.
          *
@@ -5009,6 +5067,12 @@ export declare namespace Office {
         setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (asyncResult: CommonAPI.AsyncResult<void>) => void): void;
     }
 
+    
+
+    
+
+    
+
     /**
      * A file or item attachment. Used when displaying a reply form.
      */
@@ -5153,6 +5217,8 @@ export declare namespace Office {
         set(name: string, value: any): void;
     }
 
+    
+
     /**
      * Provides methods to get and set the subject of an appointment or message in an Outlook add-in.
      *
@@ -5250,6 +5316,7 @@ export declare namespace Office {
          *                 type Office.AsyncResult. If setting the subject fails, the asyncResult.error property will contain an error code.
          */
         setAsync(data: string, callback?: (asyncResult: CommonAPI.AsyncResult<void>) => void): void;
+
     }
     /**
      * Represents a suggested task identified in an item. Read mode only.
@@ -5379,6 +5446,7 @@ export declare namespace Office {
          *                 If setting the date and time fails, the asyncResult.error property will contain an error code.
          */
         setAsync(dateTime: Date, callback?: (asyncResult: CommonAPI.AsyncResult<void>) => void): void;
+
     }
     /**
      * Information about the user associated with the mailbox. This includes their account type, display name, email address, and time zone.
@@ -5392,6 +5460,7 @@ export declare namespace Office {
      * **{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}**: Compose or Read
      */
     export interface UserProfile {
+        
         /**
          * Gets the user's display name.
          *

--- a/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_4/Outlook.d.ts
+++ b/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_4/Outlook.d.ts
@@ -28,6 +28,7 @@ export declare namespace Office {
              */
             Cloud = "cloud"
         }
+        
         /**
          * Specifies an entity's type.
          *
@@ -109,6 +110,7 @@ export declare namespace Office {
              */
             Appointment = "appointment"
         }
+        
         /**
          * Represents the current view of Outlook on the web.
          */
@@ -154,6 +156,9 @@ export declare namespace Office {
              */
             Other = "other"
         }
+        
+
+        
         /**  
          * Specifies the type of response to a meeting invitation.
          *
@@ -208,6 +213,7 @@ export declare namespace Office {
              */
             Beta = "beta"
         }
+        
     }
     export interface CoercionTypeOptions {
         coercionType?: CommonAPI.CoercionType | string;
@@ -1018,6 +1024,11 @@ export declare namespace Office {
          */
         urls: string[];
     }
+
+    
+
+    
+
     /**
      * The subclass of {@link Office.Item} dealing with appointments.
      * 
@@ -1118,6 +1129,8 @@ export declare namespace Office {
          * **{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}**: Appointment Organizer
          */
         optionalAttendees: Recipients;
+        
+        
         /**
          * Provides access to the required attendees of an event. The type of object and level of access depends on the mode of the current item. 
          * The requiredAttendees property returns an {@link Office.Recipients} object that provides methods to get or update the required attendees 
@@ -1132,6 +1145,7 @@ export declare namespace Office {
          * **{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}**: Appointment Organizer
          */
         requiredAttendees: Recipients;
+        
         /**
          * Gets or sets the date and time that the appointment is to begin.
          *
@@ -1229,6 +1243,8 @@ export declare namespace Office {
          *                 If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
          */
         addFileAttachmentAsync(uri: string, attachmentName: string, callback?: (asyncResult: CommonAPI.AsyncResult<string>) => void): void;
+        
+        
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
@@ -1449,6 +1465,8 @@ export declare namespace Office {
          *                 If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
          */
         removeAttachmentAsync(attachmentId: string, callback?: (asyncResult: CommonAPI.AsyncResult<void>) => void): void;
+       
+       
         /**
          * Asynchronously saves an item.
          *
@@ -1804,6 +1822,7 @@ export declare namespace Office {
          * **{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}**: Appointment Attendee
          */
         organizer: EmailAddressDetails;
+        
         /**
          * Provides access to the required attendees of an event. The type of object and level of access depends on the mode of the current item.
          *
@@ -1834,6 +1853,7 @@ export declare namespace Office {
          * **{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}**: Appointment Attendee
          */
         start: Date;
+        
         /**
          * Gets the description that appears in the subject field of an item.
          *
@@ -1851,6 +1871,8 @@ export declare namespace Office {
          */
         subject: string;
 
+        
+        
         /**
          * Displays a reply form that includes the sender and all recipients of the selected message or the organizer and all attendees of the 
          * selected appointment.
@@ -2064,6 +2086,8 @@ export declare namespace Office {
          * @param name - The name of the ItemHasRegularExpressionMatch rule element that defines the filter to match.
          */
         getRegExMatchesByName(name: string): string[];
+        
+        
        /**
         * Asynchronously loads custom properties for this add-in on the selected item.
         *
@@ -2089,6 +2113,9 @@ export declare namespace Office {
         *                    This object can be accessed by the asyncResult.asyncContext property in the callback function.
         */
        loadCustomPropertiesAsync(callback: (asyncResult: CommonAPI.AsyncResult<CustomProperties>) => void, userContext?: any): void;
+
+       
+        
     }
 
     /**
@@ -2144,6 +2171,12 @@ export declare namespace Office {
          */
         notificationMessages: NotificationMessages;
 
+        
+
+        
+
+        
+
        /**
         * Asynchronously loads custom properties for this add-in on the selected item.
         *
@@ -2169,6 +2202,11 @@ export declare namespace Office {
         *                    This object can be accessed by the asyncResult.asyncContext property in the callback function.
         */
        loadCustomPropertiesAsync(callback: (asyncResult: CommonAPI.AsyncResult<CustomProperties>) => void, userContext?: any): void;
+
+
+       
+
+       
     }
     /**
      * The compose mode of {@link Office.Item | Office.context.mailbox.item}.
@@ -2930,6 +2968,8 @@ export declare namespace Office {
          * @param name - The name of the ItemHasRegularExpressionMatch rule element that defines the filter to match.
          */
         getRegExMatchesByName(name: string): string[];
+        
+        
     }
     /**
      * A subclass of {@link Office.Item} for messages.
@@ -3027,6 +3067,7 @@ export declare namespace Office {
          * **{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}**: Message Compose
          */
         conversationId: string;
+        
         /**
          * Gets the type of item that an instance represents.
          *
@@ -3054,6 +3095,7 @@ export declare namespace Office {
          * **{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}**: Message Compose
          */
         notificationMessages: NotificationMessages;
+        
         /**
          * Gets or sets the description that appears in the subject field of an item.
          *
@@ -3152,6 +3194,8 @@ export declare namespace Office {
          *                 the error.
          */
         addFileAttachmentAsync(uri: string, attachmentName: string, callback?: (asyncResult: CommonAPI.AsyncResult<string>) => void): void;
+        
+        
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
@@ -3375,6 +3419,8 @@ export declare namespace Office {
          *                 If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
          */
         removeAttachmentAsync(attachmentId: string, callback?: (asyncResult: CommonAPI.AsyncResult<void>) => void): void;
+        
+        
         /**
          * Asynchronously saves an item.
          *
@@ -3742,6 +3788,8 @@ export declare namespace Office {
          * **{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}**: Message Read
          */
         notificationMessages: NotificationMessages;
+        
+        
         /**
          * Gets the email address of the sender of an email message.
          *
@@ -3792,6 +3840,8 @@ export declare namespace Office {
          */
         to: EmailAddressDetails[];
 
+        
+        
         /**
          * Displays a reply form that includes the sender and all recipients of the selected message or the organizer and all attendees of the 
          * selected appointment.
@@ -4006,6 +4056,8 @@ export declare namespace Office {
          * @param name - The name of the ItemHasRegularExpressionMatch rule element that defines the filter to match.
          */
         getRegExMatchesByName(name: string): string[];
+        
+        
         /**
          * Asynchronously loads custom properties for this add-in on the selected item.
          *
@@ -4031,6 +4083,8 @@ export declare namespace Office {
          *                    This object can be accessed by the asyncResult.asyncContext property in the callback function.
          */
         loadCustomPropertiesAsync(callback: (asyncResult: CommonAPI.AsyncResult<CustomProperties>) => void, userContext?: any): void;
+        
+        
     }
 
     /**
@@ -4255,12 +4309,14 @@ export declare namespace Office {
          * `ItemCompose`, `ItemRead`, `MessageCompose`, `MessageRead`, `AppointmentCompose`, `AppointmentRead`
          */
         item: Item & ItemCompose & ItemRead & MessageRead & MessageCompose & AppointmentRead & AppointmentCompose;
+        
         /**
          * Information about the user associated with the mailbox. This includes their account type, display name, email address, and time zone.
          * 
          * More information is under {@link Office.UserProfile}
          */
         userProfile: UserProfile;
+        
         
         /**
          * Converts an item ID formatted for REST into EWS format.
@@ -4428,6 +4484,8 @@ export declare namespace Office {
          * @param parameters - An AppointmentForm describing the new appointment. All properties are optional.
          */
         displayNewAppointmentForm(parameters: AppointmentForm): void;
+        
+        
         /**
          * Gets a string that contains a token used to get an attachment or item from an Exchange Server.
          *
@@ -5009,6 +5067,12 @@ export declare namespace Office {
         setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (asyncResult: CommonAPI.AsyncResult<void>) => void): void;
     }
 
+    
+
+    
+
+    
+
     /**
      * A file or item attachment. Used when displaying a reply form.
      */
@@ -5153,6 +5217,8 @@ export declare namespace Office {
         set(name: string, value: any): void;
     }
 
+    
+
     /**
      * Provides methods to get and set the subject of an appointment or message in an Outlook add-in.
      *
@@ -5250,6 +5316,7 @@ export declare namespace Office {
          *                 type Office.AsyncResult. If setting the subject fails, the asyncResult.error property will contain an error code.
          */
         setAsync(data: string, callback?: (asyncResult: CommonAPI.AsyncResult<void>) => void): void;
+
     }
     /**
      * Represents a suggested task identified in an item. Read mode only.
@@ -5379,6 +5446,7 @@ export declare namespace Office {
          *                 If setting the date and time fails, the asyncResult.error property will contain an error code.
          */
         setAsync(dateTime: Date, callback?: (asyncResult: CommonAPI.AsyncResult<void>) => void): void;
+
     }
     /**
      * Information about the user associated with the mailbox. This includes their account type, display name, email address, and time zone.
@@ -5392,6 +5460,7 @@ export declare namespace Office {
      * **{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}**: Compose or Read
      */
     export interface UserProfile {
+        
         /**
          * Gets the user's display name.
          *

--- a/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_5/Outlook.d.ts
+++ b/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_5/Outlook.d.ts
@@ -28,6 +28,7 @@ export declare namespace Office {
              */
             Cloud = "cloud"
         }
+        
         /**
          * Specifies an entity's type.
          *
@@ -109,6 +110,7 @@ export declare namespace Office {
              */
             Appointment = "appointment"
         }
+        
         /**
          * Represents the current view of Outlook on the web.
          */
@@ -154,6 +156,9 @@ export declare namespace Office {
              */
             Other = "other"
         }
+        
+
+        
         /**  
          * Specifies the type of response to a meeting invitation.
          *
@@ -208,6 +213,7 @@ export declare namespace Office {
              */
             Beta = "beta"
         }
+        
     }
     export interface CoercionTypeOptions {
         coercionType?: CommonAPI.CoercionType | string;
@@ -1018,6 +1024,11 @@ export declare namespace Office {
          */
         urls: string[];
     }
+
+    
+
+    
+
     /**
      * The subclass of {@link Office.Item} dealing with appointments.
      * 
@@ -1118,6 +1129,8 @@ export declare namespace Office {
          * **{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}**: Appointment Organizer
          */
         optionalAttendees: Recipients;
+        
+        
         /**
          * Provides access to the required attendees of an event. The type of object and level of access depends on the mode of the current item. 
          * The requiredAttendees property returns an {@link Office.Recipients} object that provides methods to get or update the required attendees 
@@ -1132,6 +1145,7 @@ export declare namespace Office {
          * **{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}**: Appointment Organizer
          */
         requiredAttendees: Recipients;
+        
         /**
          * Gets or sets the date and time that the appointment is to begin.
          *
@@ -1229,6 +1243,8 @@ export declare namespace Office {
          *                 If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
          */
         addFileAttachmentAsync(uri: string, attachmentName: string, callback?: (asyncResult: CommonAPI.AsyncResult<string>) => void): void;
+        
+        
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
@@ -1449,6 +1465,8 @@ export declare namespace Office {
          *                 If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
          */
         removeAttachmentAsync(attachmentId: string, callback?: (asyncResult: CommonAPI.AsyncResult<void>) => void): void;
+       
+       
         /**
          * Asynchronously saves an item.
          *
@@ -1804,6 +1822,7 @@ export declare namespace Office {
          * **{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}**: Appointment Attendee
          */
         organizer: EmailAddressDetails;
+        
         /**
          * Provides access to the required attendees of an event. The type of object and level of access depends on the mode of the current item.
          *
@@ -1834,6 +1853,7 @@ export declare namespace Office {
          * **{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}**: Appointment Attendee
          */
         start: Date;
+        
         /**
          * Gets the description that appears in the subject field of an item.
          *
@@ -1851,6 +1871,8 @@ export declare namespace Office {
          */
         subject: string;
 
+        
+        
         /**
          * Displays a reply form that includes the sender and all recipients of the selected message or the organizer and all attendees of the 
          * selected appointment.
@@ -2064,6 +2086,8 @@ export declare namespace Office {
          * @param name - The name of the ItemHasRegularExpressionMatch rule element that defines the filter to match.
          */
         getRegExMatchesByName(name: string): string[];
+        
+        
        /**
         * Asynchronously loads custom properties for this add-in on the selected item.
         *
@@ -2089,6 +2113,9 @@ export declare namespace Office {
         *                    This object can be accessed by the asyncResult.asyncContext property in the callback function.
         */
        loadCustomPropertiesAsync(callback: (asyncResult: CommonAPI.AsyncResult<CustomProperties>) => void, userContext?: any): void;
+
+       
+        
     }
 
     /**
@@ -2144,6 +2171,12 @@ export declare namespace Office {
          */
         notificationMessages: NotificationMessages;
 
+        
+
+        
+
+        
+
        /**
         * Asynchronously loads custom properties for this add-in on the selected item.
         *
@@ -2169,6 +2202,11 @@ export declare namespace Office {
         *                    This object can be accessed by the asyncResult.asyncContext property in the callback function.
         */
        loadCustomPropertiesAsync(callback: (asyncResult: CommonAPI.AsyncResult<CustomProperties>) => void, userContext?: any): void;
+
+
+       
+
+       
     }
     /**
      * The compose mode of {@link Office.Item | Office.context.mailbox.item}.
@@ -2930,6 +2968,8 @@ export declare namespace Office {
          * @param name - The name of the ItemHasRegularExpressionMatch rule element that defines the filter to match.
          */
         getRegExMatchesByName(name: string): string[];
+        
+        
     }
     /**
      * A subclass of {@link Office.Item} for messages.
@@ -3027,6 +3067,7 @@ export declare namespace Office {
          * **{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}**: Message Compose
          */
         conversationId: string;
+        
         /**
          * Gets the type of item that an instance represents.
          *
@@ -3054,6 +3095,7 @@ export declare namespace Office {
          * **{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}**: Message Compose
          */
         notificationMessages: NotificationMessages;
+        
         /**
          * Gets or sets the description that appears in the subject field of an item.
          *
@@ -3152,6 +3194,8 @@ export declare namespace Office {
          *                 the error.
          */
         addFileAttachmentAsync(uri: string, attachmentName: string, callback?: (asyncResult: CommonAPI.AsyncResult<string>) => void): void;
+        
+        
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
@@ -3375,6 +3419,8 @@ export declare namespace Office {
          *                 If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
          */
         removeAttachmentAsync(attachmentId: string, callback?: (asyncResult: CommonAPI.AsyncResult<void>) => void): void;
+        
+        
         /**
          * Asynchronously saves an item.
          *
@@ -3742,6 +3788,8 @@ export declare namespace Office {
          * **{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}**: Message Read
          */
         notificationMessages: NotificationMessages;
+        
+        
         /**
          * Gets the email address of the sender of an email message.
          *
@@ -3792,6 +3840,8 @@ export declare namespace Office {
          */
         to: EmailAddressDetails[];
 
+        
+        
         /**
          * Displays a reply form that includes the sender and all recipients of the selected message or the organizer and all attendees of the 
          * selected appointment.
@@ -4006,6 +4056,8 @@ export declare namespace Office {
          * @param name - The name of the ItemHasRegularExpressionMatch rule element that defines the filter to match.
          */
         getRegExMatchesByName(name: string): string[];
+        
+        
         /**
          * Asynchronously loads custom properties for this add-in on the selected item.
          *
@@ -4031,6 +4083,8 @@ export declare namespace Office {
          *                    This object can be accessed by the asyncResult.asyncContext property in the callback function.
          */
         loadCustomPropertiesAsync(callback: (asyncResult: CommonAPI.AsyncResult<CustomProperties>) => void, userContext?: any): void;
+        
+        
     }
 
     /**
@@ -4487,6 +4541,7 @@ export declare namespace Office {
          * @param parameters - An AppointmentForm describing the new appointment. All properties are optional.
          */
         displayNewAppointmentForm(parameters: AppointmentForm): void;
+        
         /**
          * Gets a string that contains a token used to call REST APIs or Exchange Web Services.
          *
@@ -5154,6 +5209,12 @@ export declare namespace Office {
         setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (asyncResult: CommonAPI.AsyncResult<void>) => void): void;
     }
 
+    
+
+    
+
+    
+
     /**
      * A file or item attachment. Used when displaying a reply form.
      */
@@ -5298,6 +5359,8 @@ export declare namespace Office {
         set(name: string, value: any): void;
     }
 
+    
+
     /**
      * Provides methods to get and set the subject of an appointment or message in an Outlook add-in.
      *
@@ -5395,6 +5458,7 @@ export declare namespace Office {
          *                 type Office.AsyncResult. If setting the subject fails, the asyncResult.error property will contain an error code.
          */
         setAsync(data: string, callback?: (asyncResult: CommonAPI.AsyncResult<void>) => void): void;
+
     }
     /**
      * Represents a suggested task identified in an item. Read mode only.
@@ -5524,6 +5588,7 @@ export declare namespace Office {
          *                 If setting the date and time fails, the asyncResult.error property will contain an error code.
          */
         setAsync(dateTime: Date, callback?: (asyncResult: CommonAPI.AsyncResult<void>) => void): void;
+
     }
     /**
      * Information about the user associated with the mailbox. This includes their account type, display name, email address, and time zone.
@@ -5537,6 +5602,7 @@ export declare namespace Office {
      * **{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}**: Compose or Read
      */
     export interface UserProfile {
+        
         /**
          * Gets the user's display name.
          *

--- a/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_6/Outlook.d.ts
+++ b/generate-docs/api-extractor-inputs-outlook-release/Outlook_1_6/Outlook.d.ts
@@ -28,6 +28,7 @@ export declare namespace Office {
              */
             Cloud = "cloud"
         }
+        
         /**
          * Specifies an entity's type.
          *
@@ -109,6 +110,7 @@ export declare namespace Office {
              */
             Appointment = "appointment"
         }
+        
         /**
          * Represents the current view of Outlook on the web.
          */
@@ -154,6 +156,9 @@ export declare namespace Office {
              */
             Other = "other"
         }
+        
+
+        
         /**  
          * Specifies the type of response to a meeting invitation.
          *
@@ -208,6 +213,7 @@ export declare namespace Office {
              */
             Beta = "beta"
         }
+        
     }
     export interface CoercionTypeOptions {
         coercionType?: CommonAPI.CoercionType | string;
@@ -1018,6 +1024,11 @@ export declare namespace Office {
          */
         urls: string[];
     }
+
+    
+
+    
+
     /**
      * The subclass of {@link Office.Item} dealing with appointments.
      * 
@@ -1118,6 +1129,8 @@ export declare namespace Office {
          * **{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}**: Appointment Organizer
          */
         optionalAttendees: Recipients;
+        
+        
         /**
          * Provides access to the required attendees of an event. The type of object and level of access depends on the mode of the current item. 
          * The requiredAttendees property returns an {@link Office.Recipients} object that provides methods to get or update the required attendees 
@@ -1132,6 +1145,7 @@ export declare namespace Office {
          * **{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}**: Appointment Organizer
          */
         requiredAttendees: Recipients;
+        
         /**
          * Gets or sets the date and time that the appointment is to begin.
          *
@@ -1229,6 +1243,8 @@ export declare namespace Office {
          *                 If uploading the attachment fails, the asyncResult object will contain an Error object that provides a description of the error.
          */
         addFileAttachmentAsync(uri: string, attachmentName: string, callback?: (asyncResult: CommonAPI.AsyncResult<string>) => void): void;
+        
+        
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
@@ -1449,6 +1465,8 @@ export declare namespace Office {
          *                 If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
          */
         removeAttachmentAsync(attachmentId: string, callback?: (asyncResult: CommonAPI.AsyncResult<void>) => void): void;
+       
+       
         /**
          * Asynchronously saves an item.
          *
@@ -1804,6 +1822,7 @@ export declare namespace Office {
          * **{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}**: Appointment Attendee
          */
         organizer: EmailAddressDetails;
+        
         /**
          * Provides access to the required attendees of an event. The type of object and level of access depends on the mode of the current item.
          *
@@ -1834,6 +1853,7 @@ export declare namespace Office {
          * **{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}**: Appointment Attendee
          */
         start: Date;
+        
         /**
          * Gets the description that appears in the subject field of an item.
          *
@@ -1851,6 +1871,8 @@ export declare namespace Office {
          */
         subject: string;
 
+        
+        
         /**
          * Displays a reply form that includes the sender and all recipients of the selected message or the organizer and all attendees of the 
          * selected appointment.
@@ -2135,6 +2157,9 @@ export declare namespace Office {
         *                    This object can be accessed by the asyncResult.asyncContext property in the callback function.
         */
        loadCustomPropertiesAsync(callback: (asyncResult: CommonAPI.AsyncResult<CustomProperties>) => void, userContext?: any): void;
+
+       
+        
     }
 
     /**
@@ -2190,6 +2215,12 @@ export declare namespace Office {
          */
         notificationMessages: NotificationMessages;
 
+        
+
+        
+
+        
+
        /**
         * Asynchronously loads custom properties for this add-in on the selected item.
         *
@@ -2215,6 +2246,11 @@ export declare namespace Office {
         *                    This object can be accessed by the asyncResult.asyncContext property in the callback function.
         */
        loadCustomPropertiesAsync(callback: (asyncResult: CommonAPI.AsyncResult<CustomProperties>) => void, userContext?: any): void;
+
+
+       
+
+       
     }
     /**
      * The compose mode of {@link Office.Item | Office.context.mailbox.item}.
@@ -3117,6 +3153,7 @@ export declare namespace Office {
          * **{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}**: Message Compose
          */
         conversationId: string;
+        
         /**
          * Gets the type of item that an instance represents.
          *
@@ -3144,6 +3181,7 @@ export declare namespace Office {
          * **{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}**: Message Compose
          */
         notificationMessages: NotificationMessages;
+        
         /**
          * Gets or sets the description that appears in the subject field of an item.
          *
@@ -3242,6 +3280,8 @@ export declare namespace Office {
          *                 the error.
          */
         addFileAttachmentAsync(uri: string, attachmentName: string, callback?: (asyncResult: CommonAPI.AsyncResult<string>) => void): void;
+        
+        
         /**
          * Adds an Exchange item, such as a message, as an attachment to the message or appointment.
          *
@@ -3465,6 +3505,8 @@ export declare namespace Office {
          *                 If removing the attachment fails, the asyncResult.error property will contain an error code with the reason for the failure.
          */
         removeAttachmentAsync(attachmentId: string, callback?: (asyncResult: CommonAPI.AsyncResult<void>) => void): void;
+        
+        
         /**
          * Asynchronously saves an item.
          *
@@ -3832,6 +3874,8 @@ export declare namespace Office {
          * **{@link https://docs.microsoft.com/outlook/add-ins/#extension-points | Applicable Outlook mode}**: Message Read
          */
         notificationMessages: NotificationMessages;
+        
+        
         /**
          * Gets the email address of the sender of an email message.
          *
@@ -3882,6 +3926,8 @@ export declare namespace Office {
          */
         to: EmailAddressDetails[];
 
+        
+        
         /**
          * Displays a reply form that includes the sender and all recipients of the selected message or the organizer and all attendees of the 
          * selected appointment.
@@ -4167,6 +4213,8 @@ export declare namespace Office {
          *                    This object can be accessed by the asyncResult.asyncContext property in the callback function.
          */
         loadCustomPropertiesAsync(callback: (asyncResult: CommonAPI.AsyncResult<CustomProperties>) => void, userContext?: any): void;
+        
+        
     }
 
     /**
@@ -5336,6 +5384,12 @@ export declare namespace Office {
         setAsync(recipients: (string | EmailUser | EmailAddressDetails)[], callback: (asyncResult: CommonAPI.AsyncResult<void>) => void): void;
     }
 
+    
+
+    
+
+    
+
     /**
      * A file or item attachment. Used when displaying a reply form.
      */
@@ -5480,6 +5534,8 @@ export declare namespace Office {
         set(name: string, value: any): void;
     }
 
+    
+
     /**
      * Provides methods to get and set the subject of an appointment or message in an Outlook add-in.
      *
@@ -5577,6 +5633,7 @@ export declare namespace Office {
          *                 type Office.AsyncResult. If setting the subject fails, the asyncResult.error property will contain an error code.
          */
         setAsync(data: string, callback?: (asyncResult: CommonAPI.AsyncResult<void>) => void): void;
+
     }
     /**
      * Represents a suggested task identified in an item. Read mode only.
@@ -5706,6 +5763,7 @@ export declare namespace Office {
          *                 If setting the date and time fails, the asyncResult.error property will contain an error code.
          */
         setAsync(dateTime: Date, callback?: (asyncResult: CommonAPI.AsyncResult<void>) => void): void;
+
     }
     /**
      * Information about the user associated with the mailbox. This includes their account type, display name, email address, and time zone.

--- a/generate-docs/scripts/versioned-dts-cleanup.ts
+++ b/generate-docs/scripts/versioned-dts-cleanup.ts
@@ -1,0 +1,14 @@
+// usage: node versioned-dts-cleanup [source d.ts] [host name] [version number]
+// example: node versioned-dts-cleanup outlook.d.ts Outlook 1.6
+import * as fsx from "fs-extra";
+
+console.log(`Cleaning up ${process.argv[3]} d.ts file (${process.argv[2]}`);
+let wholeDTS = fsx.readFileSync(process.argv[2]).toString();
+
+if (process.argv[3] === "Outlook") {
+    wholeDTS = wholeDTS.replace(/\/objectmodel\/requirement-set-1.[\d]*\//g, `/objectmodel/requirement-set-${process.argv[4]}/`);
+} else {
+    console.log(`Host ${process.argv[3]} has no defined clean up steps.`);
+}
+
+fsx.writeFileSync(process.argv[2], wholeDTS);


### PR DESCRIPTION
At some point, I'll need to update the version remover to remove extra blank space. For now, the d.ts files that are generated should otherwise match the hand edited ones. I've also added a way to adjust d.ts files between versions, if needed.