### PR TITLE
Update office.asyncresult.yml

### DIFF
--- a/docs/docs-ref-autogen/office/office/office.asyncresult.yml
+++ b/docs/docs-ref-autogen/office/office/office.asyncresult.yml
@@ -30,7 +30,7 @@ items:
               filterType: "all"
           },
           function (result) {
-              if (result.status === "success") {
+              if (result.status === Office.AsyncResultStatus.Succeeded) {
                   var dataValue = result.value; // Get selected data.
                   console.log('Selected data is ' + dataValue);
               } else {


### PR DESCRIPTION
The result comparison in the example is incorrect according to documentation (and me testing the example):
https://docs.microsoft.com/en-us/javascript/api/office/office.asyncresultstatus?view=word-js-preview#fields

Result should be compared to either Office.AsyncResultStatus.Succeeded or Office.AsyncResultStatus.Failed
Here it is incorrectly compared to "success".