### PR TITLE
Simplify preprocessor prompts

### DIFF
--- a/DocumentationToolingNotes.md
+++ b/DocumentationToolingNotes.md
@@ -33,7 +33,7 @@ Older versions of the APIs have their own d.ts files. These are preserved when a
 
 #### Locally testing type definition file changes
 
-Any documentation changes for the Office JavaScript API are done by editing the four d.ts files mentioned above. However, you are able to test a change before submitting a PR to DefinitelyTyped (if you need to, for example, test how your formatting will translate into markdown) by editing the corresponding file in [generate-docs/script-inputs](https://github.com/OfficeDev/office-js-docs-reference/tree/master/generate-docs/script-inputs) and running [GenerateDocs.cmd](https://github.com/OfficeDev/office-js-docs-reference/blob/master/generate-docs/GenerateDocs.cmd). When prompted, selected the "Local files" option.
+Any documentation changes for the Office JavaScript API are done by editing the four d.ts files mentioned above. However, you can test a change before submitting a PR to DefinitelyTyped (if you need to, for example, test how your formatting will translate into markdown) by editing the corresponding file in [generate-docs/script-inputs](https://github.com/OfficeDev/office-js-docs-reference/tree/master/generate-docs/script-inputs) and running [GenerateDocs.cmd](https://github.com/OfficeDev/office-js-docs-reference/blob/master/generate-docs/GenerateDocs.cmd). When prompted, select the "Local files" option.
 
 Pushing changes to a remote branch of this repo causes the docs.microsoft.com platform to build a test branch. This branch is rendered on review.docs.microsoft.com, which is only accessible by internal Microsoft personnel. Anyone reviewing your PR will check the review site for accuracy.
 

--- a/DocumentationToolingNotes.md
+++ b/DocumentationToolingNotes.md
@@ -24,12 +24,18 @@ There are four relevant d.ts files that provide source content for different sub
   - [Outlook (Preview)](https://docs.microsoft.com/javascript/api/outlook)
   - [Word (Preview)](https://docs.microsoft.com/javascript/api/word)
   - [Common API](https://docs.microsoft.com/javascript/api/office)
-- [custom-functions-runtime](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/custom-functions-runtime/index.d.ts)(The Excel Custom Functions runtime definitions.)
+- [custom-functions-runtime/index.d.ts](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/custom-functions-runtime/index.d.ts)(The Excel Custom Functions runtime definitions.)
   - [Custom Functions](https://docs.microsoft.com/javascript/api/custom-functions-runtime)
-- [office-runtime](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/office-runtime/index.d.ts)(The office runtime definitions for the Custom Functions platform.)
+- [office-runtime/index.d.ts](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/office-runtime/index.d.ts)(The office runtime definitions for the Custom Functions platform.)
   - [Office Runtime](https://docs.microsoft.com/javascript/api/office-runtime)
 
 Older versions of the APIs have their own d.ts files. These are preserved when a new API requirement set is released. They can also be generated using the [Version Remover tool](https://github.com/OfficeDev/office-js-docs-reference/blob/master/generate-docs/tools/VersionRemover.ts). These old d.ts files are maintained so that in the event APIs are patched or altered, the original behavior is still documented. This is useful if you have to target an older version of the API.
+
+#### Locally testing type definition file changes
+
+Any documentation changes for the Office JavaScript API are done by editing the four d.ts files mentioned above. However, you are able to test a change before submitting a PR to DefinitelyTyped (if you need to, for example, test how your formatting will translate into markdown) by editing the corresponding file in [generate-docs/script-inputs](https://github.com/OfficeDev/office-js-docs-reference/tree/master/generate-docs/script-inputs) and running [GenerateDocs.cmd](https://github.com/OfficeDev/office-js-docs-reference/blob/master/generate-docs/GenerateDocs.cmd). When prompted, selected the "Local files" option.
+
+Pushing changes to a remote branch of this repo causes the docs.microsoft.com platform to build a test branch. This branch is rendered on review.docs.microsoft.com, which is only accessible by internal Microsoft personnel. Anyone reviewing your PR will check the review site for accuracy.
 
 ### Code snippets
 

--- a/generate-docs/scripts/preprocessor.ts
+++ b/generate-docs/scripts/preprocessor.ts
@@ -16,7 +16,7 @@ tryCatch(async () => {
         message: `What is the source of the Office-js TypeScript definition files that should be used to generate the docs?`,
         choices: [
             { name: "DefinitelyTyped", value: "DT" },
-            { name: "CDN", value: "CDN" },
+            { name: "CDN (if available)", value: "CDN" },
             { name: "Local files [generate-docs\\script-inputs\\*.d.ts]", value: "Local" }
         ]
     });

--- a/generate-docs/scripts/preprocessor.ts
+++ b/generate-docs/scripts/preprocessor.ts
@@ -17,7 +17,7 @@ tryCatch(async () => {
         choices: [
             { name: "DefinitelyTyped", value: "DT" },
             { name: "CDN", value: "CDN" },
-            { name: "Local file [generate-docs\\script-inputs\\*.d.ts]", value: "Local" }
+            { name: "Local files [generate-docs\\script-inputs\\*.d.ts]", value: "Local" }
         ]
     });
 

--- a/generate-docs/scripts/preprocessor.ts
+++ b/generate-docs/scripts/preprocessor.ts
@@ -10,60 +10,56 @@ tryCatch(async () => {
     // Display prompts
     // ----
     console.log('\n\n');
-    const urlToCopyOfficeJsFrom = await promptFromList({
-        message: `What is the source of the Office-js TypeScript definition file that should be used to generate the RELEASE docs?`,
-        choices: [
-            { name: "DefinitelyTyped", value: "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/master/types/office-js/index.d.ts" },
-            { name: "Prod CDN", value: "https://appsforoffice.officeapps.live.com/lib/1.1/hosted/office.d.ts" },
-            { name: "Local file [generate-docs\\script-inputs\\office.d.ts]", value: "" }
-        ]
 
+    console.log('\n');
+    const sourceChoice = await promptFromList({
+        message: `What is the source of the Office-js TypeScript definition files that should be used to generate the docs?`,
+        choices: [
+            { name: "DefinitelyTyped", value: "DT" },
+            { name: "CDN", value: "CDN" },
+            { name: "Local file [generate-docs\\script-inputs\\*.d.ts]", value: "Local" }
+        ]
+    });
+
+
+    let urlToCopyOfficeJsFrom = "";
+    let urlToCopyPreviewOfficeJsFrom = "";
+    let urlToCopyCustomFunctionsRuntimeFrom = "";
+    let urlToCopyOfficeRuntimeFrom = "";
+    
+    switch (sourceChoice) {
+        case "DT":
+            urlToCopyOfficeJsFrom = "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/master/types/office-js/index.d.ts"
+            urlToCopyPreviewOfficeJsFrom = "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/master/types/office-js-preview/index.d.ts"
+            urlToCopyCustomFunctionsRuntimeFrom = "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/master/types/custom-functions-runtime/index.d.ts"
+            urlToCopyOfficeRuntimeFrom = "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/master/types/office-runtime/index.d.ts"
+            break;
+        case "CDN":
+            urlToCopyOfficeJsFrom = "https://appsforoffice.officeapps.live.com/lib/1.1/hosted/office.d.ts"
+            urlToCopyPreviewOfficeJsFrom = "https://appsforoffice.officeapps.live.com/lib/beta/hosted/office.d.ts"
+            urlToCopyCustomFunctionsRuntimeFrom = "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/master/types/custom-functions-runtime/index.d.ts"
+            urlToCopyOfficeRuntimeFrom = "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/master/types/office-runtime/index.d.ts"
+            break;
         // Note: using "appsforoffice.officeapps.live.com" instead of "appsforoffice.microsoft.com"
         //     to avoid being redirected to the EDOG environment on corpnet.
         // If we ever want to generate not just public d.ts but also "office-with-first-party.d.ts",
         //     replace the filename.
-    });
+    }
 
-    console.log('\n');
-    const urlToCopyPreviewOfficeJsFrom = await promptFromList({
-        message: `What is the source of the Office-js TypeScript definition file that should be used to generate the PREVIEW docs?`,
-        choices: [
-            { name: "DefinitelyTyped (preview)", value: "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/master/types/office-js-preview/index.d.ts" },
-            { name: "Beta CDN", value: "https://appsforoffice.officeapps.live.com/lib/beta/hosted/office.d.ts" },
-            { name: "Local file [generate-docs\\script-inputs\\office_preview.d.ts]", value: "" }
-        ]
-    });
-
-    console.log('\n');
-    const urlToCopyCustomFunctionsRuntimeFrom = await promptFromList({
-        message: `What is the source of the Custom Functions Runtime TypeScript definition file that should be used to generate the docs?`,
-        choices: [
-            { name: "DefinitelyTyped", value: "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/master/types/custom-functions-runtime/index.d.ts" },
-            { name: "Local file [generate-docs\\script-inputs\\custom-functions-runtime.d.ts]", value: "" }
-        ]
-    });
-
-    console.log('\n');
-    const urlToCopyOfficeRuntimeFrom = await promptFromList({
-        message: `What is the source of the Office Runtime TypeScript definition file that should be used to generate the docs?`,
-        choices: [
-            { name: "DefinitelyTyped", value: "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/master/types/office-runtime/index.d.ts" },
-            { name: "Local file [generate-docs\\script-inputs\\office-runtime.d.ts]", value: "" }
-        ]
-    });
-
-    console.log("\nStarting preprocessor script...");
+    console.log("\nStarting preprocessor script...\n");
 
     // ----
     // Process office.d.ts
     // ----
     const localReleaseDtsPath = "../script-inputs/office.d.ts";
     if (urlToCopyOfficeJsFrom.length > 0) {
+        console.log(`Pulling Office.js TypeScript definition file from: ${urlToCopyOfficeJsFrom}`);
         fsx.writeFileSync(localReleaseDtsPath, await fetchAndThrowOnError(urlToCopyOfficeJsFrom, "text"));
     }
 
     const localPreviewDtsPath = "../script-inputs/office_preview.d.ts";
     if (urlToCopyPreviewOfficeJsFrom.length > 0) {
+        console.log(`Pulling Office.js (preview) TypeScript definition file from: ${urlToCopyPreviewOfficeJsFrom}`);
         fsx.writeFileSync(localPreviewDtsPath, await fetchAndThrowOnError(urlToCopyPreviewOfficeJsFrom, "text"));
     }
 
@@ -141,6 +137,7 @@ tryCatch(async () => {
     // Process Custom Functions d.ts
     // ----
     if (urlToCopyCustomFunctionsRuntimeFrom.length > 0) {
+        console.log(`Pulling Custom Functions TypeScript definition file from: ${urlToCopyCustomFunctionsRuntimeFrom}`);
         fsx.writeFileSync("../script-inputs/custom-functions-runtime.d.ts", await fetchAndThrowOnError(urlToCopyCustomFunctionsRuntimeFrom, "text"));
     }
     console.log(`\nReading from ${path.resolve("../script-inputs/custom-functions-runtime.d.ts")}`);
@@ -156,6 +153,7 @@ tryCatch(async () => {
     // Process Office Runtime d.ts
     // ----
     if (urlToCopyOfficeRuntimeFrom.length > 0) {
+        console.log(`Pulling Office Runtime TypeScript definition file from: ${urlToCopyOfficeRuntimeFrom}`);
         fsx.writeFileSync("../script-inputs/office-runtime.d.ts", await fetchAndThrowOnError(urlToCopyOfficeRuntimeFrom, "text"));
     }
     console.log(`\nReading from ${path.resolve("../script-inputs/office-runtime.d.ts")}`);


### PR DESCRIPTION
This reduces the prompts asked when generating the docs from four to one. It also adds an explanation about creating docs from local files and the review site.