### PR TITLE
Locking version of API Documenter

### DIFF
--- a/generate-docs/package.json
+++ b/generate-docs/package.json
@@ -2,7 +2,7 @@
   "name": "generate-docs",
   "version": "1.0.0",
   "dependencies": {
-    "@microsoft/api-extractor": "^7.5.0",
-    "@microsoft/api-documenter": "^7.5.0"
+    "@microsoft/api-extractor": "7.5.0",
+    "@microsoft/api-documenter": "7.5.0"
   }
 }


### PR DESCRIPTION
We're unable to switch to API Documenter 7.7, so I'm removing the "get latest version" flags from the package file.