### PR TITLE
Fix linking to the OfficeExtension class pages from Rich API docs

### DIFF
--- a/docs/docs-ref-autogen/excel/excel.yml
+++ b/docs/docs-ref-autogen/excel/excel.yml
@@ -1039,7 +1039,7 @@ items:
             A previously-created API object. The batch will use the same RequestContext as the passed-in object, which
             means that any changes applied to the object will be picked up by "context.sync()".
           type:
-            - 'excel!OfficeExtension.ClientObject:class'
+            - 'office!OfficeExtension.ClientObject:class'
         - id: batch
           description: >-
             A function that takes in a RequestContext and returns a promise (typically, just the result of
@@ -1144,7 +1144,7 @@ items:
             A previously-created object. The batch will use the same RequestContext as the passed-in object, which means
             that any changes applied to the object will be picked up by "context.sync()".
           type:
-            - 'excel!OfficeExtension.ClientRequestContext:class'
+            - 'office!OfficeExtension.ClientRequestContext:class'
         - id: batch
           description: >-
             A function that takes in a RequestContext and returns a promise (typically, just the result of
@@ -2755,7 +2755,7 @@ references:
         fullName: Promise
       - name: <T>
         fullName: <T>
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.run~3:complex'
     name: '(context: Excel.RequestContext) => Promise<T>'
@@ -2786,7 +2786,7 @@ references:
     name: 'OfficeExtension.ClientObject[]'
     fullName: 'OfficeExtension.ClientObject[]'
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientObject:class'
+      - uid: 'office!OfficeExtension.ClientObject:class'
         name: OfficeExtension.ClientObject
         fullName: OfficeExtension.ClientObject
       - name: '[]'
@@ -2843,7 +2843,7 @@ references:
         fullName: Promise
       - name: <T>
         fullName: <T>
-  - uid: 'excel!OfficeExtension.ClientRequestContext:class'
+  - uid: 'office!OfficeExtension.ClientRequestContext:class'
     name: OfficeExtension.ClientRequestContext
   - uid: 'excel!Excel.run~10:complex'
     name: '(context: Excel.RequestContext) => Promise<T>'

--- a/docs/docs-ref-autogen/excel/excel/excel.application.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.application.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Application#calculate:member(1)'
@@ -361,7 +361,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Application#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -516,7 +516,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.CalculationType:enum'
     name: Excel.CalculationType
@@ -550,7 +550,7 @@ references:
     name: Excel.Interfaces.ApplicationLoadOptions
   - uid: 'excel!Excel.Interfaces.ApplicationUpdateData:interface'
     name: Interfaces.ApplicationUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ApplicationData:interface'
     name: Excel.Interfaces.ApplicationData

--- a/docs/docs-ref-autogen/excel/excel/excel.autofilter.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.autofilter.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.AutoFilter#apply:member(1)'
@@ -309,7 +309,7 @@ items:
           - 'excel!Excel.Interfaces.AutoFilterData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.AutoFilter#apply~0:complex'
     name: Range | string

--- a/docs/docs-ref-autogen/excel/excel/excel.binding.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.binding.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Binding#context:member'
@@ -357,7 +357,7 @@ items:
         type:
           - 'excel!Excel.Binding#type~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -369,7 +369,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -382,7 +382,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.BindingDataChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.BindingDataChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -396,7 +396,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.BindingSelectionChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.BindingSelectionChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <

--- a/docs/docs-ref-autogen/excel/excel/excel.bindingcollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.bindingcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.BindingCollection#add:member(1)'
@@ -493,7 +493,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.BindingCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -513,7 +513,7 @@ items:
           - 'excel!Excel.Interfaces.BindingCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Binding:class'
     name: Excel.Binding
@@ -543,7 +543,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -571,7 +571,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.BindingCollectionData:interface'
     name: Excel.Interfaces.BindingCollectionData

--- a/docs/docs-ref-autogen/excel/excel/excel.cellvalueconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.cellvalueconditionalformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.CellValueConditionalFormat#context:member'
@@ -212,7 +212,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.CellValueConditionalFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -250,7 +250,7 @@ items:
           - 'excel!Excel.Interfaces.CellValueConditionalFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -264,7 +264,7 @@ references:
     name: Excel.ConditionalCellValueRule
   - uid: 'excel!Excel.Interfaces.CellValueConditionalFormatUpdateData:interface'
     name: Interfaces.CellValueConditionalFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.CellValueConditionalFormatData:interface'
     name: Excel.Interfaces.CellValueConditionalFormatData

--- a/docs/docs-ref-autogen/excel/excel/excel.chart.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chart.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Chart#activate:member(1)'
@@ -704,7 +704,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Chart#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -977,7 +977,7 @@ items:
         type:
           - 'excel!Excel.Worksheet:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartAxes:class'
     name: Excel.ChartAxes
@@ -1037,7 +1037,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -1048,7 +1048,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -1063,7 +1063,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.ChartActivatedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.ChartActivatedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -1077,7 +1077,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.ChartDeactivatedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.ChartDeactivatedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -1104,7 +1104,7 @@ references:
     name: Excel.ChartSeriesCollection
   - uid: 'excel!Excel.Interfaces.ChartUpdateData:interface'
     name: Interfaces.ChartUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Range:class'
     name: Range

--- a/docs/docs-ref-autogen/excel/excel/excel.chartareaformat.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chartareaformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAreaFormat#border:member'
@@ -219,7 +219,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAreaFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -257,7 +257,7 @@ items:
           - 'excel!Excel.Interfaces.ChartAreaFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartBorder:class'
     name: Excel.ChartBorder
@@ -292,7 +292,7 @@ references:
     name: Excel.Interfaces.ChartAreaFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartAreaFormatUpdateData:interface'
     name: Interfaces.ChartAreaFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartAreaFormatData:interface'
     name: Excel.Interfaces.ChartAreaFormatData

--- a/docs/docs-ref-autogen/excel/excel/excel.chartaxes.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chartaxes.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAxes#categoryAxis:member'
@@ -221,7 +221,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAxes#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -297,7 +297,7 @@ items:
           });
           ```
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartAxis:class'
     name: Excel.ChartAxis
@@ -313,7 +313,7 @@ references:
     name: Excel.Interfaces.ChartAxesLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartAxesUpdateData:interface'
     name: Interfaces.ChartAxesUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartAxesData:interface'
     name: Excel.Interfaces.ChartAxesData

--- a/docs/docs-ref-autogen/excel/excel/excel.chartaxis.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chartaxis.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAxis#alignment:member'
@@ -682,7 +682,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAxis#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -964,7 +964,7 @@ items:
         type:
           - number
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartAxis#alignment~0:complex'
     name: Excel.ChartTickLabelAlignment | "Center" | "Left" | "Right"
@@ -1081,7 +1081,7 @@ references:
         fullName: ' | "Linear" | "Logarithmic"'
   - uid: 'excel!Excel.Interfaces.ChartAxisUpdateData:interface'
     name: Interfaces.ChartAxisUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Range:class'
     name: Range

--- a/docs/docs-ref-autogen/excel/excel/excel.chartaxisformat.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chartaxisformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAxisFormat#context:member'
@@ -182,7 +182,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAxisFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -220,7 +220,7 @@ items:
           - 'excel!Excel.Interfaces.ChartAxisFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -236,7 +236,7 @@ references:
     name: Excel.Interfaces.ChartAxisFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisFormatUpdateData:interface'
     name: Interfaces.ChartAxisFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisFormatData:interface'
     name: Excel.Interfaces.ChartAxisFormatData

--- a/docs/docs-ref-autogen/excel/excel/excel.chartaxistitle.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chartaxistitle.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAxisTitle#context:member'
@@ -173,7 +173,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAxisTitle#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -281,7 +281,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -293,7 +293,7 @@ references:
     name: Excel.Interfaces.ChartAxisTitleLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisTitleUpdateData:interface'
     name: Interfaces.ChartAxisTitleUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisTitleData:interface'
     name: Excel.Interfaces.ChartAxisTitleData

--- a/docs/docs-ref-autogen/excel/excel/excel.chartaxistitleformat.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chartaxistitleformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAxisTitleFormat#border:member'
@@ -182,7 +182,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAxisTitleFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -220,7 +220,7 @@ items:
           - 'excel!Excel.Interfaces.ChartAxisTitleFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartBorder:class'
     name: Excel.ChartBorder
@@ -236,7 +236,7 @@ references:
     name: Excel.Interfaces.ChartAxisTitleFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisTitleFormatUpdateData:interface'
     name: Interfaces.ChartAxisTitleFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisTitleFormatData:interface'
     name: Excel.Interfaces.ChartAxisTitleFormatData

--- a/docs/docs-ref-autogen/excel/excel/excel.chartbinoptions.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chartbinoptions.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartBinOptions#allowOverflow:member'
@@ -201,7 +201,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartBinOptions#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -284,7 +284,7 @@ items:
         type:
           - number
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -294,7 +294,7 @@ references:
     name: Excel.Interfaces.ChartBinOptionsLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartBinOptionsUpdateData:interface'
     name: Interfaces.ChartBinOptionsUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartBinOptionsData:interface'
     name: Excel.Interfaces.ChartBinOptionsData

--- a/docs/docs-ref-autogen/excel/excel/excel.chartborder.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chartborder.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartBorder#clear:member(1)'
@@ -186,7 +186,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartBorder#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -239,7 +239,7 @@ items:
         type:
           - number
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -262,7 +262,7 @@ references:
     name: Excel.Interfaces.ChartBorderLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartBorderUpdateData:interface'
     name: Interfaces.ChartBorderUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartBorderData:interface'
     name: Excel.Interfaces.ChartBorderData

--- a/docs/docs-ref-autogen/excel/excel/excel.chartboxwhiskeroptions.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chartboxwhiskeroptions.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartBoxwhiskerOptions#context:member'
@@ -154,7 +154,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartBoxwhiskerOptions#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -252,7 +252,7 @@ items:
           - 'excel!Excel.Interfaces.ChartBoxwhiskerOptionsData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -271,7 +271,7 @@ references:
         fullName: ' | "Inclusive" | "Exclusive"'
   - uid: 'excel!Excel.Interfaces.ChartBoxwhiskerOptionsUpdateData:interface'
     name: Interfaces.ChartBoxwhiskerOptionsUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartBoxwhiskerOptionsData:interface'
     name: Excel.Interfaces.ChartBoxwhiskerOptionsData

--- a/docs/docs-ref-autogen/excel/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chartcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartCollection#add:member(1)'
@@ -387,7 +387,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.ChartCollection#onActivated:member'
     summary: |-
       Occurs when a chart is activated.
@@ -535,7 +535,7 @@ items:
           - 'excel!Excel.Interfaces.ChartCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Chart:class'
     name: Excel.Chart
@@ -551,7 +551,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -579,13 +579,13 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.ChartCollection#onActivated~0:complex'
     name: OfficeExtension.EventHandlers<Excel.ChartActivatedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.ChartActivatedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -599,7 +599,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.ChartAddedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.ChartAddedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -613,7 +613,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.ChartDeactivatedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.ChartDeactivatedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -627,7 +627,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.ChartDeletedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.ChartDeletedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <

--- a/docs/docs-ref-autogen/excel/excel/excel.chartdatalabel.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chartdatalabel.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartDataLabel#autoText:member'
@@ -317,7 +317,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartDataLabel#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -526,7 +526,7 @@ items:
         type:
           - number
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -560,7 +560,7 @@ references:
         fullName: ' | "Invalid" | "None" | "Center" | "InsideEnd" | "InsideBase" | "OutsideEnd" | "Left" | "Right" | "Top" | "Bottom" | "BestFit" | "Callout"'
   - uid: 'excel!Excel.Interfaces.ChartDataLabelUpdateData:interface'
     name: Interfaces.ChartDataLabelUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartDataLabelData:interface'
     name: Excel.Interfaces.ChartDataLabelData

--- a/docs/docs-ref-autogen/excel/excel/excel.chartdatalabelformat.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chartdatalabelformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartDataLabelFormat#border:member'
@@ -182,7 +182,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartDataLabelFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -220,7 +220,7 @@ items:
           - 'excel!Excel.Interfaces.ChartDataLabelFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartBorder:class'
     name: Excel.ChartBorder
@@ -236,7 +236,7 @@ references:
     name: Excel.Interfaces.ChartDataLabelFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartDataLabelFormatUpdateData:interface'
     name: Interfaces.ChartDataLabelFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartDataLabelFormatData:interface'
     name: Excel.Interfaces.ChartDataLabelFormatData

--- a/docs/docs-ref-autogen/excel/excel/excel.chartdatalabels.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chartdatalabels.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartDataLabels#autoText:member'
@@ -285,7 +285,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartDataLabels#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -447,7 +447,7 @@ items:
         type:
           - 'excel!Excel.ChartDataLabels#verticalAlignment~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -481,7 +481,7 @@ references:
         fullName: ' | "Invalid" | "None" | "Center" | "InsideEnd" | "InsideBase" | "OutsideEnd" | "Left" | "Right" | "Top" | "Bottom" | "BestFit" | "Callout"'
   - uid: 'excel!Excel.Interfaces.ChartDataLabelsUpdateData:interface'
     name: Interfaces.ChartDataLabelsUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartDataLabelsData:interface'
     name: Excel.Interfaces.ChartDataLabelsData

--- a/docs/docs-ref-autogen/excel/excel/excel.charterrorbars.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.charterrorbars.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartErrorBars#context:member'
@@ -184,7 +184,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartErrorBars#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -252,7 +252,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -273,7 +273,7 @@ references:
     name: Excel.Interfaces.ChartErrorBarsLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartErrorBarsUpdateData:interface'
     name: Interfaces.ChartErrorBarsUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartErrorBarsData:interface'
     name: Excel.Interfaces.ChartErrorBarsData

--- a/docs/docs-ref-autogen/excel/excel/excel.charterrorbarsformat.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.charterrorbarsformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartErrorBarsFormat#context:member'
@@ -150,7 +150,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartErrorBarsFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -188,7 +188,7 @@ items:
           - 'excel!Excel.Interfaces.ChartErrorBarsFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -200,7 +200,7 @@ references:
     name: Excel.Interfaces.ChartErrorBarsFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartErrorBarsFormatUpdateData:interface'
     name: Interfaces.ChartErrorBarsFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartErrorBarsFormatData:interface'
     name: Excel.Interfaces.ChartErrorBarsFormatData

--- a/docs/docs-ref-autogen/excel/excel/excel.chartfill.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chartfill.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartFill#clear:member(1)'
@@ -138,7 +138,7 @@ items:
                     }
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel/excel/excel.chartfont.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chartfont.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     remarks: |-
 
@@ -223,7 +223,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartFont#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -291,7 +291,7 @@ items:
         type:
           - 'excel!Excel.ChartFont#underline~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -301,7 +301,7 @@ references:
     name: Excel.Interfaces.ChartFontLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartFontUpdateData:interface'
     name: Interfaces.ChartFontUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartFontData:interface'
     name: Excel.Interfaces.ChartFontData

--- a/docs/docs-ref-autogen/excel/excel/excel.chartformatstring.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chartformatstring.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartFormatString#context:member'
@@ -152,7 +152,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartFormatString#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -190,7 +190,7 @@ items:
           - 'excel!Excel.Interfaces.ChartFormatStringData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -202,7 +202,7 @@ references:
     name: Excel.Interfaces.ChartFormatStringLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartFormatStringUpdateData:interface'
     name: Interfaces.ChartFormatStringUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartFormatStringData:interface'
     name: Excel.Interfaces.ChartFormatStringData

--- a/docs/docs-ref-autogen/excel/excel/excel.chartgridlines.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chartgridlines.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartGridlines#context:member'
@@ -170,7 +170,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartGridlines#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -223,7 +223,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -235,7 +235,7 @@ references:
     name: Excel.Interfaces.ChartGridlinesLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartGridlinesUpdateData:interface'
     name: Interfaces.ChartGridlinesUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartGridlinesData:interface'
     name: Excel.Interfaces.ChartGridlinesData

--- a/docs/docs-ref-autogen/excel/excel/excel.chartgridlinesformat.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chartgridlinesformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartGridlinesFormat#context:member'
@@ -150,7 +150,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartGridlinesFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -188,7 +188,7 @@ items:
           - 'excel!Excel.Interfaces.ChartGridlinesFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -200,7 +200,7 @@ references:
     name: Excel.Interfaces.ChartGridlinesFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartGridlinesFormatUpdateData:interface'
     name: Interfaces.ChartGridlinesFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartGridlinesFormatData:interface'
     name: Excel.Interfaces.ChartGridlinesFormatData

--- a/docs/docs-ref-autogen/excel/excel/excel.chartlegend.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chartlegend.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartLegend#context:member'
@@ -254,7 +254,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartLegend#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -352,7 +352,7 @@ items:
         type:
           - number
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -375,7 +375,7 @@ references:
         fullName: ' | "Invalid" | "Top" | "Bottom" | "Left" | "Right" | "Corner" | "Custom"'
   - uid: 'excel!Excel.Interfaces.ChartLegendUpdateData:interface'
     name: Interfaces.ChartLegendUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartLegendData:interface'
     name: Excel.Interfaces.ChartLegendData

--- a/docs/docs-ref-autogen/excel/excel/excel.chartlegendentry.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chartlegendentry.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartLegendEntry#context:member'
@@ -185,7 +185,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartLegendEntry#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -268,7 +268,7 @@ items:
         type:
           - number
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -278,7 +278,7 @@ references:
     name: Excel.Interfaces.ChartLegendEntryLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartLegendEntryUpdateData:interface'
     name: Interfaces.ChartLegendEntryUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartLegendEntryData:interface'
     name: Excel.Interfaces.ChartLegendEntryData

--- a/docs/docs-ref-autogen/excel/excel/excel.chartlegendentrycollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chartlegendentrycollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartLegendEntryCollection#context:member'
@@ -148,7 +148,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.ChartLegendEntryCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -168,7 +168,7 @@ items:
           - 'excel!Excel.Interfaces.ChartLegendEntryCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -176,7 +176,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -206,7 +206,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.ChartLegendEntryCollectionData:interface'
     name: Excel.Interfaces.ChartLegendEntryCollectionData

--- a/docs/docs-ref-autogen/excel/excel/excel.chartlegendformat.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chartlegendformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartLegendFormat#border:member'
@@ -212,7 +212,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartLegendFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -250,7 +250,7 @@ items:
           - 'excel!Excel.Interfaces.ChartLegendFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartBorder:class'
     name: Excel.ChartBorder
@@ -266,7 +266,7 @@ references:
     name: Excel.Interfaces.ChartLegendFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartLegendFormatUpdateData:interface'
     name: Interfaces.ChartLegendFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartLegendFormatData:interface'
     name: Excel.Interfaces.ChartLegendFormatData

--- a/docs/docs-ref-autogen/excel/excel/excel.chartlineformat.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chartlineformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartLineFormat#clear:member(1)'
@@ -224,7 +224,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartLineFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -277,7 +277,7 @@ items:
         type:
           - number
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -300,7 +300,7 @@ references:
     name: Excel.Interfaces.ChartLineFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartLineFormatUpdateData:interface'
     name: Interfaces.ChartLineFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartLineFormatData:interface'
     name: Excel.Interfaces.ChartLineFormatData

--- a/docs/docs-ref-autogen/excel/excel/excel.chartmapoptions.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chartmapoptions.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartMapOptions#context:member'
@@ -184,7 +184,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartMapOptions#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -222,7 +222,7 @@ items:
           - 'excel!Excel.Interfaces.ChartMapOptionsData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -263,7 +263,7 @@ references:
         fullName: ' | "Automatic" | "Mercator" | "Miller" | "Robinson" | "Albers"'
   - uid: 'excel!Excel.Interfaces.ChartMapOptionsUpdateData:interface'
     name: Interfaces.ChartMapOptionsUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartMapOptionsData:interface'
     name: Excel.Interfaces.ChartMapOptionsData

--- a/docs/docs-ref-autogen/excel/excel/excel.chartpivotoptions.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chartpivotoptions.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartPivotOptions#context:member'
@@ -138,7 +138,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartPivotOptions#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -239,7 +239,7 @@ items:
           - 'excel!Excel.Interfaces.ChartPivotOptionsData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -249,7 +249,7 @@ references:
     name: Excel.Interfaces.ChartPivotOptionsLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartPivotOptionsUpdateData:interface'
     name: Interfaces.ChartPivotOptionsUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartPivotOptionsData:interface'
     name: Excel.Interfaces.ChartPivotOptionsData

--- a/docs/docs-ref-autogen/excel/excel/excel.chartplotarea.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chartplotarea.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartPlotArea#context:member'
@@ -264,7 +264,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartPlotArea#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -332,7 +332,7 @@ items:
         type:
           - number
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -353,7 +353,7 @@ references:
         fullName: ' | "Automatic" | "Custom"'
   - uid: 'excel!Excel.Interfaces.ChartPlotAreaUpdateData:interface'
     name: Interfaces.ChartPlotAreaUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartPlotAreaData:interface'
     name: Excel.Interfaces.ChartPlotAreaData

--- a/docs/docs-ref-autogen/excel/excel/excel.chartplotareaformat.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chartplotareaformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartPlotAreaFormat#border:member'
@@ -166,7 +166,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartPlotAreaFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -204,7 +204,7 @@ items:
           - 'excel!Excel.Interfaces.ChartPlotAreaFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartBorder:class'
     name: Excel.ChartBorder
@@ -218,7 +218,7 @@ references:
     name: Excel.Interfaces.ChartPlotAreaFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartPlotAreaFormatUpdateData:interface'
     name: Interfaces.ChartPlotAreaFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartPlotAreaFormatData:interface'
     name: Excel.Interfaces.ChartPlotAreaFormatData

--- a/docs/docs-ref-autogen/excel/excel/excel.chartpoint.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chartpoint.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartPoint#context:member'
@@ -249,7 +249,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartPoint#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -302,7 +302,7 @@ items:
         type:
           - any
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -329,7 +329,7 @@ references:
         fullName: ' | "Invalid" | "Automatic" | "None" | "Square" | "Diamond" | "Triangle" | "X" | "Star" | "Dot" | "Dash" | "Circle" | "Plus" | "Picture"'
   - uid: 'excel!Excel.Interfaces.ChartPointUpdateData:interface'
     name: Interfaces.ChartPointUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartPointData:interface'
     name: Excel.Interfaces.ChartPointData

--- a/docs/docs-ref-autogen/excel/excel/excel.chartpointformat.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chartpointformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartPointFormat#border:member'
@@ -168,7 +168,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartPointFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -206,7 +206,7 @@ items:
           - 'excel!Excel.Interfaces.ChartPointFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartBorder:class'
     name: Excel.ChartBorder
@@ -220,7 +220,7 @@ references:
     name: Excel.Interfaces.ChartPointFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartPointFormatUpdateData:interface'
     name: Interfaces.ChartPointFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartPointFormatData:interface'
     name: Excel.Interfaces.ChartPointFormatData

--- a/docs/docs-ref-autogen/excel/excel/excel.chartpointscollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chartpointscollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartPointsCollection#context:member'
@@ -219,7 +219,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.ChartPointsCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -239,7 +239,7 @@ items:
           - 'excel!Excel.Interfaces.ChartPointsCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -247,7 +247,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -277,7 +277,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.ChartPointsCollectionData:interface'
     name: Excel.Interfaces.ChartPointsCollectionData

--- a/docs/docs-ref-autogen/excel/excel/excel.chartseries.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chartseries.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartSeries#axisGroup:member'
@@ -1029,7 +1029,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartSeries#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -1312,7 +1312,7 @@ items:
         type:
           - 'excel!Excel.ChartErrorBars:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartSeries#axisGroup~0:complex'
     name: Excel.ChartAxisGroup | "Primary" | "Secondary"
@@ -1374,7 +1374,7 @@ references:
     name: 'OfficeExtension.ClientResult<string[]>'
     fullName: 'OfficeExtension.ClientResult<string[]>'
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: '<string[]>'
@@ -1385,7 +1385,7 @@ references:
     name: 'OfficeExtension.ClientResult<string[]>'
     fullName: 'OfficeExtension.ClientResult<string[]>'
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: '<string[]>'
@@ -1458,7 +1458,7 @@ references:
     name: Excel.ChartPointsCollection
   - uid: 'excel!Excel.Interfaces.ChartSeriesUpdateData:interface'
     name: Interfaces.ChartSeriesUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Range:class'
     name: Range

--- a/docs/docs-ref-autogen/excel/excel/excel.chartseriescollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chartseriescollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartSeriesCollection#add:member(1)'
@@ -248,7 +248,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.ChartSeriesCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -268,7 +268,7 @@ items:
           - 'excel!Excel.Interfaces.ChartSeriesCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartSeries:class'
     name: Excel.ChartSeries
@@ -278,7 +278,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -306,7 +306,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.ChartSeriesCollectionData:interface'
     name: Excel.Interfaces.ChartSeriesCollectionData

--- a/docs/docs-ref-autogen/excel/excel/excel.chartseriesformat.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chartseriesformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartSeriesFormat#context:member'
@@ -166,7 +166,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartSeriesFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -204,7 +204,7 @@ items:
           - 'excel!Excel.Interfaces.ChartSeriesFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -218,7 +218,7 @@ references:
     name: Excel.Interfaces.ChartSeriesFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartSeriesFormatUpdateData:interface'
     name: Interfaces.ChartSeriesFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartSeriesFormatData:interface'
     name: Excel.Interfaces.ChartSeriesFormatData

--- a/docs/docs-ref-autogen/excel/excel/excel.charttitle.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.charttitle.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartTitle#context:member'
@@ -328,7 +328,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartTitle#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -516,7 +516,7 @@ items:
         type:
           - number
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -548,7 +548,7 @@ references:
         fullName: ' | "Automatic" | "Top" | "Bottom" | "Left" | "Right"'
   - uid: 'excel!Excel.Interfaces.ChartTitleUpdateData:interface'
     name: Interfaces.ChartTitleUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartTitleData:interface'
     name: Excel.Interfaces.ChartTitleData

--- a/docs/docs-ref-autogen/excel/excel/excel.charttitleformat.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.charttitleformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartTitleFormat#border:member'
@@ -182,7 +182,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartTitleFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -220,7 +220,7 @@ items:
           - 'excel!Excel.Interfaces.ChartTitleFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartBorder:class'
     name: Excel.ChartBorder
@@ -236,7 +236,7 @@ references:
     name: Excel.Interfaces.ChartTitleFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartTitleFormatUpdateData:interface'
     name: Interfaces.ChartTitleFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartTitleFormatData:interface'
     name: Excel.Interfaces.ChartTitleFormatData

--- a/docs/docs-ref-autogen/excel/excel/excel.charttrendline.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.charttrendline.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartTrendline#backwardPeriod:member'
@@ -286,7 +286,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartTrendline#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -397,7 +397,7 @@ items:
 
           ```
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -411,7 +411,7 @@ references:
     name: Excel.Interfaces.ChartTrendlineLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartTrendlineUpdateData:interface'
     name: Interfaces.ChartTrendlineUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartTrendlineData:interface'
     name: Excel.Interfaces.ChartTrendlineData

--- a/docs/docs-ref-autogen/excel/excel/excel.charttrendlinecollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.charttrendlinecollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartTrendlineCollection#add:member(1)'
@@ -216,7 +216,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.ChartTrendlineCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -236,7 +236,7 @@ items:
           - 'excel!Excel.Interfaces.ChartTrendlineCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartTrendline:class'
     name: Excel.ChartTrendline
@@ -248,7 +248,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -276,7 +276,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.ChartTrendlineCollectionData:interface'
     name: Excel.Interfaces.ChartTrendlineCollectionData

--- a/docs/docs-ref-autogen/excel/excel/excel.charttrendlineformat.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.charttrendlineformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartTrendlineFormat#context:member'
@@ -199,7 +199,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartTrendlineFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -237,7 +237,7 @@ items:
           - 'excel!Excel.Interfaces.ChartTrendlineFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -249,7 +249,7 @@ references:
     name: Excel.Interfaces.ChartTrendlineFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartTrendlineFormatUpdateData:interface'
     name: Interfaces.ChartTrendlineFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartTrendlineFormatData:interface'
     name: Excel.Interfaces.ChartTrendlineFormatData

--- a/docs/docs-ref-autogen/excel/excel/excel.charttrendlinelabel.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.charttrendlinelabel.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartTrendlineLabel#autoText:member'
@@ -277,7 +277,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartTrendlineLabel#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -398,7 +398,7 @@ items:
         type:
           - number
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -419,7 +419,7 @@ references:
     name: Excel.Interfaces.ChartTrendlineLabelLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartTrendlineLabelUpdateData:interface'
     name: Interfaces.ChartTrendlineLabelUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartTrendlineLabelData:interface'
     name: Excel.Interfaces.ChartTrendlineLabelData

--- a/docs/docs-ref-autogen/excel/excel/excel.charttrendlinelabelformat.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.charttrendlinelabelformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartTrendlineLabelFormat#border:member'
@@ -182,7 +182,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartTrendlineLabelFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -220,7 +220,7 @@ items:
           - 'excel!Excel.Interfaces.ChartTrendlineLabelFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartBorder:class'
     name: Excel.ChartBorder
@@ -236,7 +236,7 @@ references:
     name: Excel.Interfaces.ChartTrendlineLabelFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartTrendlineLabelFormatUpdateData:interface'
     name: Interfaces.ChartTrendlineLabelFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartTrendlineLabelFormatData:interface'
     name: Excel.Interfaces.ChartTrendlineLabelFormatData

--- a/docs/docs-ref-autogen/excel/excel/excel.colorscaleconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.colorscaleconditionalformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ColorScaleConditionalFormat#context:member'
@@ -180,7 +180,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ColorScaleConditionalFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -235,7 +235,7 @@ items:
           - 'excel!Excel.Interfaces.ColorScaleConditionalFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -247,7 +247,7 @@ references:
     name: Excel.Interfaces.ColorScaleConditionalFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ColorScaleConditionalFormatUpdateData:interface'
     name: Interfaces.ColorScaleConditionalFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ColorScaleConditionalFormatData:interface'
     name: Excel.Interfaces.ColorScaleConditionalFormatData

--- a/docs/docs-ref-autogen/excel/excel/excel.comment.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.comment.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Comment#authorEmail:member'
@@ -412,7 +412,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Comment#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -473,7 +473,7 @@ items:
           type:
             - 'excel!Excel.CommentRichContent:interface'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Comment#contentType~0:complex'
     name: Excel.ContentType | "Plain" | "Mention"
@@ -507,7 +507,7 @@ references:
     name: Excel.CommentReplyCollection
   - uid: 'excel!Excel.Interfaces.CommentUpdateData:interface'
     name: Interfaces.CommentUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.CommentData:interface'
     name: Excel.Interfaces.CommentData

--- a/docs/docs-ref-autogen/excel/excel/excel.commentcollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.commentcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.CommentCollection#add:member(1)'
@@ -322,7 +322,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.CommentCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -342,7 +342,7 @@ items:
           - 'excel!Excel.Interfaces.CommentCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Comment:class'
     name: Excel.Comment
@@ -390,7 +390,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -427,7 +427,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.CommentCollectionData:interface'
     name: Excel.Interfaces.CommentCollectionData

--- a/docs/docs-ref-autogen/excel/excel/excel.commentreply.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.commentreply.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.CommentReply#authorEmail:member'
@@ -382,7 +382,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.CommentReply#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -443,7 +443,7 @@ items:
           type:
             - 'excel!Excel.CommentRichContent:interface'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.CommentReply#contentType~0:complex'
     name: Excel.ContentType | "Plain" | "Mention"
@@ -477,7 +477,7 @@ references:
         fullName: '[]'
   - uid: 'excel!Excel.Interfaces.CommentReplyUpdateData:interface'
     name: Interfaces.CommentReplyUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.CommentReplyData:interface'
     name: Excel.Interfaces.CommentReplyData

--- a/docs/docs-ref-autogen/excel/excel/excel.commentreplycollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.commentreplycollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.CommentReplyCollection#add:member(1)'
@@ -251,7 +251,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.CommentReplyCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -271,7 +271,7 @@ items:
           - 'excel!Excel.Interfaces.CommentReplyCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.CommentReply:class'
     name: Excel.CommentReply
@@ -301,7 +301,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -329,7 +329,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.CommentReplyCollectionData:interface'
     name: Excel.Interfaces.CommentReplyCollectionData

--- a/docs/docs-ref-autogen/excel/excel/excel.conditionaldatabarnegativeformat.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.conditionaldatabarnegativeformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ConditionalDataBarNegativeFormat#borderColor:member'
@@ -206,7 +206,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ConditionalDataBarNegativeFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -244,7 +244,7 @@ items:
           - 'excel!Excel.Interfaces.ConditionalDataBarNegativeFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -254,7 +254,7 @@ references:
     name: Excel.Interfaces.ConditionalDataBarNegativeFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ConditionalDataBarNegativeFormatUpdateData:interface'
     name: Interfaces.ConditionalDataBarNegativeFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ConditionalDataBarNegativeFormatData:interface'
     name: Excel.Interfaces.ConditionalDataBarNegativeFormatData

--- a/docs/docs-ref-autogen/excel/excel/excel.conditionaldatabarpositiveformat.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.conditionaldatabarpositiveformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ConditionalDataBarPositiveFormat#borderColor:member'
@@ -190,7 +190,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ConditionalDataBarPositiveFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -228,7 +228,7 @@ items:
           - 'excel!Excel.Interfaces.ConditionalDataBarPositiveFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -238,7 +238,7 @@ references:
     name: Excel.Interfaces.ConditionalDataBarPositiveFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ConditionalDataBarPositiveFormatUpdateData:interface'
     name: Interfaces.ConditionalDataBarPositiveFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ConditionalDataBarPositiveFormatData:interface'
     name: Excel.Interfaces.ConditionalDataBarPositiveFormatData

--- a/docs/docs-ref-autogen/excel/excel/excel.conditionalformat.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.conditionalformat.yml
@@ -14,7 +14,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ConditionalFormat#cellValue:member'
@@ -657,7 +657,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ConditionalFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -858,7 +858,7 @@ items:
 
           ```
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.CellValueConditionalFormat:class'
     name: Excel.CellValueConditionalFormat
@@ -884,7 +884,7 @@ references:
     name: Excel.PresetCriteriaConditionalFormat
   - uid: 'excel!Excel.Interfaces.ConditionalFormatUpdateData:interface'
     name: Interfaces.ConditionalFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.TextConditionalFormat:class'
     name: Excel.TextConditionalFormat

--- a/docs/docs-ref-autogen/excel/excel/excel.conditionalformatcollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.conditionalformatcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ConditionalFormatCollection#add:member(1)'
@@ -363,7 +363,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.ConditionalFormatCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -383,7 +383,7 @@ items:
           - 'excel!Excel.Interfaces.ConditionalFormatCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ConditionalFormat:class'
     name: Excel.ConditionalFormat
@@ -395,7 +395,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -423,7 +423,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.ConditionalFormatCollectionData:interface'
     name: Excel.Interfaces.ConditionalFormatCollectionData

--- a/docs/docs-ref-autogen/excel/excel/excel.conditionalformatrule.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.conditionalformatrule.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ConditionalFormatRule#context:member'
@@ -204,7 +204,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ConditionalFormatRule#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -242,7 +242,7 @@ items:
           - 'excel!Excel.Interfaces.ConditionalFormatRuleData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -252,7 +252,7 @@ references:
     name: Excel.Interfaces.ConditionalFormatRuleLoadOptions
   - uid: 'excel!Excel.Interfaces.ConditionalFormatRuleUpdateData:interface'
     name: Interfaces.ConditionalFormatRuleUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ConditionalFormatRuleData:interface'
     name: Excel.Interfaces.ConditionalFormatRuleData

--- a/docs/docs-ref-autogen/excel/excel/excel.conditionalrangeborder.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.conditionalrangeborder.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ConditionalRangeBorder#color:member'
@@ -154,7 +154,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ConditionalRangeBorder#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -228,7 +228,7 @@ items:
           - 'excel!Excel.Interfaces.ConditionalRangeBorderData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -238,7 +238,7 @@ references:
     name: Excel.Interfaces.ConditionalRangeBorderLoadOptions
   - uid: 'excel!Excel.Interfaces.ConditionalRangeBorderUpdateData:interface'
     name: Interfaces.ConditionalRangeBorderUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.ConditionalRangeBorder#sideIndex~0:complex'
     name: Excel.ConditionalRangeBorderIndex | "EdgeTop" | "EdgeBottom" | "EdgeLeft" | "EdgeRight"

--- a/docs/docs-ref-autogen/excel/excel/excel.conditionalrangebordercollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.conditionalrangebordercollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ConditionalRangeBorderCollection#bottom:member'
@@ -225,7 +225,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.ConditionalRangeBorderCollection#right:member'
     summary: |-
       Gets the right border. Read-only.
@@ -275,7 +275,7 @@ items:
         type:
           - 'excel!Excel.ConditionalRangeBorder:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ConditionalRangeBorder:class'
     name: Excel.ConditionalRangeBorder
@@ -306,7 +306,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.ConditionalRangeBorderCollectionData:interface'
     name: Excel.Interfaces.ConditionalRangeBorderCollectionData

--- a/docs/docs-ref-autogen/excel/excel/excel.conditionalrangefill.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.conditionalrangefill.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ConditionalRangeFill#clear:member(1)'
@@ -169,7 +169,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ConditionalRangeFill#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -207,7 +207,7 @@ items:
           - 'excel!Excel.Interfaces.ConditionalRangeFillData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -217,7 +217,7 @@ references:
     name: Excel.Interfaces.ConditionalRangeFillLoadOptions
   - uid: 'excel!Excel.Interfaces.ConditionalRangeFillUpdateData:interface'
     name: Interfaces.ConditionalRangeFillUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ConditionalRangeFillData:interface'
     name: Excel.Interfaces.ConditionalRangeFillData

--- a/docs/docs-ref-autogen/excel/excel/excel.conditionalrangefont.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.conditionalrangefont.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ConditionalRangeFont#bold:member'
@@ -201,7 +201,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ConditionalRangeFont#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -269,7 +269,7 @@ items:
         type:
           - 'excel!Excel.ConditionalRangeFont#underline~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -279,7 +279,7 @@ references:
     name: Excel.Interfaces.ConditionalRangeFontLoadOptions
   - uid: 'excel!Excel.Interfaces.ConditionalRangeFontUpdateData:interface'
     name: Interfaces.ConditionalRangeFontUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ConditionalRangeFontData:interface'
     name: Excel.Interfaces.ConditionalRangeFontData

--- a/docs/docs-ref-autogen/excel/excel/excel.conditionalrangeformat.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.conditionalrangeformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ConditionalRangeFormat#borders:member'
@@ -198,7 +198,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ConditionalRangeFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -236,7 +236,7 @@ items:
           - 'excel!Excel.Interfaces.ConditionalRangeFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ConditionalRangeBorderCollection:class'
     name: Excel.ConditionalRangeBorderCollection
@@ -252,7 +252,7 @@ references:
     name: Excel.Interfaces.ConditionalRangeFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ConditionalRangeFormatUpdateData:interface'
     name: Interfaces.ConditionalRangeFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ConditionalRangeFormatData:interface'
     name: Excel.Interfaces.ConditionalRangeFormatData

--- a/docs/docs-ref-autogen/excel/excel/excel.cultureinfo.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.cultureinfo.yml
@@ -15,7 +15,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.CultureInfo#context:member'
@@ -190,7 +190,7 @@ items:
           - 'excel!Excel.Interfaces.CultureInfoData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel/excel/excel.customconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.customconditionalformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.CustomConditionalFormat#context:member'
@@ -214,7 +214,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.CustomConditionalFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -252,7 +252,7 @@ items:
           - 'excel!Excel.Interfaces.CustomConditionalFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -266,7 +266,7 @@ references:
     name: Excel.ConditionalFormatRule
   - uid: 'excel!Excel.Interfaces.CustomConditionalFormatUpdateData:interface'
     name: Interfaces.CustomConditionalFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.CustomConditionalFormatData:interface'
     name: Excel.Interfaces.CustomConditionalFormatData

--- a/docs/docs-ref-autogen/excel/excel/excel.customproperty.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.customproperty.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.CustomProperty#context:member'
@@ -169,7 +169,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.CustomProperty#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -237,7 +237,7 @@ items:
         type:
           - any
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -247,7 +247,7 @@ references:
     name: Excel.Interfaces.CustomPropertyLoadOptions
   - uid: 'excel!Excel.Interfaces.CustomPropertyUpdateData:interface'
     name: Interfaces.CustomPropertyUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.CustomPropertyData:interface'
     name: Excel.Interfaces.CustomPropertyData

--- a/docs/docs-ref-autogen/excel/excel/excel.custompropertycollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.custompropertycollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.CustomPropertyCollection#add:member(1)'
@@ -215,7 +215,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.CustomPropertyCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -235,7 +235,7 @@ items:
           - 'excel!Excel.Interfaces.CustomPropertyCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.CustomProperty:class'
     name: Excel.CustomProperty
@@ -245,7 +245,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -273,7 +273,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.CustomPropertyCollectionData:interface'
     name: Excel.Interfaces.CustomPropertyCollectionData

--- a/docs/docs-ref-autogen/excel/excel/excel.customxmlpart.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.customxmlpart.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.CustomXmlPart#context:member'
@@ -343,7 +343,7 @@ items:
           - 'excel!Excel.Interfaces.CustomXmlPartData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -351,7 +351,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>

--- a/docs/docs-ref-autogen/excel/excel/excel.customxmlpartcollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.customxmlpartcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.CustomXmlPartCollection#add:member(1)'
@@ -317,7 +317,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.CustomXmlPartCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -337,7 +337,7 @@ items:
           - 'excel!Excel.Interfaces.CustomXmlPartCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.CustomXmlPart:class'
     name: Excel.CustomXmlPart
@@ -349,7 +349,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -377,7 +377,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.CustomXmlPartCollectionData:interface'
     name: Excel.Interfaces.CustomXmlPartCollectionData

--- a/docs/docs-ref-autogen/excel/excel/excel.customxmlpartscopedcollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.customxmlpartscopedcollection.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.CustomXmlPartScopedCollection#context:member'
@@ -325,7 +325,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.CustomXmlPartScopedCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -345,7 +345,7 @@ items:
           - 'excel!Excel.Interfaces.CustomXmlPartScopedCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -353,7 +353,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -383,7 +383,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.CustomXmlPartScopedCollectionData:interface'
     name: Excel.Interfaces.CustomXmlPartScopedCollectionData

--- a/docs/docs-ref-autogen/excel/excel/excel.databarconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.databarconditionalformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.DataBarConditionalFormat#axisColor:member'
@@ -259,7 +259,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.DataBarConditionalFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -330,7 +330,7 @@ items:
         type:
           - 'excel!Excel.ConditionalDataBarRule:interface'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.DataBarConditionalFormat#axisFormat~0:complex'
     name: Excel.ConditionalDataBarAxisFormat | "Automatic" | "None" | "CellMidPoint"
@@ -364,7 +364,7 @@ references:
     name: Excel.ConditionalDataBarPositiveFormat
   - uid: 'excel!Excel.Interfaces.DataBarConditionalFormatUpdateData:interface'
     name: Interfaces.DataBarConditionalFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.DataBarConditionalFormatData:interface'
     name: Excel.Interfaces.DataBarConditionalFormatData

--- a/docs/docs-ref-autogen/excel/excel/excel.dataconnectioncollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.dataconnectioncollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.DataConnectionCollection#context:member'
@@ -72,7 +72,7 @@ items:
                     }
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel/excel/excel.datapivothierarchy.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.datapivothierarchy.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.DataPivotHierarchy#context:member'
@@ -239,7 +239,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.DataPivotHierarchy#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -359,7 +359,7 @@ items:
           - 'excel!Excel.Interfaces.DataPivotHierarchyData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -371,7 +371,7 @@ references:
     name: Excel.Interfaces.DataPivotHierarchyLoadOptions
   - uid: 'excel!Excel.Interfaces.DataPivotHierarchyUpdateData:interface'
     name: Interfaces.DataPivotHierarchyUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.ShowAsRule:interface'
     name: Excel.ShowAsRule

--- a/docs/docs-ref-autogen/excel/excel/excel.datapivothierarchycollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.datapivothierarchycollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.DataPivotHierarchyCollection#add:member(1)'
@@ -193,7 +193,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.DataPivotHierarchyCollection#remove:member(1)'
     summary: |-
       Removes the PivotHierarchy from the current axis.
@@ -234,7 +234,7 @@ items:
           - 'excel!Excel.Interfaces.DataPivotHierarchyCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.DataPivotHierarchy:class'
     name: Excel.DataPivotHierarchy
@@ -246,7 +246,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -274,7 +274,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.DataPivotHierarchyCollectionData:interface'
     name: Excel.Interfaces.DataPivotHierarchyCollectionData

--- a/docs/docs-ref-autogen/excel/excel/excel.datavalidation.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.datavalidation.yml
@@ -14,7 +14,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.DataValidation#clear:member(1)'
@@ -376,7 +376,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.DataValidation#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -449,7 +449,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -467,7 +467,7 @@ references:
     name: Excel.DataValidationRule
   - uid: 'excel!Excel.Interfaces.DataValidationUpdateData:interface'
     name: Interfaces.DataValidationUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.DataValidationData:interface'
     name: Excel.Interfaces.DataValidationData

--- a/docs/docs-ref-autogen/excel/excel/excel.datetimeformatinfo.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.datetimeformatinfo.yml
@@ -14,7 +14,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.DatetimeFormatInfo#context:member'
@@ -225,7 +225,7 @@ items:
           - 'excel!Excel.Interfaces.DatetimeFormatInfoData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel/excel/excel.documentproperties.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.documentproperties.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.DocumentProperties#author:member'
@@ -296,7 +296,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.DocumentProperties#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -364,7 +364,7 @@ items:
           - 'excel!Excel.Interfaces.DocumentPropertiesData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -378,7 +378,7 @@ references:
     name: Excel.Interfaces.DocumentPropertiesLoadOptions
   - uid: 'excel!Excel.Interfaces.DocumentPropertiesUpdateData:interface'
     name: Interfaces.DocumentPropertiesUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.DocumentPropertiesData:interface'
     name: Excel.Interfaces.DocumentPropertiesData

--- a/docs/docs-ref-autogen/excel/excel/excel.filter.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.filter.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Filter#apply:member(1)'
@@ -473,7 +473,7 @@ items:
           - 'excel!Excel.Interfaces.FilterData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.FilterCriteria:interface'
     name: Excel.FilterCriteria

--- a/docs/docs-ref-autogen/excel/excel/excel.filterpivothierarchy.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.filterpivothierarchy.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.FilterPivotHierarchy#context:member'
@@ -215,7 +215,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.FilterPivotHierarchy#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -269,7 +269,7 @@ items:
           - 'excel!Excel.Interfaces.FilterPivotHierarchyData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -281,7 +281,7 @@ references:
     name: Excel.Interfaces.FilterPivotHierarchyLoadOptions
   - uid: 'excel!Excel.Interfaces.FilterPivotHierarchyUpdateData:interface'
     name: Interfaces.FilterPivotHierarchyUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.FilterPivotHierarchyData:interface'
     name: Excel.Interfaces.FilterPivotHierarchyData

--- a/docs/docs-ref-autogen/excel/excel/excel.filterpivothierarchycollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.filterpivothierarchycollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.FilterPivotHierarchyCollection#add:member(1)'
@@ -195,7 +195,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.FilterPivotHierarchyCollection#remove:member(1)'
     summary: |-
       Removes the PivotHierarchy from the current axis.
@@ -236,7 +236,7 @@ items:
           - 'excel!Excel.Interfaces.FilterPivotHierarchyCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.FilterPivotHierarchy:class'
     name: Excel.FilterPivotHierarchy
@@ -248,7 +248,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -276,7 +276,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.FilterPivotHierarchyCollectionData:interface'
     name: Excel.Interfaces.FilterPivotHierarchyCollectionData

--- a/docs/docs-ref-autogen/excel/excel/excel.formatprotection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.formatprotection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.FormatProtection#context:member'
@@ -170,7 +170,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.FormatProtection#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -208,7 +208,7 @@ items:
           - 'excel!Excel.Interfaces.FormatProtectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -218,7 +218,7 @@ references:
     name: Excel.Interfaces.FormatProtectionLoadOptions
   - uid: 'excel!Excel.Interfaces.FormatProtectionUpdateData:interface'
     name: Interfaces.FormatProtectionUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.FormatProtectionData:interface'
     name: Excel.Interfaces.FormatProtectionData

--- a/docs/docs-ref-autogen/excel/excel/excel.functionresult.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.functionresult.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.FunctionResult#context:member'
@@ -158,7 +158,7 @@ items:
         type:
           - T
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel/excel/excel.functions.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.functions.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Functions#abs:member(1)'
@@ -11184,7 +11184,7 @@ items:
           type:
             - 'excel!Excel.Functions#z_Test~3:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Functions#abs~0:complex'
     name: FunctionResult<number>

--- a/docs/docs-ref-autogen/excel/excel/excel.geometricshape.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.geometricshape.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.GeometricShape#context:member'
@@ -156,7 +156,7 @@ items:
           - 'excel!Excel.Interfaces.GeometricShapeData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel/excel/excel.groupshapecollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.groupshapecollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.GroupShapeCollection#context:member'
@@ -170,7 +170,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.GroupShapeCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -190,7 +190,7 @@ items:
           - 'excel!Excel.Interfaces.GroupShapeCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -198,7 +198,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -228,7 +228,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.GroupShapeCollectionData:interface'
     name: Excel.Interfaces.GroupShapeCollectionData

--- a/docs/docs-ref-autogen/excel/excel/excel.headerfooter.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.headerfooter.yml
@@ -8,7 +8,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.HeaderFooter#centerFooter:member'
@@ -239,7 +239,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.HeaderFooter#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -277,7 +277,7 @@ items:
           - 'excel!Excel.Interfaces.HeaderFooterData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -287,7 +287,7 @@ references:
     name: Excel.Interfaces.HeaderFooterLoadOptions
   - uid: 'excel!Excel.Interfaces.HeaderFooterUpdateData:interface'
     name: Interfaces.HeaderFooterUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.HeaderFooterData:interface'
     name: Excel.Interfaces.HeaderFooterData

--- a/docs/docs-ref-autogen/excel/excel/excel.headerfootergroup.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.headerfootergroup.yml
@@ -8,7 +8,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.HeaderFooterGroup#context:member'
@@ -198,7 +198,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.HeaderFooterGroup#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -285,7 +285,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -297,7 +297,7 @@ references:
     name: Excel.Interfaces.HeaderFooterGroupLoadOptions
   - uid: 'excel!Excel.Interfaces.HeaderFooterGroupUpdateData:interface'
     name: Interfaces.HeaderFooterGroupUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.HeaderFooterGroup#state~0:complex'
     name: Excel.HeaderFooterState | "Default" | "FirstAndDefault" | "OddAndEven" | "FirstOddAndEven"

--- a/docs/docs-ref-autogen/excel/excel/excel.iconsetconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.iconsetconditionalformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.IconSetConditionalFormat#context:member'
@@ -222,7 +222,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.IconSetConditionalFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -345,7 +345,7 @@ items:
           - 'excel!Excel.Interfaces.IconSetConditionalFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -364,7 +364,7 @@ references:
     name: Excel.Interfaces.IconSetConditionalFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.IconSetConditionalFormatUpdateData:interface'
     name: Interfaces.IconSetConditionalFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.IconSetConditionalFormat#style~0:complex'
     name: >-

--- a/docs/docs-ref-autogen/excel/excel/excel.image.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.image.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Image#context:member'
@@ -192,7 +192,7 @@ items:
           - 'excel!Excel.Interfaces.ImageData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel/excel/excel.iterativecalculation.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.iterativecalculation.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.IterativeCalculation#context:member'
@@ -182,7 +182,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.IterativeCalculation#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -220,7 +220,7 @@ items:
           - 'excel!Excel.Interfaces.IterativeCalculationData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -230,7 +230,7 @@ references:
     name: Excel.Interfaces.IterativeCalculationLoadOptions
   - uid: 'excel!Excel.Interfaces.IterativeCalculationUpdateData:interface'
     name: Interfaces.IterativeCalculationUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.IterativeCalculationData:interface'
     name: Excel.Interfaces.IterativeCalculationData

--- a/docs/docs-ref-autogen/excel/excel/excel.line.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.line.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Line#beginArrowheadLength:member'
@@ -529,7 +529,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Line#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -582,7 +582,7 @@ items:
           - 'excel!Excel.Interfaces.LineData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Line#beginArrowheadLength~0:complex'
     name: Excel.ArrowheadLength | "Short" | "Medium" | "Long"
@@ -657,7 +657,7 @@ references:
     name: Excel.Interfaces.LineLoadOptions
   - uid: 'excel!Excel.Interfaces.LineUpdateData:interface'
     name: Interfaces.LineUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.LineData:interface'
     name: Excel.Interfaces.LineData

--- a/docs/docs-ref-autogen/excel/excel/excel.nameditem.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.nameditem.yml
@@ -14,7 +14,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.NamedItem#arrayValues:member'
@@ -381,7 +381,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.NamedItem#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -500,7 +500,7 @@ items:
         type:
           - 'excel!Excel.Worksheet:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.NamedItemArrayValues:class'
     name: Excel.NamedItemArrayValues
@@ -523,7 +523,7 @@ references:
         fullName: ' | "Worksheet" | "Workbook"'
   - uid: 'excel!Excel.Interfaces.NamedItemUpdateData:interface'
     name: Interfaces.NamedItemUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.NamedItemData:interface'
     name: Excel.Interfaces.NamedItemData

--- a/docs/docs-ref-autogen/excel/excel/excel.nameditemarrayvalues.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.nameditemarrayvalues.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.NamedItemArrayValues#context:member'
@@ -154,7 +154,7 @@ items:
         type:
           - 'any[][]'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel/excel/excel.nameditemcollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.nameditemcollection.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.NamedItemCollection#add:member(1)'
@@ -294,7 +294,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.NamedItemCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -314,7 +314,7 @@ items:
           - 'excel!Excel.Interfaces.NamedItemCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.NamedItem:class'
     name: Excel.NamedItem
@@ -333,7 +333,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -361,7 +361,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.NamedItemCollectionData:interface'
     name: Excel.Interfaces.NamedItemCollectionData

--- a/docs/docs-ref-autogen/excel/excel/excel.numberformatinfo.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.numberformatinfo.yml
@@ -14,7 +14,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.NumberFormatInfo#context:member'
@@ -247,7 +247,7 @@ items:
           - 'excel!Excel.Interfaces.NumberFormatInfoData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel/excel/excel.pagebreak.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.pagebreak.yml
@@ -8,7 +8,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PageBreak#columnIndex:member'
@@ -185,7 +185,7 @@ items:
           - 'excel!Excel.Interfaces.PageBreakData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel/excel/excel.pagebreakcollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.pagebreakcollection.yml
@@ -8,7 +8,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PageBreakCollection#add:member(1)'
@@ -185,7 +185,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.PageBreakCollection#removePageBreaks:member(1)'
     summary: |-
       Resets all manual page breaks in the collection.
@@ -221,7 +221,7 @@ items:
           - 'excel!Excel.Interfaces.PageBreakCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.PageBreak:class'
     name: Excel.PageBreak
@@ -240,7 +240,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -268,7 +268,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.PageBreakCollectionData:interface'
     name: Excel.Interfaces.PageBreakCollectionData

--- a/docs/docs-ref-autogen/excel/excel/excel.pagelayout.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.pagelayout.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PageLayout#blackAndWhite:member'
@@ -605,7 +605,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.PageLayout#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -842,7 +842,7 @@ items:
 
           ```
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -915,7 +915,7 @@ references:
         fullName: ' | "DownThenOver" | "OverThenDown"'
   - uid: 'excel!Excel.Interfaces.PageLayoutUpdateData:interface'
     name: Interfaces.PageLayoutUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.PageLayout#setPrintArea~0:complex'
     name: Range | RangeAreas | string

--- a/docs/docs-ref-autogen/excel/excel/excel.pivotfield.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.pivotfield.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PivotField#applyFilter:member(1)'
@@ -359,7 +359,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.PivotField#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -524,7 +524,7 @@ items:
           - 'excel!Excel.Interfaces.PivotFieldData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.PivotField#applyFilter~0:complex'
     name: PivotValueFilter | PivotLabelFilter | PivotManualFilter | PivotDateFilter | PivotFilters
@@ -563,7 +563,7 @@ references:
     name: OfficeExtension.ClientResult<Excel.PivotFilters>
     fullName: OfficeExtension.ClientResult<Excel.PivotFilters>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <
@@ -577,7 +577,7 @@ references:
     name: OfficeExtension.ClientResult<boolean>
     fullName: OfficeExtension.ClientResult<boolean>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <boolean>
@@ -586,7 +586,7 @@ references:
     name: OfficeExtension.ClientResult<boolean>
     fullName: OfficeExtension.ClientResult<boolean>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <boolean>
@@ -599,7 +599,7 @@ references:
     name: Excel.Interfaces.PivotFieldLoadOptions
   - uid: 'excel!Excel.Interfaces.PivotFieldUpdateData:interface'
     name: Interfaces.PivotFieldUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.SortBy:enum'
     name: SortBy

--- a/docs/docs-ref-autogen/excel/excel/excel.pivotfieldcollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.pivotfieldcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PivotFieldCollection#context:member'
@@ -170,7 +170,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.PivotFieldCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -190,7 +190,7 @@ items:
           - 'excel!Excel.Interfaces.PivotFieldCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -198,7 +198,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -228,7 +228,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.PivotFieldCollectionData:interface'
     name: Excel.Interfaces.PivotFieldCollectionData

--- a/docs/docs-ref-autogen/excel/excel/excel.pivothierarchy.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.pivothierarchy.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PivotHierarchy#context:member'
@@ -182,7 +182,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.PivotHierarchy#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -220,7 +220,7 @@ items:
           - 'excel!Excel.Interfaces.PivotHierarchyData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -232,7 +232,7 @@ references:
     name: Excel.Interfaces.PivotHierarchyLoadOptions
   - uid: 'excel!Excel.Interfaces.PivotHierarchyUpdateData:interface'
     name: Interfaces.PivotHierarchyUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.PivotHierarchyData:interface'
     name: Excel.Interfaces.PivotHierarchyData

--- a/docs/docs-ref-autogen/excel/excel/excel.pivothierarchycollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.pivothierarchycollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PivotHierarchyCollection#context:member'
@@ -170,7 +170,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.PivotHierarchyCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -190,7 +190,7 @@ items:
           - 'excel!Excel.Interfaces.PivotHierarchyCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -198,7 +198,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -228,7 +228,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.PivotHierarchyCollectionData:interface'
     name: Excel.Interfaces.PivotHierarchyCollectionData

--- a/docs/docs-ref-autogen/excel/excel/excel.pivotitem.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.pivotitem.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PivotItem#context:member'
@@ -183,7 +183,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.PivotItem#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -236,7 +236,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -246,7 +246,7 @@ references:
     name: Excel.Interfaces.PivotItemLoadOptions
   - uid: 'excel!Excel.Interfaces.PivotItemUpdateData:interface'
     name: Interfaces.PivotItemUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.PivotItemData:interface'
     name: Excel.Interfaces.PivotItemData

--- a/docs/docs-ref-autogen/excel/excel/excel.pivotitemcollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.pivotitemcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PivotItemCollection#context:member'
@@ -170,7 +170,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.PivotItemCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -190,7 +190,7 @@ items:
           - 'excel!Excel.Interfaces.PivotItemCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -198,7 +198,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -228,7 +228,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.PivotItemCollectionData:interface'
     name: Excel.Interfaces.PivotItemCollectionData

--- a/docs/docs-ref-autogen/excel/excel/excel.pivotlayout.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.pivotlayout.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PivotLayout#autoFormat:member'
@@ -453,7 +453,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.PivotLayout#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -618,7 +618,7 @@ items:
           - 'excel!Excel.Interfaces.PivotLayoutData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -676,7 +676,7 @@ references:
     name: 'OfficeExtension.ClientResult<Excel.PivotItem[]>'
     fullName: 'OfficeExtension.ClientResult<Excel.PivotItem[]>'
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <
@@ -701,7 +701,7 @@ references:
     name: 'OfficeExtension.ClientResult<Excel.PivotItem[]>'
     fullName: 'OfficeExtension.ClientResult<Excel.PivotItem[]>'
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <
@@ -737,7 +737,7 @@ references:
     name: Excel.PivotTableStyle
   - uid: 'excel!Excel.Interfaces.PivotLayoutUpdateData:interface'
     name: Interfaces.PivotLayoutUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.PivotLayout#setAutoSortOnCell~0:complex'
     name: Range | string

--- a/docs/docs-ref-autogen/excel/excel/excel.pivottable.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.pivottable.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PivotTable#allowMultipleFiltersPerField:member'
@@ -460,7 +460,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.PivotTable#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -528,7 +528,7 @@ items:
         type:
           - 'excel!Excel.Worksheet:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RowColumnPivotHierarchyCollection:class'
     name: Excel.RowColumnPivotHierarchyCollection
@@ -548,7 +548,7 @@ references:
     name: Excel.Interfaces.PivotTableLoadOptions
   - uid: 'excel!Excel.Interfaces.PivotTableUpdateData:interface'
     name: Interfaces.PivotTableUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.PivotTableData:interface'
     name: Excel.Interfaces.PivotTableData

--- a/docs/docs-ref-autogen/excel/excel/excel.pivottablecollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.pivottablecollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PivotTableCollection#add:member(1)'
@@ -225,7 +225,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.PivotTableCollection#refreshAll:member(1)'
     summary: |-
       Refreshes all the pivot tables in the collection.
@@ -261,7 +261,7 @@ items:
           - 'excel!Excel.Interfaces.PivotTableCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.PivotTable:class'
     name: Excel.PivotTable
@@ -292,7 +292,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -320,7 +320,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.PivotTableCollectionData:interface'
     name: Excel.Interfaces.PivotTableCollectionData

--- a/docs/docs-ref-autogen/excel/excel/excel.pivottablescopedcollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.pivottablescopedcollection.yml
@@ -15,7 +15,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PivotTableScopedCollection#context:member'
@@ -209,7 +209,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.PivotTableScopedCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -230,7 +230,7 @@ items:
           - 'excel!Excel.Interfaces.PivotTableScopedCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -238,7 +238,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -268,7 +268,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.PivotTableScopedCollectionData:interface'
     name: Excel.Interfaces.PivotTableScopedCollectionData

--- a/docs/docs-ref-autogen/excel/excel/excel.pivottablestyle.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.pivottablestyle.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PivotTableStyle#context:member'
@@ -200,7 +200,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.PivotTableStyle#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -238,7 +238,7 @@ items:
           - 'excel!Excel.Interfaces.PivotTableStyleData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -248,7 +248,7 @@ references:
     name: Excel.Interfaces.PivotTableStyleLoadOptions
   - uid: 'excel!Excel.Interfaces.PivotTableStyleUpdateData:interface'
     name: Interfaces.PivotTableStyleUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.PivotTableStyleData:interface'
     name: Excel.Interfaces.PivotTableStyleData

--- a/docs/docs-ref-autogen/excel/excel/excel.pivottablestylecollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.pivottablestylecollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PivotTableStyleCollection#add:member(1)'
@@ -216,7 +216,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.PivotTableStyleCollection#setDefault:member(1)'
     summary: |-
       Sets the default PivotTableStyle for use in the parent object's scope.
@@ -257,7 +257,7 @@ items:
           - 'excel!Excel.Interfaces.PivotTableStyleCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.PivotTableStyle:class'
     name: Excel.PivotTableStyle
@@ -267,7 +267,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -295,7 +295,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.PivotTableStyleCollection#setDefault~0:complex'
     name: PivotTableStyle | string

--- a/docs/docs-ref-autogen/excel/excel/excel.presetcriteriaconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.presetcriteriaconditionalformat.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PresetCriteriaConditionalFormat#context:member'
@@ -212,7 +212,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.PresetCriteriaConditionalFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -250,7 +250,7 @@ items:
           - 'excel!Excel.Interfaces.PresetCriteriaConditionalFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -264,7 +264,7 @@ references:
     name: Excel.ConditionalPresetCriteriaRule
   - uid: 'excel!Excel.Interfaces.PresetCriteriaConditionalFormatUpdateData:interface'
     name: Interfaces.PresetCriteriaConditionalFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.PresetCriteriaConditionalFormatData:interface'
     name: Excel.Interfaces.PresetCriteriaConditionalFormatData

--- a/docs/docs-ref-autogen/excel/excel/excel.range.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.range.yml
@@ -16,7 +16,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Range#address:member'
@@ -3038,7 +3038,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Range#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -3647,7 +3647,7 @@ items:
         type:
           - 'excel!Excel.Worksheet:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Range#autoFill~0:complex'
     name: Range | string
@@ -3728,7 +3728,7 @@ references:
     name: 'OfficeExtension.ClientResult<CellProperties[][]>'
     fullName: 'OfficeExtension.ClientResult<Excel.CellProperties[][]>'
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <
@@ -3744,7 +3744,7 @@ references:
     name: 'OfficeExtension.ClientResult<ColumnProperties[]>'
     fullName: 'OfficeExtension.ClientResult<Excel.ColumnProperties[]>'
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <
@@ -3760,7 +3760,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -3789,7 +3789,7 @@ references:
     name: 'OfficeExtension.ClientResult<RowProperties[]>'
     fullName: 'OfficeExtension.ClientResult<Excel.RowProperties[]>'
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <
@@ -3852,7 +3852,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -3861,7 +3861,7 @@ references:
     name: Excel.ReplaceCriteria
   - uid: 'excel!Excel.Interfaces.RangeUpdateData:interface'
     name: Interfaces.RangeUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Range#setCellProperties~0:complex'
     name: 'SettableCellProperties[][]'

--- a/docs/docs-ref-autogen/excel/excel/excel.rangeareas.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.rangeareas.yml
@@ -14,7 +14,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeAreas#address:member'
@@ -852,7 +852,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.RangeAreas#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -974,7 +974,7 @@ items:
         type:
           - 'excel!Excel.Worksheet:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RangeCollection:class'
     name: Excel.RangeCollection
@@ -1058,7 +1058,7 @@ references:
     name: Excel.Interfaces.RangeAreasLoadOptions
   - uid: 'excel!Excel.Interfaces.RangeAreasUpdateData:interface'
     name: Interfaces.RangeAreasUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.RangeAreasData:interface'
     name: Excel.Interfaces.RangeAreasData

--- a/docs/docs-ref-autogen/excel/excel/excel.rangeborder.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.rangeborder.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeBorder#color:member'
@@ -156,7 +156,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.RangeBorder#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -288,7 +288,7 @@ items:
         type:
           - 'excel!Excel.RangeBorder#weight~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -298,7 +298,7 @@ references:
     name: Excel.Interfaces.RangeBorderLoadOptions
   - uid: 'excel!Excel.Interfaces.RangeBorderUpdateData:interface'
     name: Interfaces.RangeBorderUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.RangeBorder#sideIndex~0:complex'
     name: >-

--- a/docs/docs-ref-autogen/excel/excel/excel.rangebordercollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.rangebordercollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeBorderCollection#context:member'
@@ -266,7 +266,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.RangeBorderCollection#tintAndShade:member'
     summary: >-
       Returns or sets a double that lightens or darkens a color for Range Borders, the value is between -1 (darkest) and
@@ -304,7 +304,7 @@ items:
           - 'excel!Excel.Interfaces.RangeBorderCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -335,7 +335,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.RangeBorderCollectionData:interface'
     name: Excel.Interfaces.RangeBorderCollectionData

--- a/docs/docs-ref-autogen/excel/excel/excel.rangecollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.rangecollection.yml
@@ -8,7 +8,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeCollection#context:member'
@@ -145,7 +145,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.RangeCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -165,7 +165,7 @@ items:
           - 'excel!Excel.Interfaces.RangeCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -173,7 +173,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -203,7 +203,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.RangeCollectionData:interface'
     name: Excel.Interfaces.RangeCollectionData

--- a/docs/docs-ref-autogen/excel/excel/excel.rangefill.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.rangefill.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeFill#clear:member(1)'
@@ -286,7 +286,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.RangeFill#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -341,7 +341,7 @@ items:
           - 'excel!Excel.Interfaces.RangeFillData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -366,7 +366,7 @@ references:
         fullName: ' | "None" | "Solid" | "Gray50" | "Gray75" | "Gray25" | "Horizontal" | "Vertical" | "Down" | "Up" | "Checker" | "SemiGray75" | "LightHorizontal" | "LightVertical" | "LightDown" | "LightUp" | "Grid" | "CrissCross" | "Gray16" | "Gray8" | "LinearGradient" | "RectangularGradient"'
   - uid: 'excel!Excel.Interfaces.RangeFillUpdateData:interface'
     name: Interfaces.RangeFillUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.RangeFillData:interface'
     name: Excel.Interfaces.RangeFillData

--- a/docs/docs-ref-autogen/excel/excel/excel.rangefont.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.rangefont.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeFont#bold:member'
@@ -241,7 +241,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.RangeFont#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -380,7 +380,7 @@ items:
         type:
           - 'excel!Excel.RangeFont#underline~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -390,7 +390,7 @@ references:
     name: Excel.Interfaces.RangeFontLoadOptions
   - uid: 'excel!Excel.Interfaces.RangeFontUpdateData:interface'
     name: Interfaces.RangeFontUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.RangeFontData:interface'
     name: Excel.Interfaces.RangeFontData

--- a/docs/docs-ref-autogen/excel/excel/excel.rangeformat.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.rangeformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeFormat#adjustIndent:member(1)'
@@ -430,7 +430,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.RangeFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -592,7 +592,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RangeBorderCollection:class'
     name: Excel.RangeBorderCollection
@@ -632,7 +632,7 @@ references:
         fullName: ' | "Context" | "LeftToRight" | "RightToLeft"'
   - uid: 'excel!Excel.Interfaces.RangeFormatUpdateData:interface'
     name: Interfaces.RangeFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.RangeFormatData:interface'
     name: Excel.Interfaces.RangeFormatData

--- a/docs/docs-ref-autogen/excel/excel/excel.rangesort.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.rangesort.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeSort#apply:member(1)'
@@ -135,7 +135,7 @@ items:
                     }
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RangeSort#apply~0:complex'
     name: 'Excel.SortField[]'

--- a/docs/docs-ref-autogen/excel/excel/excel.rangeview.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.rangeview.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeView#cellAddresses:member'
@@ -300,7 +300,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.RangeView#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -387,7 +387,7 @@ items:
         type:
           - 'excel!Excel.RangeView#valueTypes~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -401,7 +401,7 @@ references:
     name: Excel.RangeViewCollection
   - uid: 'excel!Excel.Interfaces.RangeViewUpdateData:interface'
     name: Interfaces.RangeViewUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.RangeViewData:interface'
     name: Excel.Interfaces.RangeViewData

--- a/docs/docs-ref-autogen/excel/excel/excel.rangeviewcollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.rangeviewcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeViewCollection#context:member'
@@ -148,7 +148,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.RangeViewCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -168,7 +168,7 @@ items:
           - 'excel!Excel.Interfaces.RangeViewCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -176,7 +176,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -206,7 +206,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.RangeViewCollectionData:interface'
     name: Excel.Interfaces.RangeViewCollectionData

--- a/docs/docs-ref-autogen/excel/excel/excel.removeduplicatesresult.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.removeduplicatesresult.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RemoveDuplicatesResult#context:member'
@@ -178,7 +178,7 @@ items:
 
           ```
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel/excel/excel.requestcontext.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.requestcontext.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientRequestContext:class'
+      - 'office!OfficeExtension.ClientRequestContext:class'
     package: excel!
     children:
       - 'excel!Excel.RequestContext:constructor(1)'
@@ -67,7 +67,7 @@ items:
         type:
           - 'excel!Excel.Workbook:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientRequestContext:class'
+  - uid: 'office!OfficeExtension.ClientRequestContext:class'
     name: OfficeExtension.ClientRequestContext
   - uid: 'excel!Excel.RequestContext~0:complex'
     name: string | Session

--- a/docs/docs-ref-autogen/excel/excel/excel.rowcolumnpivothierarchy.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.rowcolumnpivothierarchy.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RowColumnPivotHierarchy#context:member'
@@ -199,7 +199,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.RowColumnPivotHierarchy#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -253,7 +253,7 @@ items:
           - 'excel!Excel.Interfaces.RowColumnPivotHierarchyData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -265,7 +265,7 @@ references:
     name: Excel.Interfaces.RowColumnPivotHierarchyLoadOptions
   - uid: 'excel!Excel.Interfaces.RowColumnPivotHierarchyUpdateData:interface'
     name: Interfaces.RowColumnPivotHierarchyUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.RowColumnPivotHierarchyData:interface'
     name: Excel.Interfaces.RowColumnPivotHierarchyData

--- a/docs/docs-ref-autogen/excel/excel/excel.rowcolumnpivothierarchycollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.rowcolumnpivothierarchycollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RowColumnPivotHierarchyCollection#add:member(1)'
@@ -195,7 +195,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.RowColumnPivotHierarchyCollection#remove:member(1)'
     summary: |-
       Removes the PivotHierarchy from the current axis.
@@ -237,7 +237,7 @@ items:
           - 'excel!Excel.Interfaces.RowColumnPivotHierarchyCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RowColumnPivotHierarchy:class'
     name: Excel.RowColumnPivotHierarchy
@@ -249,7 +249,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -277,7 +277,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.RowColumnPivotHierarchyCollectionData:interface'
     name: Excel.Interfaces.RowColumnPivotHierarchyCollectionData

--- a/docs/docs-ref-autogen/excel/excel/excel.runoptions.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.runoptions.yml
@@ -34,7 +34,7 @@ references:
     name: OfficeExtension.RunOptions<Session>
     fullName: OfficeExtension.RunOptions<Excel.Session>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.RunOptions:interface'
+      - uid: 'office!OfficeExtension.RunOptions:interface'
         name: OfficeExtension.RunOptions
         fullName: OfficeExtension.RunOptions
       - name: <

--- a/docs/docs-ref-autogen/excel/excel/excel.runtime.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.runtime.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Runtime#context:member'
@@ -178,7 +178,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Runtime#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -216,7 +216,7 @@ items:
           - 'excel!Excel.Interfaces.RuntimeData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -226,7 +226,7 @@ references:
     name: Excel.Interfaces.RuntimeLoadOptions
   - uid: 'excel!Excel.Interfaces.RuntimeUpdateData:interface'
     name: Interfaces.RuntimeUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.RuntimeData:interface'
     name: Excel.Interfaces.RuntimeData

--- a/docs/docs-ref-autogen/excel/excel/excel.setting.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.setting.yml
@@ -15,7 +15,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Setting#context:member'
@@ -200,7 +200,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Setting#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -253,7 +253,7 @@ items:
         type:
           - any
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -263,7 +263,7 @@ references:
     name: Excel.Interfaces.SettingLoadOptions
   - uid: 'excel!Excel.Interfaces.SettingUpdateData:interface'
     name: Interfaces.SettingUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.SettingData:interface'
     name: Excel.Interfaces.SettingData

--- a/docs/docs-ref-autogen/excel/excel/excel.settingcollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.settingcollection.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.SettingCollection#add:member(1)'
@@ -246,7 +246,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.SettingCollection#onSettingsChanged:member'
     summary: |-
       Occurs when the Settings in the document are changed.
@@ -301,7 +301,7 @@ items:
           - 'excel!Excel.Interfaces.SettingCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Setting:class'
     name: Excel.Setting
@@ -327,7 +327,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -355,13 +355,13 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.SettingCollection#onSettingsChanged~0:complex'
     name: OfficeExtension.EventHandlers<Excel.SettingsChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.SettingsChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <

--- a/docs/docs-ref-autogen/excel/excel/excel.shape.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.shape.yml
@@ -14,7 +14,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Shape#altTextDescription:member'
@@ -1076,7 +1076,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Shape#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -1274,7 +1274,7 @@ items:
         type:
           - number
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -1366,7 +1366,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -1377,7 +1377,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -1396,7 +1396,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.ShapeActivatedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.ShapeActivatedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -1410,7 +1410,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.ShapeDeactivatedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.ShapeDeactivatedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -1435,7 +1435,7 @@ references:
     name: Excel.ShapeScaleFrom
   - uid: 'excel!Excel.Interfaces.ShapeUpdateData:interface'
     name: Interfaces.ShapeUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.ShapeZOrder:enum'
     name: Excel.ShapeZOrder

--- a/docs/docs-ref-autogen/excel/excel/excel.shapecollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.shapecollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ShapeCollection#addGeometricShape:member(1)'
@@ -572,7 +572,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.ShapeCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -592,7 +592,7 @@ items:
           - 'excel!Excel.Interfaces.ShapeCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Shape:class'
     name: Excel.Shape
@@ -620,7 +620,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -648,7 +648,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.ShapeCollectionData:interface'
     name: Excel.Interfaces.ShapeCollectionData

--- a/docs/docs-ref-autogen/excel/excel/excel.shapefill.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.shapefill.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ShapeFill#clear:member(1)'
@@ -172,7 +172,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ShapeFill#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -268,7 +268,7 @@ items:
         type:
           - 'excel!Excel.ShapeFill#type~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -278,7 +278,7 @@ references:
     name: Excel.Interfaces.ShapeFillLoadOptions
   - uid: 'excel!Excel.Interfaces.ShapeFillUpdateData:interface'
     name: Interfaces.ShapeFillUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ShapeFillData:interface'
     name: Excel.Interfaces.ShapeFillData

--- a/docs/docs-ref-autogen/excel/excel/excel.shapefont.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.shapefont.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ShapeFont#bold:member'
@@ -206,7 +206,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ShapeFont#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -281,7 +281,7 @@ items:
         type:
           - 'excel!Excel.ShapeFont#underline~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -291,7 +291,7 @@ references:
     name: Excel.Interfaces.ShapeFontLoadOptions
   - uid: 'excel!Excel.Interfaces.ShapeFontUpdateData:interface'
     name: Interfaces.ShapeFontUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ShapeFontData:interface'
     name: Excel.Interfaces.ShapeFontData

--- a/docs/docs-ref-autogen/excel/excel/excel.shapegroup.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.shapegroup.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ShapeGroup#context:member'
@@ -210,7 +210,7 @@ items:
 
           ```
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel/excel/excel.shapelineformat.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.shapelineformat.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ShapeLineFormat#color:member'
@@ -178,7 +178,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ShapeLineFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -284,7 +284,7 @@ items:
         type:
           - number
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -307,7 +307,7 @@ references:
     name: Excel.Interfaces.ShapeLineFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ShapeLineFormatUpdateData:interface'
     name: Interfaces.ShapeLineFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.ShapeLineFormat#style~0:complex'
     name: Excel.ShapeLineStyle | "Single" | "ThickBetweenThin" | "ThickThin" | "ThinThick" | "ThinThin"

--- a/docs/docs-ref-autogen/excel/excel/excel.slicer.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.slicer.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Slicer#caption:member'
@@ -387,7 +387,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Slicer#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -586,7 +586,7 @@ items:
         type:
           - 'excel!Excel.Worksheet:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -594,7 +594,7 @@ references:
     name: 'OfficeExtension.ClientResult<string[]>'
     fullName: 'OfficeExtension.ClientResult<string[]>'
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: '<string[]>'
@@ -605,7 +605,7 @@ references:
     name: Excel.Interfaces.SlicerLoadOptions
   - uid: 'excel!Excel.Interfaces.SlicerUpdateData:interface'
     name: Interfaces.SlicerUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Slicer#setStyle~0:complex'
     name: string | PivotTableStyle | BuiltInSlicerStyle

--- a/docs/docs-ref-autogen/excel/excel/excel.slicercollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.slicercollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.SlicerCollection#add:member(1)'
@@ -275,7 +275,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.SlicerCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -295,7 +295,7 @@ items:
           - 'excel!Excel.Interfaces.SlicerCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Slicer:class'
     name: Excel.Slicer
@@ -342,7 +342,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -370,7 +370,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.SlicerCollectionData:interface'
     name: Excel.Interfaces.SlicerCollectionData

--- a/docs/docs-ref-autogen/excel/excel/excel.sliceritem.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.sliceritem.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.SlicerItem#context:member'
@@ -200,7 +200,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.SlicerItem#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -238,7 +238,7 @@ items:
           - 'excel!Excel.Interfaces.SlicerItemData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -248,7 +248,7 @@ references:
     name: Excel.Interfaces.SlicerItemLoadOptions
   - uid: 'excel!Excel.Interfaces.SlicerItemUpdateData:interface'
     name: Interfaces.SlicerItemUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.SlicerItemData:interface'
     name: Excel.Interfaces.SlicerItemData

--- a/docs/docs-ref-autogen/excel/excel/excel.sliceritemcollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.sliceritemcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.SlicerItemCollection#context:member'
@@ -192,7 +192,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.SlicerItemCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -212,7 +212,7 @@ items:
           - 'excel!Excel.Interfaces.SlicerItemCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -220,7 +220,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -250,7 +250,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.SlicerItemCollectionData:interface'
     name: Excel.Interfaces.SlicerItemCollectionData

--- a/docs/docs-ref-autogen/excel/excel/excel.slicerstyle.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.slicerstyle.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.SlicerStyle#context:member'
@@ -200,7 +200,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.SlicerStyle#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -238,7 +238,7 @@ items:
           - 'excel!Excel.Interfaces.SlicerStyleData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -248,7 +248,7 @@ references:
     name: Excel.Interfaces.SlicerStyleLoadOptions
   - uid: 'excel!Excel.Interfaces.SlicerStyleUpdateData:interface'
     name: Interfaces.SlicerStyleUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.SlicerStyleData:interface'
     name: Excel.Interfaces.SlicerStyleData

--- a/docs/docs-ref-autogen/excel/excel/excel.slicerstylecollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.slicerstylecollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.SlicerStyleCollection#add:member(1)'
@@ -216,7 +216,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.SlicerStyleCollection#setDefault:member(1)'
     summary: |-
       Sets the default SlicerStyle for use in the parent object's scope.
@@ -257,7 +257,7 @@ items:
           - 'excel!Excel.Interfaces.SlicerStyleCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.SlicerStyle:class'
     name: Excel.SlicerStyle
@@ -267,7 +267,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -295,7 +295,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.SlicerStyleCollection#setDefault~0:complex'
     name: SlicerStyle | string

--- a/docs/docs-ref-autogen/excel/excel/excel.style.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.style.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Style#autoIndent:member'
@@ -568,7 +568,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Style#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -666,7 +666,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RangeBorderCollection:class'
     name: Excel.RangeBorderCollection
@@ -704,7 +704,7 @@ references:
         fullName: ' | "Context" | "LeftToRight" | "RightToLeft"'
   - uid: 'excel!Excel.Interfaces.StyleUpdateData:interface'
     name: Interfaces.StyleUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.StyleData:interface'
     name: Excel.Interfaces.StyleData

--- a/docs/docs-ref-autogen/excel/excel/excel.stylecollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.stylecollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.StyleCollection#add:member(1)'
@@ -256,7 +256,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.StyleCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -276,7 +276,7 @@ items:
           - 'excel!Excel.Interfaces.StyleCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -284,7 +284,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -314,7 +314,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.StyleCollectionData:interface'
     name: Excel.Interfaces.StyleCollectionData

--- a/docs/docs-ref-autogen/excel/excel/excel.table.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.table.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Table#autoFilter:member'
@@ -678,7 +678,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Table#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -913,7 +913,7 @@ items:
         type:
           - 'excel!Excel.Worksheet:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.AutoFilter:class'
     name: Excel.AutoFilter
@@ -931,7 +931,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.TableChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.TableChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -945,7 +945,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.TableFilteredEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.TableFilteredEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -959,7 +959,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.TableSelectionChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.TableSelectionChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -973,7 +973,7 @@ references:
     name: Excel.TableRowCollection
   - uid: 'excel!Excel.Interfaces.TableUpdateData:interface'
     name: Interfaces.TableUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Table#setStyle~0:complex'
     name: string | PivotTableStyle | BuiltInTableStyle

--- a/docs/docs-ref-autogen/excel/excel/excel.tablecollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.tablecollection.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableCollection#add:member(1)'
@@ -342,7 +342,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.TableCollection#onAdded:member'
     summary: |-
       Occurs when new table is added in a workbook.
@@ -445,7 +445,7 @@ items:
           - 'excel!Excel.Interfaces.TableCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Table:class'
     name: Excel.Table
@@ -464,7 +464,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -492,13 +492,13 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.TableCollection#onAdded~0:complex'
     name: OfficeExtension.EventHandlers<Excel.TableAddedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.TableAddedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -512,7 +512,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.TableChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.TableChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -526,7 +526,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.TableDeletedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.TableDeletedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -540,7 +540,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.TableFilteredEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.TableFilteredEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <

--- a/docs/docs-ref-autogen/excel/excel/excel.tablecolumn.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.tablecolumn.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableColumn#context:member'
@@ -401,7 +401,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.TableColumn#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -456,7 +456,7 @@ items:
         type:
           - 'any[][]'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -470,7 +470,7 @@ references:
     name: Excel.Interfaces.TableColumnLoadOptions
   - uid: 'excel!Excel.Interfaces.TableColumnUpdateData:interface'
     name: Interfaces.TableColumnUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.TableColumnData:interface'
     name: Excel.Interfaces.TableColumnData

--- a/docs/docs-ref-autogen/excel/excel/excel.tablecolumncollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.tablecolumncollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableColumnCollection#add:member(1)'
@@ -322,7 +322,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.TableColumnCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -342,7 +342,7 @@ items:
           - 'excel!Excel.Interfaces.TableColumnCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.TableColumn:class'
     name: Excel.TableColumn
@@ -366,7 +366,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -394,7 +394,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.TableColumnCollectionData:interface'
     name: Excel.Interfaces.TableColumnCollectionData

--- a/docs/docs-ref-autogen/excel/excel/excel.tablerow.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.tablerow.yml
@@ -17,7 +17,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableRow#context:member'
@@ -247,7 +247,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.TableRow#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -302,7 +302,7 @@ items:
         type:
           - 'any[][]'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -314,7 +314,7 @@ references:
     name: Excel.Interfaces.TableRowLoadOptions
   - uid: 'excel!Excel.Interfaces.TableRowUpdateData:interface'
     name: Interfaces.TableRowUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.TableRowData:interface'
     name: Excel.Interfaces.TableRowData

--- a/docs/docs-ref-autogen/excel/excel/excel.tablerowcollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.tablerowcollection.yml
@@ -17,7 +17,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableRowCollection#add:member(1)'
@@ -290,7 +290,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.TableRowCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -310,7 +310,7 @@ items:
           - 'excel!Excel.Interfaces.TableRowCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.TableRow:class'
     name: Excel.TableRow
@@ -334,7 +334,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -362,7 +362,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.TableRowCollectionData:interface'
     name: Excel.Interfaces.TableRowCollectionData

--- a/docs/docs-ref-autogen/excel/excel/excel.tablescopedcollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.tablescopedcollection.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableScopedCollection#context:member'
@@ -169,7 +169,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.TableScopedCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -189,7 +189,7 @@ items:
           - 'excel!Excel.Interfaces.TableScopedCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -197,7 +197,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -227,7 +227,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.TableScopedCollectionData:interface'
     name: Excel.Interfaces.TableScopedCollectionData

--- a/docs/docs-ref-autogen/excel/excel/excel.tablesort.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.tablesort.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableSort#apply:member(1)'
@@ -288,7 +288,7 @@ items:
           - 'excel!Excel.Interfaces.TableSortData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.TableSort#apply~0:complex'
     name: 'Excel.SortField[]'

--- a/docs/docs-ref-autogen/excel/excel/excel.tablestyle.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.tablestyle.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableStyle#context:member'
@@ -200,7 +200,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.TableStyle#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -238,7 +238,7 @@ items:
           - 'excel!Excel.Interfaces.TableStyleData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -248,7 +248,7 @@ references:
     name: Excel.Interfaces.TableStyleLoadOptions
   - uid: 'excel!Excel.Interfaces.TableStyleUpdateData:interface'
     name: Interfaces.TableStyleUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.TableStyleData:interface'
     name: Excel.Interfaces.TableStyleData

--- a/docs/docs-ref-autogen/excel/excel/excel.tablestylecollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.tablestylecollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableStyleCollection#add:member(1)'
@@ -216,7 +216,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.TableStyleCollection#setDefault:member(1)'
     summary: |-
       Sets the default TableStyle for use in the parent object's scope.
@@ -257,7 +257,7 @@ items:
           - 'excel!Excel.Interfaces.TableStyleCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.TableStyle:class'
     name: Excel.TableStyle
@@ -267,7 +267,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -295,7 +295,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.TableStyleCollection#setDefault~0:complex'
     name: TableStyle | string

--- a/docs/docs-ref-autogen/excel/excel/excel.textconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.textconditionalformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TextConditionalFormat#context:member'
@@ -214,7 +214,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.TextConditionalFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -252,7 +252,7 @@ items:
           - 'excel!Excel.Interfaces.TextConditionalFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -266,7 +266,7 @@ references:
     name: Excel.ConditionalTextComparisonRule
   - uid: 'excel!Excel.Interfaces.TextConditionalFormatUpdateData:interface'
     name: Interfaces.TextConditionalFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.TextConditionalFormatData:interface'
     name: Excel.Interfaces.TextConditionalFormatData

--- a/docs/docs-ref-autogen/excel/excel/excel.textframe.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.textframe.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TextFrame#autoSizeSetting:member'
@@ -327,7 +327,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.TextFrame#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -427,7 +427,7 @@ items:
         type:
           - 'excel!Excel.TextFrame#verticalOverflow~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.TextFrame#autoSizeSetting~0:complex'
     name: Excel.ShapeAutoSize | "AutoSizeNone" | "AutoSizeTextToFitShape" | "AutoSizeShapeToFitText" | "AutoSizeMixed"
@@ -490,7 +490,7 @@ references:
         fullName: ' | "LeftToRight" | "RightToLeft"'
   - uid: 'excel!Excel.Interfaces.TextFrameUpdateData:interface'
     name: Interfaces.TextFrameUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.TextRange:class'
     name: Excel.TextRange

--- a/docs/docs-ref-autogen/excel/excel/excel.textrange.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.textrange.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TextRange#context:member'
@@ -179,7 +179,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.TextRange#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -232,7 +232,7 @@ items:
           - 'excel!Excel.Interfaces.TextRangeData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -244,7 +244,7 @@ references:
     name: Excel.Interfaces.TextRangeLoadOptions
   - uid: 'excel!Excel.Interfaces.TextRangeUpdateData:interface'
     name: Interfaces.TextRangeUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.TextRangeData:interface'
     name: Excel.Interfaces.TextRangeData

--- a/docs/docs-ref-autogen/excel/excel/excel.timelinestyle.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.timelinestyle.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TimelineStyle#context:member'
@@ -200,7 +200,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.TimelineStyle#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -238,7 +238,7 @@ items:
           - 'excel!Excel.Interfaces.TimelineStyleData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -248,7 +248,7 @@ references:
     name: Excel.Interfaces.TimelineStyleLoadOptions
   - uid: 'excel!Excel.Interfaces.TimelineStyleUpdateData:interface'
     name: Interfaces.TimelineStyleUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.TimelineStyleData:interface'
     name: Excel.Interfaces.TimelineStyleData

--- a/docs/docs-ref-autogen/excel/excel/excel.timelinestylecollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.timelinestylecollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TimelineStyleCollection#add:member(1)'
@@ -216,7 +216,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.TimelineStyleCollection#setDefault:member(1)'
     summary: |-
       Sets the default TimelineStyle for use in the parent object's scope.
@@ -257,7 +257,7 @@ items:
           - 'excel!Excel.Interfaces.TimelineStyleCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.TimelineStyle:class'
     name: Excel.TimelineStyle
@@ -267,7 +267,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -295,7 +295,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.TimelineStyleCollection#setDefault~0:complex'
     name: TimelineStyle | string

--- a/docs/docs-ref-autogen/excel/excel/excel.topbottomconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.topbottomconditionalformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TopBottomConditionalFormat#context:member'
@@ -168,7 +168,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.TopBottomConditionalFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -206,7 +206,7 @@ items:
           - 'excel!Excel.Interfaces.TopBottomConditionalFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -220,7 +220,7 @@ references:
     name: Excel.ConditionalTopBottomRule
   - uid: 'excel!Excel.Interfaces.TopBottomConditionalFormatUpdateData:interface'
     name: Interfaces.TopBottomConditionalFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.TopBottomConditionalFormatData:interface'
     name: Excel.Interfaces.TopBottomConditionalFormatData

--- a/docs/docs-ref-autogen/excel/excel/excel.workbook.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.workbook.yml
@@ -14,7 +14,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Workbook#application:member'
@@ -841,7 +841,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Workbook#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -1067,7 +1067,7 @@ items:
         type:
           - 'excel!Excel.WorksheetCollection:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Application:class'
     name: Excel.Application
@@ -1095,7 +1095,7 @@ references:
     name: OfficeExtension.ClientResult<boolean>
     fullName: OfficeExtension.ClientResult<boolean>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <boolean>
@@ -1112,7 +1112,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorkbookAutoSaveSettingChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorkbookAutoSaveSettingChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -1126,7 +1126,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.SelectionChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.SelectionChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -1148,7 +1148,7 @@ references:
     name: Excel.SaveBehavior
   - uid: 'excel!Excel.Interfaces.WorkbookUpdateData:interface'
     name: Interfaces.WorkbookUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.SettingCollection:class'
     name: Excel.SettingCollection

--- a/docs/docs-ref-autogen/excel/excel/excel.workbookcreated.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.workbookcreated.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.WorkbookCreated#context:member'
@@ -103,7 +103,7 @@ items:
           - 'excel!Excel.Interfaces.WorkbookCreatedData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel/excel/excel.workbookprotection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.workbookprotection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.WorkbookProtection#context:member'
@@ -258,7 +258,7 @@ items:
           type:
             - string
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel/excel/excel.worksheet.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.worksheet.yml
@@ -14,7 +14,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Worksheet#activate:member(1)'
@@ -1592,7 +1592,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Worksheet#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -1912,7 +1912,7 @@ items:
         type:
           - 'excel!Excel.Worksheet#visibility~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.AutoFilter:class'
     name: Excel.AutoFilter
@@ -1946,7 +1946,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetActivatedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetActivatedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -1960,7 +1960,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetCalculatedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetCalculatedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -1974,7 +1974,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -1988,7 +1988,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetColumnSortedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetColumnSortedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -2002,7 +2002,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetDeactivatedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetDeactivatedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -2016,7 +2016,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetFilteredEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetFilteredEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -2030,7 +2030,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetFormatChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetFormatChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -2044,7 +2044,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetRowHiddenChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetRowHiddenChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -2058,7 +2058,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetRowSortedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetRowSortedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -2072,7 +2072,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetSelectionChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetSelectionChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -2086,7 +2086,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetSingleClickedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetSingleClickedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -2106,7 +2106,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -2115,7 +2115,7 @@ references:
     name: Excel.ReplaceCriteria
   - uid: 'excel!Excel.Interfaces.WorksheetUpdateData:interface'
     name: Interfaces.WorksheetUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.ShapeCollection:class'
     name: Excel.ShapeCollection

--- a/docs/docs-ref-autogen/excel/excel/excel.worksheetcollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.worksheetcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.WorksheetCollection#add:member(1)'
@@ -539,7 +539,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.WorksheetCollection#onActivated:member'
     summary: |-
       Occurs when any worksheet in the workbook is activated.
@@ -823,7 +823,7 @@ items:
           - 'excel!Excel.Interfaces.WorksheetCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Worksheet:class'
     name: Excel.Worksheet
@@ -831,7 +831,7 @@ references:
     name: 'OfficeExtension.ClientResult<string[]>'
     fullName: 'OfficeExtension.ClientResult<string[]>'
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: '<string[]>'
@@ -851,7 +851,7 @@ references:
     name: 'OfficeExtension.ClientResult<string[]>'
     fullName: 'OfficeExtension.ClientResult<string[]>'
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: '<string[]>'
@@ -871,7 +871,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -899,13 +899,13 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.WorksheetCollection#onActivated~0:complex'
     name: OfficeExtension.EventHandlers<Excel.WorksheetActivatedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetActivatedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -919,7 +919,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetAddedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetAddedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -933,7 +933,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetCalculatedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetCalculatedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -947,7 +947,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -961,7 +961,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetColumnSortedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetColumnSortedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -975,7 +975,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetDeactivatedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetDeactivatedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -989,7 +989,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetDeletedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetDeletedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -1003,7 +1003,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetFilteredEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetFilteredEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -1017,7 +1017,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetFormatChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetFormatChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -1031,7 +1031,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetRowHiddenChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetRowHiddenChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -1045,7 +1045,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetRowSortedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetRowSortedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -1059,7 +1059,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetSelectionChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetSelectionChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -1073,7 +1073,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetSingleClickedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetSingleClickedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <

--- a/docs/docs-ref-autogen/excel/excel/excel.worksheetcustomproperty.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.worksheetcustomproperty.yml
@@ -14,7 +14,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.WorksheetCustomProperty#context:member'
@@ -168,7 +168,7 @@ items:
         type:
           - string
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel/excel/excel.worksheetcustompropertycollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.worksheetcustompropertycollection.yml
@@ -14,7 +14,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.WorksheetCustomPropertyCollection#context:member'
@@ -188,7 +188,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.WorksheetCustomPropertyCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -210,7 +210,7 @@ items:
           - 'excel!Excel.Interfaces.WorksheetCustomPropertyCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -218,7 +218,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -248,7 +248,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.WorksheetCustomPropertyCollectionData:interface'
     name: Excel.Interfaces.WorksheetCustomPropertyCollectionData

--- a/docs/docs-ref-autogen/excel/excel/excel.worksheetfreezepanes.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.worksheetfreezepanes.yml
@@ -8,7 +8,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.WorksheetFreezePanes#context:member'
@@ -278,7 +278,7 @@ items:
 
           ```
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel/excel/excel.worksheetprotection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.worksheetprotection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.WorksheetProtection#context:member'
@@ -282,7 +282,7 @@ items:
           type:
             - string
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel_1_1/excel.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel.yml
@@ -515,7 +515,7 @@ items:
             A previously-created API object. The batch will use the same RequestContext as the passed-in object, which
             means that any changes applied to the object will be picked up by "context.sync()".
           type:
-            - 'excel!OfficeExtension.ClientObject:class'
+            - 'office!OfficeExtension.ClientObject:class'
         - id: batch
           description: >-
             A function that takes in a RequestContext and returns a promise (typically, just the result of
@@ -620,7 +620,7 @@ items:
             A previously-created object. The batch will use the same RequestContext as the passed-in object, which means
             that any changes applied to the object will be picked up by "context.sync()".
           type:
-            - 'excel!OfficeExtension.ClientRequestContext:class'
+            - 'office!OfficeExtension.ClientRequestContext:class'
         - id: batch
           description: >-
             A function that takes in a RequestContext and returns a promise (typically, just the result of
@@ -1466,7 +1466,7 @@ references:
         fullName: Promise
       - name: <T>
         fullName: <T>
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.run~3:complex'
     name: '(context: Excel.RequestContext) => Promise<T>'
@@ -1497,7 +1497,7 @@ references:
     name: 'OfficeExtension.ClientObject[]'
     fullName: 'OfficeExtension.ClientObject[]'
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientObject:class'
+      - uid: 'office!OfficeExtension.ClientObject:class'
         name: OfficeExtension.ClientObject
         fullName: OfficeExtension.ClientObject
       - name: '[]'
@@ -1554,7 +1554,7 @@ references:
         fullName: Promise
       - name: <T>
         fullName: <T>
-  - uid: 'excel!OfficeExtension.ClientRequestContext:class'
+  - uid: 'office!OfficeExtension.ClientRequestContext:class'
     name: OfficeExtension.ClientRequestContext
   - uid: 'excel!Excel.run~10:complex'
     name: '(context: Excel.RequestContext) => Promise<T>'

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.application.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.application.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Application#calculate:member(1)'
@@ -232,7 +232,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Application#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -270,7 +270,7 @@ items:
           - 'excel!Excel.Interfaces.ApplicationData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.CalculationType:enum'
     name: Excel.CalculationType
@@ -291,7 +291,7 @@ references:
     name: Excel.Interfaces.ApplicationLoadOptions
   - uid: 'excel!Excel.Interfaces.ApplicationUpdateData:interface'
     name: Interfaces.ApplicationUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ApplicationData:interface'
     name: Excel.Interfaces.ApplicationData

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.binding.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.binding.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Binding#context:member'
@@ -280,7 +280,7 @@ items:
         type:
           - 'excel!Excel.Binding#type~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -292,7 +292,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.bindingcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.bindingcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.BindingCollection#context:member'
@@ -270,7 +270,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.BindingCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -290,7 +290,7 @@ items:
           - 'excel!Excel.Interfaces.BindingCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -319,7 +319,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.BindingCollectionData:interface'
     name: Excel.Interfaces.BindingCollectionData

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.chart.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.chart.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Chart#axes:member'
@@ -367,7 +367,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Chart#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -577,7 +577,7 @@ items:
         type:
           - number
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartAxes:class'
     name: Excel.ChartAxes
@@ -597,7 +597,7 @@ references:
     name: Excel.ChartSeriesCollection
   - uid: 'excel!Excel.Interfaces.ChartUpdateData:interface'
     name: Interfaces.ChartUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Range:class'
     name: Range

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.chartareaformat.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.chartareaformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAreaFormat#context:member'
@@ -166,7 +166,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAreaFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -204,7 +204,7 @@ items:
           - 'excel!Excel.Interfaces.ChartAreaFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -218,7 +218,7 @@ references:
     name: Excel.Interfaces.ChartAreaFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartAreaFormatUpdateData:interface'
     name: Interfaces.ChartAreaFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartAreaFormatData:interface'
     name: Excel.Interfaces.ChartAreaFormatData

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.chartaxes.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.chartaxes.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAxes#categoryAxis:member'
@@ -167,7 +167,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAxes#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -243,7 +243,7 @@ items:
           });
           ```
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartAxis:class'
     name: Excel.ChartAxis
@@ -255,7 +255,7 @@ references:
     name: Excel.Interfaces.ChartAxesLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartAxesUpdateData:interface'
     name: Interfaces.ChartAxesUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartAxesData:interface'
     name: Excel.Interfaces.ChartAxesData

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.chartaxis.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.chartaxis.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAxis#context:member'
@@ -275,7 +275,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAxis#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -328,7 +328,7 @@ items:
           - 'excel!Excel.Interfaces.ChartAxisData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -342,7 +342,7 @@ references:
     name: Excel.ChartGridlines
   - uid: 'excel!Excel.Interfaces.ChartAxisUpdateData:interface'
     name: Interfaces.ChartAxisUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.ChartAxisTitle:class'
     name: Excel.ChartAxisTitle

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.chartaxisformat.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.chartaxisformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAxisFormat#context:member'
@@ -166,7 +166,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAxisFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -204,7 +204,7 @@ items:
           - 'excel!Excel.Interfaces.ChartAxisFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -218,7 +218,7 @@ references:
     name: Excel.Interfaces.ChartAxisFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisFormatUpdateData:interface'
     name: Interfaces.ChartAxisFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisFormatData:interface'
     name: Excel.Interfaces.ChartAxisFormatData

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.chartaxistitle.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.chartaxistitle.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAxisTitle#context:member'
@@ -171,7 +171,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAxisTitle#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -239,7 +239,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -251,7 +251,7 @@ references:
     name: Excel.Interfaces.ChartAxisTitleLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisTitleUpdateData:interface'
     name: Interfaces.ChartAxisTitleUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisTitleData:interface'
     name: Excel.Interfaces.ChartAxisTitleData

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.chartaxistitleformat.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.chartaxistitleformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAxisTitleFormat#context:member'
@@ -150,7 +150,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAxisTitleFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -188,7 +188,7 @@ items:
           - 'excel!Excel.Interfaces.ChartAxisTitleFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -200,7 +200,7 @@ references:
     name: Excel.Interfaces.ChartAxisTitleFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisTitleFormatUpdateData:interface'
     name: Interfaces.ChartAxisTitleFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisTitleFormatData:interface'
     name: Excel.Interfaces.ChartAxisTitleFormatData

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.chartcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartCollection#add:member(1)'
@@ -342,7 +342,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.ChartCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -362,7 +362,7 @@ items:
           - 'excel!Excel.Interfaces.ChartCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Chart:class'
     name: Excel.Chart
@@ -397,7 +397,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.ChartCollectionData:interface'
     name: Excel.Interfaces.ChartCollectionData

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.chartdatalabelformat.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.chartdatalabelformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartDataLabelFormat#context:member'
@@ -166,7 +166,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartDataLabelFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -204,7 +204,7 @@ items:
           - 'excel!Excel.Interfaces.ChartDataLabelFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -218,7 +218,7 @@ references:
     name: Excel.Interfaces.ChartDataLabelFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartDataLabelFormatUpdateData:interface'
     name: Interfaces.ChartDataLabelFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartDataLabelFormatData:interface'
     name: Excel.Interfaces.ChartDataLabelFormatData

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.chartdatalabels.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.chartdatalabels.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartDataLabels#context:member'
@@ -213,7 +213,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartDataLabels#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -341,7 +341,7 @@ items:
           - 'excel!Excel.Interfaces.ChartDataLabelsData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -366,7 +366,7 @@ references:
         fullName: ' | "Invalid" | "None" | "Center" | "InsideEnd" | "InsideBase" | "OutsideEnd" | "Left" | "Right" | "Top" | "Bottom" | "BestFit" | "Callout"'
   - uid: 'excel!Excel.Interfaces.ChartDataLabelsUpdateData:interface'
     name: Interfaces.ChartDataLabelsUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartDataLabelsData:interface'
     name: Excel.Interfaces.ChartDataLabelsData

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.chartfill.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.chartfill.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartFill#clear:member(1)'
@@ -138,7 +138,7 @@ items:
                     }
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.chartfont.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.chartfont.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     remarks: |-
 
@@ -223,7 +223,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartFont#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -291,7 +291,7 @@ items:
         type:
           - 'excel!Excel.ChartFont#underline~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -301,7 +301,7 @@ references:
     name: Excel.Interfaces.ChartFontLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartFontUpdateData:interface'
     name: Interfaces.ChartFontUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartFontData:interface'
     name: Excel.Interfaces.ChartFontData

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.chartgridlines.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.chartgridlines.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartGridlines#context:member'
@@ -170,7 +170,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartGridlines#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -223,7 +223,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -235,7 +235,7 @@ references:
     name: Excel.Interfaces.ChartGridlinesLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartGridlinesUpdateData:interface'
     name: Interfaces.ChartGridlinesUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartGridlinesData:interface'
     name: Excel.Interfaces.ChartGridlinesData

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.chartgridlinesformat.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.chartgridlinesformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartGridlinesFormat#context:member'
@@ -150,7 +150,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartGridlinesFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -188,7 +188,7 @@ items:
           - 'excel!Excel.Interfaces.ChartGridlinesFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -200,7 +200,7 @@ references:
     name: Excel.Interfaces.ChartGridlinesFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartGridlinesFormatUpdateData:interface'
     name: Interfaces.ChartGridlinesFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartGridlinesFormatData:interface'
     name: Excel.Interfaces.ChartGridlinesFormatData

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.chartlegend.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.chartlegend.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartLegend#context:member'
@@ -203,7 +203,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartLegend#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -256,7 +256,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -277,7 +277,7 @@ references:
         fullName: ' | "Invalid" | "Top" | "Bottom" | "Left" | "Right" | "Corner" | "Custom"'
   - uid: 'excel!Excel.Interfaces.ChartLegendUpdateData:interface'
     name: Interfaces.ChartLegendUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartLegendData:interface'
     name: Excel.Interfaces.ChartLegendData

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.chartlegendformat.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.chartlegendformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartLegendFormat#context:member'
@@ -196,7 +196,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartLegendFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -234,7 +234,7 @@ items:
           - 'excel!Excel.Interfaces.ChartLegendFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -248,7 +248,7 @@ references:
     name: Excel.Interfaces.ChartLegendFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartLegendFormatUpdateData:interface'
     name: Interfaces.ChartLegendFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartLegendFormatData:interface'
     name: Excel.Interfaces.ChartLegendFormatData

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.chartlineformat.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.chartlineformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartLineFormat#clear:member(1)'
@@ -205,7 +205,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartLineFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -243,7 +243,7 @@ items:
           - 'excel!Excel.Interfaces.ChartLineFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -253,7 +253,7 @@ references:
     name: Excel.Interfaces.ChartLineFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartLineFormatUpdateData:interface'
     name: Interfaces.ChartLineFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartLineFormatData:interface'
     name: Excel.Interfaces.ChartLineFormatData

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.chartpoint.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.chartpoint.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartPoint#context:member'
@@ -151,7 +151,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartPoint#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -204,7 +204,7 @@ items:
         type:
           - any
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -216,7 +216,7 @@ references:
     name: Excel.Interfaces.ChartPointLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartPointUpdateData:interface'
     name: Interfaces.ChartPointUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartPointData:interface'
     name: Excel.Interfaces.ChartPointData

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.chartpointformat.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.chartpointformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartPointFormat#context:member'
@@ -150,7 +150,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartPointFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -188,7 +188,7 @@ items:
           - 'excel!Excel.Interfaces.ChartPointFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -200,7 +200,7 @@ references:
     name: Excel.Interfaces.ChartPointFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartPointFormatUpdateData:interface'
     name: Interfaces.ChartPointFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartPointFormatData:interface'
     name: Excel.Interfaces.ChartPointFormatData

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.chartpointscollection.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.chartpointscollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartPointsCollection#context:member'
@@ -202,7 +202,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.ChartPointsCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -222,7 +222,7 @@ items:
           - 'excel!Excel.Interfaces.ChartPointsCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -251,7 +251,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.ChartPointsCollectionData:interface'
     name: Excel.Interfaces.ChartPointsCollectionData

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.chartseries.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.chartseries.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartSeries#context:member'
@@ -201,7 +201,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartSeries#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -239,7 +239,7 @@ items:
           - 'excel!Excel.Interfaces.ChartSeriesData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -253,7 +253,7 @@ references:
     name: Excel.ChartPointsCollection
   - uid: 'excel!Excel.Interfaces.ChartSeriesUpdateData:interface'
     name: Interfaces.ChartSeriesUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartSeriesData:interface'
     name: Excel.Interfaces.ChartSeriesData

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.chartseriescollection.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.chartseriescollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartSeriesCollection#context:member'
@@ -203,7 +203,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.ChartSeriesCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -223,7 +223,7 @@ items:
           - 'excel!Excel.Interfaces.ChartSeriesCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -252,7 +252,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.ChartSeriesCollectionData:interface'
     name: Excel.Interfaces.ChartSeriesCollectionData

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.chartseriesformat.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.chartseriesformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartSeriesFormat#context:member'
@@ -166,7 +166,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartSeriesFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -204,7 +204,7 @@ items:
           - 'excel!Excel.Interfaces.ChartSeriesFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -218,7 +218,7 @@ references:
     name: Excel.Interfaces.ChartSeriesFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartSeriesFormatUpdateData:interface'
     name: Interfaces.ChartSeriesFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartSeriesFormatData:interface'
     name: Excel.Interfaces.ChartSeriesFormatData

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.charttitle.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.charttitle.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartTitle#context:member'
@@ -208,7 +208,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartTitle#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -276,7 +276,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -288,7 +288,7 @@ references:
     name: Excel.Interfaces.ChartTitleLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartTitleUpdateData:interface'
     name: Interfaces.ChartTitleUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartTitleData:interface'
     name: Excel.Interfaces.ChartTitleData

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.charttitleformat.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.charttitleformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartTitleFormat#context:member'
@@ -166,7 +166,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartTitleFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -204,7 +204,7 @@ items:
           - 'excel!Excel.Interfaces.ChartTitleFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -218,7 +218,7 @@ references:
     name: Excel.Interfaces.ChartTitleFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartTitleFormatUpdateData:interface'
     name: Interfaces.ChartTitleFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartTitleFormatData:interface'
     name: Excel.Interfaces.ChartTitleFormatData

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.nameditem.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.nameditem.yml
@@ -14,7 +14,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.NamedItem#context:member'
@@ -216,7 +216,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.NamedItem#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -301,7 +301,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -313,7 +313,7 @@ references:
     name: Excel.Interfaces.NamedItemLoadOptions
   - uid: 'excel!Excel.Interfaces.NamedItemUpdateData:interface'
     name: Interfaces.NamedItemUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.NamedItemData:interface'
     name: Excel.Interfaces.NamedItemData

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.nameditemcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.nameditemcollection.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.NamedItemCollection#context:member'
@@ -174,7 +174,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.NamedItemCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -194,7 +194,7 @@ items:
           - 'excel!Excel.Interfaces.NamedItemCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -223,7 +223,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.NamedItemCollectionData:interface'
     name: Excel.Interfaces.NamedItemCollectionData

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.range.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.range.yml
@@ -16,7 +16,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Range#address:member'
@@ -1176,7 +1176,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Range#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -1336,7 +1336,7 @@ items:
         type:
           - 'excel!Excel.Worksheet:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ClearApplyTo:enum'
     name: Excel.ClearApplyTo
@@ -1381,7 +1381,7 @@ references:
         fullName: ' | string'
   - uid: 'excel!Excel.Interfaces.RangeUpdateData:interface'
     name: Interfaces.RangeUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.RangeData:interface'
     name: Excel.Interfaces.RangeData

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.rangeborder.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.rangeborder.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeBorder#color:member'
@@ -155,7 +155,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.RangeBorder#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -269,7 +269,7 @@ items:
         type:
           - 'excel!Excel.RangeBorder#weight~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -279,7 +279,7 @@ references:
     name: Excel.Interfaces.RangeBorderLoadOptions
   - uid: 'excel!Excel.Interfaces.RangeBorderUpdateData:interface'
     name: Interfaces.RangeBorderUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.RangeBorder#sideIndex~0:complex'
     name: >-

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.rangebordercollection.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.rangebordercollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeBorderCollection#context:member'
@@ -265,7 +265,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.RangeBorderCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -285,7 +285,7 @@ items:
           - 'excel!Excel.Interfaces.RangeBorderCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -316,7 +316,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.RangeBorderCollectionData:interface'
     name: Excel.Interfaces.RangeBorderCollectionData

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.rangefill.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.rangefill.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeFill#clear:member(1)'
@@ -226,7 +226,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.RangeFill#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -264,7 +264,7 @@ items:
           - 'excel!Excel.Interfaces.RangeFillData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -274,7 +274,7 @@ references:
     name: Excel.Interfaces.RangeFillLoadOptions
   - uid: 'excel!Excel.Interfaces.RangeFillUpdateData:interface'
     name: Interfaces.RangeFillUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.RangeFillData:interface'
     name: Excel.Interfaces.RangeFillData

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.rangefont.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.rangefont.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeFont#bold:member'
@@ -237,7 +237,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.RangeFont#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -305,7 +305,7 @@ items:
         type:
           - 'excel!Excel.RangeFont#underline~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -315,7 +315,7 @@ references:
     name: Excel.Interfaces.RangeFontLoadOptions
   - uid: 'excel!Excel.Interfaces.RangeFontUpdateData:interface'
     name: Interfaces.RangeFontUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.RangeFontData:interface'
     name: Excel.Interfaces.RangeFontData

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.rangeformat.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.rangeformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeFormat#adjustIndent:member(1)'
@@ -290,7 +290,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.RangeFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -360,7 +360,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RangeBorderCollection:class'
     name: Excel.RangeBorderCollection
@@ -389,7 +389,7 @@ references:
     name: Excel.Interfaces.RangeFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.RangeFormatUpdateData:interface'
     name: Interfaces.RangeFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.RangeFormatData:interface'
     name: Excel.Interfaces.RangeFormatData

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.requestcontext.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.requestcontext.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientRequestContext:class'
+      - 'office!OfficeExtension.ClientRequestContext:class'
     package: excel!
     children:
       - 'excel!Excel.RequestContext:constructor(1)'
@@ -54,7 +54,7 @@ items:
         type:
           - 'excel!Excel.Workbook:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientRequestContext:class'
+  - uid: 'office!OfficeExtension.ClientRequestContext:class'
     name: OfficeExtension.ClientRequestContext
   - uid: 'excel!Excel.RequestContext~0:complex'
     name: string | Session

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.runoptions.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.runoptions.yml
@@ -34,7 +34,7 @@ references:
     name: OfficeExtension.RunOptions<Session>
     fullName: OfficeExtension.RunOptions<Excel.Session>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.RunOptions:interface'
+      - uid: 'office!OfficeExtension.RunOptions:interface'
         name: OfficeExtension.RunOptions
         fullName: OfficeExtension.RunOptions
       - name: <

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.table.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.table.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Table#columns:member'
@@ -428,7 +428,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Table#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -538,7 +538,7 @@ items:
           - 'excel!Excel.Interfaces.TableData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.TableColumnCollection:class'
     name: Excel.TableColumnCollection
@@ -554,7 +554,7 @@ references:
     name: Excel.TableRowCollection
   - uid: 'excel!Excel.Interfaces.TableUpdateData:interface'
     name: Interfaces.TableUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.TableData:interface'
     name: Excel.Interfaces.TableData

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.tablecollection.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.tablecollection.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableCollection#add:member(1)'
@@ -299,7 +299,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.TableCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -319,7 +319,7 @@ items:
           - 'excel!Excel.Interfaces.TableCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Table:class'
     name: Excel.Table
@@ -357,7 +357,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.TableCollectionData:interface'
     name: Excel.Interfaces.TableCollectionData

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.tablecolumn.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.tablecolumn.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableColumn#context:member'
@@ -385,7 +385,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.TableColumn#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -440,7 +440,7 @@ items:
         type:
           - 'any[][]'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -452,7 +452,7 @@ references:
     name: Excel.Interfaces.TableColumnLoadOptions
   - uid: 'excel!Excel.Interfaces.TableColumnUpdateData:interface'
     name: Interfaces.TableColumnUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.TableColumnData:interface'
     name: Excel.Interfaces.TableColumnData

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.tablecolumncollection.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.tablecolumncollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableColumnCollection#add:member(1)'
@@ -283,7 +283,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.TableColumnCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -303,7 +303,7 @@ items:
           - 'excel!Excel.Interfaces.TableColumnCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.TableColumn:class'
     name: Excel.TableColumn
@@ -346,7 +346,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.TableColumnCollectionData:interface'
     name: Excel.Interfaces.TableColumnCollectionData

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.tablerow.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.tablerow.yml
@@ -17,7 +17,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableRow#context:member'
@@ -247,7 +247,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.TableRow#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -302,7 +302,7 @@ items:
         type:
           - 'any[][]'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -314,7 +314,7 @@ references:
     name: Excel.Interfaces.TableRowLoadOptions
   - uid: 'excel!Excel.Interfaces.TableRowUpdateData:interface'
     name: Interfaces.TableRowUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.TableRowData:interface'
     name: Excel.Interfaces.TableRowData

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.tablerowcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.tablerowcollection.yml
@@ -17,7 +17,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableRowCollection#add:member(1)'
@@ -273,7 +273,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.TableRowCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -293,7 +293,7 @@ items:
           - 'excel!Excel.Interfaces.TableRowCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.TableRow:class'
     name: Excel.TableRow
@@ -336,7 +336,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.TableRowCollectionData:interface'
     name: Excel.Interfaces.TableRowCollectionData

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.workbook.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.workbook.yml
@@ -14,7 +14,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Workbook#application:member'
@@ -224,7 +224,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Workbook#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -292,7 +292,7 @@ items:
         type:
           - 'excel!Excel.WorksheetCollection:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Application:class'
     name: Excel.Application
@@ -310,7 +310,7 @@ references:
     name: Excel.NamedItemCollection
   - uid: 'excel!Excel.Interfaces.WorkbookUpdateData:interface'
     name: Interfaces.WorkbookUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.TableCollection:class'
     name: Excel.TableCollection

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.worksheet.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.worksheet.yml
@@ -14,7 +14,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Worksheet#activate:member(1)'
@@ -426,7 +426,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Worksheet#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -496,7 +496,7 @@ items:
         type:
           - 'excel!Excel.Worksheet#visibility~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartCollection:class'
     name: Excel.ChartCollection
@@ -510,7 +510,7 @@ references:
     name: Excel.Interfaces.WorksheetLoadOptions
   - uid: 'excel!Excel.Interfaces.WorksheetUpdateData:interface'
     name: Interfaces.WorksheetUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.TableCollection:class'
     name: Excel.TableCollection

--- a/docs/docs-ref-autogen/excel_1_1/excel/excel.worksheetcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_1/excel/excel.worksheetcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.WorksheetCollection#add:member(1)'
@@ -233,7 +233,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.WorksheetCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -253,7 +253,7 @@ items:
           - 'excel!Excel.Interfaces.WorksheetCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Worksheet:class'
     name: Excel.Worksheet
@@ -282,7 +282,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.WorksheetCollectionData:interface'
     name: Excel.Interfaces.WorksheetCollectionData

--- a/docs/docs-ref-autogen/excel_1_10/excel.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel.yml
@@ -998,7 +998,7 @@ items:
             A previously-created API object. The batch will use the same RequestContext as the passed-in object, which
             means that any changes applied to the object will be picked up by "context.sync()".
           type:
-            - 'excel!OfficeExtension.ClientObject:class'
+            - 'office!OfficeExtension.ClientObject:class'
         - id: batch
           description: >-
             A function that takes in a RequestContext and returns a promise (typically, just the result of
@@ -1103,7 +1103,7 @@ items:
             A previously-created object. The batch will use the same RequestContext as the passed-in object, which means
             that any changes applied to the object will be picked up by "context.sync()".
           type:
-            - 'excel!OfficeExtension.ClientRequestContext:class'
+            - 'office!OfficeExtension.ClientRequestContext:class'
         - id: batch
           description: >-
             A function that takes in a RequestContext and returns a promise (typically, just the result of
@@ -2646,7 +2646,7 @@ references:
         fullName: Promise
       - name: <T>
         fullName: <T>
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.run~3:complex'
     name: '(context: Excel.RequestContext) => Promise<T>'
@@ -2677,7 +2677,7 @@ references:
     name: 'OfficeExtension.ClientObject[]'
     fullName: 'OfficeExtension.ClientObject[]'
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientObject:class'
+      - uid: 'office!OfficeExtension.ClientObject:class'
         name: OfficeExtension.ClientObject
         fullName: OfficeExtension.ClientObject
       - name: '[]'
@@ -2734,7 +2734,7 @@ references:
         fullName: Promise
       - name: <T>
         fullName: <T>
-  - uid: 'excel!OfficeExtension.ClientRequestContext:class'
+  - uid: 'office!OfficeExtension.ClientRequestContext:class'
     name: OfficeExtension.ClientRequestContext
   - uid: 'excel!Excel.run~10:complex'
     name: '(context: Excel.RequestContext) => Promise<T>'

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.application.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.application.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Application#calculate:member(1)'
@@ -284,7 +284,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Application#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -401,7 +401,7 @@ items:
           - 'excel!Excel.Interfaces.ApplicationData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.CalculationType:enum'
     name: Excel.CalculationType
@@ -433,7 +433,7 @@ references:
     name: Excel.Interfaces.ApplicationLoadOptions
   - uid: 'excel!Excel.Interfaces.ApplicationUpdateData:interface'
     name: Interfaces.ApplicationUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ApplicationData:interface'
     name: Excel.Interfaces.ApplicationData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.autofilter.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.autofilter.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.AutoFilter#apply:member(1)'
@@ -309,7 +309,7 @@ items:
           - 'excel!Excel.Interfaces.AutoFilterData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.AutoFilter#apply~0:complex'
     name: Range | string

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.binding.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.binding.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Binding#context:member'
@@ -357,7 +357,7 @@ items:
         type:
           - 'excel!Excel.Binding#type~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -369,7 +369,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -382,7 +382,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.BindingDataChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.BindingDataChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -396,7 +396,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.BindingSelectionChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.BindingSelectionChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.bindingcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.bindingcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.BindingCollection#add:member(1)'
@@ -493,7 +493,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.BindingCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -513,7 +513,7 @@ items:
           - 'excel!Excel.Interfaces.BindingCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Binding:class'
     name: Excel.Binding
@@ -543,7 +543,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -571,7 +571,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.BindingCollectionData:interface'
     name: Excel.Interfaces.BindingCollectionData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.cellvalueconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.cellvalueconditionalformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.CellValueConditionalFormat#context:member'
@@ -212,7 +212,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.CellValueConditionalFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -250,7 +250,7 @@ items:
           - 'excel!Excel.Interfaces.CellValueConditionalFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -264,7 +264,7 @@ references:
     name: Excel.ConditionalCellValueRule
   - uid: 'excel!Excel.Interfaces.CellValueConditionalFormatUpdateData:interface'
     name: Interfaces.CellValueConditionalFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.CellValueConditionalFormatData:interface'
     name: Excel.Interfaces.CellValueConditionalFormatData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chart.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chart.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Chart#activate:member(1)'
@@ -704,7 +704,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Chart#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -977,7 +977,7 @@ items:
         type:
           - 'excel!Excel.Worksheet:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartAxes:class'
     name: Excel.ChartAxes
@@ -1037,7 +1037,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -1048,7 +1048,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -1063,7 +1063,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.ChartActivatedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.ChartActivatedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -1077,7 +1077,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.ChartDeactivatedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.ChartDeactivatedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -1104,7 +1104,7 @@ references:
     name: Excel.ChartSeriesCollection
   - uid: 'excel!Excel.Interfaces.ChartUpdateData:interface'
     name: Interfaces.ChartUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Range:class'
     name: Range

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chartareaformat.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chartareaformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAreaFormat#border:member'
@@ -219,7 +219,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAreaFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -257,7 +257,7 @@ items:
           - 'excel!Excel.Interfaces.ChartAreaFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartBorder:class'
     name: Excel.ChartBorder
@@ -292,7 +292,7 @@ references:
     name: Excel.Interfaces.ChartAreaFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartAreaFormatUpdateData:interface'
     name: Interfaces.ChartAreaFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartAreaFormatData:interface'
     name: Excel.Interfaces.ChartAreaFormatData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chartaxes.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chartaxes.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAxes#categoryAxis:member'
@@ -221,7 +221,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAxes#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -297,7 +297,7 @@ items:
           });
           ```
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartAxis:class'
     name: Excel.ChartAxis
@@ -313,7 +313,7 @@ references:
     name: Excel.Interfaces.ChartAxesLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartAxesUpdateData:interface'
     name: Interfaces.ChartAxesUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartAxesData:interface'
     name: Excel.Interfaces.ChartAxesData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chartaxis.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chartaxis.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAxis#alignment:member'
@@ -682,7 +682,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAxis#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -964,7 +964,7 @@ items:
         type:
           - number
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartAxis#alignment~0:complex'
     name: Excel.ChartTickLabelAlignment | "Center" | "Left" | "Right"
@@ -1081,7 +1081,7 @@ references:
         fullName: ' | "Linear" | "Logarithmic"'
   - uid: 'excel!Excel.Interfaces.ChartAxisUpdateData:interface'
     name: Interfaces.ChartAxisUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Range:class'
     name: Range

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chartaxisformat.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chartaxisformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAxisFormat#context:member'
@@ -182,7 +182,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAxisFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -220,7 +220,7 @@ items:
           - 'excel!Excel.Interfaces.ChartAxisFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -236,7 +236,7 @@ references:
     name: Excel.Interfaces.ChartAxisFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisFormatUpdateData:interface'
     name: Interfaces.ChartAxisFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisFormatData:interface'
     name: Excel.Interfaces.ChartAxisFormatData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chartaxistitle.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chartaxistitle.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAxisTitle#context:member'
@@ -172,7 +172,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAxisTitle#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -261,7 +261,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -273,7 +273,7 @@ references:
     name: Excel.Interfaces.ChartAxisTitleLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisTitleUpdateData:interface'
     name: Interfaces.ChartAxisTitleUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisTitleData:interface'
     name: Excel.Interfaces.ChartAxisTitleData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chartaxistitleformat.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chartaxistitleformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAxisTitleFormat#border:member'
@@ -182,7 +182,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAxisTitleFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -220,7 +220,7 @@ items:
           - 'excel!Excel.Interfaces.ChartAxisTitleFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartBorder:class'
     name: Excel.ChartBorder
@@ -236,7 +236,7 @@ references:
     name: Excel.Interfaces.ChartAxisTitleFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisTitleFormatUpdateData:interface'
     name: Interfaces.ChartAxisTitleFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisTitleFormatData:interface'
     name: Excel.Interfaces.ChartAxisTitleFormatData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chartbinoptions.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chartbinoptions.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartBinOptions#allowOverflow:member'
@@ -201,7 +201,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartBinOptions#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -284,7 +284,7 @@ items:
         type:
           - number
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -294,7 +294,7 @@ references:
     name: Excel.Interfaces.ChartBinOptionsLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartBinOptionsUpdateData:interface'
     name: Interfaces.ChartBinOptionsUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartBinOptionsData:interface'
     name: Excel.Interfaces.ChartBinOptionsData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chartborder.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chartborder.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartBorder#clear:member(1)'
@@ -186,7 +186,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartBorder#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -239,7 +239,7 @@ items:
         type:
           - number
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -262,7 +262,7 @@ references:
     name: Excel.Interfaces.ChartBorderLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartBorderUpdateData:interface'
     name: Interfaces.ChartBorderUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartBorderData:interface'
     name: Excel.Interfaces.ChartBorderData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chartboxwhiskeroptions.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chartboxwhiskeroptions.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartBoxwhiskerOptions#context:member'
@@ -154,7 +154,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartBoxwhiskerOptions#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -252,7 +252,7 @@ items:
           - 'excel!Excel.Interfaces.ChartBoxwhiskerOptionsData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -271,7 +271,7 @@ references:
         fullName: ' | "Inclusive" | "Exclusive"'
   - uid: 'excel!Excel.Interfaces.ChartBoxwhiskerOptionsUpdateData:interface'
     name: Interfaces.ChartBoxwhiskerOptionsUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartBoxwhiskerOptionsData:interface'
     name: Excel.Interfaces.ChartBoxwhiskerOptionsData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chartcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartCollection#add:member(1)'
@@ -387,7 +387,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.ChartCollection#onActivated:member'
     summary: |-
       Occurs when a chart is activated.
@@ -535,7 +535,7 @@ items:
           - 'excel!Excel.Interfaces.ChartCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Chart:class'
     name: Excel.Chart
@@ -551,7 +551,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -579,13 +579,13 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.ChartCollection#onActivated~0:complex'
     name: OfficeExtension.EventHandlers<Excel.ChartActivatedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.ChartActivatedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -599,7 +599,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.ChartAddedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.ChartAddedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -613,7 +613,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.ChartDeactivatedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.ChartDeactivatedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -627,7 +627,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.ChartDeletedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.ChartDeletedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chartdatalabel.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chartdatalabel.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartDataLabel#autoText:member'
@@ -317,7 +317,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartDataLabel#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -526,7 +526,7 @@ items:
         type:
           - number
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -560,7 +560,7 @@ references:
         fullName: ' | "Invalid" | "None" | "Center" | "InsideEnd" | "InsideBase" | "OutsideEnd" | "Left" | "Right" | "Top" | "Bottom" | "BestFit" | "Callout"'
   - uid: 'excel!Excel.Interfaces.ChartDataLabelUpdateData:interface'
     name: Interfaces.ChartDataLabelUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartDataLabelData:interface'
     name: Excel.Interfaces.ChartDataLabelData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chartdatalabelformat.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chartdatalabelformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartDataLabelFormat#border:member'
@@ -182,7 +182,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartDataLabelFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -220,7 +220,7 @@ items:
           - 'excel!Excel.Interfaces.ChartDataLabelFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartBorder:class'
     name: Excel.ChartBorder
@@ -236,7 +236,7 @@ references:
     name: Excel.Interfaces.ChartDataLabelFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartDataLabelFormatUpdateData:interface'
     name: Interfaces.ChartDataLabelFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartDataLabelFormatData:interface'
     name: Excel.Interfaces.ChartDataLabelFormatData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chartdatalabels.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chartdatalabels.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartDataLabels#autoText:member'
@@ -285,7 +285,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartDataLabels#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -447,7 +447,7 @@ items:
         type:
           - 'excel!Excel.ChartDataLabels#verticalAlignment~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -481,7 +481,7 @@ references:
         fullName: ' | "Invalid" | "None" | "Center" | "InsideEnd" | "InsideBase" | "OutsideEnd" | "Left" | "Right" | "Top" | "Bottom" | "BestFit" | "Callout"'
   - uid: 'excel!Excel.Interfaces.ChartDataLabelsUpdateData:interface'
     name: Interfaces.ChartDataLabelsUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartDataLabelsData:interface'
     name: Excel.Interfaces.ChartDataLabelsData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.charterrorbars.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.charterrorbars.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartErrorBars#context:member'
@@ -184,7 +184,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartErrorBars#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -252,7 +252,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -273,7 +273,7 @@ references:
     name: Excel.Interfaces.ChartErrorBarsLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartErrorBarsUpdateData:interface'
     name: Interfaces.ChartErrorBarsUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartErrorBarsData:interface'
     name: Excel.Interfaces.ChartErrorBarsData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.charterrorbarsformat.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.charterrorbarsformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartErrorBarsFormat#context:member'
@@ -150,7 +150,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartErrorBarsFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -188,7 +188,7 @@ items:
           - 'excel!Excel.Interfaces.ChartErrorBarsFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -200,7 +200,7 @@ references:
     name: Excel.Interfaces.ChartErrorBarsFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartErrorBarsFormatUpdateData:interface'
     name: Interfaces.ChartErrorBarsFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartErrorBarsFormatData:interface'
     name: Excel.Interfaces.ChartErrorBarsFormatData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chartfill.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chartfill.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartFill#clear:member(1)'
@@ -138,7 +138,7 @@ items:
                     }
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chartfont.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chartfont.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     remarks: |-
 
@@ -223,7 +223,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartFont#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -291,7 +291,7 @@ items:
         type:
           - 'excel!Excel.ChartFont#underline~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -301,7 +301,7 @@ references:
     name: Excel.Interfaces.ChartFontLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartFontUpdateData:interface'
     name: Interfaces.ChartFontUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartFontData:interface'
     name: Excel.Interfaces.ChartFontData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chartformatstring.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chartformatstring.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartFormatString#context:member'
@@ -152,7 +152,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartFormatString#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -190,7 +190,7 @@ items:
           - 'excel!Excel.Interfaces.ChartFormatStringData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -202,7 +202,7 @@ references:
     name: Excel.Interfaces.ChartFormatStringLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartFormatStringUpdateData:interface'
     name: Interfaces.ChartFormatStringUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartFormatStringData:interface'
     name: Excel.Interfaces.ChartFormatStringData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chartgridlines.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chartgridlines.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartGridlines#context:member'
@@ -170,7 +170,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartGridlines#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -223,7 +223,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -235,7 +235,7 @@ references:
     name: Excel.Interfaces.ChartGridlinesLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartGridlinesUpdateData:interface'
     name: Interfaces.ChartGridlinesUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartGridlinesData:interface'
     name: Excel.Interfaces.ChartGridlinesData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chartgridlinesformat.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chartgridlinesformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartGridlinesFormat#context:member'
@@ -150,7 +150,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartGridlinesFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -188,7 +188,7 @@ items:
           - 'excel!Excel.Interfaces.ChartGridlinesFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -200,7 +200,7 @@ references:
     name: Excel.Interfaces.ChartGridlinesFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartGridlinesFormatUpdateData:interface'
     name: Interfaces.ChartGridlinesFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartGridlinesFormatData:interface'
     name: Excel.Interfaces.ChartGridlinesFormatData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chartlegend.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chartlegend.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartLegend#context:member'
@@ -254,7 +254,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartLegend#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -352,7 +352,7 @@ items:
         type:
           - number
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -375,7 +375,7 @@ references:
         fullName: ' | "Invalid" | "Top" | "Bottom" | "Left" | "Right" | "Corner" | "Custom"'
   - uid: 'excel!Excel.Interfaces.ChartLegendUpdateData:interface'
     name: Interfaces.ChartLegendUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartLegendData:interface'
     name: Excel.Interfaces.ChartLegendData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chartlegendentry.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chartlegendentry.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartLegendEntry#context:member'
@@ -185,7 +185,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartLegendEntry#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -268,7 +268,7 @@ items:
         type:
           - number
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -278,7 +278,7 @@ references:
     name: Excel.Interfaces.ChartLegendEntryLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartLegendEntryUpdateData:interface'
     name: Interfaces.ChartLegendEntryUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartLegendEntryData:interface'
     name: Excel.Interfaces.ChartLegendEntryData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chartlegendentrycollection.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chartlegendentrycollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartLegendEntryCollection#context:member'
@@ -148,7 +148,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.ChartLegendEntryCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -168,7 +168,7 @@ items:
           - 'excel!Excel.Interfaces.ChartLegendEntryCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -176,7 +176,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -206,7 +206,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.ChartLegendEntryCollectionData:interface'
     name: Excel.Interfaces.ChartLegendEntryCollectionData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chartlegendformat.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chartlegendformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartLegendFormat#border:member'
@@ -212,7 +212,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartLegendFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -250,7 +250,7 @@ items:
           - 'excel!Excel.Interfaces.ChartLegendFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartBorder:class'
     name: Excel.ChartBorder
@@ -266,7 +266,7 @@ references:
     name: Excel.Interfaces.ChartLegendFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartLegendFormatUpdateData:interface'
     name: Interfaces.ChartLegendFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartLegendFormatData:interface'
     name: Excel.Interfaces.ChartLegendFormatData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chartlineformat.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chartlineformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartLineFormat#clear:member(1)'
@@ -224,7 +224,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartLineFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -277,7 +277,7 @@ items:
         type:
           - number
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -300,7 +300,7 @@ references:
     name: Excel.Interfaces.ChartLineFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartLineFormatUpdateData:interface'
     name: Interfaces.ChartLineFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartLineFormatData:interface'
     name: Excel.Interfaces.ChartLineFormatData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chartmapoptions.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chartmapoptions.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartMapOptions#context:member'
@@ -184,7 +184,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartMapOptions#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -222,7 +222,7 @@ items:
           - 'excel!Excel.Interfaces.ChartMapOptionsData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -263,7 +263,7 @@ references:
         fullName: ' | "Automatic" | "Mercator" | "Miller" | "Robinson" | "Albers"'
   - uid: 'excel!Excel.Interfaces.ChartMapOptionsUpdateData:interface'
     name: Interfaces.ChartMapOptionsUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartMapOptionsData:interface'
     name: Excel.Interfaces.ChartMapOptionsData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chartpivotoptions.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chartpivotoptions.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartPivotOptions#context:member'
@@ -138,7 +138,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartPivotOptions#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -239,7 +239,7 @@ items:
           - 'excel!Excel.Interfaces.ChartPivotOptionsData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -249,7 +249,7 @@ references:
     name: Excel.Interfaces.ChartPivotOptionsLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartPivotOptionsUpdateData:interface'
     name: Interfaces.ChartPivotOptionsUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartPivotOptionsData:interface'
     name: Excel.Interfaces.ChartPivotOptionsData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chartplotarea.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chartplotarea.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartPlotArea#context:member'
@@ -264,7 +264,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartPlotArea#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -332,7 +332,7 @@ items:
         type:
           - number
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -353,7 +353,7 @@ references:
         fullName: ' | "Automatic" | "Custom"'
   - uid: 'excel!Excel.Interfaces.ChartPlotAreaUpdateData:interface'
     name: Interfaces.ChartPlotAreaUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartPlotAreaData:interface'
     name: Excel.Interfaces.ChartPlotAreaData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chartplotareaformat.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chartplotareaformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartPlotAreaFormat#border:member'
@@ -166,7 +166,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartPlotAreaFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -204,7 +204,7 @@ items:
           - 'excel!Excel.Interfaces.ChartPlotAreaFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartBorder:class'
     name: Excel.ChartBorder
@@ -218,7 +218,7 @@ references:
     name: Excel.Interfaces.ChartPlotAreaFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartPlotAreaFormatUpdateData:interface'
     name: Interfaces.ChartPlotAreaFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartPlotAreaFormatData:interface'
     name: Excel.Interfaces.ChartPlotAreaFormatData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chartpoint.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chartpoint.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartPoint#context:member'
@@ -249,7 +249,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartPoint#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -302,7 +302,7 @@ items:
         type:
           - any
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -329,7 +329,7 @@ references:
         fullName: ' | "Invalid" | "Automatic" | "None" | "Square" | "Diamond" | "Triangle" | "X" | "Star" | "Dot" | "Dash" | "Circle" | "Plus" | "Picture"'
   - uid: 'excel!Excel.Interfaces.ChartPointUpdateData:interface'
     name: Interfaces.ChartPointUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartPointData:interface'
     name: Excel.Interfaces.ChartPointData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chartpointformat.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chartpointformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartPointFormat#border:member'
@@ -168,7 +168,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartPointFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -206,7 +206,7 @@ items:
           - 'excel!Excel.Interfaces.ChartPointFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartBorder:class'
     name: Excel.ChartBorder
@@ -220,7 +220,7 @@ references:
     name: Excel.Interfaces.ChartPointFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartPointFormatUpdateData:interface'
     name: Interfaces.ChartPointFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartPointFormatData:interface'
     name: Excel.Interfaces.ChartPointFormatData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chartpointscollection.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chartpointscollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartPointsCollection#context:member'
@@ -219,7 +219,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.ChartPointsCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -239,7 +239,7 @@ items:
           - 'excel!Excel.Interfaces.ChartPointsCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -247,7 +247,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -277,7 +277,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.ChartPointsCollectionData:interface'
     name: Excel.Interfaces.ChartPointsCollectionData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chartseries.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chartseries.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartSeries#axisGroup:member'
@@ -976,7 +976,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartSeries#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -1259,7 +1259,7 @@ items:
         type:
           - 'excel!Excel.ChartErrorBars:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartSeries#axisGroup~0:complex'
     name: Excel.ChartAxisGroup | "Primary" | "Secondary"
@@ -1385,7 +1385,7 @@ references:
     name: Excel.ChartPointsCollection
   - uid: 'excel!Excel.Interfaces.ChartSeriesUpdateData:interface'
     name: Interfaces.ChartSeriesUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Range:class'
     name: Range

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chartseriescollection.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chartseriescollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartSeriesCollection#add:member(1)'
@@ -248,7 +248,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.ChartSeriesCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -268,7 +268,7 @@ items:
           - 'excel!Excel.Interfaces.ChartSeriesCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartSeries:class'
     name: Excel.ChartSeries
@@ -278,7 +278,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -306,7 +306,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.ChartSeriesCollectionData:interface'
     name: Excel.Interfaces.ChartSeriesCollectionData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.chartseriesformat.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.chartseriesformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartSeriesFormat#context:member'
@@ -166,7 +166,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartSeriesFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -204,7 +204,7 @@ items:
           - 'excel!Excel.Interfaces.ChartSeriesFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -218,7 +218,7 @@ references:
     name: Excel.Interfaces.ChartSeriesFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartSeriesFormatUpdateData:interface'
     name: Interfaces.ChartSeriesFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartSeriesFormatData:interface'
     name: Excel.Interfaces.ChartSeriesFormatData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.charttitle.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.charttitle.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartTitle#context:member'
@@ -328,7 +328,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartTitle#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -516,7 +516,7 @@ items:
         type:
           - number
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -548,7 +548,7 @@ references:
         fullName: ' | "Automatic" | "Top" | "Bottom" | "Left" | "Right"'
   - uid: 'excel!Excel.Interfaces.ChartTitleUpdateData:interface'
     name: Interfaces.ChartTitleUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartTitleData:interface'
     name: Excel.Interfaces.ChartTitleData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.charttitleformat.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.charttitleformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartTitleFormat#border:member'
@@ -182,7 +182,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartTitleFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -220,7 +220,7 @@ items:
           - 'excel!Excel.Interfaces.ChartTitleFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartBorder:class'
     name: Excel.ChartBorder
@@ -236,7 +236,7 @@ references:
     name: Excel.Interfaces.ChartTitleFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartTitleFormatUpdateData:interface'
     name: Interfaces.ChartTitleFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartTitleFormatData:interface'
     name: Excel.Interfaces.ChartTitleFormatData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.charttrendline.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.charttrendline.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartTrendline#backwardPeriod:member'
@@ -286,7 +286,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartTrendline#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -397,7 +397,7 @@ items:
 
           ```
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -411,7 +411,7 @@ references:
     name: Excel.Interfaces.ChartTrendlineLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartTrendlineUpdateData:interface'
     name: Interfaces.ChartTrendlineUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartTrendlineData:interface'
     name: Excel.Interfaces.ChartTrendlineData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.charttrendlinecollection.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.charttrendlinecollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartTrendlineCollection#add:member(1)'
@@ -216,7 +216,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.ChartTrendlineCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -236,7 +236,7 @@ items:
           - 'excel!Excel.Interfaces.ChartTrendlineCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartTrendline:class'
     name: Excel.ChartTrendline
@@ -248,7 +248,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -276,7 +276,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.ChartTrendlineCollectionData:interface'
     name: Excel.Interfaces.ChartTrendlineCollectionData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.charttrendlineformat.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.charttrendlineformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartTrendlineFormat#context:member'
@@ -199,7 +199,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartTrendlineFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -237,7 +237,7 @@ items:
           - 'excel!Excel.Interfaces.ChartTrendlineFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -249,7 +249,7 @@ references:
     name: Excel.Interfaces.ChartTrendlineFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartTrendlineFormatUpdateData:interface'
     name: Interfaces.ChartTrendlineFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartTrendlineFormatData:interface'
     name: Excel.Interfaces.ChartTrendlineFormatData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.charttrendlinelabel.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.charttrendlinelabel.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartTrendlineLabel#autoText:member'
@@ -277,7 +277,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartTrendlineLabel#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -398,7 +398,7 @@ items:
         type:
           - number
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -419,7 +419,7 @@ references:
     name: Excel.Interfaces.ChartTrendlineLabelLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartTrendlineLabelUpdateData:interface'
     name: Interfaces.ChartTrendlineLabelUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartTrendlineLabelData:interface'
     name: Excel.Interfaces.ChartTrendlineLabelData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.charttrendlinelabelformat.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.charttrendlinelabelformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartTrendlineLabelFormat#border:member'
@@ -182,7 +182,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartTrendlineLabelFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -220,7 +220,7 @@ items:
           - 'excel!Excel.Interfaces.ChartTrendlineLabelFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartBorder:class'
     name: Excel.ChartBorder
@@ -236,7 +236,7 @@ references:
     name: Excel.Interfaces.ChartTrendlineLabelFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartTrendlineLabelFormatUpdateData:interface'
     name: Interfaces.ChartTrendlineLabelFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartTrendlineLabelFormatData:interface'
     name: Excel.Interfaces.ChartTrendlineLabelFormatData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.colorscaleconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.colorscaleconditionalformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ColorScaleConditionalFormat#context:member'
@@ -180,7 +180,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ColorScaleConditionalFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -235,7 +235,7 @@ items:
           - 'excel!Excel.Interfaces.ColorScaleConditionalFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -247,7 +247,7 @@ references:
     name: Excel.Interfaces.ColorScaleConditionalFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ColorScaleConditionalFormatUpdateData:interface'
     name: Interfaces.ColorScaleConditionalFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ColorScaleConditionalFormatData:interface'
     name: Excel.Interfaces.ColorScaleConditionalFormatData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.comment.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.comment.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Comment#authorEmail:member'
@@ -356,7 +356,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Comment#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -417,7 +417,7 @@ items:
           type:
             - 'excel!Excel.CommentRichContent:interface'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -442,7 +442,7 @@ references:
     name: Excel.CommentReplyCollection
   - uid: 'excel!Excel.Interfaces.CommentUpdateData:interface'
     name: Interfaces.CommentUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.CommentData:interface'
     name: Excel.Interfaces.CommentData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.commentcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.commentcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.CommentCollection#add:member(1)'
@@ -322,7 +322,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.CommentCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -342,7 +342,7 @@ items:
           - 'excel!Excel.Interfaces.CommentCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Comment:class'
     name: Excel.Comment
@@ -390,7 +390,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -427,7 +427,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.CommentCollectionData:interface'
     name: Excel.Interfaces.CommentCollectionData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.commentreply.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.commentreply.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.CommentReply#authorEmail:member'
@@ -344,7 +344,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.CommentReply#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -405,7 +405,7 @@ items:
           type:
             - 'excel!Excel.CommentRichContent:interface'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -430,7 +430,7 @@ references:
         fullName: '[]'
   - uid: 'excel!Excel.Interfaces.CommentReplyUpdateData:interface'
     name: Interfaces.CommentReplyUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.CommentReplyData:interface'
     name: Excel.Interfaces.CommentReplyData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.commentreplycollection.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.commentreplycollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.CommentReplyCollection#add:member(1)'
@@ -251,7 +251,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.CommentReplyCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -271,7 +271,7 @@ items:
           - 'excel!Excel.Interfaces.CommentReplyCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.CommentReply:class'
     name: Excel.CommentReply
@@ -301,7 +301,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -329,7 +329,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.CommentReplyCollectionData:interface'
     name: Excel.Interfaces.CommentReplyCollectionData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.conditionaldatabarnegativeformat.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.conditionaldatabarnegativeformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ConditionalDataBarNegativeFormat#borderColor:member'
@@ -206,7 +206,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ConditionalDataBarNegativeFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -244,7 +244,7 @@ items:
           - 'excel!Excel.Interfaces.ConditionalDataBarNegativeFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -254,7 +254,7 @@ references:
     name: Excel.Interfaces.ConditionalDataBarNegativeFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ConditionalDataBarNegativeFormatUpdateData:interface'
     name: Interfaces.ConditionalDataBarNegativeFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ConditionalDataBarNegativeFormatData:interface'
     name: Excel.Interfaces.ConditionalDataBarNegativeFormatData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.conditionaldatabarpositiveformat.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.conditionaldatabarpositiveformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ConditionalDataBarPositiveFormat#borderColor:member'
@@ -190,7 +190,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ConditionalDataBarPositiveFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -228,7 +228,7 @@ items:
           - 'excel!Excel.Interfaces.ConditionalDataBarPositiveFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -238,7 +238,7 @@ references:
     name: Excel.Interfaces.ConditionalDataBarPositiveFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ConditionalDataBarPositiveFormatUpdateData:interface'
     name: Interfaces.ConditionalDataBarPositiveFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ConditionalDataBarPositiveFormatData:interface'
     name: Excel.Interfaces.ConditionalDataBarPositiveFormatData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.conditionalformat.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.conditionalformat.yml
@@ -14,7 +14,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ConditionalFormat#cellValue:member'
@@ -657,7 +657,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ConditionalFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -858,7 +858,7 @@ items:
 
           ```
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.CellValueConditionalFormat:class'
     name: Excel.CellValueConditionalFormat
@@ -884,7 +884,7 @@ references:
     name: Excel.PresetCriteriaConditionalFormat
   - uid: 'excel!Excel.Interfaces.ConditionalFormatUpdateData:interface'
     name: Interfaces.ConditionalFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.TextConditionalFormat:class'
     name: Excel.TextConditionalFormat

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.conditionalformatcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.conditionalformatcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ConditionalFormatCollection#add:member(1)'
@@ -363,7 +363,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.ConditionalFormatCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -383,7 +383,7 @@ items:
           - 'excel!Excel.Interfaces.ConditionalFormatCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ConditionalFormat:class'
     name: Excel.ConditionalFormat
@@ -395,7 +395,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -423,7 +423,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.ConditionalFormatCollectionData:interface'
     name: Excel.Interfaces.ConditionalFormatCollectionData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.conditionalformatrule.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.conditionalformatrule.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ConditionalFormatRule#context:member'
@@ -204,7 +204,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ConditionalFormatRule#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -242,7 +242,7 @@ items:
           - 'excel!Excel.Interfaces.ConditionalFormatRuleData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -252,7 +252,7 @@ references:
     name: Excel.Interfaces.ConditionalFormatRuleLoadOptions
   - uid: 'excel!Excel.Interfaces.ConditionalFormatRuleUpdateData:interface'
     name: Interfaces.ConditionalFormatRuleUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ConditionalFormatRuleData:interface'
     name: Excel.Interfaces.ConditionalFormatRuleData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.conditionalrangeborder.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.conditionalrangeborder.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ConditionalRangeBorder#color:member'
@@ -154,7 +154,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ConditionalRangeBorder#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -228,7 +228,7 @@ items:
           - 'excel!Excel.Interfaces.ConditionalRangeBorderData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -238,7 +238,7 @@ references:
     name: Excel.Interfaces.ConditionalRangeBorderLoadOptions
   - uid: 'excel!Excel.Interfaces.ConditionalRangeBorderUpdateData:interface'
     name: Interfaces.ConditionalRangeBorderUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.ConditionalRangeBorder#sideIndex~0:complex'
     name: Excel.ConditionalRangeBorderIndex | "EdgeTop" | "EdgeBottom" | "EdgeLeft" | "EdgeRight"

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.conditionalrangebordercollection.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.conditionalrangebordercollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ConditionalRangeBorderCollection#bottom:member'
@@ -225,7 +225,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.ConditionalRangeBorderCollection#right:member'
     summary: |-
       Gets the right border. Read-only.
@@ -275,7 +275,7 @@ items:
         type:
           - 'excel!Excel.ConditionalRangeBorder:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ConditionalRangeBorder:class'
     name: Excel.ConditionalRangeBorder
@@ -306,7 +306,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.ConditionalRangeBorderCollectionData:interface'
     name: Excel.Interfaces.ConditionalRangeBorderCollectionData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.conditionalrangefill.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.conditionalrangefill.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ConditionalRangeFill#clear:member(1)'
@@ -169,7 +169,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ConditionalRangeFill#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -207,7 +207,7 @@ items:
           - 'excel!Excel.Interfaces.ConditionalRangeFillData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -217,7 +217,7 @@ references:
     name: Excel.Interfaces.ConditionalRangeFillLoadOptions
   - uid: 'excel!Excel.Interfaces.ConditionalRangeFillUpdateData:interface'
     name: Interfaces.ConditionalRangeFillUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ConditionalRangeFillData:interface'
     name: Excel.Interfaces.ConditionalRangeFillData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.conditionalrangefont.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.conditionalrangefont.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ConditionalRangeFont#bold:member'
@@ -201,7 +201,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ConditionalRangeFont#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -269,7 +269,7 @@ items:
         type:
           - 'excel!Excel.ConditionalRangeFont#underline~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -279,7 +279,7 @@ references:
     name: Excel.Interfaces.ConditionalRangeFontLoadOptions
   - uid: 'excel!Excel.Interfaces.ConditionalRangeFontUpdateData:interface'
     name: Interfaces.ConditionalRangeFontUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ConditionalRangeFontData:interface'
     name: Excel.Interfaces.ConditionalRangeFontData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.conditionalrangeformat.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.conditionalrangeformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ConditionalRangeFormat#borders:member'
@@ -198,7 +198,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ConditionalRangeFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -236,7 +236,7 @@ items:
           - 'excel!Excel.Interfaces.ConditionalRangeFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ConditionalRangeBorderCollection:class'
     name: Excel.ConditionalRangeBorderCollection
@@ -252,7 +252,7 @@ references:
     name: Excel.Interfaces.ConditionalRangeFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ConditionalRangeFormatUpdateData:interface'
     name: Interfaces.ConditionalRangeFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ConditionalRangeFormatData:interface'
     name: Excel.Interfaces.ConditionalRangeFormatData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.customconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.customconditionalformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.CustomConditionalFormat#context:member'
@@ -214,7 +214,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.CustomConditionalFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -252,7 +252,7 @@ items:
           - 'excel!Excel.Interfaces.CustomConditionalFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -266,7 +266,7 @@ references:
     name: Excel.ConditionalFormatRule
   - uid: 'excel!Excel.Interfaces.CustomConditionalFormatUpdateData:interface'
     name: Interfaces.CustomConditionalFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.CustomConditionalFormatData:interface'
     name: Excel.Interfaces.CustomConditionalFormatData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.customproperty.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.customproperty.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.CustomProperty#context:member'
@@ -169,7 +169,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.CustomProperty#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -237,7 +237,7 @@ items:
         type:
           - any
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -247,7 +247,7 @@ references:
     name: Excel.Interfaces.CustomPropertyLoadOptions
   - uid: 'excel!Excel.Interfaces.CustomPropertyUpdateData:interface'
     name: Interfaces.CustomPropertyUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.CustomPropertyData:interface'
     name: Excel.Interfaces.CustomPropertyData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.custompropertycollection.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.custompropertycollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.CustomPropertyCollection#add:member(1)'
@@ -215,7 +215,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.CustomPropertyCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -235,7 +235,7 @@ items:
           - 'excel!Excel.Interfaces.CustomPropertyCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.CustomProperty:class'
     name: Excel.CustomProperty
@@ -245,7 +245,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -273,7 +273,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.CustomPropertyCollectionData:interface'
     name: Excel.Interfaces.CustomPropertyCollectionData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.customxmlpart.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.customxmlpart.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.CustomXmlPart#context:member'
@@ -343,7 +343,7 @@ items:
           - 'excel!Excel.Interfaces.CustomXmlPartData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -351,7 +351,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.customxmlpartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.customxmlpartcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.CustomXmlPartCollection#add:member(1)'
@@ -317,7 +317,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.CustomXmlPartCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -337,7 +337,7 @@ items:
           - 'excel!Excel.Interfaces.CustomXmlPartCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.CustomXmlPart:class'
     name: Excel.CustomXmlPart
@@ -349,7 +349,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -377,7 +377,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.CustomXmlPartCollectionData:interface'
     name: Excel.Interfaces.CustomXmlPartCollectionData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.customxmlpartscopedcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.customxmlpartscopedcollection.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.CustomXmlPartScopedCollection#context:member'
@@ -325,7 +325,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.CustomXmlPartScopedCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -345,7 +345,7 @@ items:
           - 'excel!Excel.Interfaces.CustomXmlPartScopedCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -353,7 +353,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -383,7 +383,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.CustomXmlPartScopedCollectionData:interface'
     name: Excel.Interfaces.CustomXmlPartScopedCollectionData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.databarconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.databarconditionalformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.DataBarConditionalFormat#axisColor:member'
@@ -259,7 +259,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.DataBarConditionalFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -330,7 +330,7 @@ items:
         type:
           - 'excel!Excel.ConditionalDataBarRule:interface'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.DataBarConditionalFormat#axisFormat~0:complex'
     name: Excel.ConditionalDataBarAxisFormat | "Automatic" | "None" | "CellMidPoint"
@@ -364,7 +364,7 @@ references:
     name: Excel.ConditionalDataBarPositiveFormat
   - uid: 'excel!Excel.Interfaces.DataBarConditionalFormatUpdateData:interface'
     name: Interfaces.DataBarConditionalFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.DataBarConditionalFormatData:interface'
     name: Excel.Interfaces.DataBarConditionalFormatData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.dataconnectioncollection.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.dataconnectioncollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.DataConnectionCollection#context:member'
@@ -72,7 +72,7 @@ items:
                     }
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.datapivothierarchy.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.datapivothierarchy.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.DataPivotHierarchy#context:member'
@@ -239,7 +239,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.DataPivotHierarchy#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -359,7 +359,7 @@ items:
           - 'excel!Excel.Interfaces.DataPivotHierarchyData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -371,7 +371,7 @@ references:
     name: Excel.Interfaces.DataPivotHierarchyLoadOptions
   - uid: 'excel!Excel.Interfaces.DataPivotHierarchyUpdateData:interface'
     name: Interfaces.DataPivotHierarchyUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.ShowAsRule:interface'
     name: Excel.ShowAsRule

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.datapivothierarchycollection.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.datapivothierarchycollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.DataPivotHierarchyCollection#add:member(1)'
@@ -193,7 +193,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.DataPivotHierarchyCollection#remove:member(1)'
     summary: |-
       Removes the PivotHierarchy from the current axis.
@@ -234,7 +234,7 @@ items:
           - 'excel!Excel.Interfaces.DataPivotHierarchyCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.DataPivotHierarchy:class'
     name: Excel.DataPivotHierarchy
@@ -246,7 +246,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -274,7 +274,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.DataPivotHierarchyCollectionData:interface'
     name: Excel.Interfaces.DataPivotHierarchyCollectionData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.datavalidation.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.datavalidation.yml
@@ -14,7 +14,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.DataValidation#clear:member(1)'
@@ -376,7 +376,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.DataValidation#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -449,7 +449,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -467,7 +467,7 @@ references:
     name: Excel.DataValidationRule
   - uid: 'excel!Excel.Interfaces.DataValidationUpdateData:interface'
     name: Interfaces.DataValidationUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.DataValidationData:interface'
     name: Excel.Interfaces.DataValidationData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.documentproperties.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.documentproperties.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.DocumentProperties#author:member'
@@ -296,7 +296,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.DocumentProperties#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -364,7 +364,7 @@ items:
           - 'excel!Excel.Interfaces.DocumentPropertiesData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -378,7 +378,7 @@ references:
     name: Excel.Interfaces.DocumentPropertiesLoadOptions
   - uid: 'excel!Excel.Interfaces.DocumentPropertiesUpdateData:interface'
     name: Interfaces.DocumentPropertiesUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.DocumentPropertiesData:interface'
     name: Excel.Interfaces.DocumentPropertiesData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.filter.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.filter.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Filter#apply:member(1)'
@@ -473,7 +473,7 @@ items:
           - 'excel!Excel.Interfaces.FilterData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.FilterCriteria:interface'
     name: Excel.FilterCriteria

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.filterpivothierarchy.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.filterpivothierarchy.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.FilterPivotHierarchy#context:member'
@@ -215,7 +215,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.FilterPivotHierarchy#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -269,7 +269,7 @@ items:
           - 'excel!Excel.Interfaces.FilterPivotHierarchyData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -281,7 +281,7 @@ references:
     name: Excel.Interfaces.FilterPivotHierarchyLoadOptions
   - uid: 'excel!Excel.Interfaces.FilterPivotHierarchyUpdateData:interface'
     name: Interfaces.FilterPivotHierarchyUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.FilterPivotHierarchyData:interface'
     name: Excel.Interfaces.FilterPivotHierarchyData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.filterpivothierarchycollection.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.filterpivothierarchycollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.FilterPivotHierarchyCollection#add:member(1)'
@@ -195,7 +195,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.FilterPivotHierarchyCollection#remove:member(1)'
     summary: |-
       Removes the PivotHierarchy from the current axis.
@@ -236,7 +236,7 @@ items:
           - 'excel!Excel.Interfaces.FilterPivotHierarchyCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.FilterPivotHierarchy:class'
     name: Excel.FilterPivotHierarchy
@@ -248,7 +248,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -276,7 +276,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.FilterPivotHierarchyCollectionData:interface'
     name: Excel.Interfaces.FilterPivotHierarchyCollectionData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.formatprotection.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.formatprotection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.FormatProtection#context:member'
@@ -170,7 +170,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.FormatProtection#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -208,7 +208,7 @@ items:
           - 'excel!Excel.Interfaces.FormatProtectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -218,7 +218,7 @@ references:
     name: Excel.Interfaces.FormatProtectionLoadOptions
   - uid: 'excel!Excel.Interfaces.FormatProtectionUpdateData:interface'
     name: Interfaces.FormatProtectionUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.FormatProtectionData:interface'
     name: Excel.Interfaces.FormatProtectionData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.functionresult.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.functionresult.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.FunctionResult#context:member'
@@ -158,7 +158,7 @@ items:
         type:
           - T
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.functions.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.functions.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Functions#abs:member(1)'
@@ -11184,7 +11184,7 @@ items:
           type:
             - 'excel!Excel.Functions#z_Test~3:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Functions#abs~0:complex'
     name: FunctionResult<number>

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.geometricshape.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.geometricshape.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.GeometricShape#context:member'
@@ -156,7 +156,7 @@ items:
           - 'excel!Excel.Interfaces.GeometricShapeData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.groupshapecollection.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.groupshapecollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.GroupShapeCollection#context:member'
@@ -170,7 +170,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.GroupShapeCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -190,7 +190,7 @@ items:
           - 'excel!Excel.Interfaces.GroupShapeCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -198,7 +198,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -228,7 +228,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.GroupShapeCollectionData:interface'
     name: Excel.Interfaces.GroupShapeCollectionData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.headerfooter.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.headerfooter.yml
@@ -8,7 +8,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.HeaderFooter#centerFooter:member'
@@ -239,7 +239,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.HeaderFooter#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -277,7 +277,7 @@ items:
           - 'excel!Excel.Interfaces.HeaderFooterData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -287,7 +287,7 @@ references:
     name: Excel.Interfaces.HeaderFooterLoadOptions
   - uid: 'excel!Excel.Interfaces.HeaderFooterUpdateData:interface'
     name: Interfaces.HeaderFooterUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.HeaderFooterData:interface'
     name: Excel.Interfaces.HeaderFooterData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.headerfootergroup.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.headerfootergroup.yml
@@ -8,7 +8,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.HeaderFooterGroup#context:member'
@@ -198,7 +198,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.HeaderFooterGroup#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -285,7 +285,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -297,7 +297,7 @@ references:
     name: Excel.Interfaces.HeaderFooterGroupLoadOptions
   - uid: 'excel!Excel.Interfaces.HeaderFooterGroupUpdateData:interface'
     name: Interfaces.HeaderFooterGroupUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.HeaderFooterGroup#state~0:complex'
     name: Excel.HeaderFooterState | "Default" | "FirstAndDefault" | "OddAndEven" | "FirstOddAndEven"

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.iconsetconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.iconsetconditionalformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.IconSetConditionalFormat#context:member'
@@ -222,7 +222,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.IconSetConditionalFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -345,7 +345,7 @@ items:
           - 'excel!Excel.Interfaces.IconSetConditionalFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -364,7 +364,7 @@ references:
     name: Excel.Interfaces.IconSetConditionalFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.IconSetConditionalFormatUpdateData:interface'
     name: Interfaces.IconSetConditionalFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.IconSetConditionalFormat#style~0:complex'
     name: >-

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.image.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.image.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Image#context:member'
@@ -192,7 +192,7 @@ items:
           - 'excel!Excel.Interfaces.ImageData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.iterativecalculation.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.iterativecalculation.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.IterativeCalculation#context:member'
@@ -182,7 +182,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.IterativeCalculation#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -220,7 +220,7 @@ items:
           - 'excel!Excel.Interfaces.IterativeCalculationData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -230,7 +230,7 @@ references:
     name: Excel.Interfaces.IterativeCalculationLoadOptions
   - uid: 'excel!Excel.Interfaces.IterativeCalculationUpdateData:interface'
     name: Interfaces.IterativeCalculationUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.IterativeCalculationData:interface'
     name: Excel.Interfaces.IterativeCalculationData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.line.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.line.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Line#beginArrowheadLength:member'
@@ -529,7 +529,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Line#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -582,7 +582,7 @@ items:
           - 'excel!Excel.Interfaces.LineData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Line#beginArrowheadLength~0:complex'
     name: Excel.ArrowheadLength | "Short" | "Medium" | "Long"
@@ -657,7 +657,7 @@ references:
     name: Excel.Interfaces.LineLoadOptions
   - uid: 'excel!Excel.Interfaces.LineUpdateData:interface'
     name: Interfaces.LineUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.LineData:interface'
     name: Excel.Interfaces.LineData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.nameditem.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.nameditem.yml
@@ -14,7 +14,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.NamedItem#arrayValues:member'
@@ -381,7 +381,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.NamedItem#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -500,7 +500,7 @@ items:
         type:
           - 'excel!Excel.Worksheet:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.NamedItemArrayValues:class'
     name: Excel.NamedItemArrayValues
@@ -523,7 +523,7 @@ references:
         fullName: ' | "Worksheet" | "Workbook"'
   - uid: 'excel!Excel.Interfaces.NamedItemUpdateData:interface'
     name: Interfaces.NamedItemUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.NamedItemData:interface'
     name: Excel.Interfaces.NamedItemData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.nameditemarrayvalues.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.nameditemarrayvalues.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.NamedItemArrayValues#context:member'
@@ -154,7 +154,7 @@ items:
         type:
           - 'any[][]'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.nameditemcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.nameditemcollection.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.NamedItemCollection#add:member(1)'
@@ -294,7 +294,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.NamedItemCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -314,7 +314,7 @@ items:
           - 'excel!Excel.Interfaces.NamedItemCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.NamedItem:class'
     name: Excel.NamedItem
@@ -333,7 +333,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -361,7 +361,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.NamedItemCollectionData:interface'
     name: Excel.Interfaces.NamedItemCollectionData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.pagebreak.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.pagebreak.yml
@@ -8,7 +8,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PageBreak#columnIndex:member'
@@ -185,7 +185,7 @@ items:
           - 'excel!Excel.Interfaces.PageBreakData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.pagebreakcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.pagebreakcollection.yml
@@ -8,7 +8,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PageBreakCollection#add:member(1)'
@@ -185,7 +185,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.PageBreakCollection#removePageBreaks:member(1)'
     summary: |-
       Resets all manual page breaks in the collection.
@@ -221,7 +221,7 @@ items:
           - 'excel!Excel.Interfaces.PageBreakCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.PageBreak:class'
     name: Excel.PageBreak
@@ -240,7 +240,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -268,7 +268,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.PageBreakCollectionData:interface'
     name: Excel.Interfaces.PageBreakCollectionData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.pagelayout.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.pagelayout.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PageLayout#blackAndWhite:member'
@@ -605,7 +605,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.PageLayout#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -842,7 +842,7 @@ items:
 
           ```
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -915,7 +915,7 @@ references:
         fullName: ' | "DownThenOver" | "OverThenDown"'
   - uid: 'excel!Excel.Interfaces.PageLayoutUpdateData:interface'
     name: Interfaces.PageLayoutUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.PageLayout#setPrintArea~0:complex'
     name: Range | RangeAreas | string

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.pivotfield.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.pivotfield.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PivotField#context:member'
@@ -187,7 +187,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.PivotField#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -352,7 +352,7 @@ items:
           - 'excel!Excel.Interfaces.PivotFieldData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -364,7 +364,7 @@ references:
     name: Excel.Interfaces.PivotFieldLoadOptions
   - uid: 'excel!Excel.Interfaces.PivotFieldUpdateData:interface'
     name: Interfaces.PivotFieldUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.SortBy:enum'
     name: SortBy

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.pivotfieldcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.pivotfieldcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PivotFieldCollection#context:member'
@@ -170,7 +170,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.PivotFieldCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -190,7 +190,7 @@ items:
           - 'excel!Excel.Interfaces.PivotFieldCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -198,7 +198,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -228,7 +228,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.PivotFieldCollectionData:interface'
     name: Excel.Interfaces.PivotFieldCollectionData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.pivothierarchy.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.pivothierarchy.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PivotHierarchy#context:member'
@@ -182,7 +182,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.PivotHierarchy#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -220,7 +220,7 @@ items:
           - 'excel!Excel.Interfaces.PivotHierarchyData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -232,7 +232,7 @@ references:
     name: Excel.Interfaces.PivotHierarchyLoadOptions
   - uid: 'excel!Excel.Interfaces.PivotHierarchyUpdateData:interface'
     name: Interfaces.PivotHierarchyUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.PivotHierarchyData:interface'
     name: Excel.Interfaces.PivotHierarchyData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.pivothierarchycollection.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.pivothierarchycollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PivotHierarchyCollection#context:member'
@@ -170,7 +170,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.PivotHierarchyCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -190,7 +190,7 @@ items:
           - 'excel!Excel.Interfaces.PivotHierarchyCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -198,7 +198,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -228,7 +228,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.PivotHierarchyCollectionData:interface'
     name: Excel.Interfaces.PivotHierarchyCollectionData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.pivotitem.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.pivotitem.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PivotItem#context:member'
@@ -183,7 +183,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.PivotItem#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -236,7 +236,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -246,7 +246,7 @@ references:
     name: Excel.Interfaces.PivotItemLoadOptions
   - uid: 'excel!Excel.Interfaces.PivotItemUpdateData:interface'
     name: Interfaces.PivotItemUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.PivotItemData:interface'
     name: Excel.Interfaces.PivotItemData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.pivotitemcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.pivotitemcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PivotItemCollection#context:member'
@@ -170,7 +170,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.PivotItemCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -190,7 +190,7 @@ items:
           - 'excel!Excel.Interfaces.PivotItemCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -198,7 +198,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -228,7 +228,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.PivotItemCollectionData:interface'
     name: Excel.Interfaces.PivotItemCollectionData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.pivotlayout.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.pivotlayout.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PivotLayout#autoFormat:member'
@@ -396,7 +396,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.PivotLayout#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -535,7 +535,7 @@ items:
           - 'excel!Excel.Interfaces.PivotLayoutData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -556,7 +556,7 @@ references:
     name: 'OfficeExtension.ClientResult<Excel.PivotItem[]>'
     fullName: 'OfficeExtension.ClientResult<Excel.PivotItem[]>'
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <
@@ -581,7 +581,7 @@ references:
     name: 'OfficeExtension.ClientResult<Excel.PivotItem[]>'
     fullName: 'OfficeExtension.ClientResult<Excel.PivotItem[]>'
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <
@@ -615,7 +615,7 @@ references:
     name: Excel.Interfaces.PivotLayoutLoadOptions
   - uid: 'excel!Excel.Interfaces.PivotLayoutUpdateData:interface'
     name: Interfaces.PivotLayoutUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.PivotLayout#setAutoSortOnCell~0:complex'
     name: Range | string

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.pivottable.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.pivottable.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PivotTable#columnHierarchies:member'
@@ -440,7 +440,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.PivotTable#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -508,7 +508,7 @@ items:
         type:
           - 'excel!Excel.Worksheet:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RowColumnPivotHierarchyCollection:class'
     name: Excel.RowColumnPivotHierarchyCollection
@@ -528,7 +528,7 @@ references:
     name: Excel.Interfaces.PivotTableLoadOptions
   - uid: 'excel!Excel.Interfaces.PivotTableUpdateData:interface'
     name: Interfaces.PivotTableUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.PivotTableData:interface'
     name: Excel.Interfaces.PivotTableData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.pivottablecollection.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.pivottablecollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PivotTableCollection#add:member(1)'
@@ -225,7 +225,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.PivotTableCollection#refreshAll:member(1)'
     summary: |-
       Refreshes all the pivot tables in the collection.
@@ -261,7 +261,7 @@ items:
           - 'excel!Excel.Interfaces.PivotTableCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.PivotTable:class'
     name: Excel.PivotTable
@@ -292,7 +292,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -320,7 +320,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.PivotTableCollectionData:interface'
     name: Excel.Interfaces.PivotTableCollectionData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.pivottablestyle.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.pivottablestyle.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PivotTableStyle#context:member'
@@ -200,7 +200,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.PivotTableStyle#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -238,7 +238,7 @@ items:
           - 'excel!Excel.Interfaces.PivotTableStyleData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -248,7 +248,7 @@ references:
     name: Excel.Interfaces.PivotTableStyleLoadOptions
   - uid: 'excel!Excel.Interfaces.PivotTableStyleUpdateData:interface'
     name: Interfaces.PivotTableStyleUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.PivotTableStyleData:interface'
     name: Excel.Interfaces.PivotTableStyleData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.pivottablestylecollection.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.pivottablestylecollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PivotTableStyleCollection#add:member(1)'
@@ -216,7 +216,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.PivotTableStyleCollection#setDefault:member(1)'
     summary: |-
       Sets the default PivotTableStyle for use in the parent object's scope.
@@ -257,7 +257,7 @@ items:
           - 'excel!Excel.Interfaces.PivotTableStyleCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.PivotTableStyle:class'
     name: Excel.PivotTableStyle
@@ -267,7 +267,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -295,7 +295,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.PivotTableStyleCollection#setDefault~0:complex'
     name: PivotTableStyle | string

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.presetcriteriaconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.presetcriteriaconditionalformat.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PresetCriteriaConditionalFormat#context:member'
@@ -212,7 +212,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.PresetCriteriaConditionalFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -250,7 +250,7 @@ items:
           - 'excel!Excel.Interfaces.PresetCriteriaConditionalFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -264,7 +264,7 @@ references:
     name: Excel.ConditionalPresetCriteriaRule
   - uid: 'excel!Excel.Interfaces.PresetCriteriaConditionalFormatUpdateData:interface'
     name: Interfaces.PresetCriteriaConditionalFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.PresetCriteriaConditionalFormatData:interface'
     name: Excel.Interfaces.PresetCriteriaConditionalFormatData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.range.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.range.yml
@@ -16,7 +16,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Range#address:member'
@@ -2867,7 +2867,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Range#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -3476,7 +3476,7 @@ items:
         type:
           - 'excel!Excel.Worksheet:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Range#autoFill~0:complex'
     name: Range | string
@@ -3557,7 +3557,7 @@ references:
     name: 'OfficeExtension.ClientResult<CellProperties[][]>'
     fullName: 'OfficeExtension.ClientResult<Excel.CellProperties[][]>'
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <
@@ -3573,7 +3573,7 @@ references:
     name: 'OfficeExtension.ClientResult<ColumnProperties[]>'
     fullName: 'OfficeExtension.ClientResult<Excel.ColumnProperties[]>'
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <
@@ -3589,7 +3589,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -3616,7 +3616,7 @@ references:
     name: 'OfficeExtension.ClientResult<RowProperties[]>'
     fullName: 'OfficeExtension.ClientResult<Excel.RowProperties[]>'
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <
@@ -3670,7 +3670,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -3679,7 +3679,7 @@ references:
     name: Excel.ReplaceCriteria
   - uid: 'excel!Excel.Interfaces.RangeUpdateData:interface'
     name: Interfaces.RangeUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Range#setCellProperties~0:complex'
     name: 'SettableCellProperties[][]'

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.rangeareas.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.rangeareas.yml
@@ -14,7 +14,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeAreas#address:member'
@@ -852,7 +852,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.RangeAreas#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -974,7 +974,7 @@ items:
         type:
           - 'excel!Excel.Worksheet:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RangeCollection:class'
     name: Excel.RangeCollection
@@ -1058,7 +1058,7 @@ references:
     name: Excel.Interfaces.RangeAreasLoadOptions
   - uid: 'excel!Excel.Interfaces.RangeAreasUpdateData:interface'
     name: Interfaces.RangeAreasUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.RangeAreasData:interface'
     name: Excel.Interfaces.RangeAreasData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.rangeborder.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.rangeborder.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeBorder#color:member'
@@ -156,7 +156,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.RangeBorder#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -288,7 +288,7 @@ items:
         type:
           - 'excel!Excel.RangeBorder#weight~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -298,7 +298,7 @@ references:
     name: Excel.Interfaces.RangeBorderLoadOptions
   - uid: 'excel!Excel.Interfaces.RangeBorderUpdateData:interface'
     name: Interfaces.RangeBorderUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.RangeBorder#sideIndex~0:complex'
     name: >-

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.rangebordercollection.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.rangebordercollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeBorderCollection#context:member'
@@ -266,7 +266,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.RangeBorderCollection#tintAndShade:member'
     summary: >-
       Returns or sets a double that lightens or darkens a color for Range Borders, the value is between -1 (darkest) and
@@ -304,7 +304,7 @@ items:
           - 'excel!Excel.Interfaces.RangeBorderCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -335,7 +335,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.RangeBorderCollectionData:interface'
     name: Excel.Interfaces.RangeBorderCollectionData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.rangecollection.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.rangecollection.yml
@@ -8,7 +8,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeCollection#context:member'
@@ -145,7 +145,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.RangeCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -165,7 +165,7 @@ items:
           - 'excel!Excel.Interfaces.RangeCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -173,7 +173,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -203,7 +203,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.RangeCollectionData:interface'
     name: Excel.Interfaces.RangeCollectionData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.rangefill.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.rangefill.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeFill#clear:member(1)'
@@ -286,7 +286,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.RangeFill#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -341,7 +341,7 @@ items:
           - 'excel!Excel.Interfaces.RangeFillData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -366,7 +366,7 @@ references:
         fullName: ' | "None" | "Solid" | "Gray50" | "Gray75" | "Gray25" | "Horizontal" | "Vertical" | "Down" | "Up" | "Checker" | "SemiGray75" | "LightHorizontal" | "LightVertical" | "LightDown" | "LightUp" | "Grid" | "CrissCross" | "Gray16" | "Gray8" | "LinearGradient" | "RectangularGradient"'
   - uid: 'excel!Excel.Interfaces.RangeFillUpdateData:interface'
     name: Interfaces.RangeFillUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.RangeFillData:interface'
     name: Excel.Interfaces.RangeFillData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.rangefont.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.rangefont.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeFont#bold:member'
@@ -241,7 +241,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.RangeFont#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -380,7 +380,7 @@ items:
         type:
           - 'excel!Excel.RangeFont#underline~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -390,7 +390,7 @@ references:
     name: Excel.Interfaces.RangeFontLoadOptions
   - uid: 'excel!Excel.Interfaces.RangeFontUpdateData:interface'
     name: Interfaces.RangeFontUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.RangeFontData:interface'
     name: Excel.Interfaces.RangeFontData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.rangeformat.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.rangeformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeFormat#adjustIndent:member(1)'
@@ -430,7 +430,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.RangeFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -592,7 +592,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RangeBorderCollection:class'
     name: Excel.RangeBorderCollection
@@ -632,7 +632,7 @@ references:
         fullName: ' | "Context" | "LeftToRight" | "RightToLeft"'
   - uid: 'excel!Excel.Interfaces.RangeFormatUpdateData:interface'
     name: Interfaces.RangeFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.RangeFormatData:interface'
     name: Excel.Interfaces.RangeFormatData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.rangesort.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.rangesort.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeSort#apply:member(1)'
@@ -135,7 +135,7 @@ items:
                     }
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RangeSort#apply~0:complex'
     name: 'Excel.SortField[]'

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.rangeview.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.rangeview.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeView#cellAddresses:member'
@@ -300,7 +300,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.RangeView#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -387,7 +387,7 @@ items:
         type:
           - 'excel!Excel.RangeView#valueTypes~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -401,7 +401,7 @@ references:
     name: Excel.RangeViewCollection
   - uid: 'excel!Excel.Interfaces.RangeViewUpdateData:interface'
     name: Interfaces.RangeViewUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.RangeViewData:interface'
     name: Excel.Interfaces.RangeViewData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.rangeviewcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.rangeviewcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeViewCollection#context:member'
@@ -148,7 +148,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.RangeViewCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -168,7 +168,7 @@ items:
           - 'excel!Excel.Interfaces.RangeViewCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -176,7 +176,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -206,7 +206,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.RangeViewCollectionData:interface'
     name: Excel.Interfaces.RangeViewCollectionData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.removeduplicatesresult.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.removeduplicatesresult.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RemoveDuplicatesResult#context:member'
@@ -178,7 +178,7 @@ items:
 
           ```
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.requestcontext.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.requestcontext.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientRequestContext:class'
+      - 'office!OfficeExtension.ClientRequestContext:class'
     package: excel!
     children:
       - 'excel!Excel.RequestContext:constructor(1)'
@@ -67,7 +67,7 @@ items:
         type:
           - 'excel!Excel.Workbook:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientRequestContext:class'
+  - uid: 'office!OfficeExtension.ClientRequestContext:class'
     name: OfficeExtension.ClientRequestContext
   - uid: 'excel!Excel.RequestContext~0:complex'
     name: string | Session

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.rowcolumnpivothierarchy.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.rowcolumnpivothierarchy.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RowColumnPivotHierarchy#context:member'
@@ -199,7 +199,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.RowColumnPivotHierarchy#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -253,7 +253,7 @@ items:
           - 'excel!Excel.Interfaces.RowColumnPivotHierarchyData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -265,7 +265,7 @@ references:
     name: Excel.Interfaces.RowColumnPivotHierarchyLoadOptions
   - uid: 'excel!Excel.Interfaces.RowColumnPivotHierarchyUpdateData:interface'
     name: Interfaces.RowColumnPivotHierarchyUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.RowColumnPivotHierarchyData:interface'
     name: Excel.Interfaces.RowColumnPivotHierarchyData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.rowcolumnpivothierarchycollection.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.rowcolumnpivothierarchycollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RowColumnPivotHierarchyCollection#add:member(1)'
@@ -195,7 +195,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.RowColumnPivotHierarchyCollection#remove:member(1)'
     summary: |-
       Removes the PivotHierarchy from the current axis.
@@ -237,7 +237,7 @@ items:
           - 'excel!Excel.Interfaces.RowColumnPivotHierarchyCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RowColumnPivotHierarchy:class'
     name: Excel.RowColumnPivotHierarchy
@@ -249,7 +249,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -277,7 +277,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.RowColumnPivotHierarchyCollectionData:interface'
     name: Excel.Interfaces.RowColumnPivotHierarchyCollectionData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.runoptions.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.runoptions.yml
@@ -34,7 +34,7 @@ references:
     name: OfficeExtension.RunOptions<Session>
     fullName: OfficeExtension.RunOptions<Excel.Session>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.RunOptions:interface'
+      - uid: 'office!OfficeExtension.RunOptions:interface'
         name: OfficeExtension.RunOptions
         fullName: OfficeExtension.RunOptions
       - name: <

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.runtime.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.runtime.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Runtime#context:member'
@@ -178,7 +178,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Runtime#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -216,7 +216,7 @@ items:
           - 'excel!Excel.Interfaces.RuntimeData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -226,7 +226,7 @@ references:
     name: Excel.Interfaces.RuntimeLoadOptions
   - uid: 'excel!Excel.Interfaces.RuntimeUpdateData:interface'
     name: Interfaces.RuntimeUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.RuntimeData:interface'
     name: Excel.Interfaces.RuntimeData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.setting.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.setting.yml
@@ -15,7 +15,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Setting#context:member'
@@ -200,7 +200,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Setting#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -253,7 +253,7 @@ items:
         type:
           - any
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -263,7 +263,7 @@ references:
     name: Excel.Interfaces.SettingLoadOptions
   - uid: 'excel!Excel.Interfaces.SettingUpdateData:interface'
     name: Interfaces.SettingUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.SettingData:interface'
     name: Excel.Interfaces.SettingData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.settingcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.settingcollection.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.SettingCollection#add:member(1)'
@@ -246,7 +246,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.SettingCollection#onSettingsChanged:member'
     summary: |-
       Occurs when the Settings in the document are changed.
@@ -301,7 +301,7 @@ items:
           - 'excel!Excel.Interfaces.SettingCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Setting:class'
     name: Excel.Setting
@@ -327,7 +327,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -355,13 +355,13 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.SettingCollection#onSettingsChanged~0:complex'
     name: OfficeExtension.EventHandlers<Excel.SettingsChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.SettingsChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.shape.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.shape.yml
@@ -14,7 +14,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Shape#altTextDescription:member'
@@ -1076,7 +1076,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Shape#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -1274,7 +1274,7 @@ items:
         type:
           - number
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -1366,7 +1366,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -1377,7 +1377,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -1396,7 +1396,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.ShapeActivatedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.ShapeActivatedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -1410,7 +1410,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.ShapeDeactivatedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.ShapeDeactivatedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -1435,7 +1435,7 @@ references:
     name: Excel.ShapeScaleFrom
   - uid: 'excel!Excel.Interfaces.ShapeUpdateData:interface'
     name: Interfaces.ShapeUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.ShapeZOrder:enum'
     name: Excel.ShapeZOrder

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.shapecollection.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.shapecollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ShapeCollection#addGeometricShape:member(1)'
@@ -546,7 +546,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.ShapeCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -566,7 +566,7 @@ items:
           - 'excel!Excel.Interfaces.ShapeCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Shape:class'
     name: Excel.Shape
@@ -594,7 +594,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -622,7 +622,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.ShapeCollectionData:interface'
     name: Excel.Interfaces.ShapeCollectionData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.shapefill.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.shapefill.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ShapeFill#clear:member(1)'
@@ -172,7 +172,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ShapeFill#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -268,7 +268,7 @@ items:
         type:
           - 'excel!Excel.ShapeFill#type~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -278,7 +278,7 @@ references:
     name: Excel.Interfaces.ShapeFillLoadOptions
   - uid: 'excel!Excel.Interfaces.ShapeFillUpdateData:interface'
     name: Interfaces.ShapeFillUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ShapeFillData:interface'
     name: Excel.Interfaces.ShapeFillData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.shapefont.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.shapefont.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ShapeFont#bold:member'
@@ -206,7 +206,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ShapeFont#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -281,7 +281,7 @@ items:
         type:
           - 'excel!Excel.ShapeFont#underline~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -291,7 +291,7 @@ references:
     name: Excel.Interfaces.ShapeFontLoadOptions
   - uid: 'excel!Excel.Interfaces.ShapeFontUpdateData:interface'
     name: Interfaces.ShapeFontUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ShapeFontData:interface'
     name: Excel.Interfaces.ShapeFontData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.shapegroup.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.shapegroup.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ShapeGroup#context:member'
@@ -210,7 +210,7 @@ items:
 
           ```
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.shapelineformat.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.shapelineformat.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ShapeLineFormat#color:member'
@@ -178,7 +178,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ShapeLineFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -284,7 +284,7 @@ items:
         type:
           - number
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -307,7 +307,7 @@ references:
     name: Excel.Interfaces.ShapeLineFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ShapeLineFormatUpdateData:interface'
     name: Interfaces.ShapeLineFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.ShapeLineFormat#style~0:complex'
     name: Excel.ShapeLineStyle | "Single" | "ThickBetweenThin" | "ThickThin" | "ThinThick" | "ThinThin"

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.slicer.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.slicer.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Slicer#caption:member'
@@ -366,7 +366,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Slicer#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -521,7 +521,7 @@ items:
         type:
           - 'excel!Excel.Worksheet:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -529,7 +529,7 @@ references:
     name: 'OfficeExtension.ClientResult<string[]>'
     fullName: 'OfficeExtension.ClientResult<string[]>'
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: '<string[]>'
@@ -540,7 +540,7 @@ references:
     name: Excel.Interfaces.SlicerLoadOptions
   - uid: 'excel!Excel.Interfaces.SlicerUpdateData:interface'
     name: Interfaces.SlicerUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.SlicerItemCollection:class'
     name: Excel.SlicerItemCollection

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.slicercollection.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.slicercollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.SlicerCollection#add:member(1)'
@@ -275,7 +275,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.SlicerCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -295,7 +295,7 @@ items:
           - 'excel!Excel.Interfaces.SlicerCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Slicer:class'
     name: Excel.Slicer
@@ -342,7 +342,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -370,7 +370,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.SlicerCollectionData:interface'
     name: Excel.Interfaces.SlicerCollectionData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.sliceritem.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.sliceritem.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.SlicerItem#context:member'
@@ -200,7 +200,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.SlicerItem#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -238,7 +238,7 @@ items:
           - 'excel!Excel.Interfaces.SlicerItemData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -248,7 +248,7 @@ references:
     name: Excel.Interfaces.SlicerItemLoadOptions
   - uid: 'excel!Excel.Interfaces.SlicerItemUpdateData:interface'
     name: Interfaces.SlicerItemUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.SlicerItemData:interface'
     name: Excel.Interfaces.SlicerItemData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.sliceritemcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.sliceritemcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.SlicerItemCollection#context:member'
@@ -192,7 +192,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.SlicerItemCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -212,7 +212,7 @@ items:
           - 'excel!Excel.Interfaces.SlicerItemCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -220,7 +220,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -250,7 +250,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.SlicerItemCollectionData:interface'
     name: Excel.Interfaces.SlicerItemCollectionData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.slicerstyle.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.slicerstyle.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.SlicerStyle#context:member'
@@ -200,7 +200,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.SlicerStyle#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -238,7 +238,7 @@ items:
           - 'excel!Excel.Interfaces.SlicerStyleData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -248,7 +248,7 @@ references:
     name: Excel.Interfaces.SlicerStyleLoadOptions
   - uid: 'excel!Excel.Interfaces.SlicerStyleUpdateData:interface'
     name: Interfaces.SlicerStyleUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.SlicerStyleData:interface'
     name: Excel.Interfaces.SlicerStyleData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.slicerstylecollection.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.slicerstylecollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.SlicerStyleCollection#add:member(1)'
@@ -216,7 +216,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.SlicerStyleCollection#setDefault:member(1)'
     summary: |-
       Sets the default SlicerStyle for use in the parent object's scope.
@@ -257,7 +257,7 @@ items:
           - 'excel!Excel.Interfaces.SlicerStyleCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.SlicerStyle:class'
     name: Excel.SlicerStyle
@@ -267,7 +267,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -295,7 +295,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.SlicerStyleCollection#setDefault~0:complex'
     name: SlicerStyle | string

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.style.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.style.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Style#autoIndent:member'
@@ -568,7 +568,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Style#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -666,7 +666,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RangeBorderCollection:class'
     name: Excel.RangeBorderCollection
@@ -704,7 +704,7 @@ references:
         fullName: ' | "Context" | "LeftToRight" | "RightToLeft"'
   - uid: 'excel!Excel.Interfaces.StyleUpdateData:interface'
     name: Interfaces.StyleUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.StyleData:interface'
     name: Excel.Interfaces.StyleData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.stylecollection.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.stylecollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.StyleCollection#add:member(1)'
@@ -256,7 +256,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.StyleCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -276,7 +276,7 @@ items:
           - 'excel!Excel.Interfaces.StyleCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -284,7 +284,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -314,7 +314,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.StyleCollectionData:interface'
     name: Excel.Interfaces.StyleCollectionData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.table.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.table.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Table#autoFilter:member'
@@ -637,7 +637,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Table#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -828,7 +828,7 @@ items:
         type:
           - 'excel!Excel.Worksheet:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.AutoFilter:class'
     name: Excel.AutoFilter
@@ -846,7 +846,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.TableChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.TableChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -860,7 +860,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.TableSelectionChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.TableSelectionChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -874,7 +874,7 @@ references:
     name: Excel.TableRowCollection
   - uid: 'excel!Excel.Interfaces.TableUpdateData:interface'
     name: Interfaces.TableUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.TableSort:class'
     name: Excel.TableSort

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.tablecollection.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.tablecollection.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableCollection#add:member(1)'
@@ -341,7 +341,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.TableCollection#onAdded:member'
     summary: |-
       Occurs when new table is added in a workbook.
@@ -426,7 +426,7 @@ items:
           - 'excel!Excel.Interfaces.TableCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Table:class'
     name: Excel.Table
@@ -445,7 +445,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -473,13 +473,13 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.TableCollection#onAdded~0:complex'
     name: OfficeExtension.EventHandlers<Excel.TableAddedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.TableAddedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -493,7 +493,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.TableChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.TableChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -507,7 +507,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.TableDeletedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.TableDeletedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.tablecolumn.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.tablecolumn.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableColumn#context:member'
@@ -401,7 +401,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.TableColumn#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -456,7 +456,7 @@ items:
         type:
           - 'any[][]'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -470,7 +470,7 @@ references:
     name: Excel.Interfaces.TableColumnLoadOptions
   - uid: 'excel!Excel.Interfaces.TableColumnUpdateData:interface'
     name: Interfaces.TableColumnUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.TableColumnData:interface'
     name: Excel.Interfaces.TableColumnData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.tablecolumncollection.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.tablecolumncollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableColumnCollection#add:member(1)'
@@ -322,7 +322,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.TableColumnCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -342,7 +342,7 @@ items:
           - 'excel!Excel.Interfaces.TableColumnCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.TableColumn:class'
     name: Excel.TableColumn
@@ -366,7 +366,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -394,7 +394,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.TableColumnCollectionData:interface'
     name: Excel.Interfaces.TableColumnCollectionData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.tablerow.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.tablerow.yml
@@ -17,7 +17,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableRow#context:member'
@@ -247,7 +247,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.TableRow#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -302,7 +302,7 @@ items:
         type:
           - 'any[][]'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -314,7 +314,7 @@ references:
     name: Excel.Interfaces.TableRowLoadOptions
   - uid: 'excel!Excel.Interfaces.TableRowUpdateData:interface'
     name: Interfaces.TableRowUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.TableRowData:interface'
     name: Excel.Interfaces.TableRowData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.tablerowcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.tablerowcollection.yml
@@ -17,7 +17,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableRowCollection#add:member(1)'
@@ -290,7 +290,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.TableRowCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -310,7 +310,7 @@ items:
           - 'excel!Excel.Interfaces.TableRowCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.TableRow:class'
     name: Excel.TableRow
@@ -334,7 +334,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -362,7 +362,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.TableRowCollectionData:interface'
     name: Excel.Interfaces.TableRowCollectionData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.tablescopedcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.tablescopedcollection.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableScopedCollection#context:member'
@@ -169,7 +169,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.TableScopedCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -189,7 +189,7 @@ items:
           - 'excel!Excel.Interfaces.TableScopedCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -197,7 +197,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -227,7 +227,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.TableScopedCollectionData:interface'
     name: Excel.Interfaces.TableScopedCollectionData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.tablesort.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.tablesort.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableSort#apply:member(1)'
@@ -288,7 +288,7 @@ items:
           - 'excel!Excel.Interfaces.TableSortData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.TableSort#apply~0:complex'
     name: 'Excel.SortField[]'

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.tablestyle.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.tablestyle.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableStyle#context:member'
@@ -200,7 +200,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.TableStyle#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -238,7 +238,7 @@ items:
           - 'excel!Excel.Interfaces.TableStyleData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -248,7 +248,7 @@ references:
     name: Excel.Interfaces.TableStyleLoadOptions
   - uid: 'excel!Excel.Interfaces.TableStyleUpdateData:interface'
     name: Interfaces.TableStyleUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.TableStyleData:interface'
     name: Excel.Interfaces.TableStyleData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.tablestylecollection.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.tablestylecollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableStyleCollection#add:member(1)'
@@ -216,7 +216,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.TableStyleCollection#setDefault:member(1)'
     summary: |-
       Sets the default TableStyle for use in the parent object's scope.
@@ -257,7 +257,7 @@ items:
           - 'excel!Excel.Interfaces.TableStyleCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.TableStyle:class'
     name: Excel.TableStyle
@@ -267,7 +267,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -295,7 +295,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.TableStyleCollection#setDefault~0:complex'
     name: TableStyle | string

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.textconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.textconditionalformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TextConditionalFormat#context:member'
@@ -214,7 +214,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.TextConditionalFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -252,7 +252,7 @@ items:
           - 'excel!Excel.Interfaces.TextConditionalFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -266,7 +266,7 @@ references:
     name: Excel.ConditionalTextComparisonRule
   - uid: 'excel!Excel.Interfaces.TextConditionalFormatUpdateData:interface'
     name: Interfaces.TextConditionalFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.TextConditionalFormatData:interface'
     name: Excel.Interfaces.TextConditionalFormatData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.textframe.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.textframe.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TextFrame#autoSizeSetting:member'
@@ -327,7 +327,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.TextFrame#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -427,7 +427,7 @@ items:
         type:
           - 'excel!Excel.TextFrame#verticalOverflow~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.TextFrame#autoSizeSetting~0:complex'
     name: Excel.ShapeAutoSize | "AutoSizeNone" | "AutoSizeTextToFitShape" | "AutoSizeShapeToFitText" | "AutoSizeMixed"
@@ -490,7 +490,7 @@ references:
         fullName: ' | "LeftToRight" | "RightToLeft"'
   - uid: 'excel!Excel.Interfaces.TextFrameUpdateData:interface'
     name: Interfaces.TextFrameUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.TextRange:class'
     name: Excel.TextRange

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.textrange.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.textrange.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TextRange#context:member'
@@ -179,7 +179,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.TextRange#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -232,7 +232,7 @@ items:
           - 'excel!Excel.Interfaces.TextRangeData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -244,7 +244,7 @@ references:
     name: Excel.Interfaces.TextRangeLoadOptions
   - uid: 'excel!Excel.Interfaces.TextRangeUpdateData:interface'
     name: Interfaces.TextRangeUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.TextRangeData:interface'
     name: Excel.Interfaces.TextRangeData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.timelinestyle.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.timelinestyle.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TimelineStyle#context:member'
@@ -200,7 +200,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.TimelineStyle#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -238,7 +238,7 @@ items:
           - 'excel!Excel.Interfaces.TimelineStyleData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -248,7 +248,7 @@ references:
     name: Excel.Interfaces.TimelineStyleLoadOptions
   - uid: 'excel!Excel.Interfaces.TimelineStyleUpdateData:interface'
     name: Interfaces.TimelineStyleUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.TimelineStyleData:interface'
     name: Excel.Interfaces.TimelineStyleData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.timelinestylecollection.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.timelinestylecollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TimelineStyleCollection#add:member(1)'
@@ -216,7 +216,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.TimelineStyleCollection#setDefault:member(1)'
     summary: |-
       Sets the default TimelineStyle for use in the parent object's scope.
@@ -257,7 +257,7 @@ items:
           - 'excel!Excel.Interfaces.TimelineStyleCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.TimelineStyle:class'
     name: Excel.TimelineStyle
@@ -267,7 +267,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -295,7 +295,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.TimelineStyleCollection#setDefault~0:complex'
     name: TimelineStyle | string

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.topbottomconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.topbottomconditionalformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TopBottomConditionalFormat#context:member'
@@ -168,7 +168,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.TopBottomConditionalFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -206,7 +206,7 @@ items:
           - 'excel!Excel.Interfaces.TopBottomConditionalFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -220,7 +220,7 @@ references:
     name: Excel.ConditionalTopBottomRule
   - uid: 'excel!Excel.Interfaces.TopBottomConditionalFormatUpdateData:interface'
     name: Interfaces.TopBottomConditionalFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.TopBottomConditionalFormatData:interface'
     name: Excel.Interfaces.TopBottomConditionalFormatData

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.workbook.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.workbook.yml
@@ -14,7 +14,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Workbook#application:member'
@@ -712,7 +712,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Workbook#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -920,7 +920,7 @@ items:
         type:
           - 'excel!Excel.WorksheetCollection:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Application:class'
     name: Excel.Application
@@ -946,7 +946,7 @@ references:
     name: OfficeExtension.ClientResult<boolean>
     fullName: OfficeExtension.ClientResult<boolean>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <boolean>
@@ -963,7 +963,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorkbookAutoSaveSettingChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorkbookAutoSaveSettingChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -977,7 +977,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.SelectionChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.SelectionChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -997,7 +997,7 @@ references:
     name: Excel.WorkbookProtection
   - uid: 'excel!Excel.Interfaces.WorkbookUpdateData:interface'
     name: Interfaces.WorkbookUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.SettingCollection:class'
     name: Excel.SettingCollection

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.workbookcreated.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.workbookcreated.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.WorkbookCreated#context:member'
@@ -103,7 +103,7 @@ items:
           - 'excel!Excel.Interfaces.WorkbookCreatedData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.workbookprotection.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.workbookprotection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.WorkbookProtection#context:member'
@@ -258,7 +258,7 @@ items:
           type:
             - string
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.worksheet.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.worksheet.yml
@@ -14,7 +14,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Worksheet#activate:member(1)'
@@ -1518,7 +1518,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Worksheet#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -1838,7 +1838,7 @@ items:
         type:
           - 'excel!Excel.Worksheet#visibility~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.AutoFilter:class'
     name: Excel.AutoFilter
@@ -1870,7 +1870,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetActivatedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetActivatedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -1884,7 +1884,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetCalculatedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetCalculatedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -1898,7 +1898,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -1912,7 +1912,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetColumnSortedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetColumnSortedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -1926,7 +1926,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetDeactivatedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetDeactivatedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -1940,7 +1940,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetFormatChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetFormatChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -1954,7 +1954,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetRowSortedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetRowSortedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -1968,7 +1968,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetSelectionChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetSelectionChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -1982,7 +1982,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetSingleClickedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetSingleClickedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -2002,7 +2002,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -2011,7 +2011,7 @@ references:
     name: Excel.ReplaceCriteria
   - uid: 'excel!Excel.Interfaces.WorksheetUpdateData:interface'
     name: Interfaces.WorksheetUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.ShapeCollection:class'
     name: Excel.ShapeCollection

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.worksheetcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.worksheetcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.WorksheetCollection#add:member(1)'
@@ -404,7 +404,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.WorksheetCollection#onActivated:member'
     summary: |-
       Occurs when any worksheet in the workbook is activated.
@@ -652,7 +652,7 @@ items:
           - 'excel!Excel.Interfaces.WorksheetCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Worksheet:class'
     name: Excel.Worksheet
@@ -662,7 +662,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -690,13 +690,13 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.WorksheetCollection#onActivated~0:complex'
     name: OfficeExtension.EventHandlers<Excel.WorksheetActivatedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetActivatedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -710,7 +710,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetAddedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetAddedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -724,7 +724,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetCalculatedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetCalculatedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -738,7 +738,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -752,7 +752,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetColumnSortedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetColumnSortedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -766,7 +766,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetDeactivatedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetDeactivatedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -780,7 +780,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetDeletedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetDeletedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -794,7 +794,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetFormatChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetFormatChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -808,7 +808,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetRowSortedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetRowSortedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -822,7 +822,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetSelectionChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetSelectionChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -836,7 +836,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetSingleClickedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetSingleClickedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.worksheetfreezepanes.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.worksheetfreezepanes.yml
@@ -8,7 +8,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.WorksheetFreezePanes#context:member'
@@ -278,7 +278,7 @@ items:
 
           ```
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel_1_10/excel/excel.worksheetprotection.yml
+++ b/docs/docs-ref-autogen/excel_1_10/excel/excel.worksheetprotection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.WorksheetProtection#context:member'
@@ -282,7 +282,7 @@ items:
           type:
             - string
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel_1_2/excel.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel.yml
@@ -567,7 +567,7 @@ items:
             A previously-created API object. The batch will use the same RequestContext as the passed-in object, which
             means that any changes applied to the object will be picked up by "context.sync()".
           type:
-            - 'excel!OfficeExtension.ClientObject:class'
+            - 'office!OfficeExtension.ClientObject:class'
         - id: batch
           description: >-
             A function that takes in a RequestContext and returns a promise (typically, just the result of
@@ -672,7 +672,7 @@ items:
             A previously-created object. The batch will use the same RequestContext as the passed-in object, which means
             that any changes applied to the object will be picked up by "context.sync()".
           type:
-            - 'excel!OfficeExtension.ClientRequestContext:class'
+            - 'office!OfficeExtension.ClientRequestContext:class'
         - id: batch
           description: >-
             A function that takes in a RequestContext and returns a promise (typically, just the result of
@@ -1584,7 +1584,7 @@ references:
         fullName: Promise
       - name: <T>
         fullName: <T>
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.run~3:complex'
     name: '(context: Excel.RequestContext) => Promise<T>'
@@ -1615,7 +1615,7 @@ references:
     name: 'OfficeExtension.ClientObject[]'
     fullName: 'OfficeExtension.ClientObject[]'
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientObject:class'
+      - uid: 'office!OfficeExtension.ClientObject:class'
         name: OfficeExtension.ClientObject
         fullName: OfficeExtension.ClientObject
       - name: '[]'
@@ -1672,7 +1672,7 @@ references:
         fullName: Promise
       - name: <T>
         fullName: <T>
-  - uid: 'excel!OfficeExtension.ClientRequestContext:class'
+  - uid: 'office!OfficeExtension.ClientRequestContext:class'
     name: OfficeExtension.ClientRequestContext
   - uid: 'excel!Excel.run~10:complex'
     name: '(context: Excel.RequestContext) => Promise<T>'

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.application.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.application.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Application#calculate:member(1)'
@@ -232,7 +232,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Application#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -270,7 +270,7 @@ items:
           - 'excel!Excel.Interfaces.ApplicationData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.CalculationType:enum'
     name: Excel.CalculationType
@@ -291,7 +291,7 @@ references:
     name: Excel.Interfaces.ApplicationLoadOptions
   - uid: 'excel!Excel.Interfaces.ApplicationUpdateData:interface'
     name: Interfaces.ApplicationUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ApplicationData:interface'
     name: Excel.Interfaces.ApplicationData

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.binding.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.binding.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Binding#context:member'
@@ -340,7 +340,7 @@ items:
         type:
           - 'excel!Excel.Binding#type~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -352,7 +352,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -365,7 +365,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.BindingDataChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.BindingDataChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -379,7 +379,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.BindingSelectionChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.BindingSelectionChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.bindingcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.bindingcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.BindingCollection#context:member'
@@ -270,7 +270,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.BindingCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -290,7 +290,7 @@ items:
           - 'excel!Excel.Interfaces.BindingCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -319,7 +319,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.BindingCollectionData:interface'
     name: Excel.Interfaces.BindingCollectionData

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.chart.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.chart.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Chart#axes:member'
@@ -456,7 +456,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Chart#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -681,7 +681,7 @@ items:
         type:
           - 'excel!Excel.Worksheet:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartAxes:class'
     name: Excel.ChartAxes
@@ -695,7 +695,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -706,7 +706,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -721,7 +721,7 @@ references:
     name: Excel.ChartSeriesCollection
   - uid: 'excel!Excel.Interfaces.ChartUpdateData:interface'
     name: Interfaces.ChartUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Range:class'
     name: Range

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.chartareaformat.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.chartareaformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAreaFormat#context:member'
@@ -166,7 +166,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAreaFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -204,7 +204,7 @@ items:
           - 'excel!Excel.Interfaces.ChartAreaFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -218,7 +218,7 @@ references:
     name: Excel.Interfaces.ChartAreaFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartAreaFormatUpdateData:interface'
     name: Interfaces.ChartAreaFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartAreaFormatData:interface'
     name: Excel.Interfaces.ChartAreaFormatData

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.chartaxes.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.chartaxes.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAxes#categoryAxis:member'
@@ -167,7 +167,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAxes#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -243,7 +243,7 @@ items:
           });
           ```
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartAxis:class'
     name: Excel.ChartAxis
@@ -255,7 +255,7 @@ references:
     name: Excel.Interfaces.ChartAxesLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartAxesUpdateData:interface'
     name: Interfaces.ChartAxesUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartAxesData:interface'
     name: Excel.Interfaces.ChartAxesData

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.chartaxis.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.chartaxis.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAxis#context:member'
@@ -275,7 +275,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAxis#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -328,7 +328,7 @@ items:
           - 'excel!Excel.Interfaces.ChartAxisData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -342,7 +342,7 @@ references:
     name: Excel.ChartGridlines
   - uid: 'excel!Excel.Interfaces.ChartAxisUpdateData:interface'
     name: Interfaces.ChartAxisUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.ChartAxisTitle:class'
     name: Excel.ChartAxisTitle

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.chartaxisformat.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.chartaxisformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAxisFormat#context:member'
@@ -166,7 +166,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAxisFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -204,7 +204,7 @@ items:
           - 'excel!Excel.Interfaces.ChartAxisFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -218,7 +218,7 @@ references:
     name: Excel.Interfaces.ChartAxisFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisFormatUpdateData:interface'
     name: Interfaces.ChartAxisFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisFormatData:interface'
     name: Excel.Interfaces.ChartAxisFormatData

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.chartaxistitle.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.chartaxistitle.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAxisTitle#context:member'
@@ -171,7 +171,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAxisTitle#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -239,7 +239,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -251,7 +251,7 @@ references:
     name: Excel.Interfaces.ChartAxisTitleLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisTitleUpdateData:interface'
     name: Interfaces.ChartAxisTitleUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisTitleData:interface'
     name: Excel.Interfaces.ChartAxisTitleData

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.chartaxistitleformat.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.chartaxistitleformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAxisTitleFormat#context:member'
@@ -150,7 +150,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAxisTitleFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -188,7 +188,7 @@ items:
           - 'excel!Excel.Interfaces.ChartAxisTitleFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -200,7 +200,7 @@ references:
     name: Excel.Interfaces.ChartAxisTitleFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisTitleFormatUpdateData:interface'
     name: Interfaces.ChartAxisTitleFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisTitleFormatData:interface'
     name: Excel.Interfaces.ChartAxisTitleFormatData

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.chartcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartCollection#add:member(1)'
@@ -342,7 +342,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.ChartCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -362,7 +362,7 @@ items:
           - 'excel!Excel.Interfaces.ChartCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Chart:class'
     name: Excel.Chart
@@ -397,7 +397,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.ChartCollectionData:interface'
     name: Excel.Interfaces.ChartCollectionData

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.chartdatalabelformat.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.chartdatalabelformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartDataLabelFormat#context:member'
@@ -166,7 +166,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartDataLabelFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -204,7 +204,7 @@ items:
           - 'excel!Excel.Interfaces.ChartDataLabelFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -218,7 +218,7 @@ references:
     name: Excel.Interfaces.ChartDataLabelFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartDataLabelFormatUpdateData:interface'
     name: Interfaces.ChartDataLabelFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartDataLabelFormatData:interface'
     name: Excel.Interfaces.ChartDataLabelFormatData

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.chartdatalabels.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.chartdatalabels.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartDataLabels#context:member'
@@ -213,7 +213,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartDataLabels#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -341,7 +341,7 @@ items:
           - 'excel!Excel.Interfaces.ChartDataLabelsData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -366,7 +366,7 @@ references:
         fullName: ' | "Invalid" | "None" | "Center" | "InsideEnd" | "InsideBase" | "OutsideEnd" | "Left" | "Right" | "Top" | "Bottom" | "BestFit" | "Callout"'
   - uid: 'excel!Excel.Interfaces.ChartDataLabelsUpdateData:interface'
     name: Interfaces.ChartDataLabelsUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartDataLabelsData:interface'
     name: Excel.Interfaces.ChartDataLabelsData

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.chartfill.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.chartfill.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartFill#clear:member(1)'
@@ -138,7 +138,7 @@ items:
                     }
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.chartfont.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.chartfont.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     remarks: |-
 
@@ -223,7 +223,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartFont#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -291,7 +291,7 @@ items:
         type:
           - 'excel!Excel.ChartFont#underline~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -301,7 +301,7 @@ references:
     name: Excel.Interfaces.ChartFontLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartFontUpdateData:interface'
     name: Interfaces.ChartFontUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartFontData:interface'
     name: Excel.Interfaces.ChartFontData

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.chartgridlines.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.chartgridlines.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartGridlines#context:member'
@@ -170,7 +170,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartGridlines#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -223,7 +223,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -235,7 +235,7 @@ references:
     name: Excel.Interfaces.ChartGridlinesLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartGridlinesUpdateData:interface'
     name: Interfaces.ChartGridlinesUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartGridlinesData:interface'
     name: Excel.Interfaces.ChartGridlinesData

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.chartgridlinesformat.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.chartgridlinesformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartGridlinesFormat#context:member'
@@ -150,7 +150,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartGridlinesFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -188,7 +188,7 @@ items:
           - 'excel!Excel.Interfaces.ChartGridlinesFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -200,7 +200,7 @@ references:
     name: Excel.Interfaces.ChartGridlinesFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartGridlinesFormatUpdateData:interface'
     name: Interfaces.ChartGridlinesFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartGridlinesFormatData:interface'
     name: Excel.Interfaces.ChartGridlinesFormatData

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.chartlegend.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.chartlegend.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartLegend#context:member'
@@ -203,7 +203,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartLegend#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -256,7 +256,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -277,7 +277,7 @@ references:
         fullName: ' | "Invalid" | "Top" | "Bottom" | "Left" | "Right" | "Corner" | "Custom"'
   - uid: 'excel!Excel.Interfaces.ChartLegendUpdateData:interface'
     name: Interfaces.ChartLegendUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartLegendData:interface'
     name: Excel.Interfaces.ChartLegendData

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.chartlegendformat.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.chartlegendformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartLegendFormat#context:member'
@@ -196,7 +196,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartLegendFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -234,7 +234,7 @@ items:
           - 'excel!Excel.Interfaces.ChartLegendFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -248,7 +248,7 @@ references:
     name: Excel.Interfaces.ChartLegendFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartLegendFormatUpdateData:interface'
     name: Interfaces.ChartLegendFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartLegendFormatData:interface'
     name: Excel.Interfaces.ChartLegendFormatData

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.chartlineformat.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.chartlineformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartLineFormat#clear:member(1)'
@@ -205,7 +205,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartLineFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -243,7 +243,7 @@ items:
           - 'excel!Excel.Interfaces.ChartLineFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -253,7 +253,7 @@ references:
     name: Excel.Interfaces.ChartLineFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartLineFormatUpdateData:interface'
     name: Interfaces.ChartLineFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartLineFormatData:interface'
     name: Excel.Interfaces.ChartLineFormatData

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.chartpoint.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.chartpoint.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartPoint#context:member'
@@ -151,7 +151,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartPoint#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -204,7 +204,7 @@ items:
         type:
           - any
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -216,7 +216,7 @@ references:
     name: Excel.Interfaces.ChartPointLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartPointUpdateData:interface'
     name: Interfaces.ChartPointUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartPointData:interface'
     name: Excel.Interfaces.ChartPointData

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.chartpointformat.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.chartpointformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartPointFormat#context:member'
@@ -150,7 +150,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartPointFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -188,7 +188,7 @@ items:
           - 'excel!Excel.Interfaces.ChartPointFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -200,7 +200,7 @@ references:
     name: Excel.Interfaces.ChartPointFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartPointFormatUpdateData:interface'
     name: Interfaces.ChartPointFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartPointFormatData:interface'
     name: Excel.Interfaces.ChartPointFormatData

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.chartpointscollection.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.chartpointscollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartPointsCollection#context:member'
@@ -202,7 +202,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.ChartPointsCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -222,7 +222,7 @@ items:
           - 'excel!Excel.Interfaces.ChartPointsCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -251,7 +251,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.ChartPointsCollectionData:interface'
     name: Excel.Interfaces.ChartPointsCollectionData

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.chartseries.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.chartseries.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartSeries#context:member'
@@ -201,7 +201,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartSeries#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -239,7 +239,7 @@ items:
           - 'excel!Excel.Interfaces.ChartSeriesData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -253,7 +253,7 @@ references:
     name: Excel.ChartPointsCollection
   - uid: 'excel!Excel.Interfaces.ChartSeriesUpdateData:interface'
     name: Interfaces.ChartSeriesUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartSeriesData:interface'
     name: Excel.Interfaces.ChartSeriesData

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.chartseriescollection.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.chartseriescollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartSeriesCollection#context:member'
@@ -203,7 +203,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.ChartSeriesCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -223,7 +223,7 @@ items:
           - 'excel!Excel.Interfaces.ChartSeriesCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -252,7 +252,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.ChartSeriesCollectionData:interface'
     name: Excel.Interfaces.ChartSeriesCollectionData

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.chartseriesformat.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.chartseriesformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartSeriesFormat#context:member'
@@ -166,7 +166,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartSeriesFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -204,7 +204,7 @@ items:
           - 'excel!Excel.Interfaces.ChartSeriesFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -218,7 +218,7 @@ references:
     name: Excel.Interfaces.ChartSeriesFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartSeriesFormatUpdateData:interface'
     name: Interfaces.ChartSeriesFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartSeriesFormatData:interface'
     name: Excel.Interfaces.ChartSeriesFormatData

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.charttitle.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.charttitle.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartTitle#context:member'
@@ -208,7 +208,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartTitle#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -276,7 +276,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -288,7 +288,7 @@ references:
     name: Excel.Interfaces.ChartTitleLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartTitleUpdateData:interface'
     name: Interfaces.ChartTitleUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartTitleData:interface'
     name: Excel.Interfaces.ChartTitleData

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.charttitleformat.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.charttitleformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartTitleFormat#context:member'
@@ -166,7 +166,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartTitleFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -204,7 +204,7 @@ items:
           - 'excel!Excel.Interfaces.ChartTitleFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -218,7 +218,7 @@ references:
     name: Excel.Interfaces.ChartTitleFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartTitleFormatUpdateData:interface'
     name: Interfaces.ChartTitleFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartTitleFormatData:interface'
     name: Excel.Interfaces.ChartTitleFormatData

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.filter.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.filter.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Filter#apply:member(1)'
@@ -473,7 +473,7 @@ items:
           - 'excel!Excel.Interfaces.FilterData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.FilterCriteria:interface'
     name: Excel.FilterCriteria

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.formatprotection.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.formatprotection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.FormatProtection#context:member'
@@ -170,7 +170,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.FormatProtection#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -208,7 +208,7 @@ items:
           - 'excel!Excel.Interfaces.FormatProtectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -218,7 +218,7 @@ references:
     name: Excel.Interfaces.FormatProtectionLoadOptions
   - uid: 'excel!Excel.Interfaces.FormatProtectionUpdateData:interface'
     name: Interfaces.FormatProtectionUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.FormatProtectionData:interface'
     name: Excel.Interfaces.FormatProtectionData

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.functionresult.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.functionresult.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.FunctionResult#context:member'
@@ -158,7 +158,7 @@ items:
         type:
           - T
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.functions.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.functions.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Functions#abs:member(1)'
@@ -11184,7 +11184,7 @@ items:
           type:
             - 'excel!Excel.Functions#z_Test~3:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Functions#abs~0:complex'
     name: FunctionResult<number>

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.nameditem.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.nameditem.yml
@@ -14,7 +14,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.NamedItem#context:member'
@@ -216,7 +216,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.NamedItem#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -301,7 +301,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -313,7 +313,7 @@ references:
     name: Excel.Interfaces.NamedItemLoadOptions
   - uid: 'excel!Excel.Interfaces.NamedItemUpdateData:interface'
     name: Interfaces.NamedItemUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.NamedItemData:interface'
     name: Excel.Interfaces.NamedItemData

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.nameditemcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.nameditemcollection.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.NamedItemCollection#context:member'
@@ -174,7 +174,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.NamedItemCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -194,7 +194,7 @@ items:
           - 'excel!Excel.Interfaces.NamedItemCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -223,7 +223,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.NamedItemCollectionData:interface'
     name: Excel.Interfaces.NamedItemCollectionData

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.range.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.range.yml
@@ -16,7 +16,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Range#address:member'
@@ -1506,7 +1506,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Range#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -1752,7 +1752,7 @@ items:
         type:
           - 'excel!Excel.Worksheet:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ClearApplyTo:enum'
     name: Excel.ClearApplyTo
@@ -1797,7 +1797,7 @@ references:
         fullName: ' | string'
   - uid: 'excel!Excel.Interfaces.RangeUpdateData:interface'
     name: Interfaces.RangeUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.RangeSort:class'
     name: Excel.RangeSort

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.rangeborder.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.rangeborder.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeBorder#color:member'
@@ -155,7 +155,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.RangeBorder#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -269,7 +269,7 @@ items:
         type:
           - 'excel!Excel.RangeBorder#weight~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -279,7 +279,7 @@ references:
     name: Excel.Interfaces.RangeBorderLoadOptions
   - uid: 'excel!Excel.Interfaces.RangeBorderUpdateData:interface'
     name: Interfaces.RangeBorderUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.RangeBorder#sideIndex~0:complex'
     name: >-

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.rangebordercollection.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.rangebordercollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeBorderCollection#context:member'
@@ -265,7 +265,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.RangeBorderCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -285,7 +285,7 @@ items:
           - 'excel!Excel.Interfaces.RangeBorderCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -316,7 +316,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.RangeBorderCollectionData:interface'
     name: Excel.Interfaces.RangeBorderCollectionData

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.rangefill.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.rangefill.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeFill#clear:member(1)'
@@ -226,7 +226,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.RangeFill#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -264,7 +264,7 @@ items:
           - 'excel!Excel.Interfaces.RangeFillData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -274,7 +274,7 @@ references:
     name: Excel.Interfaces.RangeFillLoadOptions
   - uid: 'excel!Excel.Interfaces.RangeFillUpdateData:interface'
     name: Interfaces.RangeFillUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.RangeFillData:interface'
     name: Excel.Interfaces.RangeFillData

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.rangefont.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.rangefont.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeFont#bold:member'
@@ -237,7 +237,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.RangeFont#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -305,7 +305,7 @@ items:
         type:
           - 'excel!Excel.RangeFont#underline~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -315,7 +315,7 @@ references:
     name: Excel.Interfaces.RangeFontLoadOptions
   - uid: 'excel!Excel.Interfaces.RangeFontUpdateData:interface'
     name: Interfaces.RangeFontUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.RangeFontData:interface'
     name: Excel.Interfaces.RangeFontData

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.rangeformat.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.rangeformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeFormat#adjustIndent:member(1)'
@@ -378,7 +378,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.RangeFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -448,7 +448,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RangeBorderCollection:class'
     name: Excel.RangeBorderCollection
@@ -479,7 +479,7 @@ references:
     name: Excel.FormatProtection
   - uid: 'excel!Excel.Interfaces.RangeFormatUpdateData:interface'
     name: Interfaces.RangeFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.RangeFormatData:interface'
     name: Excel.Interfaces.RangeFormatData

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.rangesort.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.rangesort.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeSort#apply:member(1)'
@@ -135,7 +135,7 @@ items:
                     }
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RangeSort#apply~0:complex'
     name: 'Excel.SortField[]'

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.requestcontext.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.requestcontext.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientRequestContext:class'
+      - 'office!OfficeExtension.ClientRequestContext:class'
     package: excel!
     children:
       - 'excel!Excel.RequestContext:constructor(1)'
@@ -54,7 +54,7 @@ items:
         type:
           - 'excel!Excel.Workbook:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientRequestContext:class'
+  - uid: 'office!OfficeExtension.ClientRequestContext:class'
     name: OfficeExtension.ClientRequestContext
   - uid: 'excel!Excel.RequestContext~0:complex'
     name: string | Session

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.runoptions.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.runoptions.yml
@@ -34,7 +34,7 @@ references:
     name: OfficeExtension.RunOptions<Session>
     fullName: OfficeExtension.RunOptions<Excel.Session>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.RunOptions:interface'
+      - uid: 'office!OfficeExtension.RunOptions:interface'
         name: OfficeExtension.RunOptions
         fullName: OfficeExtension.RunOptions
       - name: <

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.table.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.table.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Table#clearFilters:member(1)'
@@ -498,7 +498,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Table#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -638,7 +638,7 @@ items:
         type:
           - 'excel!Excel.Worksheet:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.TableColumnCollection:class'
     name: Excel.TableColumnCollection
@@ -654,7 +654,7 @@ references:
     name: Excel.TableRowCollection
   - uid: 'excel!Excel.Interfaces.TableUpdateData:interface'
     name: Interfaces.TableUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.TableSort:class'
     name: Excel.TableSort

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.tablecollection.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.tablecollection.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableCollection#add:member(1)'
@@ -299,7 +299,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.TableCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -319,7 +319,7 @@ items:
           - 'excel!Excel.Interfaces.TableCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Table:class'
     name: Excel.Table
@@ -357,7 +357,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.TableCollectionData:interface'
     name: Excel.Interfaces.TableCollectionData

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.tablecolumn.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.tablecolumn.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableColumn#context:member'
@@ -401,7 +401,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.TableColumn#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -456,7 +456,7 @@ items:
         type:
           - 'any[][]'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -470,7 +470,7 @@ references:
     name: Excel.Interfaces.TableColumnLoadOptions
   - uid: 'excel!Excel.Interfaces.TableColumnUpdateData:interface'
     name: Interfaces.TableColumnUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.TableColumnData:interface'
     name: Excel.Interfaces.TableColumnData

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.tablecolumncollection.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.tablecolumncollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableColumnCollection#add:member(1)'
@@ -283,7 +283,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.TableColumnCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -303,7 +303,7 @@ items:
           - 'excel!Excel.Interfaces.TableColumnCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.TableColumn:class'
     name: Excel.TableColumn
@@ -346,7 +346,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.TableColumnCollectionData:interface'
     name: Excel.Interfaces.TableColumnCollectionData

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.tablerow.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.tablerow.yml
@@ -17,7 +17,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableRow#context:member'
@@ -247,7 +247,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.TableRow#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -302,7 +302,7 @@ items:
         type:
           - 'any[][]'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -314,7 +314,7 @@ references:
     name: Excel.Interfaces.TableRowLoadOptions
   - uid: 'excel!Excel.Interfaces.TableRowUpdateData:interface'
     name: Interfaces.TableRowUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.TableRowData:interface'
     name: Excel.Interfaces.TableRowData

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.tablerowcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.tablerowcollection.yml
@@ -17,7 +17,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableRowCollection#add:member(1)'
@@ -273,7 +273,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.TableRowCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -293,7 +293,7 @@ items:
           - 'excel!Excel.Interfaces.TableRowCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.TableRow:class'
     name: Excel.TableRow
@@ -336,7 +336,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.TableRowCollectionData:interface'
     name: Excel.Interfaces.TableRowCollectionData

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.tablesort.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.tablesort.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableSort#apply:member(1)'
@@ -288,7 +288,7 @@ items:
           - 'excel!Excel.Interfaces.TableSortData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.TableSort#apply~0:complex'
     name: 'Excel.SortField[]'

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.workbook.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.workbook.yml
@@ -14,7 +14,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Workbook#application:member'
@@ -256,7 +256,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Workbook#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -324,7 +324,7 @@ items:
         type:
           - 'excel!Excel.WorksheetCollection:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Application:class'
     name: Excel.Application
@@ -346,7 +346,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.SelectionChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.SelectionChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -358,7 +358,7 @@ references:
         fullName: '>'
   - uid: 'excel!Excel.Interfaces.WorkbookUpdateData:interface'
     name: Interfaces.WorkbookUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.TableCollection:class'
     name: Excel.TableCollection

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.worksheet.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.worksheet.yml
@@ -14,7 +14,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Worksheet#activate:member(1)'
@@ -525,7 +525,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Worksheet#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -595,7 +595,7 @@ items:
         type:
           - 'excel!Excel.Worksheet#visibility~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartCollection:class'
     name: Excel.ChartCollection
@@ -611,7 +611,7 @@ references:
     name: Excel.WorksheetProtection
   - uid: 'excel!Excel.Interfaces.WorksheetUpdateData:interface'
     name: Interfaces.WorksheetUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.TableCollection:class'
     name: Excel.TableCollection

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.worksheetcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.worksheetcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.WorksheetCollection#add:member(1)'
@@ -233,7 +233,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.WorksheetCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -253,7 +253,7 @@ items:
           - 'excel!Excel.Interfaces.WorksheetCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Worksheet:class'
     name: Excel.Worksheet
@@ -282,7 +282,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.WorksheetCollectionData:interface'
     name: Excel.Interfaces.WorksheetCollectionData

--- a/docs/docs-ref-autogen/excel_1_2/excel/excel.worksheetprotection.yml
+++ b/docs/docs-ref-autogen/excel_1_2/excel/excel.worksheetprotection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.WorksheetProtection#context:member'
@@ -226,7 +226,7 @@ items:
           - 'excel!Excel.Interfaces.WorksheetProtectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel_1_3/excel.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel.yml
@@ -575,7 +575,7 @@ items:
             A previously-created API object. The batch will use the same RequestContext as the passed-in object, which
             means that any changes applied to the object will be picked up by "context.sync()".
           type:
-            - 'excel!OfficeExtension.ClientObject:class'
+            - 'office!OfficeExtension.ClientObject:class'
         - id: batch
           description: >-
             A function that takes in a RequestContext and returns a promise (typically, just the result of
@@ -680,7 +680,7 @@ items:
             A previously-created object. The batch will use the same RequestContext as the passed-in object, which means
             that any changes applied to the object will be picked up by "context.sync()".
           type:
-            - 'excel!OfficeExtension.ClientRequestContext:class'
+            - 'office!OfficeExtension.ClientRequestContext:class'
         - id: batch
           description: >-
             A function that takes in a RequestContext and returns a promise (typically, just the result of
@@ -1608,7 +1608,7 @@ references:
         fullName: Promise
       - name: <T>
         fullName: <T>
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.run~3:complex'
     name: '(context: Excel.RequestContext) => Promise<T>'
@@ -1639,7 +1639,7 @@ references:
     name: 'OfficeExtension.ClientObject[]'
     fullName: 'OfficeExtension.ClientObject[]'
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientObject:class'
+      - uid: 'office!OfficeExtension.ClientObject:class'
         name: OfficeExtension.ClientObject
         fullName: OfficeExtension.ClientObject
       - name: '[]'
@@ -1696,7 +1696,7 @@ references:
         fullName: Promise
       - name: <T>
         fullName: <T>
-  - uid: 'excel!OfficeExtension.ClientRequestContext:class'
+  - uid: 'office!OfficeExtension.ClientRequestContext:class'
     name: OfficeExtension.ClientRequestContext
   - uid: 'excel!Excel.run~10:complex'
     name: '(context: Excel.RequestContext) => Promise<T>'

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.application.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.application.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Application#calculate:member(1)'
@@ -232,7 +232,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Application#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -270,7 +270,7 @@ items:
           - 'excel!Excel.Interfaces.ApplicationData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.CalculationType:enum'
     name: Excel.CalculationType
@@ -291,7 +291,7 @@ references:
     name: Excel.Interfaces.ApplicationLoadOptions
   - uid: 'excel!Excel.Interfaces.ApplicationUpdateData:interface'
     name: Interfaces.ApplicationUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ApplicationData:interface'
     name: Excel.Interfaces.ApplicationData

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.binding.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.binding.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Binding#context:member'
@@ -357,7 +357,7 @@ items:
         type:
           - 'excel!Excel.Binding#type~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -369,7 +369,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -382,7 +382,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.BindingDataChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.BindingDataChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -396,7 +396,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.BindingSelectionChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.BindingSelectionChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.bindingcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.bindingcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.BindingCollection#add:member(1)'
@@ -454,7 +454,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.BindingCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -474,7 +474,7 @@ items:
           - 'excel!Excel.Interfaces.BindingCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Binding:class'
     name: Excel.Binding
@@ -523,7 +523,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.BindingCollectionData:interface'
     name: Excel.Interfaces.BindingCollectionData

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.chart.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.chart.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Chart#axes:member'
@@ -456,7 +456,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Chart#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -681,7 +681,7 @@ items:
         type:
           - 'excel!Excel.Worksheet:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartAxes:class'
     name: Excel.ChartAxes
@@ -695,7 +695,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -706,7 +706,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -721,7 +721,7 @@ references:
     name: Excel.ChartSeriesCollection
   - uid: 'excel!Excel.Interfaces.ChartUpdateData:interface'
     name: Interfaces.ChartUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Range:class'
     name: Range

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.chartareaformat.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.chartareaformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAreaFormat#context:member'
@@ -166,7 +166,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAreaFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -204,7 +204,7 @@ items:
           - 'excel!Excel.Interfaces.ChartAreaFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -218,7 +218,7 @@ references:
     name: Excel.Interfaces.ChartAreaFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartAreaFormatUpdateData:interface'
     name: Interfaces.ChartAreaFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartAreaFormatData:interface'
     name: Excel.Interfaces.ChartAreaFormatData

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.chartaxes.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.chartaxes.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAxes#categoryAxis:member'
@@ -167,7 +167,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAxes#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -243,7 +243,7 @@ items:
           });
           ```
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartAxis:class'
     name: Excel.ChartAxis
@@ -255,7 +255,7 @@ references:
     name: Excel.Interfaces.ChartAxesLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartAxesUpdateData:interface'
     name: Interfaces.ChartAxesUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartAxesData:interface'
     name: Excel.Interfaces.ChartAxesData

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.chartaxis.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.chartaxis.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAxis#context:member'
@@ -275,7 +275,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAxis#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -328,7 +328,7 @@ items:
           - 'excel!Excel.Interfaces.ChartAxisData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -342,7 +342,7 @@ references:
     name: Excel.ChartGridlines
   - uid: 'excel!Excel.Interfaces.ChartAxisUpdateData:interface'
     name: Interfaces.ChartAxisUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.ChartAxisTitle:class'
     name: Excel.ChartAxisTitle

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.chartaxisformat.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.chartaxisformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAxisFormat#context:member'
@@ -166,7 +166,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAxisFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -204,7 +204,7 @@ items:
           - 'excel!Excel.Interfaces.ChartAxisFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -218,7 +218,7 @@ references:
     name: Excel.Interfaces.ChartAxisFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisFormatUpdateData:interface'
     name: Interfaces.ChartAxisFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisFormatData:interface'
     name: Excel.Interfaces.ChartAxisFormatData

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.chartaxistitle.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.chartaxistitle.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAxisTitle#context:member'
@@ -171,7 +171,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAxisTitle#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -239,7 +239,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -251,7 +251,7 @@ references:
     name: Excel.Interfaces.ChartAxisTitleLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisTitleUpdateData:interface'
     name: Interfaces.ChartAxisTitleUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisTitleData:interface'
     name: Excel.Interfaces.ChartAxisTitleData

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.chartaxistitleformat.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.chartaxistitleformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAxisTitleFormat#context:member'
@@ -150,7 +150,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAxisTitleFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -188,7 +188,7 @@ items:
           - 'excel!Excel.Interfaces.ChartAxisTitleFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -200,7 +200,7 @@ references:
     name: Excel.Interfaces.ChartAxisTitleFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisTitleFormatUpdateData:interface'
     name: Interfaces.ChartAxisTitleFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisTitleFormatData:interface'
     name: Excel.Interfaces.ChartAxisTitleFormatData

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.chartcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartCollection#add:member(1)'
@@ -342,7 +342,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.ChartCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -362,7 +362,7 @@ items:
           - 'excel!Excel.Interfaces.ChartCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Chart:class'
     name: Excel.Chart
@@ -397,7 +397,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.ChartCollectionData:interface'
     name: Excel.Interfaces.ChartCollectionData

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.chartdatalabelformat.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.chartdatalabelformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartDataLabelFormat#context:member'
@@ -166,7 +166,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartDataLabelFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -204,7 +204,7 @@ items:
           - 'excel!Excel.Interfaces.ChartDataLabelFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -218,7 +218,7 @@ references:
     name: Excel.Interfaces.ChartDataLabelFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartDataLabelFormatUpdateData:interface'
     name: Interfaces.ChartDataLabelFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartDataLabelFormatData:interface'
     name: Excel.Interfaces.ChartDataLabelFormatData

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.chartdatalabels.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.chartdatalabels.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartDataLabels#context:member'
@@ -213,7 +213,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartDataLabels#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -341,7 +341,7 @@ items:
           - 'excel!Excel.Interfaces.ChartDataLabelsData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -366,7 +366,7 @@ references:
         fullName: ' | "Invalid" | "None" | "Center" | "InsideEnd" | "InsideBase" | "OutsideEnd" | "Left" | "Right" | "Top" | "Bottom" | "BestFit" | "Callout"'
   - uid: 'excel!Excel.Interfaces.ChartDataLabelsUpdateData:interface'
     name: Interfaces.ChartDataLabelsUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartDataLabelsData:interface'
     name: Excel.Interfaces.ChartDataLabelsData

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.chartfill.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.chartfill.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartFill#clear:member(1)'
@@ -138,7 +138,7 @@ items:
                     }
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.chartfont.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.chartfont.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     remarks: |-
 
@@ -223,7 +223,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartFont#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -291,7 +291,7 @@ items:
         type:
           - 'excel!Excel.ChartFont#underline~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -301,7 +301,7 @@ references:
     name: Excel.Interfaces.ChartFontLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartFontUpdateData:interface'
     name: Interfaces.ChartFontUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartFontData:interface'
     name: Excel.Interfaces.ChartFontData

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.chartgridlines.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.chartgridlines.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartGridlines#context:member'
@@ -170,7 +170,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartGridlines#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -223,7 +223,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -235,7 +235,7 @@ references:
     name: Excel.Interfaces.ChartGridlinesLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartGridlinesUpdateData:interface'
     name: Interfaces.ChartGridlinesUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartGridlinesData:interface'
     name: Excel.Interfaces.ChartGridlinesData

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.chartgridlinesformat.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.chartgridlinesformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartGridlinesFormat#context:member'
@@ -150,7 +150,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartGridlinesFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -188,7 +188,7 @@ items:
           - 'excel!Excel.Interfaces.ChartGridlinesFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -200,7 +200,7 @@ references:
     name: Excel.Interfaces.ChartGridlinesFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartGridlinesFormatUpdateData:interface'
     name: Interfaces.ChartGridlinesFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartGridlinesFormatData:interface'
     name: Excel.Interfaces.ChartGridlinesFormatData

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.chartlegend.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.chartlegend.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartLegend#context:member'
@@ -203,7 +203,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartLegend#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -256,7 +256,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -277,7 +277,7 @@ references:
         fullName: ' | "Invalid" | "Top" | "Bottom" | "Left" | "Right" | "Corner" | "Custom"'
   - uid: 'excel!Excel.Interfaces.ChartLegendUpdateData:interface'
     name: Interfaces.ChartLegendUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartLegendData:interface'
     name: Excel.Interfaces.ChartLegendData

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.chartlegendformat.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.chartlegendformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartLegendFormat#context:member'
@@ -196,7 +196,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartLegendFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -234,7 +234,7 @@ items:
           - 'excel!Excel.Interfaces.ChartLegendFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -248,7 +248,7 @@ references:
     name: Excel.Interfaces.ChartLegendFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartLegendFormatUpdateData:interface'
     name: Interfaces.ChartLegendFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartLegendFormatData:interface'
     name: Excel.Interfaces.ChartLegendFormatData

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.chartlineformat.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.chartlineformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartLineFormat#clear:member(1)'
@@ -205,7 +205,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartLineFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -243,7 +243,7 @@ items:
           - 'excel!Excel.Interfaces.ChartLineFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -253,7 +253,7 @@ references:
     name: Excel.Interfaces.ChartLineFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartLineFormatUpdateData:interface'
     name: Interfaces.ChartLineFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartLineFormatData:interface'
     name: Excel.Interfaces.ChartLineFormatData

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.chartpoint.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.chartpoint.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartPoint#context:member'
@@ -151,7 +151,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartPoint#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -204,7 +204,7 @@ items:
         type:
           - any
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -216,7 +216,7 @@ references:
     name: Excel.Interfaces.ChartPointLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartPointUpdateData:interface'
     name: Interfaces.ChartPointUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartPointData:interface'
     name: Excel.Interfaces.ChartPointData

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.chartpointformat.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.chartpointformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartPointFormat#context:member'
@@ -150,7 +150,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartPointFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -188,7 +188,7 @@ items:
           - 'excel!Excel.Interfaces.ChartPointFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -200,7 +200,7 @@ references:
     name: Excel.Interfaces.ChartPointFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartPointFormatUpdateData:interface'
     name: Interfaces.ChartPointFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartPointFormatData:interface'
     name: Excel.Interfaces.ChartPointFormatData

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.chartpointscollection.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.chartpointscollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartPointsCollection#context:member'
@@ -202,7 +202,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.ChartPointsCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -222,7 +222,7 @@ items:
           - 'excel!Excel.Interfaces.ChartPointsCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -251,7 +251,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.ChartPointsCollectionData:interface'
     name: Excel.Interfaces.ChartPointsCollectionData

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.chartseries.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.chartseries.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartSeries#context:member'
@@ -201,7 +201,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartSeries#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -239,7 +239,7 @@ items:
           - 'excel!Excel.Interfaces.ChartSeriesData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -253,7 +253,7 @@ references:
     name: Excel.ChartPointsCollection
   - uid: 'excel!Excel.Interfaces.ChartSeriesUpdateData:interface'
     name: Interfaces.ChartSeriesUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartSeriesData:interface'
     name: Excel.Interfaces.ChartSeriesData

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.chartseriescollection.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.chartseriescollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartSeriesCollection#context:member'
@@ -203,7 +203,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.ChartSeriesCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -223,7 +223,7 @@ items:
           - 'excel!Excel.Interfaces.ChartSeriesCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -252,7 +252,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.ChartSeriesCollectionData:interface'
     name: Excel.Interfaces.ChartSeriesCollectionData

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.chartseriesformat.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.chartseriesformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartSeriesFormat#context:member'
@@ -166,7 +166,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartSeriesFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -204,7 +204,7 @@ items:
           - 'excel!Excel.Interfaces.ChartSeriesFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -218,7 +218,7 @@ references:
     name: Excel.Interfaces.ChartSeriesFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartSeriesFormatUpdateData:interface'
     name: Interfaces.ChartSeriesFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartSeriesFormatData:interface'
     name: Excel.Interfaces.ChartSeriesFormatData

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.charttitle.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.charttitle.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartTitle#context:member'
@@ -208,7 +208,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartTitle#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -276,7 +276,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -288,7 +288,7 @@ references:
     name: Excel.Interfaces.ChartTitleLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartTitleUpdateData:interface'
     name: Interfaces.ChartTitleUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartTitleData:interface'
     name: Excel.Interfaces.ChartTitleData

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.charttitleformat.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.charttitleformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartTitleFormat#context:member'
@@ -166,7 +166,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartTitleFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -204,7 +204,7 @@ items:
           - 'excel!Excel.Interfaces.ChartTitleFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -218,7 +218,7 @@ references:
     name: Excel.Interfaces.ChartTitleFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartTitleFormatUpdateData:interface'
     name: Interfaces.ChartTitleFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartTitleFormatData:interface'
     name: Excel.Interfaces.ChartTitleFormatData

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.filter.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.filter.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Filter#apply:member(1)'
@@ -473,7 +473,7 @@ items:
           - 'excel!Excel.Interfaces.FilterData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.FilterCriteria:interface'
     name: Excel.FilterCriteria

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.formatprotection.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.formatprotection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.FormatProtection#context:member'
@@ -170,7 +170,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.FormatProtection#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -208,7 +208,7 @@ items:
           - 'excel!Excel.Interfaces.FormatProtectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -218,7 +218,7 @@ references:
     name: Excel.Interfaces.FormatProtectionLoadOptions
   - uid: 'excel!Excel.Interfaces.FormatProtectionUpdateData:interface'
     name: Interfaces.FormatProtectionUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.FormatProtectionData:interface'
     name: Excel.Interfaces.FormatProtectionData

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.functionresult.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.functionresult.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.FunctionResult#context:member'
@@ -158,7 +158,7 @@ items:
         type:
           - T
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.functions.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.functions.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Functions#abs:member(1)'
@@ -11184,7 +11184,7 @@ items:
           type:
             - 'excel!Excel.Functions#z_Test~3:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Functions#abs~0:complex'
     name: FunctionResult<number>

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.nameditem.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.nameditem.yml
@@ -14,7 +14,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.NamedItem#context:member'
@@ -216,7 +216,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.NamedItem#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -301,7 +301,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -313,7 +313,7 @@ references:
     name: Excel.Interfaces.NamedItemLoadOptions
   - uid: 'excel!Excel.Interfaces.NamedItemUpdateData:interface'
     name: Interfaces.NamedItemUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.NamedItemData:interface'
     name: Excel.Interfaces.NamedItemData

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.nameditemcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.nameditemcollection.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.NamedItemCollection#context:member'
@@ -174,7 +174,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.NamedItemCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -194,7 +194,7 @@ items:
           - 'excel!Excel.Interfaces.NamedItemCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -223,7 +223,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.NamedItemCollectionData:interface'
     name: Excel.Interfaces.NamedItemCollectionData

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.pivottable.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.pivottable.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PivotTable#context:member'
@@ -170,7 +170,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.PivotTable#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -223,7 +223,7 @@ items:
         type:
           - 'excel!Excel.Worksheet:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -233,7 +233,7 @@ references:
     name: Excel.Interfaces.PivotTableLoadOptions
   - uid: 'excel!Excel.Interfaces.PivotTableUpdateData:interface'
     name: Interfaces.PivotTableUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.PivotTableData:interface'
     name: Excel.Interfaces.PivotTableData

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.pivottablecollection.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.pivottablecollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PivotTableCollection#context:member'
@@ -132,7 +132,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.PivotTableCollection#refreshAll:member(1)'
     summary: |-
       Refreshes all the pivot tables in the collection.
@@ -168,7 +168,7 @@ items:
           - 'excel!Excel.Interfaces.PivotTableCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -197,7 +197,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.PivotTableCollectionData:interface'
     name: Excel.Interfaces.PivotTableCollectionData

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.range.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.range.yml
@@ -16,7 +16,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Range#address:member'
@@ -1523,7 +1523,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Range#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -1769,7 +1769,7 @@ items:
         type:
           - 'excel!Excel.Worksheet:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ClearApplyTo:enum'
     name: Excel.ClearApplyTo
@@ -1816,7 +1816,7 @@ references:
         fullName: ' | string'
   - uid: 'excel!Excel.Interfaces.RangeUpdateData:interface'
     name: Interfaces.RangeUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.RangeSort:class'
     name: Excel.RangeSort

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.rangeborder.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.rangeborder.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeBorder#color:member'
@@ -155,7 +155,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.RangeBorder#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -269,7 +269,7 @@ items:
         type:
           - 'excel!Excel.RangeBorder#weight~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -279,7 +279,7 @@ references:
     name: Excel.Interfaces.RangeBorderLoadOptions
   - uid: 'excel!Excel.Interfaces.RangeBorderUpdateData:interface'
     name: Interfaces.RangeBorderUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.RangeBorder#sideIndex~0:complex'
     name: >-

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.rangebordercollection.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.rangebordercollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeBorderCollection#context:member'
@@ -265,7 +265,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.RangeBorderCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -285,7 +285,7 @@ items:
           - 'excel!Excel.Interfaces.RangeBorderCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -316,7 +316,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.RangeBorderCollectionData:interface'
     name: Excel.Interfaces.RangeBorderCollectionData

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.rangefill.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.rangefill.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeFill#clear:member(1)'
@@ -226,7 +226,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.RangeFill#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -264,7 +264,7 @@ items:
           - 'excel!Excel.Interfaces.RangeFillData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -274,7 +274,7 @@ references:
     name: Excel.Interfaces.RangeFillLoadOptions
   - uid: 'excel!Excel.Interfaces.RangeFillUpdateData:interface'
     name: Interfaces.RangeFillUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.RangeFillData:interface'
     name: Excel.Interfaces.RangeFillData

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.rangefont.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.rangefont.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeFont#bold:member'
@@ -237,7 +237,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.RangeFont#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -305,7 +305,7 @@ items:
         type:
           - 'excel!Excel.RangeFont#underline~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -315,7 +315,7 @@ references:
     name: Excel.Interfaces.RangeFontLoadOptions
   - uid: 'excel!Excel.Interfaces.RangeFontUpdateData:interface'
     name: Interfaces.RangeFontUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.RangeFontData:interface'
     name: Excel.Interfaces.RangeFontData

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.rangeformat.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.rangeformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeFormat#adjustIndent:member(1)'
@@ -378,7 +378,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.RangeFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -448,7 +448,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RangeBorderCollection:class'
     name: Excel.RangeBorderCollection
@@ -479,7 +479,7 @@ references:
     name: Excel.FormatProtection
   - uid: 'excel!Excel.Interfaces.RangeFormatUpdateData:interface'
     name: Interfaces.RangeFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.RangeFormatData:interface'
     name: Excel.Interfaces.RangeFormatData

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.rangesort.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.rangesort.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeSort#apply:member(1)'
@@ -135,7 +135,7 @@ items:
                     }
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RangeSort#apply~0:complex'
     name: 'Excel.SortField[]'

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.rangeview.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.rangeview.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeView#cellAddresses:member'
@@ -300,7 +300,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.RangeView#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -387,7 +387,7 @@ items:
         type:
           - 'excel!Excel.RangeView#valueTypes~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -401,7 +401,7 @@ references:
     name: Excel.RangeViewCollection
   - uid: 'excel!Excel.Interfaces.RangeViewUpdateData:interface'
     name: Interfaces.RangeViewUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.RangeViewData:interface'
     name: Excel.Interfaces.RangeViewData

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.rangeviewcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.rangeviewcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeViewCollection#context:member'
@@ -131,7 +131,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.RangeViewCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -151,7 +151,7 @@ items:
           - 'excel!Excel.Interfaces.RangeViewCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -180,7 +180,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.RangeViewCollectionData:interface'
     name: Excel.Interfaces.RangeViewCollectionData

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.requestcontext.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.requestcontext.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientRequestContext:class'
+      - 'office!OfficeExtension.ClientRequestContext:class'
     package: excel!
     children:
       - 'excel!Excel.RequestContext:constructor(1)'
@@ -54,7 +54,7 @@ items:
         type:
           - 'excel!Excel.Workbook:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientRequestContext:class'
+  - uid: 'office!OfficeExtension.ClientRequestContext:class'
     name: OfficeExtension.ClientRequestContext
   - uid: 'excel!Excel.RequestContext~0:complex'
     name: string | Session

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.runoptions.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.runoptions.yml
@@ -34,7 +34,7 @@ references:
     name: OfficeExtension.RunOptions<Session>
     fullName: OfficeExtension.RunOptions<Excel.Session>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.RunOptions:interface'
+      - uid: 'office!OfficeExtension.RunOptions:interface'
         name: OfficeExtension.RunOptions
         fullName: OfficeExtension.RunOptions
       - name: <

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.table.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.table.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Table#clearFilters:member(1)'
@@ -533,7 +533,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Table#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -724,7 +724,7 @@ items:
         type:
           - 'excel!Excel.Worksheet:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.TableColumnCollection:class'
     name: Excel.TableColumnCollection
@@ -740,7 +740,7 @@ references:
     name: Excel.TableRowCollection
   - uid: 'excel!Excel.Interfaces.TableUpdateData:interface'
     name: Interfaces.TableUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.TableSort:class'
     name: Excel.TableSort

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.tablecollection.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.tablecollection.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableCollection#add:member(1)'
@@ -299,7 +299,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.TableCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -319,7 +319,7 @@ items:
           - 'excel!Excel.Interfaces.TableCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Table:class'
     name: Excel.Table
@@ -357,7 +357,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.TableCollectionData:interface'
     name: Excel.Interfaces.TableCollectionData

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.tablecolumn.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.tablecolumn.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableColumn#context:member'
@@ -401,7 +401,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.TableColumn#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -456,7 +456,7 @@ items:
         type:
           - 'any[][]'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -470,7 +470,7 @@ references:
     name: Excel.Interfaces.TableColumnLoadOptions
   - uid: 'excel!Excel.Interfaces.TableColumnUpdateData:interface'
     name: Interfaces.TableColumnUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.TableColumnData:interface'
     name: Excel.Interfaces.TableColumnData

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.tablecolumncollection.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.tablecolumncollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableColumnCollection#add:member(1)'
@@ -283,7 +283,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.TableColumnCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -303,7 +303,7 @@ items:
           - 'excel!Excel.Interfaces.TableColumnCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.TableColumn:class'
     name: Excel.TableColumn
@@ -346,7 +346,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.TableColumnCollectionData:interface'
     name: Excel.Interfaces.TableColumnCollectionData

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.tablerow.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.tablerow.yml
@@ -17,7 +17,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableRow#context:member'
@@ -247,7 +247,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.TableRow#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -302,7 +302,7 @@ items:
         type:
           - 'any[][]'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -314,7 +314,7 @@ references:
     name: Excel.Interfaces.TableRowLoadOptions
   - uid: 'excel!Excel.Interfaces.TableRowUpdateData:interface'
     name: Interfaces.TableRowUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.TableRowData:interface'
     name: Excel.Interfaces.TableRowData

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.tablerowcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.tablerowcollection.yml
@@ -17,7 +17,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableRowCollection#add:member(1)'
@@ -273,7 +273,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.TableRowCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -293,7 +293,7 @@ items:
           - 'excel!Excel.Interfaces.TableRowCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.TableRow:class'
     name: Excel.TableRow
@@ -336,7 +336,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.TableRowCollectionData:interface'
     name: Excel.Interfaces.TableRowCollectionData

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.tablesort.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.tablesort.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableSort#apply:member(1)'
@@ -288,7 +288,7 @@ items:
           - 'excel!Excel.Interfaces.TableSortData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.TableSort#apply~0:complex'
     name: 'Excel.SortField[]'

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.workbook.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.workbook.yml
@@ -14,7 +14,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Workbook#application:member'
@@ -272,7 +272,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Workbook#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -340,7 +340,7 @@ items:
         type:
           - 'excel!Excel.WorksheetCollection:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Application:class'
     name: Excel.Application
@@ -362,7 +362,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.SelectionChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.SelectionChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -376,7 +376,7 @@ references:
     name: Excel.PivotTableCollection
   - uid: 'excel!Excel.Interfaces.WorkbookUpdateData:interface'
     name: Interfaces.WorkbookUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.TableCollection:class'
     name: Excel.TableCollection

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.worksheet.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.worksheet.yml
@@ -14,7 +14,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Worksheet#activate:member(1)'
@@ -541,7 +541,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Worksheet#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -611,7 +611,7 @@ items:
         type:
           - 'excel!Excel.Worksheet#visibility~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartCollection:class'
     name: Excel.ChartCollection
@@ -629,7 +629,7 @@ references:
     name: Excel.WorksheetProtection
   - uid: 'excel!Excel.Interfaces.WorksheetUpdateData:interface'
     name: Interfaces.WorksheetUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.TableCollection:class'
     name: Excel.TableCollection

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.worksheetcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.worksheetcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.WorksheetCollection#add:member(1)'
@@ -233,7 +233,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.WorksheetCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -253,7 +253,7 @@ items:
           - 'excel!Excel.Interfaces.WorksheetCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Worksheet:class'
     name: Excel.Worksheet
@@ -282,7 +282,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.WorksheetCollectionData:interface'
     name: Excel.Interfaces.WorksheetCollectionData

--- a/docs/docs-ref-autogen/excel_1_3/excel/excel.worksheetprotection.yml
+++ b/docs/docs-ref-autogen/excel_1_3/excel/excel.worksheetprotection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.WorksheetProtection#context:member'
@@ -226,7 +226,7 @@ items:
           - 'excel!Excel.Interfaces.WorksheetProtectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel_1_4/excel.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel.yml
@@ -581,7 +581,7 @@ items:
             A previously-created API object. The batch will use the same RequestContext as the passed-in object, which
             means that any changes applied to the object will be picked up by "context.sync()".
           type:
-            - 'excel!OfficeExtension.ClientObject:class'
+            - 'office!OfficeExtension.ClientObject:class'
         - id: batch
           description: >-
             A function that takes in a RequestContext and returns a promise (typically, just the result of
@@ -686,7 +686,7 @@ items:
             A previously-created object. The batch will use the same RequestContext as the passed-in object, which means
             that any changes applied to the object will be picked up by "context.sync()".
           type:
-            - 'excel!OfficeExtension.ClientRequestContext:class'
+            - 'office!OfficeExtension.ClientRequestContext:class'
         - id: batch
           description: >-
             A function that takes in a RequestContext and returns a promise (typically, just the result of
@@ -1620,7 +1620,7 @@ references:
         fullName: Promise
       - name: <T>
         fullName: <T>
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.run~3:complex'
     name: '(context: Excel.RequestContext) => Promise<T>'
@@ -1651,7 +1651,7 @@ references:
     name: 'OfficeExtension.ClientObject[]'
     fullName: 'OfficeExtension.ClientObject[]'
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientObject:class'
+      - uid: 'office!OfficeExtension.ClientObject:class'
         name: OfficeExtension.ClientObject
         fullName: OfficeExtension.ClientObject
       - name: '[]'
@@ -1708,7 +1708,7 @@ references:
         fullName: Promise
       - name: <T>
         fullName: <T>
-  - uid: 'excel!OfficeExtension.ClientRequestContext:class'
+  - uid: 'office!OfficeExtension.ClientRequestContext:class'
     name: OfficeExtension.ClientRequestContext
   - uid: 'excel!Excel.run~10:complex'
     name: '(context: Excel.RequestContext) => Promise<T>'

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.application.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.application.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Application#calculate:member(1)'
@@ -232,7 +232,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Application#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -270,7 +270,7 @@ items:
           - 'excel!Excel.Interfaces.ApplicationData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.CalculationType:enum'
     name: Excel.CalculationType
@@ -291,7 +291,7 @@ references:
     name: Excel.Interfaces.ApplicationLoadOptions
   - uid: 'excel!Excel.Interfaces.ApplicationUpdateData:interface'
     name: Interfaces.ApplicationUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ApplicationData:interface'
     name: Excel.Interfaces.ApplicationData

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.binding.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.binding.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Binding#context:member'
@@ -357,7 +357,7 @@ items:
         type:
           - 'excel!Excel.Binding#type~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -369,7 +369,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -382,7 +382,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.BindingDataChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.BindingDataChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -396,7 +396,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.BindingSelectionChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.BindingSelectionChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.bindingcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.bindingcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.BindingCollection#add:member(1)'
@@ -493,7 +493,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.BindingCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -513,7 +513,7 @@ items:
           - 'excel!Excel.Interfaces.BindingCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Binding:class'
     name: Excel.Binding
@@ -543,7 +543,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -571,7 +571,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.BindingCollectionData:interface'
     name: Excel.Interfaces.BindingCollectionData

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.chart.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.chart.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Chart#axes:member'
@@ -456,7 +456,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Chart#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -681,7 +681,7 @@ items:
         type:
           - 'excel!Excel.Worksheet:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartAxes:class'
     name: Excel.ChartAxes
@@ -695,7 +695,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -706,7 +706,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -721,7 +721,7 @@ references:
     name: Excel.ChartSeriesCollection
   - uid: 'excel!Excel.Interfaces.ChartUpdateData:interface'
     name: Interfaces.ChartUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Range:class'
     name: Range

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.chartareaformat.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.chartareaformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAreaFormat#context:member'
@@ -166,7 +166,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAreaFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -204,7 +204,7 @@ items:
           - 'excel!Excel.Interfaces.ChartAreaFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -218,7 +218,7 @@ references:
     name: Excel.Interfaces.ChartAreaFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartAreaFormatUpdateData:interface'
     name: Interfaces.ChartAreaFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartAreaFormatData:interface'
     name: Excel.Interfaces.ChartAreaFormatData

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.chartaxes.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.chartaxes.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAxes#categoryAxis:member'
@@ -167,7 +167,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAxes#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -243,7 +243,7 @@ items:
           });
           ```
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartAxis:class'
     name: Excel.ChartAxis
@@ -255,7 +255,7 @@ references:
     name: Excel.Interfaces.ChartAxesLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartAxesUpdateData:interface'
     name: Interfaces.ChartAxesUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartAxesData:interface'
     name: Excel.Interfaces.ChartAxesData

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.chartaxis.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.chartaxis.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAxis#context:member'
@@ -275,7 +275,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAxis#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -328,7 +328,7 @@ items:
           - 'excel!Excel.Interfaces.ChartAxisData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -342,7 +342,7 @@ references:
     name: Excel.ChartGridlines
   - uid: 'excel!Excel.Interfaces.ChartAxisUpdateData:interface'
     name: Interfaces.ChartAxisUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.ChartAxisTitle:class'
     name: Excel.ChartAxisTitle

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.chartaxisformat.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.chartaxisformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAxisFormat#context:member'
@@ -166,7 +166,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAxisFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -204,7 +204,7 @@ items:
           - 'excel!Excel.Interfaces.ChartAxisFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -218,7 +218,7 @@ references:
     name: Excel.Interfaces.ChartAxisFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisFormatUpdateData:interface'
     name: Interfaces.ChartAxisFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisFormatData:interface'
     name: Excel.Interfaces.ChartAxisFormatData

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.chartaxistitle.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.chartaxistitle.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAxisTitle#context:member'
@@ -171,7 +171,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAxisTitle#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -239,7 +239,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -251,7 +251,7 @@ references:
     name: Excel.Interfaces.ChartAxisTitleLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisTitleUpdateData:interface'
     name: Interfaces.ChartAxisTitleUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisTitleData:interface'
     name: Excel.Interfaces.ChartAxisTitleData

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.chartaxistitleformat.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.chartaxistitleformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAxisTitleFormat#context:member'
@@ -150,7 +150,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAxisTitleFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -188,7 +188,7 @@ items:
           - 'excel!Excel.Interfaces.ChartAxisTitleFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -200,7 +200,7 @@ references:
     name: Excel.Interfaces.ChartAxisTitleFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisTitleFormatUpdateData:interface'
     name: Interfaces.ChartAxisTitleFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisTitleFormatData:interface'
     name: Excel.Interfaces.ChartAxisTitleFormatData

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.chartcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartCollection#add:member(1)'
@@ -383,7 +383,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.ChartCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -403,7 +403,7 @@ items:
           - 'excel!Excel.Interfaces.ChartCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Chart:class'
     name: Excel.Chart
@@ -419,7 +419,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -447,7 +447,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.ChartCollectionData:interface'
     name: Excel.Interfaces.ChartCollectionData

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.chartdatalabelformat.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.chartdatalabelformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartDataLabelFormat#context:member'
@@ -166,7 +166,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartDataLabelFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -204,7 +204,7 @@ items:
           - 'excel!Excel.Interfaces.ChartDataLabelFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -218,7 +218,7 @@ references:
     name: Excel.Interfaces.ChartDataLabelFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartDataLabelFormatUpdateData:interface'
     name: Interfaces.ChartDataLabelFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartDataLabelFormatData:interface'
     name: Excel.Interfaces.ChartDataLabelFormatData

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.chartdatalabels.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.chartdatalabels.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartDataLabels#context:member'
@@ -213,7 +213,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartDataLabels#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -341,7 +341,7 @@ items:
           - 'excel!Excel.Interfaces.ChartDataLabelsData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -366,7 +366,7 @@ references:
         fullName: ' | "Invalid" | "None" | "Center" | "InsideEnd" | "InsideBase" | "OutsideEnd" | "Left" | "Right" | "Top" | "Bottom" | "BestFit" | "Callout"'
   - uid: 'excel!Excel.Interfaces.ChartDataLabelsUpdateData:interface'
     name: Interfaces.ChartDataLabelsUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartDataLabelsData:interface'
     name: Excel.Interfaces.ChartDataLabelsData

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.chartfill.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.chartfill.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartFill#clear:member(1)'
@@ -138,7 +138,7 @@ items:
                     }
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.chartfont.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.chartfont.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     remarks: |-
 
@@ -223,7 +223,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartFont#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -291,7 +291,7 @@ items:
         type:
           - 'excel!Excel.ChartFont#underline~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -301,7 +301,7 @@ references:
     name: Excel.Interfaces.ChartFontLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartFontUpdateData:interface'
     name: Interfaces.ChartFontUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartFontData:interface'
     name: Excel.Interfaces.ChartFontData

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.chartgridlines.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.chartgridlines.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartGridlines#context:member'
@@ -170,7 +170,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartGridlines#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -223,7 +223,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -235,7 +235,7 @@ references:
     name: Excel.Interfaces.ChartGridlinesLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartGridlinesUpdateData:interface'
     name: Interfaces.ChartGridlinesUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartGridlinesData:interface'
     name: Excel.Interfaces.ChartGridlinesData

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.chartgridlinesformat.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.chartgridlinesformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartGridlinesFormat#context:member'
@@ -150,7 +150,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartGridlinesFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -188,7 +188,7 @@ items:
           - 'excel!Excel.Interfaces.ChartGridlinesFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -200,7 +200,7 @@ references:
     name: Excel.Interfaces.ChartGridlinesFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartGridlinesFormatUpdateData:interface'
     name: Interfaces.ChartGridlinesFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartGridlinesFormatData:interface'
     name: Excel.Interfaces.ChartGridlinesFormatData

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.chartlegend.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.chartlegend.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartLegend#context:member'
@@ -203,7 +203,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartLegend#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -256,7 +256,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -277,7 +277,7 @@ references:
         fullName: ' | "Invalid" | "Top" | "Bottom" | "Left" | "Right" | "Corner" | "Custom"'
   - uid: 'excel!Excel.Interfaces.ChartLegendUpdateData:interface'
     name: Interfaces.ChartLegendUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartLegendData:interface'
     name: Excel.Interfaces.ChartLegendData

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.chartlegendformat.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.chartlegendformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartLegendFormat#context:member'
@@ -196,7 +196,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartLegendFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -234,7 +234,7 @@ items:
           - 'excel!Excel.Interfaces.ChartLegendFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -248,7 +248,7 @@ references:
     name: Excel.Interfaces.ChartLegendFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartLegendFormatUpdateData:interface'
     name: Interfaces.ChartLegendFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartLegendFormatData:interface'
     name: Excel.Interfaces.ChartLegendFormatData

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.chartlineformat.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.chartlineformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartLineFormat#clear:member(1)'
@@ -205,7 +205,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartLineFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -243,7 +243,7 @@ items:
           - 'excel!Excel.Interfaces.ChartLineFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -253,7 +253,7 @@ references:
     name: Excel.Interfaces.ChartLineFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartLineFormatUpdateData:interface'
     name: Interfaces.ChartLineFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartLineFormatData:interface'
     name: Excel.Interfaces.ChartLineFormatData

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.chartpoint.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.chartpoint.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartPoint#context:member'
@@ -151,7 +151,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartPoint#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -204,7 +204,7 @@ items:
         type:
           - any
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -216,7 +216,7 @@ references:
     name: Excel.Interfaces.ChartPointLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartPointUpdateData:interface'
     name: Interfaces.ChartPointUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartPointData:interface'
     name: Excel.Interfaces.ChartPointData

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.chartpointformat.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.chartpointformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartPointFormat#context:member'
@@ -150,7 +150,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartPointFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -188,7 +188,7 @@ items:
           - 'excel!Excel.Interfaces.ChartPointFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -200,7 +200,7 @@ references:
     name: Excel.Interfaces.ChartPointFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartPointFormatUpdateData:interface'
     name: Interfaces.ChartPointFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartPointFormatData:interface'
     name: Excel.Interfaces.ChartPointFormatData

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.chartpointscollection.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.chartpointscollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartPointsCollection#context:member'
@@ -219,7 +219,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.ChartPointsCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -239,7 +239,7 @@ items:
           - 'excel!Excel.Interfaces.ChartPointsCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -247,7 +247,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -277,7 +277,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.ChartPointsCollectionData:interface'
     name: Excel.Interfaces.ChartPointsCollectionData

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.chartseries.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.chartseries.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartSeries#context:member'
@@ -201,7 +201,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartSeries#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -239,7 +239,7 @@ items:
           - 'excel!Excel.Interfaces.ChartSeriesData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -253,7 +253,7 @@ references:
     name: Excel.ChartPointsCollection
   - uid: 'excel!Excel.Interfaces.ChartSeriesUpdateData:interface'
     name: Interfaces.ChartSeriesUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartSeriesData:interface'
     name: Excel.Interfaces.ChartSeriesData

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.chartseriescollection.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.chartseriescollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartSeriesCollection#context:member'
@@ -220,7 +220,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.ChartSeriesCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -240,7 +240,7 @@ items:
           - 'excel!Excel.Interfaces.ChartSeriesCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -248,7 +248,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -278,7 +278,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.ChartSeriesCollectionData:interface'
     name: Excel.Interfaces.ChartSeriesCollectionData

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.chartseriesformat.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.chartseriesformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartSeriesFormat#context:member'
@@ -166,7 +166,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartSeriesFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -204,7 +204,7 @@ items:
           - 'excel!Excel.Interfaces.ChartSeriesFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -218,7 +218,7 @@ references:
     name: Excel.Interfaces.ChartSeriesFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartSeriesFormatUpdateData:interface'
     name: Interfaces.ChartSeriesFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartSeriesFormatData:interface'
     name: Excel.Interfaces.ChartSeriesFormatData

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.charttitle.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.charttitle.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartTitle#context:member'
@@ -208,7 +208,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartTitle#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -276,7 +276,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -288,7 +288,7 @@ references:
     name: Excel.Interfaces.ChartTitleLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartTitleUpdateData:interface'
     name: Interfaces.ChartTitleUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartTitleData:interface'
     name: Excel.Interfaces.ChartTitleData

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.charttitleformat.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.charttitleformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartTitleFormat#context:member'
@@ -166,7 +166,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartTitleFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -204,7 +204,7 @@ items:
           - 'excel!Excel.Interfaces.ChartTitleFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -218,7 +218,7 @@ references:
     name: Excel.Interfaces.ChartTitleFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartTitleFormatUpdateData:interface'
     name: Interfaces.ChartTitleFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartTitleFormatData:interface'
     name: Excel.Interfaces.ChartTitleFormatData

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.filter.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.filter.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Filter#apply:member(1)'
@@ -473,7 +473,7 @@ items:
           - 'excel!Excel.Interfaces.FilterData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.FilterCriteria:interface'
     name: Excel.FilterCriteria

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.formatprotection.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.formatprotection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.FormatProtection#context:member'
@@ -170,7 +170,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.FormatProtection#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -208,7 +208,7 @@ items:
           - 'excel!Excel.Interfaces.FormatProtectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -218,7 +218,7 @@ references:
     name: Excel.Interfaces.FormatProtectionLoadOptions
   - uid: 'excel!Excel.Interfaces.FormatProtectionUpdateData:interface'
     name: Interfaces.FormatProtectionUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.FormatProtectionData:interface'
     name: Excel.Interfaces.FormatProtectionData

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.functionresult.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.functionresult.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.FunctionResult#context:member'
@@ -158,7 +158,7 @@ items:
         type:
           - T
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.functions.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.functions.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Functions#abs:member(1)'
@@ -11184,7 +11184,7 @@ items:
           type:
             - 'excel!Excel.Functions#z_Test~3:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Functions#abs~0:complex'
     name: FunctionResult<number>

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.nameditem.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.nameditem.yml
@@ -14,7 +14,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.NamedItem#comment:member'
@@ -317,7 +317,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.NamedItem#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -436,7 +436,7 @@ items:
         type:
           - 'excel!Excel.Worksheet:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -457,7 +457,7 @@ references:
         fullName: ' | "Worksheet" | "Workbook"'
   - uid: 'excel!Excel.Interfaces.NamedItemUpdateData:interface'
     name: Interfaces.NamedItemUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.NamedItemData:interface'
     name: Excel.Interfaces.NamedItemData

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.nameditemcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.nameditemcollection.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.NamedItemCollection#add:member(1)'
@@ -294,7 +294,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.NamedItemCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -314,7 +314,7 @@ items:
           - 'excel!Excel.Interfaces.NamedItemCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.NamedItem:class'
     name: Excel.NamedItem
@@ -333,7 +333,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -361,7 +361,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.NamedItemCollectionData:interface'
     name: Excel.Interfaces.NamedItemCollectionData

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.pivottable.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.pivottable.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PivotTable#context:member'
@@ -170,7 +170,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.PivotTable#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -223,7 +223,7 @@ items:
         type:
           - 'excel!Excel.Worksheet:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -233,7 +233,7 @@ references:
     name: Excel.Interfaces.PivotTableLoadOptions
   - uid: 'excel!Excel.Interfaces.PivotTableUpdateData:interface'
     name: Interfaces.PivotTableUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.PivotTableData:interface'
     name: Excel.Interfaces.PivotTableData

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.pivottablecollection.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.pivottablecollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PivotTableCollection#context:member'
@@ -171,7 +171,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.PivotTableCollection#refreshAll:member(1)'
     summary: |-
       Refreshes all the pivot tables in the collection.
@@ -207,7 +207,7 @@ items:
           - 'excel!Excel.Interfaces.PivotTableCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -215,7 +215,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -245,7 +245,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.PivotTableCollectionData:interface'
     name: Excel.Interfaces.PivotTableCollectionData

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.range.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.range.yml
@@ -16,7 +16,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Range#address:member'
@@ -1681,7 +1681,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Range#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -1927,7 +1927,7 @@ items:
         type:
           - 'excel!Excel.Worksheet:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ClearApplyTo:enum'
     name: Excel.ClearApplyTo
@@ -1983,7 +1983,7 @@ references:
         fullName: ' | string'
   - uid: 'excel!Excel.Interfaces.RangeUpdateData:interface'
     name: Interfaces.RangeUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.RangeSort:class'
     name: Excel.RangeSort

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.rangeborder.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.rangeborder.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeBorder#color:member'
@@ -155,7 +155,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.RangeBorder#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -269,7 +269,7 @@ items:
         type:
           - 'excel!Excel.RangeBorder#weight~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -279,7 +279,7 @@ references:
     name: Excel.Interfaces.RangeBorderLoadOptions
   - uid: 'excel!Excel.Interfaces.RangeBorderUpdateData:interface'
     name: Interfaces.RangeBorderUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.RangeBorder#sideIndex~0:complex'
     name: >-

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.rangebordercollection.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.rangebordercollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeBorderCollection#context:member'
@@ -265,7 +265,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.RangeBorderCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -285,7 +285,7 @@ items:
           - 'excel!Excel.Interfaces.RangeBorderCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -316,7 +316,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.RangeBorderCollectionData:interface'
     name: Excel.Interfaces.RangeBorderCollectionData

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.rangefill.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.rangefill.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeFill#clear:member(1)'
@@ -226,7 +226,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.RangeFill#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -264,7 +264,7 @@ items:
           - 'excel!Excel.Interfaces.RangeFillData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -274,7 +274,7 @@ references:
     name: Excel.Interfaces.RangeFillLoadOptions
   - uid: 'excel!Excel.Interfaces.RangeFillUpdateData:interface'
     name: Interfaces.RangeFillUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.RangeFillData:interface'
     name: Excel.Interfaces.RangeFillData

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.rangefont.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.rangefont.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeFont#bold:member'
@@ -237,7 +237,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.RangeFont#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -305,7 +305,7 @@ items:
         type:
           - 'excel!Excel.RangeFont#underline~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -315,7 +315,7 @@ references:
     name: Excel.Interfaces.RangeFontLoadOptions
   - uid: 'excel!Excel.Interfaces.RangeFontUpdateData:interface'
     name: Interfaces.RangeFontUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.RangeFontData:interface'
     name: Excel.Interfaces.RangeFontData

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.rangeformat.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.rangeformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeFormat#adjustIndent:member(1)'
@@ -378,7 +378,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.RangeFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -448,7 +448,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RangeBorderCollection:class'
     name: Excel.RangeBorderCollection
@@ -479,7 +479,7 @@ references:
     name: Excel.FormatProtection
   - uid: 'excel!Excel.Interfaces.RangeFormatUpdateData:interface'
     name: Interfaces.RangeFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.RangeFormatData:interface'
     name: Excel.Interfaces.RangeFormatData

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.rangesort.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.rangesort.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeSort#apply:member(1)'
@@ -135,7 +135,7 @@ items:
                     }
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RangeSort#apply~0:complex'
     name: 'Excel.SortField[]'

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.rangeview.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.rangeview.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeView#cellAddresses:member'
@@ -300,7 +300,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.RangeView#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -387,7 +387,7 @@ items:
         type:
           - 'excel!Excel.RangeView#valueTypes~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -401,7 +401,7 @@ references:
     name: Excel.RangeViewCollection
   - uid: 'excel!Excel.Interfaces.RangeViewUpdateData:interface'
     name: Interfaces.RangeViewUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.RangeViewData:interface'
     name: Excel.Interfaces.RangeViewData

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.rangeviewcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.rangeviewcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeViewCollection#context:member'
@@ -148,7 +148,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.RangeViewCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -168,7 +168,7 @@ items:
           - 'excel!Excel.Interfaces.RangeViewCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -176,7 +176,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -206,7 +206,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.RangeViewCollectionData:interface'
     name: Excel.Interfaces.RangeViewCollectionData

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.requestcontext.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.requestcontext.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientRequestContext:class'
+      - 'office!OfficeExtension.ClientRequestContext:class'
     package: excel!
     children:
       - 'excel!Excel.RequestContext:constructor(1)'
@@ -54,7 +54,7 @@ items:
         type:
           - 'excel!Excel.Workbook:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientRequestContext:class'
+  - uid: 'office!OfficeExtension.ClientRequestContext:class'
     name: OfficeExtension.ClientRequestContext
   - uid: 'excel!Excel.RequestContext~0:complex'
     name: string | Session

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.runoptions.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.runoptions.yml
@@ -34,7 +34,7 @@ references:
     name: OfficeExtension.RunOptions<Session>
     fullName: OfficeExtension.RunOptions<Excel.Session>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.RunOptions:interface'
+      - uid: 'office!OfficeExtension.RunOptions:interface'
         name: OfficeExtension.RunOptions
         fullName: OfficeExtension.RunOptions
       - name: <

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.setting.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.setting.yml
@@ -15,7 +15,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Setting#context:member'
@@ -200,7 +200,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Setting#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -253,7 +253,7 @@ items:
         type:
           - any
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -263,7 +263,7 @@ references:
     name: Excel.Interfaces.SettingLoadOptions
   - uid: 'excel!Excel.Interfaces.SettingUpdateData:interface'
     name: Interfaces.SettingUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.SettingData:interface'
     name: Excel.Interfaces.SettingData

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.settingcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.settingcollection.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.SettingCollection#add:member(1)'
@@ -246,7 +246,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.SettingCollection#onSettingsChanged:member'
     summary: |-
       Occurs when the Settings in the document are changed.
@@ -301,7 +301,7 @@ items:
           - 'excel!Excel.Interfaces.SettingCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Setting:class'
     name: Excel.Setting
@@ -327,7 +327,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -355,13 +355,13 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.SettingCollection#onSettingsChanged~0:complex'
     name: OfficeExtension.EventHandlers<Excel.SettingsChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.SettingsChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.table.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.table.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Table#clearFilters:member(1)'
@@ -533,7 +533,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Table#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -724,7 +724,7 @@ items:
         type:
           - 'excel!Excel.Worksheet:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.TableColumnCollection:class'
     name: Excel.TableColumnCollection
@@ -740,7 +740,7 @@ references:
     name: Excel.TableRowCollection
   - uid: 'excel!Excel.Interfaces.TableUpdateData:interface'
     name: Interfaces.TableUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.TableSort:class'
     name: Excel.TableSort

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.tablecollection.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.tablecollection.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableCollection#add:member(1)'
@@ -338,7 +338,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.TableCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -358,7 +358,7 @@ items:
           - 'excel!Excel.Interfaces.TableCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Table:class'
     name: Excel.Table
@@ -377,7 +377,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -405,7 +405,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.TableCollectionData:interface'
     name: Excel.Interfaces.TableCollectionData

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.tablecolumn.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.tablecolumn.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableColumn#context:member'
@@ -401,7 +401,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.TableColumn#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -456,7 +456,7 @@ items:
         type:
           - 'any[][]'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -470,7 +470,7 @@ references:
     name: Excel.Interfaces.TableColumnLoadOptions
   - uid: 'excel!Excel.Interfaces.TableColumnUpdateData:interface'
     name: Interfaces.TableColumnUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.TableColumnData:interface'
     name: Excel.Interfaces.TableColumnData

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.tablecolumncollection.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.tablecolumncollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableColumnCollection#add:member(1)'
@@ -322,7 +322,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.TableColumnCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -342,7 +342,7 @@ items:
           - 'excel!Excel.Interfaces.TableColumnCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.TableColumn:class'
     name: Excel.TableColumn
@@ -366,7 +366,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -394,7 +394,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.TableColumnCollectionData:interface'
     name: Excel.Interfaces.TableColumnCollectionData

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.tablerow.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.tablerow.yml
@@ -17,7 +17,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableRow#context:member'
@@ -247,7 +247,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.TableRow#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -302,7 +302,7 @@ items:
         type:
           - 'any[][]'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -314,7 +314,7 @@ references:
     name: Excel.Interfaces.TableRowLoadOptions
   - uid: 'excel!Excel.Interfaces.TableRowUpdateData:interface'
     name: Interfaces.TableRowUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.TableRowData:interface'
     name: Excel.Interfaces.TableRowData

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.tablerowcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.tablerowcollection.yml
@@ -17,7 +17,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableRowCollection#add:member(1)'
@@ -290,7 +290,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.TableRowCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -310,7 +310,7 @@ items:
           - 'excel!Excel.Interfaces.TableRowCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.TableRow:class'
     name: Excel.TableRow
@@ -334,7 +334,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -362,7 +362,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.TableRowCollectionData:interface'
     name: Excel.Interfaces.TableRowCollectionData

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.tablesort.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.tablesort.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableSort#apply:member(1)'
@@ -288,7 +288,7 @@ items:
           - 'excel!Excel.Interfaces.TableSortData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.TableSort#apply~0:complex'
     name: 'Excel.SortField[]'

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.workbook.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.workbook.yml
@@ -14,7 +14,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Workbook#application:member'
@@ -273,7 +273,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Workbook#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -356,7 +356,7 @@ items:
         type:
           - 'excel!Excel.WorksheetCollection:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Application:class'
     name: Excel.Application
@@ -378,7 +378,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.SelectionChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.SelectionChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -392,7 +392,7 @@ references:
     name: Excel.PivotTableCollection
   - uid: 'excel!Excel.Interfaces.WorkbookUpdateData:interface'
     name: Interfaces.WorkbookUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.SettingCollection:class'
     name: Excel.SettingCollection

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.worksheet.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.worksheet.yml
@@ -14,7 +14,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Worksheet#activate:member(1)'
@@ -581,7 +581,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Worksheet#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -651,7 +651,7 @@ items:
         type:
           - 'excel!Excel.Worksheet#visibility~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartCollection:class'
     name: Excel.ChartCollection
@@ -671,7 +671,7 @@ references:
     name: Excel.WorksheetProtection
   - uid: 'excel!Excel.Interfaces.WorksheetUpdateData:interface'
     name: Interfaces.WorksheetUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.TableCollection:class'
     name: Excel.TableCollection

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.worksheetcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.worksheetcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.WorksheetCollection#add:member(1)'
@@ -277,7 +277,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.WorksheetCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -297,7 +297,7 @@ items:
           - 'excel!Excel.Interfaces.WorksheetCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Worksheet:class'
     name: Excel.Worksheet
@@ -307,7 +307,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -335,7 +335,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.WorksheetCollectionData:interface'
     name: Excel.Interfaces.WorksheetCollectionData

--- a/docs/docs-ref-autogen/excel_1_4/excel/excel.worksheetprotection.yml
+++ b/docs/docs-ref-autogen/excel_1_4/excel/excel.worksheetprotection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.WorksheetProtection#context:member'
@@ -226,7 +226,7 @@ items:
           - 'excel!Excel.Interfaces.WorksheetProtectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel_1_5/excel.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel.yml
@@ -589,7 +589,7 @@ items:
             A previously-created API object. The batch will use the same RequestContext as the passed-in object, which
             means that any changes applied to the object will be picked up by "context.sync()".
           type:
-            - 'excel!OfficeExtension.ClientObject:class'
+            - 'office!OfficeExtension.ClientObject:class'
         - id: batch
           description: >-
             A function that takes in a RequestContext and returns a promise (typically, just the result of
@@ -694,7 +694,7 @@ items:
             A previously-created object. The batch will use the same RequestContext as the passed-in object, which means
             that any changes applied to the object will be picked up by "context.sync()".
           type:
-            - 'excel!OfficeExtension.ClientRequestContext:class'
+            - 'office!OfficeExtension.ClientRequestContext:class'
         - id: batch
           description: >-
             A function that takes in a RequestContext and returns a promise (typically, just the result of
@@ -1642,7 +1642,7 @@ references:
         fullName: Promise
       - name: <T>
         fullName: <T>
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.run~3:complex'
     name: '(context: Excel.RequestContext) => Promise<T>'
@@ -1673,7 +1673,7 @@ references:
     name: 'OfficeExtension.ClientObject[]'
     fullName: 'OfficeExtension.ClientObject[]'
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientObject:class'
+      - uid: 'office!OfficeExtension.ClientObject:class'
         name: OfficeExtension.ClientObject
         fullName: OfficeExtension.ClientObject
       - name: '[]'
@@ -1730,7 +1730,7 @@ references:
         fullName: Promise
       - name: <T>
         fullName: <T>
-  - uid: 'excel!OfficeExtension.ClientRequestContext:class'
+  - uid: 'office!OfficeExtension.ClientRequestContext:class'
     name: OfficeExtension.ClientRequestContext
   - uid: 'excel!Excel.run~10:complex'
     name: '(context: Excel.RequestContext) => Promise<T>'

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.application.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.application.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Application#calculate:member(1)'
@@ -232,7 +232,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Application#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -270,7 +270,7 @@ items:
           - 'excel!Excel.Interfaces.ApplicationData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.CalculationType:enum'
     name: Excel.CalculationType
@@ -291,7 +291,7 @@ references:
     name: Excel.Interfaces.ApplicationLoadOptions
   - uid: 'excel!Excel.Interfaces.ApplicationUpdateData:interface'
     name: Interfaces.ApplicationUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ApplicationData:interface'
     name: Excel.Interfaces.ApplicationData

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.binding.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.binding.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Binding#context:member'
@@ -357,7 +357,7 @@ items:
         type:
           - 'excel!Excel.Binding#type~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -369,7 +369,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -382,7 +382,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.BindingDataChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.BindingDataChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -396,7 +396,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.BindingSelectionChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.BindingSelectionChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.bindingcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.bindingcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.BindingCollection#add:member(1)'
@@ -493,7 +493,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.BindingCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -513,7 +513,7 @@ items:
           - 'excel!Excel.Interfaces.BindingCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Binding:class'
     name: Excel.Binding
@@ -543,7 +543,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -571,7 +571,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.BindingCollectionData:interface'
     name: Excel.Interfaces.BindingCollectionData

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.chart.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.chart.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Chart#axes:member'
@@ -456,7 +456,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Chart#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -681,7 +681,7 @@ items:
         type:
           - 'excel!Excel.Worksheet:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartAxes:class'
     name: Excel.ChartAxes
@@ -695,7 +695,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -706,7 +706,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -721,7 +721,7 @@ references:
     name: Excel.ChartSeriesCollection
   - uid: 'excel!Excel.Interfaces.ChartUpdateData:interface'
     name: Interfaces.ChartUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Range:class'
     name: Range

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.chartareaformat.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.chartareaformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAreaFormat#context:member'
@@ -166,7 +166,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAreaFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -204,7 +204,7 @@ items:
           - 'excel!Excel.Interfaces.ChartAreaFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -218,7 +218,7 @@ references:
     name: Excel.Interfaces.ChartAreaFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartAreaFormatUpdateData:interface'
     name: Interfaces.ChartAreaFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartAreaFormatData:interface'
     name: Excel.Interfaces.ChartAreaFormatData

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.chartaxes.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.chartaxes.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAxes#categoryAxis:member'
@@ -167,7 +167,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAxes#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -243,7 +243,7 @@ items:
           });
           ```
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartAxis:class'
     name: Excel.ChartAxis
@@ -255,7 +255,7 @@ references:
     name: Excel.Interfaces.ChartAxesLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartAxesUpdateData:interface'
     name: Interfaces.ChartAxesUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartAxesData:interface'
     name: Excel.Interfaces.ChartAxesData

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.chartaxis.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.chartaxis.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAxis#context:member'
@@ -275,7 +275,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAxis#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -328,7 +328,7 @@ items:
           - 'excel!Excel.Interfaces.ChartAxisData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -342,7 +342,7 @@ references:
     name: Excel.ChartGridlines
   - uid: 'excel!Excel.Interfaces.ChartAxisUpdateData:interface'
     name: Interfaces.ChartAxisUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.ChartAxisTitle:class'
     name: Excel.ChartAxisTitle

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.chartaxisformat.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.chartaxisformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAxisFormat#context:member'
@@ -166,7 +166,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAxisFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -204,7 +204,7 @@ items:
           - 'excel!Excel.Interfaces.ChartAxisFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -218,7 +218,7 @@ references:
     name: Excel.Interfaces.ChartAxisFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisFormatUpdateData:interface'
     name: Interfaces.ChartAxisFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisFormatData:interface'
     name: Excel.Interfaces.ChartAxisFormatData

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.chartaxistitle.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.chartaxistitle.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAxisTitle#context:member'
@@ -171,7 +171,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAxisTitle#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -239,7 +239,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -251,7 +251,7 @@ references:
     name: Excel.Interfaces.ChartAxisTitleLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisTitleUpdateData:interface'
     name: Interfaces.ChartAxisTitleUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisTitleData:interface'
     name: Excel.Interfaces.ChartAxisTitleData

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.chartaxistitleformat.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.chartaxistitleformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAxisTitleFormat#context:member'
@@ -150,7 +150,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAxisTitleFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -188,7 +188,7 @@ items:
           - 'excel!Excel.Interfaces.ChartAxisTitleFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -200,7 +200,7 @@ references:
     name: Excel.Interfaces.ChartAxisTitleFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisTitleFormatUpdateData:interface'
     name: Interfaces.ChartAxisTitleFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisTitleFormatData:interface'
     name: Excel.Interfaces.ChartAxisTitleFormatData

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.chartcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartCollection#add:member(1)'
@@ -383,7 +383,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.ChartCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -403,7 +403,7 @@ items:
           - 'excel!Excel.Interfaces.ChartCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Chart:class'
     name: Excel.Chart
@@ -419,7 +419,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -447,7 +447,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.ChartCollectionData:interface'
     name: Excel.Interfaces.ChartCollectionData

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.chartdatalabelformat.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.chartdatalabelformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartDataLabelFormat#context:member'
@@ -166,7 +166,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartDataLabelFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -204,7 +204,7 @@ items:
           - 'excel!Excel.Interfaces.ChartDataLabelFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -218,7 +218,7 @@ references:
     name: Excel.Interfaces.ChartDataLabelFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartDataLabelFormatUpdateData:interface'
     name: Interfaces.ChartDataLabelFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartDataLabelFormatData:interface'
     name: Excel.Interfaces.ChartDataLabelFormatData

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.chartdatalabels.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.chartdatalabels.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartDataLabels#context:member'
@@ -213,7 +213,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartDataLabels#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -341,7 +341,7 @@ items:
           - 'excel!Excel.Interfaces.ChartDataLabelsData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -366,7 +366,7 @@ references:
         fullName: ' | "Invalid" | "None" | "Center" | "InsideEnd" | "InsideBase" | "OutsideEnd" | "Left" | "Right" | "Top" | "Bottom" | "BestFit" | "Callout"'
   - uid: 'excel!Excel.Interfaces.ChartDataLabelsUpdateData:interface'
     name: Interfaces.ChartDataLabelsUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartDataLabelsData:interface'
     name: Excel.Interfaces.ChartDataLabelsData

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.chartfill.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.chartfill.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartFill#clear:member(1)'
@@ -138,7 +138,7 @@ items:
                     }
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.chartfont.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.chartfont.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     remarks: |-
 
@@ -223,7 +223,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartFont#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -291,7 +291,7 @@ items:
         type:
           - 'excel!Excel.ChartFont#underline~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -301,7 +301,7 @@ references:
     name: Excel.Interfaces.ChartFontLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartFontUpdateData:interface'
     name: Interfaces.ChartFontUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartFontData:interface'
     name: Excel.Interfaces.ChartFontData

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.chartgridlines.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.chartgridlines.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartGridlines#context:member'
@@ -170,7 +170,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartGridlines#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -223,7 +223,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -235,7 +235,7 @@ references:
     name: Excel.Interfaces.ChartGridlinesLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartGridlinesUpdateData:interface'
     name: Interfaces.ChartGridlinesUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartGridlinesData:interface'
     name: Excel.Interfaces.ChartGridlinesData

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.chartgridlinesformat.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.chartgridlinesformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartGridlinesFormat#context:member'
@@ -150,7 +150,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartGridlinesFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -188,7 +188,7 @@ items:
           - 'excel!Excel.Interfaces.ChartGridlinesFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -200,7 +200,7 @@ references:
     name: Excel.Interfaces.ChartGridlinesFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartGridlinesFormatUpdateData:interface'
     name: Interfaces.ChartGridlinesFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartGridlinesFormatData:interface'
     name: Excel.Interfaces.ChartGridlinesFormatData

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.chartlegend.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.chartlegend.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartLegend#context:member'
@@ -203,7 +203,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartLegend#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -256,7 +256,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -277,7 +277,7 @@ references:
         fullName: ' | "Invalid" | "Top" | "Bottom" | "Left" | "Right" | "Corner" | "Custom"'
   - uid: 'excel!Excel.Interfaces.ChartLegendUpdateData:interface'
     name: Interfaces.ChartLegendUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartLegendData:interface'
     name: Excel.Interfaces.ChartLegendData

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.chartlegendformat.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.chartlegendformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartLegendFormat#context:member'
@@ -196,7 +196,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartLegendFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -234,7 +234,7 @@ items:
           - 'excel!Excel.Interfaces.ChartLegendFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -248,7 +248,7 @@ references:
     name: Excel.Interfaces.ChartLegendFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartLegendFormatUpdateData:interface'
     name: Interfaces.ChartLegendFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartLegendFormatData:interface'
     name: Excel.Interfaces.ChartLegendFormatData

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.chartlineformat.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.chartlineformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartLineFormat#clear:member(1)'
@@ -205,7 +205,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartLineFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -243,7 +243,7 @@ items:
           - 'excel!Excel.Interfaces.ChartLineFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -253,7 +253,7 @@ references:
     name: Excel.Interfaces.ChartLineFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartLineFormatUpdateData:interface'
     name: Interfaces.ChartLineFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartLineFormatData:interface'
     name: Excel.Interfaces.ChartLineFormatData

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.chartpoint.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.chartpoint.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartPoint#context:member'
@@ -151,7 +151,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartPoint#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -204,7 +204,7 @@ items:
         type:
           - any
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -216,7 +216,7 @@ references:
     name: Excel.Interfaces.ChartPointLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartPointUpdateData:interface'
     name: Interfaces.ChartPointUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartPointData:interface'
     name: Excel.Interfaces.ChartPointData

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.chartpointformat.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.chartpointformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartPointFormat#context:member'
@@ -150,7 +150,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartPointFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -188,7 +188,7 @@ items:
           - 'excel!Excel.Interfaces.ChartPointFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -200,7 +200,7 @@ references:
     name: Excel.Interfaces.ChartPointFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartPointFormatUpdateData:interface'
     name: Interfaces.ChartPointFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartPointFormatData:interface'
     name: Excel.Interfaces.ChartPointFormatData

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.chartpointscollection.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.chartpointscollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartPointsCollection#context:member'
@@ -219,7 +219,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.ChartPointsCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -239,7 +239,7 @@ items:
           - 'excel!Excel.Interfaces.ChartPointsCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -247,7 +247,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -277,7 +277,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.ChartPointsCollectionData:interface'
     name: Excel.Interfaces.ChartPointsCollectionData

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.chartseries.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.chartseries.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartSeries#context:member'
@@ -201,7 +201,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartSeries#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -239,7 +239,7 @@ items:
           - 'excel!Excel.Interfaces.ChartSeriesData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -253,7 +253,7 @@ references:
     name: Excel.ChartPointsCollection
   - uid: 'excel!Excel.Interfaces.ChartSeriesUpdateData:interface'
     name: Interfaces.ChartSeriesUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartSeriesData:interface'
     name: Excel.Interfaces.ChartSeriesData

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.chartseriescollection.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.chartseriescollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartSeriesCollection#context:member'
@@ -220,7 +220,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.ChartSeriesCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -240,7 +240,7 @@ items:
           - 'excel!Excel.Interfaces.ChartSeriesCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -248,7 +248,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -278,7 +278,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.ChartSeriesCollectionData:interface'
     name: Excel.Interfaces.ChartSeriesCollectionData

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.chartseriesformat.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.chartseriesformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartSeriesFormat#context:member'
@@ -166,7 +166,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartSeriesFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -204,7 +204,7 @@ items:
           - 'excel!Excel.Interfaces.ChartSeriesFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -218,7 +218,7 @@ references:
     name: Excel.Interfaces.ChartSeriesFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartSeriesFormatUpdateData:interface'
     name: Interfaces.ChartSeriesFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartSeriesFormatData:interface'
     name: Excel.Interfaces.ChartSeriesFormatData

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.charttitle.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.charttitle.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartTitle#context:member'
@@ -208,7 +208,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartTitle#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -276,7 +276,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -288,7 +288,7 @@ references:
     name: Excel.Interfaces.ChartTitleLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartTitleUpdateData:interface'
     name: Interfaces.ChartTitleUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartTitleData:interface'
     name: Excel.Interfaces.ChartTitleData

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.charttitleformat.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.charttitleformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartTitleFormat#context:member'
@@ -166,7 +166,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartTitleFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -204,7 +204,7 @@ items:
           - 'excel!Excel.Interfaces.ChartTitleFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -218,7 +218,7 @@ references:
     name: Excel.Interfaces.ChartTitleFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartTitleFormatUpdateData:interface'
     name: Interfaces.ChartTitleFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartTitleFormatData:interface'
     name: Excel.Interfaces.ChartTitleFormatData

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.customxmlpart.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.customxmlpart.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.CustomXmlPart#context:member'
@@ -343,7 +343,7 @@ items:
           - 'excel!Excel.Interfaces.CustomXmlPartData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -351,7 +351,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.customxmlpartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.customxmlpartcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.CustomXmlPartCollection#add:member(1)'
@@ -317,7 +317,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.CustomXmlPartCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -337,7 +337,7 @@ items:
           - 'excel!Excel.Interfaces.CustomXmlPartCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.CustomXmlPart:class'
     name: Excel.CustomXmlPart
@@ -349,7 +349,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -377,7 +377,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.CustomXmlPartCollectionData:interface'
     name: Excel.Interfaces.CustomXmlPartCollectionData

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.customxmlpartscopedcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.customxmlpartscopedcollection.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.CustomXmlPartScopedCollection#context:member'
@@ -325,7 +325,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.CustomXmlPartScopedCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -345,7 +345,7 @@ items:
           - 'excel!Excel.Interfaces.CustomXmlPartScopedCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -353,7 +353,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -383,7 +383,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.CustomXmlPartScopedCollectionData:interface'
     name: Excel.Interfaces.CustomXmlPartScopedCollectionData

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.filter.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.filter.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Filter#apply:member(1)'
@@ -473,7 +473,7 @@ items:
           - 'excel!Excel.Interfaces.FilterData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.FilterCriteria:interface'
     name: Excel.FilterCriteria

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.formatprotection.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.formatprotection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.FormatProtection#context:member'
@@ -170,7 +170,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.FormatProtection#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -208,7 +208,7 @@ items:
           - 'excel!Excel.Interfaces.FormatProtectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -218,7 +218,7 @@ references:
     name: Excel.Interfaces.FormatProtectionLoadOptions
   - uid: 'excel!Excel.Interfaces.FormatProtectionUpdateData:interface'
     name: Interfaces.FormatProtectionUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.FormatProtectionData:interface'
     name: Excel.Interfaces.FormatProtectionData

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.functionresult.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.functionresult.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.FunctionResult#context:member'
@@ -158,7 +158,7 @@ items:
         type:
           - T
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.functions.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.functions.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Functions#abs:member(1)'
@@ -11184,7 +11184,7 @@ items:
           type:
             - 'excel!Excel.Functions#z_Test~3:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Functions#abs~0:complex'
     name: FunctionResult<number>

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.nameditem.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.nameditem.yml
@@ -14,7 +14,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.NamedItem#comment:member'
@@ -317,7 +317,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.NamedItem#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -436,7 +436,7 @@ items:
         type:
           - 'excel!Excel.Worksheet:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -457,7 +457,7 @@ references:
         fullName: ' | "Worksheet" | "Workbook"'
   - uid: 'excel!Excel.Interfaces.NamedItemUpdateData:interface'
     name: Interfaces.NamedItemUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.NamedItemData:interface'
     name: Excel.Interfaces.NamedItemData

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.nameditemcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.nameditemcollection.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.NamedItemCollection#add:member(1)'
@@ -294,7 +294,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.NamedItemCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -314,7 +314,7 @@ items:
           - 'excel!Excel.Interfaces.NamedItemCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.NamedItem:class'
     name: Excel.NamedItem
@@ -333,7 +333,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -361,7 +361,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.NamedItemCollectionData:interface'
     name: Excel.Interfaces.NamedItemCollectionData

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.pivottable.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.pivottable.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PivotTable#context:member'
@@ -186,7 +186,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.PivotTable#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -239,7 +239,7 @@ items:
         type:
           - 'excel!Excel.Worksheet:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -249,7 +249,7 @@ references:
     name: Excel.Interfaces.PivotTableLoadOptions
   - uid: 'excel!Excel.Interfaces.PivotTableUpdateData:interface'
     name: Interfaces.PivotTableUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.PivotTableData:interface'
     name: Excel.Interfaces.PivotTableData

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.pivottablecollection.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.pivottablecollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PivotTableCollection#context:member'
@@ -171,7 +171,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.PivotTableCollection#refreshAll:member(1)'
     summary: |-
       Refreshes all the pivot tables in the collection.
@@ -207,7 +207,7 @@ items:
           - 'excel!Excel.Interfaces.PivotTableCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -215,7 +215,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -245,7 +245,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.PivotTableCollectionData:interface'
     name: Excel.Interfaces.PivotTableCollectionData

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.range.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.range.yml
@@ -16,7 +16,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Range#address:member'
@@ -1681,7 +1681,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Range#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -1927,7 +1927,7 @@ items:
         type:
           - 'excel!Excel.Worksheet:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ClearApplyTo:enum'
     name: Excel.ClearApplyTo
@@ -1983,7 +1983,7 @@ references:
         fullName: ' | string'
   - uid: 'excel!Excel.Interfaces.RangeUpdateData:interface'
     name: Interfaces.RangeUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.RangeSort:class'
     name: Excel.RangeSort

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.rangeborder.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.rangeborder.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeBorder#color:member'
@@ -155,7 +155,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.RangeBorder#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -269,7 +269,7 @@ items:
         type:
           - 'excel!Excel.RangeBorder#weight~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -279,7 +279,7 @@ references:
     name: Excel.Interfaces.RangeBorderLoadOptions
   - uid: 'excel!Excel.Interfaces.RangeBorderUpdateData:interface'
     name: Interfaces.RangeBorderUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.RangeBorder#sideIndex~0:complex'
     name: >-

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.rangebordercollection.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.rangebordercollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeBorderCollection#context:member'
@@ -265,7 +265,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.RangeBorderCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -285,7 +285,7 @@ items:
           - 'excel!Excel.Interfaces.RangeBorderCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -316,7 +316,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.RangeBorderCollectionData:interface'
     name: Excel.Interfaces.RangeBorderCollectionData

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.rangefill.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.rangefill.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeFill#clear:member(1)'
@@ -226,7 +226,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.RangeFill#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -264,7 +264,7 @@ items:
           - 'excel!Excel.Interfaces.RangeFillData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -274,7 +274,7 @@ references:
     name: Excel.Interfaces.RangeFillLoadOptions
   - uid: 'excel!Excel.Interfaces.RangeFillUpdateData:interface'
     name: Interfaces.RangeFillUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.RangeFillData:interface'
     name: Excel.Interfaces.RangeFillData

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.rangefont.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.rangefont.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeFont#bold:member'
@@ -237,7 +237,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.RangeFont#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -305,7 +305,7 @@ items:
         type:
           - 'excel!Excel.RangeFont#underline~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -315,7 +315,7 @@ references:
     name: Excel.Interfaces.RangeFontLoadOptions
   - uid: 'excel!Excel.Interfaces.RangeFontUpdateData:interface'
     name: Interfaces.RangeFontUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.RangeFontData:interface'
     name: Excel.Interfaces.RangeFontData

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.rangeformat.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.rangeformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeFormat#adjustIndent:member(1)'
@@ -378,7 +378,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.RangeFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -448,7 +448,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RangeBorderCollection:class'
     name: Excel.RangeBorderCollection
@@ -479,7 +479,7 @@ references:
     name: Excel.FormatProtection
   - uid: 'excel!Excel.Interfaces.RangeFormatUpdateData:interface'
     name: Interfaces.RangeFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.RangeFormatData:interface'
     name: Excel.Interfaces.RangeFormatData

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.rangesort.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.rangesort.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeSort#apply:member(1)'
@@ -135,7 +135,7 @@ items:
                     }
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RangeSort#apply~0:complex'
     name: 'Excel.SortField[]'

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.rangeview.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.rangeview.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeView#cellAddresses:member'
@@ -300,7 +300,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.RangeView#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -387,7 +387,7 @@ items:
         type:
           - 'excel!Excel.RangeView#valueTypes~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -401,7 +401,7 @@ references:
     name: Excel.RangeViewCollection
   - uid: 'excel!Excel.Interfaces.RangeViewUpdateData:interface'
     name: Interfaces.RangeViewUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.RangeViewData:interface'
     name: Excel.Interfaces.RangeViewData

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.rangeviewcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.rangeviewcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeViewCollection#context:member'
@@ -148,7 +148,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.RangeViewCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -168,7 +168,7 @@ items:
           - 'excel!Excel.Interfaces.RangeViewCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -176,7 +176,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -206,7 +206,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.RangeViewCollectionData:interface'
     name: Excel.Interfaces.RangeViewCollectionData

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.requestcontext.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.requestcontext.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientRequestContext:class'
+      - 'office!OfficeExtension.ClientRequestContext:class'
     package: excel!
     children:
       - 'excel!Excel.RequestContext:constructor(1)'
@@ -67,7 +67,7 @@ items:
         type:
           - 'excel!Excel.Workbook:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientRequestContext:class'
+  - uid: 'office!OfficeExtension.ClientRequestContext:class'
     name: OfficeExtension.ClientRequestContext
   - uid: 'excel!Excel.RequestContext~0:complex'
     name: string | Session

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.runoptions.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.runoptions.yml
@@ -34,7 +34,7 @@ references:
     name: OfficeExtension.RunOptions<Session>
     fullName: OfficeExtension.RunOptions<Excel.Session>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.RunOptions:interface'
+      - uid: 'office!OfficeExtension.RunOptions:interface'
         name: OfficeExtension.RunOptions
         fullName: OfficeExtension.RunOptions
       - name: <

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.runtime.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.runtime.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Runtime#context:member'
@@ -134,7 +134,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Runtime#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -172,7 +172,7 @@ items:
           - 'excel!Excel.Interfaces.RuntimeData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -182,7 +182,7 @@ references:
     name: Excel.Interfaces.RuntimeLoadOptions
   - uid: 'excel!Excel.Interfaces.RuntimeUpdateData:interface'
     name: Interfaces.RuntimeUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.RuntimeData:interface'
     name: Excel.Interfaces.RuntimeData

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.setting.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.setting.yml
@@ -15,7 +15,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Setting#context:member'
@@ -200,7 +200,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Setting#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -253,7 +253,7 @@ items:
         type:
           - any
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -263,7 +263,7 @@ references:
     name: Excel.Interfaces.SettingLoadOptions
   - uid: 'excel!Excel.Interfaces.SettingUpdateData:interface'
     name: Interfaces.SettingUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.SettingData:interface'
     name: Excel.Interfaces.SettingData

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.settingcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.settingcollection.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.SettingCollection#add:member(1)'
@@ -246,7 +246,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.SettingCollection#onSettingsChanged:member'
     summary: |-
       Occurs when the Settings in the document are changed.
@@ -301,7 +301,7 @@ items:
           - 'excel!Excel.Interfaces.SettingCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Setting:class'
     name: Excel.Setting
@@ -327,7 +327,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -355,13 +355,13 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.SettingCollection#onSettingsChanged~0:complex'
     name: OfficeExtension.EventHandlers<Excel.SettingsChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.SettingsChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.table.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.table.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Table#clearFilters:member(1)'
@@ -533,7 +533,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Table#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -724,7 +724,7 @@ items:
         type:
           - 'excel!Excel.Worksheet:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.TableColumnCollection:class'
     name: Excel.TableColumnCollection
@@ -740,7 +740,7 @@ references:
     name: Excel.TableRowCollection
   - uid: 'excel!Excel.Interfaces.TableUpdateData:interface'
     name: Interfaces.TableUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.TableSort:class'
     name: Excel.TableSort

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.tablecollection.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.tablecollection.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableCollection#add:member(1)'
@@ -338,7 +338,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.TableCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -358,7 +358,7 @@ items:
           - 'excel!Excel.Interfaces.TableCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Table:class'
     name: Excel.Table
@@ -377,7 +377,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -405,7 +405,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.TableCollectionData:interface'
     name: Excel.Interfaces.TableCollectionData

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.tablecolumn.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.tablecolumn.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableColumn#context:member'
@@ -401,7 +401,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.TableColumn#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -456,7 +456,7 @@ items:
         type:
           - 'any[][]'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -470,7 +470,7 @@ references:
     name: Excel.Interfaces.TableColumnLoadOptions
   - uid: 'excel!Excel.Interfaces.TableColumnUpdateData:interface'
     name: Interfaces.TableColumnUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.TableColumnData:interface'
     name: Excel.Interfaces.TableColumnData

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.tablecolumncollection.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.tablecolumncollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableColumnCollection#add:member(1)'
@@ -322,7 +322,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.TableColumnCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -342,7 +342,7 @@ items:
           - 'excel!Excel.Interfaces.TableColumnCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.TableColumn:class'
     name: Excel.TableColumn
@@ -366,7 +366,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -394,7 +394,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.TableColumnCollectionData:interface'
     name: Excel.Interfaces.TableColumnCollectionData

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.tablerow.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.tablerow.yml
@@ -17,7 +17,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableRow#context:member'
@@ -247,7 +247,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.TableRow#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -302,7 +302,7 @@ items:
         type:
           - 'any[][]'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -314,7 +314,7 @@ references:
     name: Excel.Interfaces.TableRowLoadOptions
   - uid: 'excel!Excel.Interfaces.TableRowUpdateData:interface'
     name: Interfaces.TableRowUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.TableRowData:interface'
     name: Excel.Interfaces.TableRowData

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.tablerowcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.tablerowcollection.yml
@@ -17,7 +17,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableRowCollection#add:member(1)'
@@ -290,7 +290,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.TableRowCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -310,7 +310,7 @@ items:
           - 'excel!Excel.Interfaces.TableRowCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.TableRow:class'
     name: Excel.TableRow
@@ -334,7 +334,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -362,7 +362,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.TableRowCollectionData:interface'
     name: Excel.Interfaces.TableRowCollectionData

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.tablesort.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.tablesort.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableSort#apply:member(1)'
@@ -288,7 +288,7 @@ items:
           - 'excel!Excel.Interfaces.TableSortData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.TableSort#apply~0:complex'
     name: 'Excel.SortField[]'

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.workbook.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.workbook.yml
@@ -14,7 +14,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Workbook#application:member'
@@ -289,7 +289,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Workbook#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -372,7 +372,7 @@ items:
         type:
           - 'excel!Excel.WorksheetCollection:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Application:class'
     name: Excel.Application
@@ -396,7 +396,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.SelectionChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.SelectionChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -410,7 +410,7 @@ references:
     name: Excel.PivotTableCollection
   - uid: 'excel!Excel.Interfaces.WorkbookUpdateData:interface'
     name: Interfaces.WorkbookUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.SettingCollection:class'
     name: Excel.SettingCollection

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.worksheet.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.worksheet.yml
@@ -14,7 +14,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Worksheet#activate:member(1)'
@@ -743,7 +743,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Worksheet#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -813,7 +813,7 @@ items:
         type:
           - 'excel!Excel.Worksheet#visibility~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartCollection:class'
     name: Excel.ChartCollection
@@ -833,7 +833,7 @@ references:
     name: Excel.WorksheetProtection
   - uid: 'excel!Excel.Interfaces.WorksheetUpdateData:interface'
     name: Interfaces.WorksheetUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.TableCollection:class'
     name: Excel.TableCollection

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.worksheetcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.worksheetcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.WorksheetCollection#add:member(1)'
@@ -393,7 +393,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.WorksheetCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -413,7 +413,7 @@ items:
           - 'excel!Excel.Interfaces.WorksheetCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Worksheet:class'
     name: Excel.Worksheet
@@ -423,7 +423,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -451,7 +451,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.WorksheetCollectionData:interface'
     name: Excel.Interfaces.WorksheetCollectionData

--- a/docs/docs-ref-autogen/excel_1_5/excel/excel.worksheetprotection.yml
+++ b/docs/docs-ref-autogen/excel_1_5/excel/excel.worksheetprotection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.WorksheetProtection#context:member'
@@ -226,7 +226,7 @@ items:
           - 'excel!Excel.Interfaces.WorksheetProtectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel_1_6/excel.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel.yml
@@ -648,7 +648,7 @@ items:
             A previously-created API object. The batch will use the same RequestContext as the passed-in object, which
             means that any changes applied to the object will be picked up by "context.sync()".
           type:
-            - 'excel!OfficeExtension.ClientObject:class'
+            - 'office!OfficeExtension.ClientObject:class'
         - id: batch
           description: >-
             A function that takes in a RequestContext and returns a promise (typically, just the result of
@@ -753,7 +753,7 @@ items:
             A previously-created object. The batch will use the same RequestContext as the passed-in object, which means
             that any changes applied to the object will be picked up by "context.sync()".
           type:
-            - 'excel!OfficeExtension.ClientRequestContext:class'
+            - 'office!OfficeExtension.ClientRequestContext:class'
         - id: batch
           description: >-
             A function that takes in a RequestContext and returns a promise (typically, just the result of
@@ -1815,7 +1815,7 @@ references:
         fullName: Promise
       - name: <T>
         fullName: <T>
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.run~3:complex'
     name: '(context: Excel.RequestContext) => Promise<T>'
@@ -1846,7 +1846,7 @@ references:
     name: 'OfficeExtension.ClientObject[]'
     fullName: 'OfficeExtension.ClientObject[]'
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientObject:class'
+      - uid: 'office!OfficeExtension.ClientObject:class'
         name: OfficeExtension.ClientObject
         fullName: OfficeExtension.ClientObject
       - name: '[]'
@@ -1903,7 +1903,7 @@ references:
         fullName: Promise
       - name: <T>
         fullName: <T>
-  - uid: 'excel!OfficeExtension.ClientRequestContext:class'
+  - uid: 'office!OfficeExtension.ClientRequestContext:class'
     name: OfficeExtension.ClientRequestContext
   - uid: 'excel!Excel.run~10:complex'
     name: '(context: Excel.RequestContext) => Promise<T>'

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.application.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.application.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Application#calculate:member(1)'
@@ -233,7 +233,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Application#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -289,7 +289,7 @@ items:
           - 'excel!Excel.Interfaces.ApplicationData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.CalculationType:enum'
     name: Excel.CalculationType
@@ -310,7 +310,7 @@ references:
     name: Excel.Interfaces.ApplicationLoadOptions
   - uid: 'excel!Excel.Interfaces.ApplicationUpdateData:interface'
     name: Interfaces.ApplicationUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ApplicationData:interface'
     name: Excel.Interfaces.ApplicationData

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.binding.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.binding.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Binding#context:member'
@@ -357,7 +357,7 @@ items:
         type:
           - 'excel!Excel.Binding#type~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -369,7 +369,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -382,7 +382,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.BindingDataChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.BindingDataChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -396,7 +396,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.BindingSelectionChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.BindingSelectionChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.bindingcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.bindingcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.BindingCollection#add:member(1)'
@@ -493,7 +493,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.BindingCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -513,7 +513,7 @@ items:
           - 'excel!Excel.Interfaces.BindingCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Binding:class'
     name: Excel.Binding
@@ -543,7 +543,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -571,7 +571,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.BindingCollectionData:interface'
     name: Excel.Interfaces.BindingCollectionData

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.cellvalueconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.cellvalueconditionalformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.CellValueConditionalFormat#context:member'
@@ -212,7 +212,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.CellValueConditionalFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -250,7 +250,7 @@ items:
           - 'excel!Excel.Interfaces.CellValueConditionalFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -264,7 +264,7 @@ references:
     name: Excel.ConditionalCellValueRule
   - uid: 'excel!Excel.Interfaces.CellValueConditionalFormatUpdateData:interface'
     name: Interfaces.CellValueConditionalFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.CellValueConditionalFormatData:interface'
     name: Excel.Interfaces.CellValueConditionalFormatData

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.chart.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.chart.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Chart#axes:member'
@@ -456,7 +456,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Chart#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -681,7 +681,7 @@ items:
         type:
           - 'excel!Excel.Worksheet:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartAxes:class'
     name: Excel.ChartAxes
@@ -695,7 +695,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -706,7 +706,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -721,7 +721,7 @@ references:
     name: Excel.ChartSeriesCollection
   - uid: 'excel!Excel.Interfaces.ChartUpdateData:interface'
     name: Interfaces.ChartUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Range:class'
     name: Range

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.chartareaformat.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.chartareaformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAreaFormat#context:member'
@@ -166,7 +166,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAreaFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -204,7 +204,7 @@ items:
           - 'excel!Excel.Interfaces.ChartAreaFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -218,7 +218,7 @@ references:
     name: Excel.Interfaces.ChartAreaFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartAreaFormatUpdateData:interface'
     name: Interfaces.ChartAreaFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartAreaFormatData:interface'
     name: Excel.Interfaces.ChartAreaFormatData

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.chartaxes.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.chartaxes.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAxes#categoryAxis:member'
@@ -167,7 +167,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAxes#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -243,7 +243,7 @@ items:
           });
           ```
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartAxis:class'
     name: Excel.ChartAxis
@@ -255,7 +255,7 @@ references:
     name: Excel.Interfaces.ChartAxesLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartAxesUpdateData:interface'
     name: Interfaces.ChartAxesUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartAxesData:interface'
     name: Excel.Interfaces.ChartAxesData

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.chartaxis.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.chartaxis.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAxis#context:member'
@@ -275,7 +275,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAxis#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -328,7 +328,7 @@ items:
           - 'excel!Excel.Interfaces.ChartAxisData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -342,7 +342,7 @@ references:
     name: Excel.ChartGridlines
   - uid: 'excel!Excel.Interfaces.ChartAxisUpdateData:interface'
     name: Interfaces.ChartAxisUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.ChartAxisTitle:class'
     name: Excel.ChartAxisTitle

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.chartaxisformat.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.chartaxisformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAxisFormat#context:member'
@@ -166,7 +166,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAxisFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -204,7 +204,7 @@ items:
           - 'excel!Excel.Interfaces.ChartAxisFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -218,7 +218,7 @@ references:
     name: Excel.Interfaces.ChartAxisFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisFormatUpdateData:interface'
     name: Interfaces.ChartAxisFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisFormatData:interface'
     name: Excel.Interfaces.ChartAxisFormatData

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.chartaxistitle.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.chartaxistitle.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAxisTitle#context:member'
@@ -171,7 +171,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAxisTitle#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -239,7 +239,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -251,7 +251,7 @@ references:
     name: Excel.Interfaces.ChartAxisTitleLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisTitleUpdateData:interface'
     name: Interfaces.ChartAxisTitleUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisTitleData:interface'
     name: Excel.Interfaces.ChartAxisTitleData

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.chartaxistitleformat.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.chartaxistitleformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAxisTitleFormat#context:member'
@@ -150,7 +150,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAxisTitleFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -188,7 +188,7 @@ items:
           - 'excel!Excel.Interfaces.ChartAxisTitleFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -200,7 +200,7 @@ references:
     name: Excel.Interfaces.ChartAxisTitleFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisTitleFormatUpdateData:interface'
     name: Interfaces.ChartAxisTitleFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisTitleFormatData:interface'
     name: Excel.Interfaces.ChartAxisTitleFormatData

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.chartcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartCollection#add:member(1)'
@@ -383,7 +383,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.ChartCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -403,7 +403,7 @@ items:
           - 'excel!Excel.Interfaces.ChartCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Chart:class'
     name: Excel.Chart
@@ -419,7 +419,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -447,7 +447,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.ChartCollectionData:interface'
     name: Excel.Interfaces.ChartCollectionData

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.chartdatalabelformat.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.chartdatalabelformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartDataLabelFormat#context:member'
@@ -166,7 +166,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartDataLabelFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -204,7 +204,7 @@ items:
           - 'excel!Excel.Interfaces.ChartDataLabelFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -218,7 +218,7 @@ references:
     name: Excel.Interfaces.ChartDataLabelFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartDataLabelFormatUpdateData:interface'
     name: Interfaces.ChartDataLabelFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartDataLabelFormatData:interface'
     name: Excel.Interfaces.ChartDataLabelFormatData

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.chartdatalabels.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.chartdatalabels.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartDataLabels#context:member'
@@ -213,7 +213,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartDataLabels#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -341,7 +341,7 @@ items:
           - 'excel!Excel.Interfaces.ChartDataLabelsData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -366,7 +366,7 @@ references:
         fullName: ' | "Invalid" | "None" | "Center" | "InsideEnd" | "InsideBase" | "OutsideEnd" | "Left" | "Right" | "Top" | "Bottom" | "BestFit" | "Callout"'
   - uid: 'excel!Excel.Interfaces.ChartDataLabelsUpdateData:interface'
     name: Interfaces.ChartDataLabelsUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartDataLabelsData:interface'
     name: Excel.Interfaces.ChartDataLabelsData

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.chartfill.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.chartfill.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartFill#clear:member(1)'
@@ -138,7 +138,7 @@ items:
                     }
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.chartfont.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.chartfont.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     remarks: |-
 
@@ -223,7 +223,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartFont#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -291,7 +291,7 @@ items:
         type:
           - 'excel!Excel.ChartFont#underline~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -301,7 +301,7 @@ references:
     name: Excel.Interfaces.ChartFontLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartFontUpdateData:interface'
     name: Interfaces.ChartFontUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartFontData:interface'
     name: Excel.Interfaces.ChartFontData

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.chartgridlines.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.chartgridlines.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartGridlines#context:member'
@@ -170,7 +170,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartGridlines#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -223,7 +223,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -235,7 +235,7 @@ references:
     name: Excel.Interfaces.ChartGridlinesLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartGridlinesUpdateData:interface'
     name: Interfaces.ChartGridlinesUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartGridlinesData:interface'
     name: Excel.Interfaces.ChartGridlinesData

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.chartgridlinesformat.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.chartgridlinesformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartGridlinesFormat#context:member'
@@ -150,7 +150,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartGridlinesFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -188,7 +188,7 @@ items:
           - 'excel!Excel.Interfaces.ChartGridlinesFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -200,7 +200,7 @@ references:
     name: Excel.Interfaces.ChartGridlinesFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartGridlinesFormatUpdateData:interface'
     name: Interfaces.ChartGridlinesFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartGridlinesFormatData:interface'
     name: Excel.Interfaces.ChartGridlinesFormatData

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.chartlegend.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.chartlegend.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartLegend#context:member'
@@ -203,7 +203,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartLegend#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -256,7 +256,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -277,7 +277,7 @@ references:
         fullName: ' | "Invalid" | "Top" | "Bottom" | "Left" | "Right" | "Corner" | "Custom"'
   - uid: 'excel!Excel.Interfaces.ChartLegendUpdateData:interface'
     name: Interfaces.ChartLegendUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartLegendData:interface'
     name: Excel.Interfaces.ChartLegendData

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.chartlegendformat.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.chartlegendformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartLegendFormat#context:member'
@@ -196,7 +196,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartLegendFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -234,7 +234,7 @@ items:
           - 'excel!Excel.Interfaces.ChartLegendFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -248,7 +248,7 @@ references:
     name: Excel.Interfaces.ChartLegendFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartLegendFormatUpdateData:interface'
     name: Interfaces.ChartLegendFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartLegendFormatData:interface'
     name: Excel.Interfaces.ChartLegendFormatData

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.chartlineformat.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.chartlineformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartLineFormat#clear:member(1)'
@@ -205,7 +205,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartLineFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -243,7 +243,7 @@ items:
           - 'excel!Excel.Interfaces.ChartLineFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -253,7 +253,7 @@ references:
     name: Excel.Interfaces.ChartLineFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartLineFormatUpdateData:interface'
     name: Interfaces.ChartLineFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartLineFormatData:interface'
     name: Excel.Interfaces.ChartLineFormatData

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.chartpoint.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.chartpoint.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartPoint#context:member'
@@ -151,7 +151,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartPoint#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -204,7 +204,7 @@ items:
         type:
           - any
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -216,7 +216,7 @@ references:
     name: Excel.Interfaces.ChartPointLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartPointUpdateData:interface'
     name: Interfaces.ChartPointUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartPointData:interface'
     name: Excel.Interfaces.ChartPointData

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.chartpointformat.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.chartpointformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartPointFormat#context:member'
@@ -150,7 +150,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartPointFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -188,7 +188,7 @@ items:
           - 'excel!Excel.Interfaces.ChartPointFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -200,7 +200,7 @@ references:
     name: Excel.Interfaces.ChartPointFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartPointFormatUpdateData:interface'
     name: Interfaces.ChartPointFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartPointFormatData:interface'
     name: Excel.Interfaces.ChartPointFormatData

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.chartpointscollection.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.chartpointscollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartPointsCollection#context:member'
@@ -219,7 +219,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.ChartPointsCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -239,7 +239,7 @@ items:
           - 'excel!Excel.Interfaces.ChartPointsCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -247,7 +247,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -277,7 +277,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.ChartPointsCollectionData:interface'
     name: Excel.Interfaces.ChartPointsCollectionData

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.chartseries.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.chartseries.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartSeries#context:member'
@@ -201,7 +201,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartSeries#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -239,7 +239,7 @@ items:
           - 'excel!Excel.Interfaces.ChartSeriesData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -253,7 +253,7 @@ references:
     name: Excel.ChartPointsCollection
   - uid: 'excel!Excel.Interfaces.ChartSeriesUpdateData:interface'
     name: Interfaces.ChartSeriesUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartSeriesData:interface'
     name: Excel.Interfaces.ChartSeriesData

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.chartseriescollection.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.chartseriescollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartSeriesCollection#context:member'
@@ -220,7 +220,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.ChartSeriesCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -240,7 +240,7 @@ items:
           - 'excel!Excel.Interfaces.ChartSeriesCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -248,7 +248,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -278,7 +278,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.ChartSeriesCollectionData:interface'
     name: Excel.Interfaces.ChartSeriesCollectionData

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.chartseriesformat.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.chartseriesformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartSeriesFormat#context:member'
@@ -166,7 +166,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartSeriesFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -204,7 +204,7 @@ items:
           - 'excel!Excel.Interfaces.ChartSeriesFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -218,7 +218,7 @@ references:
     name: Excel.Interfaces.ChartSeriesFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartSeriesFormatUpdateData:interface'
     name: Interfaces.ChartSeriesFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartSeriesFormatData:interface'
     name: Excel.Interfaces.ChartSeriesFormatData

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.charttitle.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.charttitle.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartTitle#context:member'
@@ -208,7 +208,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartTitle#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -276,7 +276,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -288,7 +288,7 @@ references:
     name: Excel.Interfaces.ChartTitleLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartTitleUpdateData:interface'
     name: Interfaces.ChartTitleUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartTitleData:interface'
     name: Excel.Interfaces.ChartTitleData

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.charttitleformat.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.charttitleformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartTitleFormat#context:member'
@@ -166,7 +166,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartTitleFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -204,7 +204,7 @@ items:
           - 'excel!Excel.Interfaces.ChartTitleFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -218,7 +218,7 @@ references:
     name: Excel.Interfaces.ChartTitleFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartTitleFormatUpdateData:interface'
     name: Interfaces.ChartTitleFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartTitleFormatData:interface'
     name: Excel.Interfaces.ChartTitleFormatData

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.colorscaleconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.colorscaleconditionalformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ColorScaleConditionalFormat#context:member'
@@ -180,7 +180,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ColorScaleConditionalFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -235,7 +235,7 @@ items:
           - 'excel!Excel.Interfaces.ColorScaleConditionalFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -247,7 +247,7 @@ references:
     name: Excel.Interfaces.ColorScaleConditionalFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ColorScaleConditionalFormatUpdateData:interface'
     name: Interfaces.ColorScaleConditionalFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ColorScaleConditionalFormatData:interface'
     name: Excel.Interfaces.ColorScaleConditionalFormatData

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.conditionaldatabarnegativeformat.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.conditionaldatabarnegativeformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ConditionalDataBarNegativeFormat#borderColor:member'
@@ -206,7 +206,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ConditionalDataBarNegativeFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -244,7 +244,7 @@ items:
           - 'excel!Excel.Interfaces.ConditionalDataBarNegativeFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -254,7 +254,7 @@ references:
     name: Excel.Interfaces.ConditionalDataBarNegativeFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ConditionalDataBarNegativeFormatUpdateData:interface'
     name: Interfaces.ConditionalDataBarNegativeFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ConditionalDataBarNegativeFormatData:interface'
     name: Excel.Interfaces.ConditionalDataBarNegativeFormatData

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.conditionaldatabarpositiveformat.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.conditionaldatabarpositiveformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ConditionalDataBarPositiveFormat#borderColor:member'
@@ -190,7 +190,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ConditionalDataBarPositiveFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -228,7 +228,7 @@ items:
           - 'excel!Excel.Interfaces.ConditionalDataBarPositiveFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -238,7 +238,7 @@ references:
     name: Excel.Interfaces.ConditionalDataBarPositiveFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ConditionalDataBarPositiveFormatUpdateData:interface'
     name: Interfaces.ConditionalDataBarPositiveFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ConditionalDataBarPositiveFormatData:interface'
     name: Excel.Interfaces.ConditionalDataBarPositiveFormatData

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.conditionalformat.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.conditionalformat.yml
@@ -14,7 +14,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ConditionalFormat#cellValue:member'
@@ -640,7 +640,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ConditionalFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -841,7 +841,7 @@ items:
 
           ```
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.CellValueConditionalFormat:class'
     name: Excel.CellValueConditionalFormat
@@ -865,7 +865,7 @@ references:
     name: Excel.PresetCriteriaConditionalFormat
   - uid: 'excel!Excel.Interfaces.ConditionalFormatUpdateData:interface'
     name: Interfaces.ConditionalFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.TextConditionalFormat:class'
     name: Excel.TextConditionalFormat

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.conditionalformatcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.conditionalformatcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ConditionalFormatCollection#add:member(1)'
@@ -363,7 +363,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.ConditionalFormatCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -383,7 +383,7 @@ items:
           - 'excel!Excel.Interfaces.ConditionalFormatCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ConditionalFormat:class'
     name: Excel.ConditionalFormat
@@ -395,7 +395,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -423,7 +423,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.ConditionalFormatCollectionData:interface'
     name: Excel.Interfaces.ConditionalFormatCollectionData

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.conditionalformatrule.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.conditionalformatrule.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ConditionalFormatRule#context:member'
@@ -204,7 +204,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ConditionalFormatRule#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -242,7 +242,7 @@ items:
           - 'excel!Excel.Interfaces.ConditionalFormatRuleData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -252,7 +252,7 @@ references:
     name: Excel.Interfaces.ConditionalFormatRuleLoadOptions
   - uid: 'excel!Excel.Interfaces.ConditionalFormatRuleUpdateData:interface'
     name: Interfaces.ConditionalFormatRuleUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ConditionalFormatRuleData:interface'
     name: Excel.Interfaces.ConditionalFormatRuleData

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.conditionalrangeborder.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.conditionalrangeborder.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ConditionalRangeBorder#color:member'
@@ -154,7 +154,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ConditionalRangeBorder#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -228,7 +228,7 @@ items:
           - 'excel!Excel.Interfaces.ConditionalRangeBorderData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -238,7 +238,7 @@ references:
     name: Excel.Interfaces.ConditionalRangeBorderLoadOptions
   - uid: 'excel!Excel.Interfaces.ConditionalRangeBorderUpdateData:interface'
     name: Interfaces.ConditionalRangeBorderUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.ConditionalRangeBorder#sideIndex~0:complex'
     name: Excel.ConditionalRangeBorderIndex | "EdgeTop" | "EdgeBottom" | "EdgeLeft" | "EdgeRight"

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.conditionalrangebordercollection.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.conditionalrangebordercollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ConditionalRangeBorderCollection#bottom:member'
@@ -225,7 +225,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.ConditionalRangeBorderCollection#right:member'
     summary: |-
       Gets the right border. Read-only.
@@ -275,7 +275,7 @@ items:
         type:
           - 'excel!Excel.ConditionalRangeBorder:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ConditionalRangeBorder:class'
     name: Excel.ConditionalRangeBorder
@@ -306,7 +306,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.ConditionalRangeBorderCollectionData:interface'
     name: Excel.Interfaces.ConditionalRangeBorderCollectionData

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.conditionalrangefill.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.conditionalrangefill.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ConditionalRangeFill#clear:member(1)'
@@ -169,7 +169,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ConditionalRangeFill#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -207,7 +207,7 @@ items:
           - 'excel!Excel.Interfaces.ConditionalRangeFillData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -217,7 +217,7 @@ references:
     name: Excel.Interfaces.ConditionalRangeFillLoadOptions
   - uid: 'excel!Excel.Interfaces.ConditionalRangeFillUpdateData:interface'
     name: Interfaces.ConditionalRangeFillUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ConditionalRangeFillData:interface'
     name: Excel.Interfaces.ConditionalRangeFillData

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.conditionalrangefont.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.conditionalrangefont.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ConditionalRangeFont#bold:member'
@@ -201,7 +201,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ConditionalRangeFont#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -269,7 +269,7 @@ items:
         type:
           - 'excel!Excel.ConditionalRangeFont#underline~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -279,7 +279,7 @@ references:
     name: Excel.Interfaces.ConditionalRangeFontLoadOptions
   - uid: 'excel!Excel.Interfaces.ConditionalRangeFontUpdateData:interface'
     name: Interfaces.ConditionalRangeFontUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ConditionalRangeFontData:interface'
     name: Excel.Interfaces.ConditionalRangeFontData

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.conditionalrangeformat.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.conditionalrangeformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ConditionalRangeFormat#borders:member'
@@ -198,7 +198,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ConditionalRangeFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -236,7 +236,7 @@ items:
           - 'excel!Excel.Interfaces.ConditionalRangeFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ConditionalRangeBorderCollection:class'
     name: Excel.ConditionalRangeBorderCollection
@@ -252,7 +252,7 @@ references:
     name: Excel.Interfaces.ConditionalRangeFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ConditionalRangeFormatUpdateData:interface'
     name: Interfaces.ConditionalRangeFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ConditionalRangeFormatData:interface'
     name: Excel.Interfaces.ConditionalRangeFormatData

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.customconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.customconditionalformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.CustomConditionalFormat#context:member'
@@ -214,7 +214,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.CustomConditionalFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -252,7 +252,7 @@ items:
           - 'excel!Excel.Interfaces.CustomConditionalFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -266,7 +266,7 @@ references:
     name: Excel.ConditionalFormatRule
   - uid: 'excel!Excel.Interfaces.CustomConditionalFormatUpdateData:interface'
     name: Interfaces.CustomConditionalFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.CustomConditionalFormatData:interface'
     name: Excel.Interfaces.CustomConditionalFormatData

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.customxmlpart.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.customxmlpart.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.CustomXmlPart#context:member'
@@ -343,7 +343,7 @@ items:
           - 'excel!Excel.Interfaces.CustomXmlPartData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -351,7 +351,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.customxmlpartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.customxmlpartcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.CustomXmlPartCollection#add:member(1)'
@@ -317,7 +317,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.CustomXmlPartCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -337,7 +337,7 @@ items:
           - 'excel!Excel.Interfaces.CustomXmlPartCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.CustomXmlPart:class'
     name: Excel.CustomXmlPart
@@ -349,7 +349,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -377,7 +377,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.CustomXmlPartCollectionData:interface'
     name: Excel.Interfaces.CustomXmlPartCollectionData

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.customxmlpartscopedcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.customxmlpartscopedcollection.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.CustomXmlPartScopedCollection#context:member'
@@ -325,7 +325,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.CustomXmlPartScopedCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -345,7 +345,7 @@ items:
           - 'excel!Excel.Interfaces.CustomXmlPartScopedCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -353,7 +353,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -383,7 +383,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.CustomXmlPartScopedCollectionData:interface'
     name: Excel.Interfaces.CustomXmlPartScopedCollectionData

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.databarconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.databarconditionalformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.DataBarConditionalFormat#axisColor:member'
@@ -259,7 +259,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.DataBarConditionalFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -330,7 +330,7 @@ items:
         type:
           - 'excel!Excel.ConditionalDataBarRule:interface'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.DataBarConditionalFormat#axisFormat~0:complex'
     name: Excel.ConditionalDataBarAxisFormat | "Automatic" | "None" | "CellMidPoint"
@@ -364,7 +364,7 @@ references:
     name: Excel.ConditionalDataBarPositiveFormat
   - uid: 'excel!Excel.Interfaces.DataBarConditionalFormatUpdateData:interface'
     name: Interfaces.DataBarConditionalFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.DataBarConditionalFormatData:interface'
     name: Excel.Interfaces.DataBarConditionalFormatData

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.filter.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.filter.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Filter#apply:member(1)'
@@ -473,7 +473,7 @@ items:
           - 'excel!Excel.Interfaces.FilterData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.FilterCriteria:interface'
     name: Excel.FilterCriteria

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.formatprotection.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.formatprotection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.FormatProtection#context:member'
@@ -170,7 +170,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.FormatProtection#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -208,7 +208,7 @@ items:
           - 'excel!Excel.Interfaces.FormatProtectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -218,7 +218,7 @@ references:
     name: Excel.Interfaces.FormatProtectionLoadOptions
   - uid: 'excel!Excel.Interfaces.FormatProtectionUpdateData:interface'
     name: Interfaces.FormatProtectionUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.FormatProtectionData:interface'
     name: Excel.Interfaces.FormatProtectionData

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.functionresult.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.functionresult.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.FunctionResult#context:member'
@@ -158,7 +158,7 @@ items:
         type:
           - T
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.functions.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.functions.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Functions#abs:member(1)'
@@ -11184,7 +11184,7 @@ items:
           type:
             - 'excel!Excel.Functions#z_Test~3:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Functions#abs~0:complex'
     name: FunctionResult<number>

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.iconsetconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.iconsetconditionalformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.IconSetConditionalFormat#context:member'
@@ -222,7 +222,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.IconSetConditionalFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -345,7 +345,7 @@ items:
           - 'excel!Excel.Interfaces.IconSetConditionalFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -364,7 +364,7 @@ references:
     name: Excel.Interfaces.IconSetConditionalFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.IconSetConditionalFormatUpdateData:interface'
     name: Interfaces.IconSetConditionalFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.IconSetConditionalFormat#style~0:complex'
     name: >-

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.nameditem.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.nameditem.yml
@@ -14,7 +14,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.NamedItem#comment:member'
@@ -317,7 +317,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.NamedItem#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -436,7 +436,7 @@ items:
         type:
           - 'excel!Excel.Worksheet:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -457,7 +457,7 @@ references:
         fullName: ' | "Worksheet" | "Workbook"'
   - uid: 'excel!Excel.Interfaces.NamedItemUpdateData:interface'
     name: Interfaces.NamedItemUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.NamedItemData:interface'
     name: Excel.Interfaces.NamedItemData

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.nameditemcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.nameditemcollection.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.NamedItemCollection#add:member(1)'
@@ -294,7 +294,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.NamedItemCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -314,7 +314,7 @@ items:
           - 'excel!Excel.Interfaces.NamedItemCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.NamedItem:class'
     name: Excel.NamedItem
@@ -333,7 +333,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -361,7 +361,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.NamedItemCollectionData:interface'
     name: Excel.Interfaces.NamedItemCollectionData

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.pivottable.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.pivottable.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PivotTable#context:member'
@@ -186,7 +186,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.PivotTable#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -239,7 +239,7 @@ items:
         type:
           - 'excel!Excel.Worksheet:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -249,7 +249,7 @@ references:
     name: Excel.Interfaces.PivotTableLoadOptions
   - uid: 'excel!Excel.Interfaces.PivotTableUpdateData:interface'
     name: Interfaces.PivotTableUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.PivotTableData:interface'
     name: Excel.Interfaces.PivotTableData

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.pivottablecollection.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.pivottablecollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PivotTableCollection#context:member'
@@ -171,7 +171,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.PivotTableCollection#refreshAll:member(1)'
     summary: |-
       Refreshes all the pivot tables in the collection.
@@ -207,7 +207,7 @@ items:
           - 'excel!Excel.Interfaces.PivotTableCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -215,7 +215,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -245,7 +245,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.PivotTableCollectionData:interface'
     name: Excel.Interfaces.PivotTableCollectionData

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.presetcriteriaconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.presetcriteriaconditionalformat.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PresetCriteriaConditionalFormat#context:member'
@@ -212,7 +212,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.PresetCriteriaConditionalFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -250,7 +250,7 @@ items:
           - 'excel!Excel.Interfaces.PresetCriteriaConditionalFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -264,7 +264,7 @@ references:
     name: Excel.ConditionalPresetCriteriaRule
   - uid: 'excel!Excel.Interfaces.PresetCriteriaConditionalFormatUpdateData:interface'
     name: Interfaces.PresetCriteriaConditionalFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.PresetCriteriaConditionalFormatData:interface'
     name: Excel.Interfaces.PresetCriteriaConditionalFormatData

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.range.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.range.yml
@@ -16,7 +16,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Range#address:member'
@@ -1714,7 +1714,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Range#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -1960,7 +1960,7 @@ items:
         type:
           - 'excel!Excel.Worksheet:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ClearApplyTo:enum'
     name: Excel.ClearApplyTo
@@ -2018,7 +2018,7 @@ references:
         fullName: ' | string'
   - uid: 'excel!Excel.Interfaces.RangeUpdateData:interface'
     name: Interfaces.RangeUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.RangeSort:class'
     name: Excel.RangeSort

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.rangeborder.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.rangeborder.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeBorder#color:member'
@@ -155,7 +155,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.RangeBorder#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -269,7 +269,7 @@ items:
         type:
           - 'excel!Excel.RangeBorder#weight~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -279,7 +279,7 @@ references:
     name: Excel.Interfaces.RangeBorderLoadOptions
   - uid: 'excel!Excel.Interfaces.RangeBorderUpdateData:interface'
     name: Interfaces.RangeBorderUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.RangeBorder#sideIndex~0:complex'
     name: >-

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.rangebordercollection.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.rangebordercollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeBorderCollection#context:member'
@@ -265,7 +265,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.RangeBorderCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -285,7 +285,7 @@ items:
           - 'excel!Excel.Interfaces.RangeBorderCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -316,7 +316,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.RangeBorderCollectionData:interface'
     name: Excel.Interfaces.RangeBorderCollectionData

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.rangefill.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.rangefill.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeFill#clear:member(1)'
@@ -226,7 +226,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.RangeFill#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -264,7 +264,7 @@ items:
           - 'excel!Excel.Interfaces.RangeFillData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -274,7 +274,7 @@ references:
     name: Excel.Interfaces.RangeFillLoadOptions
   - uid: 'excel!Excel.Interfaces.RangeFillUpdateData:interface'
     name: Interfaces.RangeFillUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.RangeFillData:interface'
     name: Excel.Interfaces.RangeFillData

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.rangefont.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.rangefont.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeFont#bold:member'
@@ -237,7 +237,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.RangeFont#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -305,7 +305,7 @@ items:
         type:
           - 'excel!Excel.RangeFont#underline~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -315,7 +315,7 @@ references:
     name: Excel.Interfaces.RangeFontLoadOptions
   - uid: 'excel!Excel.Interfaces.RangeFontUpdateData:interface'
     name: Interfaces.RangeFontUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.RangeFontData:interface'
     name: Excel.Interfaces.RangeFontData

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.rangeformat.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.rangeformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeFormat#adjustIndent:member(1)'
@@ -378,7 +378,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.RangeFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -448,7 +448,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RangeBorderCollection:class'
     name: Excel.RangeBorderCollection
@@ -479,7 +479,7 @@ references:
     name: Excel.FormatProtection
   - uid: 'excel!Excel.Interfaces.RangeFormatUpdateData:interface'
     name: Interfaces.RangeFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.RangeFormatData:interface'
     name: Excel.Interfaces.RangeFormatData

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.rangesort.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.rangesort.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeSort#apply:member(1)'
@@ -135,7 +135,7 @@ items:
                     }
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RangeSort#apply~0:complex'
     name: 'Excel.SortField[]'

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.rangeview.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.rangeview.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeView#cellAddresses:member'
@@ -300,7 +300,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.RangeView#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -387,7 +387,7 @@ items:
         type:
           - 'excel!Excel.RangeView#valueTypes~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -401,7 +401,7 @@ references:
     name: Excel.RangeViewCollection
   - uid: 'excel!Excel.Interfaces.RangeViewUpdateData:interface'
     name: Interfaces.RangeViewUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.RangeViewData:interface'
     name: Excel.Interfaces.RangeViewData

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.rangeviewcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.rangeviewcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeViewCollection#context:member'
@@ -148,7 +148,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.RangeViewCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -168,7 +168,7 @@ items:
           - 'excel!Excel.Interfaces.RangeViewCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -176,7 +176,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -206,7 +206,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.RangeViewCollectionData:interface'
     name: Excel.Interfaces.RangeViewCollectionData

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.requestcontext.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.requestcontext.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientRequestContext:class'
+      - 'office!OfficeExtension.ClientRequestContext:class'
     package: excel!
     children:
       - 'excel!Excel.RequestContext:constructor(1)'
@@ -67,7 +67,7 @@ items:
         type:
           - 'excel!Excel.Workbook:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientRequestContext:class'
+  - uid: 'office!OfficeExtension.ClientRequestContext:class'
     name: OfficeExtension.ClientRequestContext
   - uid: 'excel!Excel.RequestContext~0:complex'
     name: string | Session

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.runoptions.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.runoptions.yml
@@ -34,7 +34,7 @@ references:
     name: OfficeExtension.RunOptions<Session>
     fullName: OfficeExtension.RunOptions<Excel.Session>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.RunOptions:interface'
+      - uid: 'office!OfficeExtension.RunOptions:interface'
         name: OfficeExtension.RunOptions
         fullName: OfficeExtension.RunOptions
       - name: <

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.runtime.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.runtime.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Runtime#context:member'
@@ -134,7 +134,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Runtime#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -172,7 +172,7 @@ items:
           - 'excel!Excel.Interfaces.RuntimeData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -182,7 +182,7 @@ references:
     name: Excel.Interfaces.RuntimeLoadOptions
   - uid: 'excel!Excel.Interfaces.RuntimeUpdateData:interface'
     name: Interfaces.RuntimeUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.RuntimeData:interface'
     name: Excel.Interfaces.RuntimeData

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.setting.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.setting.yml
@@ -15,7 +15,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Setting#context:member'
@@ -200,7 +200,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Setting#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -253,7 +253,7 @@ items:
         type:
           - any
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -263,7 +263,7 @@ references:
     name: Excel.Interfaces.SettingLoadOptions
   - uid: 'excel!Excel.Interfaces.SettingUpdateData:interface'
     name: Interfaces.SettingUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.SettingData:interface'
     name: Excel.Interfaces.SettingData

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.settingcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.settingcollection.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.SettingCollection#add:member(1)'
@@ -246,7 +246,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.SettingCollection#onSettingsChanged:member'
     summary: |-
       Occurs when the Settings in the document are changed.
@@ -301,7 +301,7 @@ items:
           - 'excel!Excel.Interfaces.SettingCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Setting:class'
     name: Excel.Setting
@@ -327,7 +327,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -355,13 +355,13 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.SettingCollection#onSettingsChanged~0:complex'
     name: OfficeExtension.EventHandlers<Excel.SettingsChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.SettingsChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.table.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.table.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Table#clearFilters:member(1)'
@@ -533,7 +533,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Table#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -724,7 +724,7 @@ items:
         type:
           - 'excel!Excel.Worksheet:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.TableColumnCollection:class'
     name: Excel.TableColumnCollection
@@ -740,7 +740,7 @@ references:
     name: Excel.TableRowCollection
   - uid: 'excel!Excel.Interfaces.TableUpdateData:interface'
     name: Interfaces.TableUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.TableSort:class'
     name: Excel.TableSort

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.tablecollection.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.tablecollection.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableCollection#add:member(1)'
@@ -338,7 +338,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.TableCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -358,7 +358,7 @@ items:
           - 'excel!Excel.Interfaces.TableCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Table:class'
     name: Excel.Table
@@ -377,7 +377,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -405,7 +405,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.TableCollectionData:interface'
     name: Excel.Interfaces.TableCollectionData

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.tablecolumn.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.tablecolumn.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableColumn#context:member'
@@ -401,7 +401,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.TableColumn#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -456,7 +456,7 @@ items:
         type:
           - 'any[][]'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -470,7 +470,7 @@ references:
     name: Excel.Interfaces.TableColumnLoadOptions
   - uid: 'excel!Excel.Interfaces.TableColumnUpdateData:interface'
     name: Interfaces.TableColumnUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.TableColumnData:interface'
     name: Excel.Interfaces.TableColumnData

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.tablecolumncollection.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.tablecolumncollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableColumnCollection#add:member(1)'
@@ -322,7 +322,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.TableColumnCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -342,7 +342,7 @@ items:
           - 'excel!Excel.Interfaces.TableColumnCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.TableColumn:class'
     name: Excel.TableColumn
@@ -366,7 +366,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -394,7 +394,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.TableColumnCollectionData:interface'
     name: Excel.Interfaces.TableColumnCollectionData

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.tablerow.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.tablerow.yml
@@ -17,7 +17,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableRow#context:member'
@@ -247,7 +247,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.TableRow#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -302,7 +302,7 @@ items:
         type:
           - 'any[][]'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -314,7 +314,7 @@ references:
     name: Excel.Interfaces.TableRowLoadOptions
   - uid: 'excel!Excel.Interfaces.TableRowUpdateData:interface'
     name: Interfaces.TableRowUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.TableRowData:interface'
     name: Excel.Interfaces.TableRowData

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.tablerowcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.tablerowcollection.yml
@@ -17,7 +17,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableRowCollection#add:member(1)'
@@ -290,7 +290,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.TableRowCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -310,7 +310,7 @@ items:
           - 'excel!Excel.Interfaces.TableRowCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.TableRow:class'
     name: Excel.TableRow
@@ -334,7 +334,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -362,7 +362,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.TableRowCollectionData:interface'
     name: Excel.Interfaces.TableRowCollectionData

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.tablesort.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.tablesort.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableSort#apply:member(1)'
@@ -288,7 +288,7 @@ items:
           - 'excel!Excel.Interfaces.TableSortData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.TableSort#apply~0:complex'
     name: 'Excel.SortField[]'

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.textconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.textconditionalformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TextConditionalFormat#context:member'
@@ -214,7 +214,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.TextConditionalFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -252,7 +252,7 @@ items:
           - 'excel!Excel.Interfaces.TextConditionalFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -266,7 +266,7 @@ references:
     name: Excel.ConditionalTextComparisonRule
   - uid: 'excel!Excel.Interfaces.TextConditionalFormatUpdateData:interface'
     name: Interfaces.TextConditionalFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.TextConditionalFormatData:interface'
     name: Excel.Interfaces.TextConditionalFormatData

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.topbottomconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.topbottomconditionalformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TopBottomConditionalFormat#context:member'
@@ -168,7 +168,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.TopBottomConditionalFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -206,7 +206,7 @@ items:
           - 'excel!Excel.Interfaces.TopBottomConditionalFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -220,7 +220,7 @@ references:
     name: Excel.ConditionalTopBottomRule
   - uid: 'excel!Excel.Interfaces.TopBottomConditionalFormatUpdateData:interface'
     name: Interfaces.TopBottomConditionalFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.TopBottomConditionalFormatData:interface'
     name: Excel.Interfaces.TopBottomConditionalFormatData

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.workbook.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.workbook.yml
@@ -14,7 +14,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Workbook#application:member'
@@ -289,7 +289,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Workbook#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -372,7 +372,7 @@ items:
         type:
           - 'excel!Excel.WorksheetCollection:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Application:class'
     name: Excel.Application
@@ -396,7 +396,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.SelectionChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.SelectionChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -410,7 +410,7 @@ references:
     name: Excel.PivotTableCollection
   - uid: 'excel!Excel.Interfaces.WorkbookUpdateData:interface'
     name: Interfaces.WorkbookUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.SettingCollection:class'
     name: Excel.SettingCollection

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.worksheet.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.worksheet.yml
@@ -14,7 +14,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Worksheet#activate:member(1)'
@@ -765,7 +765,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Worksheet#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -835,7 +835,7 @@ items:
         type:
           - 'excel!Excel.Worksheet#visibility~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartCollection:class'
     name: Excel.ChartCollection
@@ -855,7 +855,7 @@ references:
     name: Excel.WorksheetProtection
   - uid: 'excel!Excel.Interfaces.WorksheetUpdateData:interface'
     name: Interfaces.WorksheetUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.TableCollection:class'
     name: Excel.TableCollection

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.worksheetcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.worksheetcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.WorksheetCollection#add:member(1)'
@@ -393,7 +393,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.WorksheetCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -413,7 +413,7 @@ items:
           - 'excel!Excel.Interfaces.WorksheetCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Worksheet:class'
     name: Excel.Worksheet
@@ -423,7 +423,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -451,7 +451,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.WorksheetCollectionData:interface'
     name: Excel.Interfaces.WorksheetCollectionData

--- a/docs/docs-ref-autogen/excel_1_6/excel/excel.worksheetprotection.yml
+++ b/docs/docs-ref-autogen/excel_1_6/excel/excel.worksheetprotection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.WorksheetProtection#context:member'
@@ -226,7 +226,7 @@ items:
           - 'excel!Excel.Interfaces.WorksheetProtectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel_1_7/excel.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel.yml
@@ -714,7 +714,7 @@ items:
             A previously-created API object. The batch will use the same RequestContext as the passed-in object, which
             means that any changes applied to the object will be picked up by "context.sync()".
           type:
-            - 'excel!OfficeExtension.ClientObject:class'
+            - 'office!OfficeExtension.ClientObject:class'
         - id: batch
           description: >-
             A function that takes in a RequestContext and returns a promise (typically, just the result of
@@ -819,7 +819,7 @@ items:
             A previously-created object. The batch will use the same RequestContext as the passed-in object, which means
             that any changes applied to the object will be picked up by "context.sync()".
           type:
-            - 'excel!OfficeExtension.ClientRequestContext:class'
+            - 'office!OfficeExtension.ClientRequestContext:class'
         - id: batch
           description: >-
             A function that takes in a RequestContext and returns a promise (typically, just the result of
@@ -1987,7 +1987,7 @@ references:
         fullName: Promise
       - name: <T>
         fullName: <T>
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.run~3:complex'
     name: '(context: Excel.RequestContext) => Promise<T>'
@@ -2018,7 +2018,7 @@ references:
     name: 'OfficeExtension.ClientObject[]'
     fullName: 'OfficeExtension.ClientObject[]'
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientObject:class'
+      - uid: 'office!OfficeExtension.ClientObject:class'
         name: OfficeExtension.ClientObject
         fullName: OfficeExtension.ClientObject
       - name: '[]'
@@ -2075,7 +2075,7 @@ references:
         fullName: Promise
       - name: <T>
         fullName: <T>
-  - uid: 'excel!OfficeExtension.ClientRequestContext:class'
+  - uid: 'office!OfficeExtension.ClientRequestContext:class'
     name: OfficeExtension.ClientRequestContext
   - uid: 'excel!Excel.run~10:complex'
     name: '(context: Excel.RequestContext) => Promise<T>'

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.application.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.application.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Application#calculate:member(1)'
@@ -233,7 +233,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Application#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -289,7 +289,7 @@ items:
           - 'excel!Excel.Interfaces.ApplicationData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.CalculationType:enum'
     name: Excel.CalculationType
@@ -310,7 +310,7 @@ references:
     name: Excel.Interfaces.ApplicationLoadOptions
   - uid: 'excel!Excel.Interfaces.ApplicationUpdateData:interface'
     name: Interfaces.ApplicationUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ApplicationData:interface'
     name: Excel.Interfaces.ApplicationData

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.binding.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.binding.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Binding#context:member'
@@ -357,7 +357,7 @@ items:
         type:
           - 'excel!Excel.Binding#type~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -369,7 +369,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -382,7 +382,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.BindingDataChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.BindingDataChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -396,7 +396,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.BindingSelectionChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.BindingSelectionChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.bindingcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.bindingcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.BindingCollection#add:member(1)'
@@ -493,7 +493,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.BindingCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -513,7 +513,7 @@ items:
           - 'excel!Excel.Interfaces.BindingCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Binding:class'
     name: Excel.Binding
@@ -543,7 +543,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -571,7 +571,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.BindingCollectionData:interface'
     name: Excel.Interfaces.BindingCollectionData

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.cellvalueconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.cellvalueconditionalformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.CellValueConditionalFormat#context:member'
@@ -212,7 +212,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.CellValueConditionalFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -250,7 +250,7 @@ items:
           - 'excel!Excel.Interfaces.CellValueConditionalFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -264,7 +264,7 @@ references:
     name: Excel.ConditionalCellValueRule
   - uid: 'excel!Excel.Interfaces.CellValueConditionalFormatUpdateData:interface'
     name: Interfaces.CellValueConditionalFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.CellValueConditionalFormatData:interface'
     name: Excel.Interfaces.CellValueConditionalFormatData

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.chart.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.chart.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Chart#axes:member'
@@ -503,7 +503,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Chart#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -743,7 +743,7 @@ items:
         type:
           - 'excel!Excel.Worksheet:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartAxes:class'
     name: Excel.ChartAxes
@@ -794,7 +794,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -805,7 +805,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -820,7 +820,7 @@ references:
     name: Excel.ChartSeriesCollection
   - uid: 'excel!Excel.Interfaces.ChartUpdateData:interface'
     name: Interfaces.ChartUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Range:class'
     name: Range

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.chartareaformat.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.chartareaformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAreaFormat#border:member'
@@ -182,7 +182,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAreaFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -220,7 +220,7 @@ items:
           - 'excel!Excel.Interfaces.ChartAreaFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartBorder:class'
     name: Excel.ChartBorder
@@ -236,7 +236,7 @@ references:
     name: Excel.Interfaces.ChartAreaFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartAreaFormatUpdateData:interface'
     name: Interfaces.ChartAreaFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartAreaFormatData:interface'
     name: Excel.Interfaces.ChartAreaFormatData

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.chartaxes.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.chartaxes.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAxes#categoryAxis:member'
@@ -221,7 +221,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAxes#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -297,7 +297,7 @@ items:
           });
           ```
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartAxis:class'
     name: Excel.ChartAxis
@@ -313,7 +313,7 @@ references:
     name: Excel.Interfaces.ChartAxesLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartAxesUpdateData:interface'
     name: Interfaces.ChartAxesUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartAxesData:interface'
     name: Excel.Interfaces.ChartAxesData

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.chartaxis.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.chartaxis.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAxis#axisGroup:member'
@@ -546,7 +546,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAxis#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -790,7 +790,7 @@ items:
         type:
           - number
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartAxis#axisGroup~0:complex'
     name: Excel.ChartAxisGroup | "Primary" | "Secondary"
@@ -889,7 +889,7 @@ references:
         fullName: ' | "Linear" | "Logarithmic"'
   - uid: 'excel!Excel.Interfaces.ChartAxisUpdateData:interface'
     name: Interfaces.ChartAxisUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Range:class'
     name: Range

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.chartaxisformat.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.chartaxisformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAxisFormat#context:member'
@@ -166,7 +166,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAxisFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -204,7 +204,7 @@ items:
           - 'excel!Excel.Interfaces.ChartAxisFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -218,7 +218,7 @@ references:
     name: Excel.Interfaces.ChartAxisFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisFormatUpdateData:interface'
     name: Interfaces.ChartAxisFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisFormatData:interface'
     name: Excel.Interfaces.ChartAxisFormatData

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.chartaxistitle.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.chartaxistitle.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAxisTitle#context:member'
@@ -171,7 +171,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAxisTitle#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -239,7 +239,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -251,7 +251,7 @@ references:
     name: Excel.Interfaces.ChartAxisTitleLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisTitleUpdateData:interface'
     name: Interfaces.ChartAxisTitleUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisTitleData:interface'
     name: Excel.Interfaces.ChartAxisTitleData

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.chartaxistitleformat.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.chartaxistitleformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAxisTitleFormat#context:member'
@@ -150,7 +150,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAxisTitleFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -188,7 +188,7 @@ items:
           - 'excel!Excel.Interfaces.ChartAxisTitleFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -200,7 +200,7 @@ references:
     name: Excel.Interfaces.ChartAxisTitleFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisTitleFormatUpdateData:interface'
     name: Interfaces.ChartAxisTitleFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisTitleFormatData:interface'
     name: Excel.Interfaces.ChartAxisTitleFormatData

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.chartborder.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.chartborder.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartBorder#color:member'
@@ -169,7 +169,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartBorder#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -222,7 +222,7 @@ items:
         type:
           - number
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -245,7 +245,7 @@ references:
     name: Excel.Interfaces.ChartBorderLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartBorderUpdateData:interface'
     name: Interfaces.ChartBorderUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartBorderData:interface'
     name: Excel.Interfaces.ChartBorderData

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.chartcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartCollection#add:member(1)'
@@ -383,7 +383,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.ChartCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -403,7 +403,7 @@ items:
           - 'excel!Excel.Interfaces.ChartCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Chart:class'
     name: Excel.Chart
@@ -419,7 +419,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -447,7 +447,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.ChartCollectionData:interface'
     name: Excel.Interfaces.ChartCollectionData

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.chartdatalabel.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.chartdatalabel.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartDataLabel#context:member'
@@ -176,7 +176,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartDataLabel#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -304,7 +304,7 @@ items:
           - 'excel!Excel.Interfaces.ChartDataLabelData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -327,7 +327,7 @@ references:
         fullName: ' | "Invalid" | "None" | "Center" | "InsideEnd" | "InsideBase" | "OutsideEnd" | "Left" | "Right" | "Top" | "Bottom" | "BestFit" | "Callout"'
   - uid: 'excel!Excel.Interfaces.ChartDataLabelUpdateData:interface'
     name: Interfaces.ChartDataLabelUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartDataLabelData:interface'
     name: Excel.Interfaces.ChartDataLabelData

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.chartdatalabelformat.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.chartdatalabelformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartDataLabelFormat#context:member'
@@ -166,7 +166,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartDataLabelFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -204,7 +204,7 @@ items:
           - 'excel!Excel.Interfaces.ChartDataLabelFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -218,7 +218,7 @@ references:
     name: Excel.Interfaces.ChartDataLabelFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartDataLabelFormatUpdateData:interface'
     name: Interfaces.ChartDataLabelFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartDataLabelFormatData:interface'
     name: Excel.Interfaces.ChartDataLabelFormatData

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.chartdatalabels.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.chartdatalabels.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartDataLabels#context:member'
@@ -213,7 +213,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartDataLabels#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -341,7 +341,7 @@ items:
           - 'excel!Excel.Interfaces.ChartDataLabelsData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -366,7 +366,7 @@ references:
         fullName: ' | "Invalid" | "None" | "Center" | "InsideEnd" | "InsideBase" | "OutsideEnd" | "Left" | "Right" | "Top" | "Bottom" | "BestFit" | "Callout"'
   - uid: 'excel!Excel.Interfaces.ChartDataLabelsUpdateData:interface'
     name: Interfaces.ChartDataLabelsUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartDataLabelsData:interface'
     name: Excel.Interfaces.ChartDataLabelsData

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.chartfill.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.chartfill.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartFill#clear:member(1)'
@@ -138,7 +138,7 @@ items:
                     }
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.chartfont.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.chartfont.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     remarks: |-
 
@@ -223,7 +223,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartFont#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -291,7 +291,7 @@ items:
         type:
           - 'excel!Excel.ChartFont#underline~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -301,7 +301,7 @@ references:
     name: Excel.Interfaces.ChartFontLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartFontUpdateData:interface'
     name: Interfaces.ChartFontUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartFontData:interface'
     name: Excel.Interfaces.ChartFontData

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.chartformatstring.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.chartformatstring.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartFormatString#context:member'
@@ -152,7 +152,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartFormatString#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -190,7 +190,7 @@ items:
           - 'excel!Excel.Interfaces.ChartFormatStringData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -202,7 +202,7 @@ references:
     name: Excel.Interfaces.ChartFormatStringLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartFormatStringUpdateData:interface'
     name: Interfaces.ChartFormatStringUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartFormatStringData:interface'
     name: Excel.Interfaces.ChartFormatStringData

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.chartgridlines.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.chartgridlines.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartGridlines#context:member'
@@ -170,7 +170,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartGridlines#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -223,7 +223,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -235,7 +235,7 @@ references:
     name: Excel.Interfaces.ChartGridlinesLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartGridlinesUpdateData:interface'
     name: Interfaces.ChartGridlinesUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartGridlinesData:interface'
     name: Excel.Interfaces.ChartGridlinesData

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.chartgridlinesformat.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.chartgridlinesformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartGridlinesFormat#context:member'
@@ -150,7 +150,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartGridlinesFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -188,7 +188,7 @@ items:
           - 'excel!Excel.Interfaces.ChartGridlinesFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -200,7 +200,7 @@ references:
     name: Excel.Interfaces.ChartGridlinesFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartGridlinesFormatUpdateData:interface'
     name: Interfaces.ChartGridlinesFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartGridlinesFormatData:interface'
     name: Excel.Interfaces.ChartGridlinesFormatData

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.chartlegend.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.chartlegend.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartLegend#context:member'
@@ -254,7 +254,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartLegend#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -352,7 +352,7 @@ items:
         type:
           - number
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -375,7 +375,7 @@ references:
         fullName: ' | "Invalid" | "Top" | "Bottom" | "Left" | "Right" | "Corner" | "Custom"'
   - uid: 'excel!Excel.Interfaces.ChartLegendUpdateData:interface'
     name: Interfaces.ChartLegendUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartLegendData:interface'
     name: Excel.Interfaces.ChartLegendData

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.chartlegendentry.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.chartlegendentry.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartLegendEntry#context:member'
@@ -135,7 +135,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartLegendEntry#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -188,7 +188,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -198,7 +198,7 @@ references:
     name: Excel.Interfaces.ChartLegendEntryLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartLegendEntryUpdateData:interface'
     name: Interfaces.ChartLegendEntryUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartLegendEntryData:interface'
     name: Excel.Interfaces.ChartLegendEntryData

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.chartlegendentrycollection.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.chartlegendentrycollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartLegendEntryCollection#context:member'
@@ -148,7 +148,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.ChartLegendEntryCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -168,7 +168,7 @@ items:
           - 'excel!Excel.Interfaces.ChartLegendEntryCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -176,7 +176,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -206,7 +206,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.ChartLegendEntryCollectionData:interface'
     name: Excel.Interfaces.ChartLegendEntryCollectionData

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.chartlegendformat.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.chartlegendformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartLegendFormat#context:member'
@@ -196,7 +196,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartLegendFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -234,7 +234,7 @@ items:
           - 'excel!Excel.Interfaces.ChartLegendFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -248,7 +248,7 @@ references:
     name: Excel.Interfaces.ChartLegendFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartLegendFormatUpdateData:interface'
     name: Interfaces.ChartLegendFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartLegendFormatData:interface'
     name: Excel.Interfaces.ChartLegendFormatData

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.chartlineformat.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.chartlineformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartLineFormat#clear:member(1)'
@@ -224,7 +224,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartLineFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -277,7 +277,7 @@ items:
         type:
           - number
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -300,7 +300,7 @@ references:
     name: Excel.Interfaces.ChartLineFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartLineFormatUpdateData:interface'
     name: Interfaces.ChartLineFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartLineFormatData:interface'
     name: Excel.Interfaces.ChartLineFormatData

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.chartpoint.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.chartpoint.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartPoint#context:member'
@@ -249,7 +249,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartPoint#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -302,7 +302,7 @@ items:
         type:
           - any
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -329,7 +329,7 @@ references:
         fullName: ' | "Invalid" | "Automatic" | "None" | "Square" | "Diamond" | "Triangle" | "X" | "Star" | "Dot" | "Dash" | "Circle" | "Plus" | "Picture"'
   - uid: 'excel!Excel.Interfaces.ChartPointUpdateData:interface'
     name: Interfaces.ChartPointUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartPointData:interface'
     name: Excel.Interfaces.ChartPointData

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.chartpointformat.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.chartpointformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartPointFormat#border:member'
@@ -168,7 +168,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartPointFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -206,7 +206,7 @@ items:
           - 'excel!Excel.Interfaces.ChartPointFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartBorder:class'
     name: Excel.ChartBorder
@@ -220,7 +220,7 @@ references:
     name: Excel.Interfaces.ChartPointFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartPointFormatUpdateData:interface'
     name: Interfaces.ChartPointFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartPointFormatData:interface'
     name: Excel.Interfaces.ChartPointFormatData

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.chartpointscollection.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.chartpointscollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartPointsCollection#context:member'
@@ -219,7 +219,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.ChartPointsCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -239,7 +239,7 @@ items:
           - 'excel!Excel.Interfaces.ChartPointsCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -247,7 +247,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -277,7 +277,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.ChartPointsCollectionData:interface'
     name: Excel.Interfaces.ChartPointsCollectionData

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.chartseries.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.chartseries.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartSeries#chartType:member'
@@ -591,7 +591,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartSeries#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -763,7 +763,7 @@ items:
         type:
           - 'excel!Excel.ChartTrendlineCollection:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartSeries#chartType~0:complex'
     name: >-
@@ -827,7 +827,7 @@ references:
     name: Excel.ChartPointsCollection
   - uid: 'excel!Excel.Interfaces.ChartSeriesUpdateData:interface'
     name: Interfaces.ChartSeriesUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Range:class'
     name: Range

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.chartseriescollection.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.chartseriescollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartSeriesCollection#add:member(1)'
@@ -248,7 +248,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.ChartSeriesCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -268,7 +268,7 @@ items:
           - 'excel!Excel.Interfaces.ChartSeriesCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartSeries:class'
     name: Excel.ChartSeries
@@ -278,7 +278,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -306,7 +306,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.ChartSeriesCollectionData:interface'
     name: Excel.Interfaces.ChartSeriesCollectionData

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.chartseriesformat.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.chartseriesformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartSeriesFormat#context:member'
@@ -166,7 +166,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartSeriesFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -204,7 +204,7 @@ items:
           - 'excel!Excel.Interfaces.ChartSeriesFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -218,7 +218,7 @@ references:
     name: Excel.Interfaces.ChartSeriesFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartSeriesFormatUpdateData:interface'
     name: Interfaces.ChartSeriesFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartSeriesFormatData:interface'
     name: Excel.Interfaces.ChartSeriesFormatData

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.charttitle.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.charttitle.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartTitle#context:member'
@@ -328,7 +328,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartTitle#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -516,7 +516,7 @@ items:
         type:
           - number
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -548,7 +548,7 @@ references:
         fullName: ' | "Automatic" | "Top" | "Bottom" | "Left" | "Right"'
   - uid: 'excel!Excel.Interfaces.ChartTitleUpdateData:interface'
     name: Interfaces.ChartTitleUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartTitleData:interface'
     name: Excel.Interfaces.ChartTitleData

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.charttitleformat.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.charttitleformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartTitleFormat#border:member'
@@ -182,7 +182,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartTitleFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -220,7 +220,7 @@ items:
           - 'excel!Excel.Interfaces.ChartTitleFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartBorder:class'
     name: Excel.ChartBorder
@@ -236,7 +236,7 @@ references:
     name: Excel.Interfaces.ChartTitleFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartTitleFormatUpdateData:interface'
     name: Interfaces.ChartTitleFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartTitleFormatData:interface'
     name: Excel.Interfaces.ChartTitleFormatData

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.charttrendline.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.charttrendline.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartTrendline#context:member'
@@ -236,7 +236,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartTrendline#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -317,7 +317,7 @@ items:
 
           ```
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -329,7 +329,7 @@ references:
     name: Excel.Interfaces.ChartTrendlineLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartTrendlineUpdateData:interface'
     name: Interfaces.ChartTrendlineUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartTrendlineData:interface'
     name: Excel.Interfaces.ChartTrendlineData

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.charttrendlinecollection.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.charttrendlinecollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartTrendlineCollection#add:member(1)'
@@ -216,7 +216,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.ChartTrendlineCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -236,7 +236,7 @@ items:
           - 'excel!Excel.Interfaces.ChartTrendlineCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartTrendline:class'
     name: Excel.ChartTrendline
@@ -248,7 +248,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -276,7 +276,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.ChartTrendlineCollectionData:interface'
     name: Excel.Interfaces.ChartTrendlineCollectionData

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.charttrendlineformat.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.charttrendlineformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartTrendlineFormat#context:member'
@@ -199,7 +199,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartTrendlineFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -237,7 +237,7 @@ items:
           - 'excel!Excel.Interfaces.ChartTrendlineFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -249,7 +249,7 @@ references:
     name: Excel.Interfaces.ChartTrendlineFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartTrendlineFormatUpdateData:interface'
     name: Interfaces.ChartTrendlineFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartTrendlineFormatData:interface'
     name: Excel.Interfaces.ChartTrendlineFormatData

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.colorscaleconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.colorscaleconditionalformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ColorScaleConditionalFormat#context:member'
@@ -180,7 +180,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ColorScaleConditionalFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -235,7 +235,7 @@ items:
           - 'excel!Excel.Interfaces.ColorScaleConditionalFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -247,7 +247,7 @@ references:
     name: Excel.Interfaces.ColorScaleConditionalFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ColorScaleConditionalFormatUpdateData:interface'
     name: Interfaces.ColorScaleConditionalFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ColorScaleConditionalFormatData:interface'
     name: Excel.Interfaces.ColorScaleConditionalFormatData

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.conditionaldatabarnegativeformat.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.conditionaldatabarnegativeformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ConditionalDataBarNegativeFormat#borderColor:member'
@@ -206,7 +206,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ConditionalDataBarNegativeFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -244,7 +244,7 @@ items:
           - 'excel!Excel.Interfaces.ConditionalDataBarNegativeFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -254,7 +254,7 @@ references:
     name: Excel.Interfaces.ConditionalDataBarNegativeFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ConditionalDataBarNegativeFormatUpdateData:interface'
     name: Interfaces.ConditionalDataBarNegativeFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ConditionalDataBarNegativeFormatData:interface'
     name: Excel.Interfaces.ConditionalDataBarNegativeFormatData

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.conditionaldatabarpositiveformat.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.conditionaldatabarpositiveformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ConditionalDataBarPositiveFormat#borderColor:member'
@@ -190,7 +190,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ConditionalDataBarPositiveFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -228,7 +228,7 @@ items:
           - 'excel!Excel.Interfaces.ConditionalDataBarPositiveFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -238,7 +238,7 @@ references:
     name: Excel.Interfaces.ConditionalDataBarPositiveFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ConditionalDataBarPositiveFormatUpdateData:interface'
     name: Interfaces.ConditionalDataBarPositiveFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ConditionalDataBarPositiveFormatData:interface'
     name: Excel.Interfaces.ConditionalDataBarPositiveFormatData

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.conditionalformat.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.conditionalformat.yml
@@ -14,7 +14,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ConditionalFormat#cellValue:member'
@@ -640,7 +640,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ConditionalFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -841,7 +841,7 @@ items:
 
           ```
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.CellValueConditionalFormat:class'
     name: Excel.CellValueConditionalFormat
@@ -865,7 +865,7 @@ references:
     name: Excel.PresetCriteriaConditionalFormat
   - uid: 'excel!Excel.Interfaces.ConditionalFormatUpdateData:interface'
     name: Interfaces.ConditionalFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.TextConditionalFormat:class'
     name: Excel.TextConditionalFormat

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.conditionalformatcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.conditionalformatcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ConditionalFormatCollection#add:member(1)'
@@ -363,7 +363,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.ConditionalFormatCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -383,7 +383,7 @@ items:
           - 'excel!Excel.Interfaces.ConditionalFormatCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ConditionalFormat:class'
     name: Excel.ConditionalFormat
@@ -395,7 +395,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -423,7 +423,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.ConditionalFormatCollectionData:interface'
     name: Excel.Interfaces.ConditionalFormatCollectionData

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.conditionalformatrule.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.conditionalformatrule.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ConditionalFormatRule#context:member'
@@ -204,7 +204,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ConditionalFormatRule#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -242,7 +242,7 @@ items:
           - 'excel!Excel.Interfaces.ConditionalFormatRuleData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -252,7 +252,7 @@ references:
     name: Excel.Interfaces.ConditionalFormatRuleLoadOptions
   - uid: 'excel!Excel.Interfaces.ConditionalFormatRuleUpdateData:interface'
     name: Interfaces.ConditionalFormatRuleUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ConditionalFormatRuleData:interface'
     name: Excel.Interfaces.ConditionalFormatRuleData

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.conditionalrangeborder.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.conditionalrangeborder.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ConditionalRangeBorder#color:member'
@@ -154,7 +154,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ConditionalRangeBorder#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -228,7 +228,7 @@ items:
           - 'excel!Excel.Interfaces.ConditionalRangeBorderData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -238,7 +238,7 @@ references:
     name: Excel.Interfaces.ConditionalRangeBorderLoadOptions
   - uid: 'excel!Excel.Interfaces.ConditionalRangeBorderUpdateData:interface'
     name: Interfaces.ConditionalRangeBorderUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.ConditionalRangeBorder#sideIndex~0:complex'
     name: Excel.ConditionalRangeBorderIndex | "EdgeTop" | "EdgeBottom" | "EdgeLeft" | "EdgeRight"

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.conditionalrangebordercollection.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.conditionalrangebordercollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ConditionalRangeBorderCollection#bottom:member'
@@ -225,7 +225,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.ConditionalRangeBorderCollection#right:member'
     summary: |-
       Gets the right border. Read-only.
@@ -275,7 +275,7 @@ items:
         type:
           - 'excel!Excel.ConditionalRangeBorder:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ConditionalRangeBorder:class'
     name: Excel.ConditionalRangeBorder
@@ -306,7 +306,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.ConditionalRangeBorderCollectionData:interface'
     name: Excel.Interfaces.ConditionalRangeBorderCollectionData

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.conditionalrangefill.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.conditionalrangefill.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ConditionalRangeFill#clear:member(1)'
@@ -169,7 +169,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ConditionalRangeFill#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -207,7 +207,7 @@ items:
           - 'excel!Excel.Interfaces.ConditionalRangeFillData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -217,7 +217,7 @@ references:
     name: Excel.Interfaces.ConditionalRangeFillLoadOptions
   - uid: 'excel!Excel.Interfaces.ConditionalRangeFillUpdateData:interface'
     name: Interfaces.ConditionalRangeFillUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ConditionalRangeFillData:interface'
     name: Excel.Interfaces.ConditionalRangeFillData

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.conditionalrangefont.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.conditionalrangefont.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ConditionalRangeFont#bold:member'
@@ -201,7 +201,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ConditionalRangeFont#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -269,7 +269,7 @@ items:
         type:
           - 'excel!Excel.ConditionalRangeFont#underline~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -279,7 +279,7 @@ references:
     name: Excel.Interfaces.ConditionalRangeFontLoadOptions
   - uid: 'excel!Excel.Interfaces.ConditionalRangeFontUpdateData:interface'
     name: Interfaces.ConditionalRangeFontUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ConditionalRangeFontData:interface'
     name: Excel.Interfaces.ConditionalRangeFontData

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.conditionalrangeformat.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.conditionalrangeformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ConditionalRangeFormat#borders:member'
@@ -198,7 +198,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ConditionalRangeFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -236,7 +236,7 @@ items:
           - 'excel!Excel.Interfaces.ConditionalRangeFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ConditionalRangeBorderCollection:class'
     name: Excel.ConditionalRangeBorderCollection
@@ -252,7 +252,7 @@ references:
     name: Excel.Interfaces.ConditionalRangeFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ConditionalRangeFormatUpdateData:interface'
     name: Interfaces.ConditionalRangeFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ConditionalRangeFormatData:interface'
     name: Excel.Interfaces.ConditionalRangeFormatData

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.customconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.customconditionalformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.CustomConditionalFormat#context:member'
@@ -214,7 +214,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.CustomConditionalFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -252,7 +252,7 @@ items:
           - 'excel!Excel.Interfaces.CustomConditionalFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -266,7 +266,7 @@ references:
     name: Excel.ConditionalFormatRule
   - uid: 'excel!Excel.Interfaces.CustomConditionalFormatUpdateData:interface'
     name: Interfaces.CustomConditionalFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.CustomConditionalFormatData:interface'
     name: Excel.Interfaces.CustomConditionalFormatData

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.customproperty.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.customproperty.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.CustomProperty#context:member'
@@ -169,7 +169,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.CustomProperty#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -237,7 +237,7 @@ items:
         type:
           - any
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -247,7 +247,7 @@ references:
     name: Excel.Interfaces.CustomPropertyLoadOptions
   - uid: 'excel!Excel.Interfaces.CustomPropertyUpdateData:interface'
     name: Interfaces.CustomPropertyUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.CustomPropertyData:interface'
     name: Excel.Interfaces.CustomPropertyData

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.custompropertycollection.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.custompropertycollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.CustomPropertyCollection#add:member(1)'
@@ -215,7 +215,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.CustomPropertyCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -235,7 +235,7 @@ items:
           - 'excel!Excel.Interfaces.CustomPropertyCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.CustomProperty:class'
     name: Excel.CustomProperty
@@ -245,7 +245,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -273,7 +273,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.CustomPropertyCollectionData:interface'
     name: Excel.Interfaces.CustomPropertyCollectionData

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.customxmlpart.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.customxmlpart.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.CustomXmlPart#context:member'
@@ -343,7 +343,7 @@ items:
           - 'excel!Excel.Interfaces.CustomXmlPartData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -351,7 +351,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.customxmlpartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.customxmlpartcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.CustomXmlPartCollection#add:member(1)'
@@ -317,7 +317,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.CustomXmlPartCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -337,7 +337,7 @@ items:
           - 'excel!Excel.Interfaces.CustomXmlPartCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.CustomXmlPart:class'
     name: Excel.CustomXmlPart
@@ -349,7 +349,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -377,7 +377,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.CustomXmlPartCollectionData:interface'
     name: Excel.Interfaces.CustomXmlPartCollectionData

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.customxmlpartscopedcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.customxmlpartscopedcollection.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.CustomXmlPartScopedCollection#context:member'
@@ -325,7 +325,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.CustomXmlPartScopedCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -345,7 +345,7 @@ items:
           - 'excel!Excel.Interfaces.CustomXmlPartScopedCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -353,7 +353,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -383,7 +383,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.CustomXmlPartScopedCollectionData:interface'
     name: Excel.Interfaces.CustomXmlPartScopedCollectionData

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.databarconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.databarconditionalformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.DataBarConditionalFormat#axisColor:member'
@@ -259,7 +259,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.DataBarConditionalFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -330,7 +330,7 @@ items:
         type:
           - 'excel!Excel.ConditionalDataBarRule:interface'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.DataBarConditionalFormat#axisFormat~0:complex'
     name: Excel.ConditionalDataBarAxisFormat | "Automatic" | "None" | "CellMidPoint"
@@ -364,7 +364,7 @@ references:
     name: Excel.ConditionalDataBarPositiveFormat
   - uid: 'excel!Excel.Interfaces.DataBarConditionalFormatUpdateData:interface'
     name: Interfaces.DataBarConditionalFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.DataBarConditionalFormatData:interface'
     name: Excel.Interfaces.DataBarConditionalFormatData

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.dataconnectioncollection.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.dataconnectioncollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.DataConnectionCollection#context:member'
@@ -72,7 +72,7 @@ items:
                     }
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.documentproperties.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.documentproperties.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.DocumentProperties#author:member'
@@ -296,7 +296,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.DocumentProperties#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -364,7 +364,7 @@ items:
           - 'excel!Excel.Interfaces.DocumentPropertiesData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -378,7 +378,7 @@ references:
     name: Excel.Interfaces.DocumentPropertiesLoadOptions
   - uid: 'excel!Excel.Interfaces.DocumentPropertiesUpdateData:interface'
     name: Interfaces.DocumentPropertiesUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.DocumentPropertiesData:interface'
     name: Excel.Interfaces.DocumentPropertiesData

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.filter.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.filter.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Filter#apply:member(1)'
@@ -473,7 +473,7 @@ items:
           - 'excel!Excel.Interfaces.FilterData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.FilterCriteria:interface'
     name: Excel.FilterCriteria

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.formatprotection.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.formatprotection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.FormatProtection#context:member'
@@ -170,7 +170,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.FormatProtection#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -208,7 +208,7 @@ items:
           - 'excel!Excel.Interfaces.FormatProtectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -218,7 +218,7 @@ references:
     name: Excel.Interfaces.FormatProtectionLoadOptions
   - uid: 'excel!Excel.Interfaces.FormatProtectionUpdateData:interface'
     name: Interfaces.FormatProtectionUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.FormatProtectionData:interface'
     name: Excel.Interfaces.FormatProtectionData

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.functionresult.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.functionresult.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.FunctionResult#context:member'
@@ -158,7 +158,7 @@ items:
         type:
           - T
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.functions.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.functions.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Functions#abs:member(1)'
@@ -11184,7 +11184,7 @@ items:
           type:
             - 'excel!Excel.Functions#z_Test~3:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Functions#abs~0:complex'
     name: FunctionResult<number>

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.iconsetconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.iconsetconditionalformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.IconSetConditionalFormat#context:member'
@@ -222,7 +222,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.IconSetConditionalFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -345,7 +345,7 @@ items:
           - 'excel!Excel.Interfaces.IconSetConditionalFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -364,7 +364,7 @@ references:
     name: Excel.Interfaces.IconSetConditionalFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.IconSetConditionalFormatUpdateData:interface'
     name: Interfaces.IconSetConditionalFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.IconSetConditionalFormat#style~0:complex'
     name: >-

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.nameditem.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.nameditem.yml
@@ -14,7 +14,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.NamedItem#arrayValues:member'
@@ -381,7 +381,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.NamedItem#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -500,7 +500,7 @@ items:
         type:
           - 'excel!Excel.Worksheet:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.NamedItemArrayValues:class'
     name: Excel.NamedItemArrayValues
@@ -523,7 +523,7 @@ references:
         fullName: ' | "Worksheet" | "Workbook"'
   - uid: 'excel!Excel.Interfaces.NamedItemUpdateData:interface'
     name: Interfaces.NamedItemUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.NamedItemData:interface'
     name: Excel.Interfaces.NamedItemData

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.nameditemarrayvalues.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.nameditemarrayvalues.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.NamedItemArrayValues#context:member'
@@ -154,7 +154,7 @@ items:
         type:
           - 'any[][]'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.nameditemcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.nameditemcollection.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.NamedItemCollection#add:member(1)'
@@ -294,7 +294,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.NamedItemCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -314,7 +314,7 @@ items:
           - 'excel!Excel.Interfaces.NamedItemCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.NamedItem:class'
     name: Excel.NamedItem
@@ -333,7 +333,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -361,7 +361,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.NamedItemCollectionData:interface'
     name: Excel.Interfaces.NamedItemCollectionData

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.pivottable.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.pivottable.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PivotTable#context:member'
@@ -186,7 +186,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.PivotTable#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -239,7 +239,7 @@ items:
         type:
           - 'excel!Excel.Worksheet:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -249,7 +249,7 @@ references:
     name: Excel.Interfaces.PivotTableLoadOptions
   - uid: 'excel!Excel.Interfaces.PivotTableUpdateData:interface'
     name: Interfaces.PivotTableUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.PivotTableData:interface'
     name: Excel.Interfaces.PivotTableData

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.pivottablecollection.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.pivottablecollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PivotTableCollection#context:member'
@@ -171,7 +171,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.PivotTableCollection#refreshAll:member(1)'
     summary: |-
       Refreshes all the pivot tables in the collection.
@@ -207,7 +207,7 @@ items:
           - 'excel!Excel.Interfaces.PivotTableCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -215,7 +215,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -245,7 +245,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.PivotTableCollectionData:interface'
     name: Excel.Interfaces.PivotTableCollectionData

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.presetcriteriaconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.presetcriteriaconditionalformat.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PresetCriteriaConditionalFormat#context:member'
@@ -212,7 +212,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.PresetCriteriaConditionalFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -250,7 +250,7 @@ items:
           - 'excel!Excel.Interfaces.PresetCriteriaConditionalFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -264,7 +264,7 @@ references:
     name: Excel.ConditionalPresetCriteriaRule
   - uid: 'excel!Excel.Interfaces.PresetCriteriaConditionalFormatUpdateData:interface'
     name: Interfaces.PresetCriteriaConditionalFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.PresetCriteriaConditionalFormatData:interface'
     name: Excel.Interfaces.PresetCriteriaConditionalFormatData

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.range.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.range.yml
@@ -16,7 +16,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Range#address:member'
@@ -1889,7 +1889,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Range#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -2193,7 +2193,7 @@ items:
         type:
           - 'excel!Excel.Worksheet:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ClearApplyTo:enum'
     name: Excel.ClearApplyTo
@@ -2220,7 +2220,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -2262,7 +2262,7 @@ references:
         fullName: ' | string'
   - uid: 'excel!Excel.Interfaces.RangeUpdateData:interface'
     name: Interfaces.RangeUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.RangeSort:class'
     name: Excel.RangeSort

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.rangeborder.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.rangeborder.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeBorder#color:member'
@@ -155,7 +155,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.RangeBorder#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -269,7 +269,7 @@ items:
         type:
           - 'excel!Excel.RangeBorder#weight~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -279,7 +279,7 @@ references:
     name: Excel.Interfaces.RangeBorderLoadOptions
   - uid: 'excel!Excel.Interfaces.RangeBorderUpdateData:interface'
     name: Interfaces.RangeBorderUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.RangeBorder#sideIndex~0:complex'
     name: >-

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.rangebordercollection.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.rangebordercollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeBorderCollection#context:member'
@@ -265,7 +265,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.RangeBorderCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -285,7 +285,7 @@ items:
           - 'excel!Excel.Interfaces.RangeBorderCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -316,7 +316,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.RangeBorderCollectionData:interface'
     name: Excel.Interfaces.RangeBorderCollectionData

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.rangefill.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.rangefill.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeFill#clear:member(1)'
@@ -226,7 +226,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.RangeFill#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -264,7 +264,7 @@ items:
           - 'excel!Excel.Interfaces.RangeFillData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -274,7 +274,7 @@ references:
     name: Excel.Interfaces.RangeFillLoadOptions
   - uid: 'excel!Excel.Interfaces.RangeFillUpdateData:interface'
     name: Interfaces.RangeFillUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.RangeFillData:interface'
     name: Excel.Interfaces.RangeFillData

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.rangefont.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.rangefont.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeFont#bold:member'
@@ -237,7 +237,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.RangeFont#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -305,7 +305,7 @@ items:
         type:
           - 'excel!Excel.RangeFont#underline~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -315,7 +315,7 @@ references:
     name: Excel.Interfaces.RangeFontLoadOptions
   - uid: 'excel!Excel.Interfaces.RangeFontUpdateData:interface'
     name: Interfaces.RangeFontUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.RangeFontData:interface'
     name: Excel.Interfaces.RangeFontData

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.rangeformat.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.rangeformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeFormat#adjustIndent:member(1)'
@@ -381,7 +381,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.RangeFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -528,7 +528,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RangeBorderCollection:class'
     name: Excel.RangeBorderCollection
@@ -559,7 +559,7 @@ references:
     name: Excel.FormatProtection
   - uid: 'excel!Excel.Interfaces.RangeFormatUpdateData:interface'
     name: Interfaces.RangeFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.RangeFormatData:interface'
     name: Excel.Interfaces.RangeFormatData

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.rangesort.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.rangesort.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeSort#apply:member(1)'
@@ -135,7 +135,7 @@ items:
                     }
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RangeSort#apply~0:complex'
     name: 'Excel.SortField[]'

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.rangeview.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.rangeview.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeView#cellAddresses:member'
@@ -300,7 +300,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.RangeView#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -387,7 +387,7 @@ items:
         type:
           - 'excel!Excel.RangeView#valueTypes~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -401,7 +401,7 @@ references:
     name: Excel.RangeViewCollection
   - uid: 'excel!Excel.Interfaces.RangeViewUpdateData:interface'
     name: Interfaces.RangeViewUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.RangeViewData:interface'
     name: Excel.Interfaces.RangeViewData

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.rangeviewcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.rangeviewcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeViewCollection#context:member'
@@ -148,7 +148,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.RangeViewCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -168,7 +168,7 @@ items:
           - 'excel!Excel.Interfaces.RangeViewCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -176,7 +176,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -206,7 +206,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.RangeViewCollectionData:interface'
     name: Excel.Interfaces.RangeViewCollectionData

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.requestcontext.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.requestcontext.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientRequestContext:class'
+      - 'office!OfficeExtension.ClientRequestContext:class'
     package: excel!
     children:
       - 'excel!Excel.RequestContext:constructor(1)'
@@ -67,7 +67,7 @@ items:
         type:
           - 'excel!Excel.Workbook:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientRequestContext:class'
+  - uid: 'office!OfficeExtension.ClientRequestContext:class'
     name: OfficeExtension.ClientRequestContext
   - uid: 'excel!Excel.RequestContext~0:complex'
     name: string | Session

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.runoptions.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.runoptions.yml
@@ -34,7 +34,7 @@ references:
     name: OfficeExtension.RunOptions<Session>
     fullName: OfficeExtension.RunOptions<Excel.Session>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.RunOptions:interface'
+      - uid: 'office!OfficeExtension.RunOptions:interface'
         name: OfficeExtension.RunOptions
         fullName: OfficeExtension.RunOptions
       - name: <

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.runtime.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.runtime.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Runtime#context:member'
@@ -134,7 +134,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Runtime#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -172,7 +172,7 @@ items:
           - 'excel!Excel.Interfaces.RuntimeData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -182,7 +182,7 @@ references:
     name: Excel.Interfaces.RuntimeLoadOptions
   - uid: 'excel!Excel.Interfaces.RuntimeUpdateData:interface'
     name: Interfaces.RuntimeUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.RuntimeData:interface'
     name: Excel.Interfaces.RuntimeData

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.setting.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.setting.yml
@@ -15,7 +15,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Setting#context:member'
@@ -200,7 +200,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Setting#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -253,7 +253,7 @@ items:
         type:
           - any
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -263,7 +263,7 @@ references:
     name: Excel.Interfaces.SettingLoadOptions
   - uid: 'excel!Excel.Interfaces.SettingUpdateData:interface'
     name: Interfaces.SettingUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.SettingData:interface'
     name: Excel.Interfaces.SettingData

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.settingcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.settingcollection.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.SettingCollection#add:member(1)'
@@ -246,7 +246,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.SettingCollection#onSettingsChanged:member'
     summary: |-
       Occurs when the Settings in the document are changed.
@@ -301,7 +301,7 @@ items:
           - 'excel!Excel.Interfaces.SettingCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Setting:class'
     name: Excel.Setting
@@ -327,7 +327,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -355,13 +355,13 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.SettingCollection#onSettingsChanged~0:complex'
     name: OfficeExtension.EventHandlers<Excel.SettingsChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.SettingsChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.style.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.style.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Style#borders:member'
@@ -551,7 +551,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Style#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -634,7 +634,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RangeBorderCollection:class'
     name: Excel.RangeBorderCollection
@@ -672,7 +672,7 @@ references:
         fullName: ' | "Context" | "LeftToRight" | "RightToLeft"'
   - uid: 'excel!Excel.Interfaces.StyleUpdateData:interface'
     name: Interfaces.StyleUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.StyleData:interface'
     name: Excel.Interfaces.StyleData

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.stylecollection.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.stylecollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.StyleCollection#add:member(1)'
@@ -217,7 +217,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.StyleCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -237,7 +237,7 @@ items:
           - 'excel!Excel.Interfaces.StyleCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -266,7 +266,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.StyleCollectionData:interface'
     name: Excel.Interfaces.StyleCollectionData

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.table.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.table.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Table#clearFilters:member(1)'
@@ -605,7 +605,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Table#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -796,7 +796,7 @@ items:
         type:
           - 'excel!Excel.Worksheet:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.TableColumnCollection:class'
     name: Excel.TableColumnCollection
@@ -812,7 +812,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.TableChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.TableChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -826,7 +826,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.TableSelectionChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.TableSelectionChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -840,7 +840,7 @@ references:
     name: Excel.TableRowCollection
   - uid: 'excel!Excel.Interfaces.TableUpdateData:interface'
     name: Interfaces.TableUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.TableSort:class'
     name: Excel.TableSort

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.tablecollection.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.tablecollection.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableCollection#add:member(1)'
@@ -339,7 +339,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.TableCollection#onChanged:member'
     summary: |-
       Occurs when data changes on any table in a workbook, or a worksheet.
@@ -394,7 +394,7 @@ items:
           - 'excel!Excel.Interfaces.TableCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Table:class'
     name: Excel.Table
@@ -413,7 +413,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -441,13 +441,13 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.TableCollection#onChanged~0:complex'
     name: OfficeExtension.EventHandlers<Excel.TableChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.TableChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.tablecolumn.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.tablecolumn.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableColumn#context:member'
@@ -401,7 +401,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.TableColumn#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -456,7 +456,7 @@ items:
         type:
           - 'any[][]'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -470,7 +470,7 @@ references:
     name: Excel.Interfaces.TableColumnLoadOptions
   - uid: 'excel!Excel.Interfaces.TableColumnUpdateData:interface'
     name: Interfaces.TableColumnUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.TableColumnData:interface'
     name: Excel.Interfaces.TableColumnData

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.tablecolumncollection.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.tablecolumncollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableColumnCollection#add:member(1)'
@@ -322,7 +322,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.TableColumnCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -342,7 +342,7 @@ items:
           - 'excel!Excel.Interfaces.TableColumnCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.TableColumn:class'
     name: Excel.TableColumn
@@ -366,7 +366,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -394,7 +394,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.TableColumnCollectionData:interface'
     name: Excel.Interfaces.TableColumnCollectionData

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.tablerow.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.tablerow.yml
@@ -17,7 +17,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableRow#context:member'
@@ -247,7 +247,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.TableRow#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -302,7 +302,7 @@ items:
         type:
           - 'any[][]'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -314,7 +314,7 @@ references:
     name: Excel.Interfaces.TableRowLoadOptions
   - uid: 'excel!Excel.Interfaces.TableRowUpdateData:interface'
     name: Interfaces.TableRowUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.TableRowData:interface'
     name: Excel.Interfaces.TableRowData

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.tablerowcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.tablerowcollection.yml
@@ -17,7 +17,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableRowCollection#add:member(1)'
@@ -290,7 +290,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.TableRowCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -310,7 +310,7 @@ items:
           - 'excel!Excel.Interfaces.TableRowCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.TableRow:class'
     name: Excel.TableRow
@@ -334,7 +334,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -362,7 +362,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.TableRowCollectionData:interface'
     name: Excel.Interfaces.TableRowCollectionData

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.tablesort.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.tablesort.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableSort#apply:member(1)'
@@ -288,7 +288,7 @@ items:
           - 'excel!Excel.Interfaces.TableSortData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.TableSort#apply~0:complex'
     name: 'Excel.SortField[]'

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.textconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.textconditionalformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TextConditionalFormat#context:member'
@@ -214,7 +214,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.TextConditionalFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -252,7 +252,7 @@ items:
           - 'excel!Excel.Interfaces.TextConditionalFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -266,7 +266,7 @@ references:
     name: Excel.ConditionalTextComparisonRule
   - uid: 'excel!Excel.Interfaces.TextConditionalFormatUpdateData:interface'
     name: Interfaces.TextConditionalFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.TextConditionalFormatData:interface'
     name: Excel.Interfaces.TextConditionalFormatData

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.topbottomconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.topbottomconditionalformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TopBottomConditionalFormat#context:member'
@@ -168,7 +168,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.TopBottomConditionalFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -206,7 +206,7 @@ items:
           - 'excel!Excel.Interfaces.TopBottomConditionalFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -220,7 +220,7 @@ references:
     name: Excel.ConditionalTopBottomRule
   - uid: 'excel!Excel.Interfaces.TopBottomConditionalFormatUpdateData:interface'
     name: Interfaces.TopBottomConditionalFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.TopBottomConditionalFormatData:interface'
     name: Excel.Interfaces.TopBottomConditionalFormatData

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.workbook.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.workbook.yml
@@ -14,7 +14,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Workbook#application:member'
@@ -430,7 +430,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Workbook#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -561,7 +561,7 @@ items:
         type:
           - 'excel!Excel.WorksheetCollection:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Application:class'
     name: Excel.Application
@@ -587,7 +587,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.SelectionChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.SelectionChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -605,7 +605,7 @@ references:
     name: Excel.WorkbookProtection
   - uid: 'excel!Excel.Interfaces.WorkbookUpdateData:interface'
     name: Interfaces.WorkbookUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.SettingCollection:class'
     name: Excel.SettingCollection

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.workbookprotection.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.workbookprotection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.WorkbookProtection#context:member'
@@ -258,7 +258,7 @@ items:
           type:
             - string
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.worksheet.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.worksheet.yml
@@ -14,7 +14,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Worksheet#activate:member(1)'
@@ -1043,7 +1043,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Worksheet#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -1184,7 +1184,7 @@ items:
         type:
           - 'excel!Excel.Worksheet#visibility~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartCollection:class'
     name: Excel.ChartCollection
@@ -1206,7 +1206,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetActivatedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetActivatedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -1220,7 +1220,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -1234,7 +1234,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetDeactivatedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetDeactivatedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -1248,7 +1248,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetSelectionChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetSelectionChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -1264,7 +1264,7 @@ references:
     name: Excel.WorksheetProtection
   - uid: 'excel!Excel.Interfaces.WorksheetUpdateData:interface'
     name: Interfaces.WorksheetUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.TableCollection:class'
     name: Excel.TableCollection

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.worksheetcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.worksheetcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.WorksheetCollection#add:member(1)'
@@ -397,7 +397,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.WorksheetCollection#onActivated:member'
     summary: |-
       Occurs when any worksheet in the workbook is activated.
@@ -537,7 +537,7 @@ items:
           - 'excel!Excel.Interfaces.WorksheetCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Worksheet:class'
     name: Excel.Worksheet
@@ -547,7 +547,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -575,13 +575,13 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.WorksheetCollection#onActivated~0:complex'
     name: OfficeExtension.EventHandlers<Excel.WorksheetActivatedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetActivatedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -595,7 +595,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetAddedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetAddedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -609,7 +609,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetDeactivatedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetDeactivatedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -623,7 +623,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetDeletedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetDeletedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.worksheetfreezepanes.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.worksheetfreezepanes.yml
@@ -8,7 +8,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.WorksheetFreezePanes#context:member'
@@ -278,7 +278,7 @@ items:
 
           ```
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel_1_7/excel/excel.worksheetprotection.yml
+++ b/docs/docs-ref-autogen/excel_1_7/excel/excel.worksheetprotection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.WorksheetProtection#context:member'
@@ -282,7 +282,7 @@ items:
           type:
             - string
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel_1_8/excel.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel.yml
@@ -820,7 +820,7 @@ items:
             A previously-created API object. The batch will use the same RequestContext as the passed-in object, which
             means that any changes applied to the object will be picked up by "context.sync()".
           type:
-            - 'excel!OfficeExtension.ClientObject:class'
+            - 'office!OfficeExtension.ClientObject:class'
         - id: batch
           description: >-
             A function that takes in a RequestContext and returns a promise (typically, just the result of
@@ -925,7 +925,7 @@ items:
             A previously-created object. The batch will use the same RequestContext as the passed-in object, which means
             that any changes applied to the object will be picked up by "context.sync()".
           type:
-            - 'excel!OfficeExtension.ClientRequestContext:class'
+            - 'office!OfficeExtension.ClientRequestContext:class'
         - id: batch
           description: >-
             A function that takes in a RequestContext and returns a promise (typically, just the result of
@@ -2218,7 +2218,7 @@ references:
         fullName: Promise
       - name: <T>
         fullName: <T>
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.run~3:complex'
     name: '(context: Excel.RequestContext) => Promise<T>'
@@ -2249,7 +2249,7 @@ references:
     name: 'OfficeExtension.ClientObject[]'
     fullName: 'OfficeExtension.ClientObject[]'
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientObject:class'
+      - uid: 'office!OfficeExtension.ClientObject:class'
         name: OfficeExtension.ClientObject
         fullName: OfficeExtension.ClientObject
       - name: '[]'
@@ -2306,7 +2306,7 @@ references:
         fullName: Promise
       - name: <T>
         fullName: <T>
-  - uid: 'excel!OfficeExtension.ClientRequestContext:class'
+  - uid: 'office!OfficeExtension.ClientRequestContext:class'
     name: OfficeExtension.ClientRequestContext
   - uid: 'excel!Excel.run~10:complex'
     name: '(context: Excel.RequestContext) => Promise<T>'

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.application.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.application.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Application#calculate:member(1)'
@@ -233,7 +233,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Application#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -289,7 +289,7 @@ items:
           - 'excel!Excel.Interfaces.ApplicationData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.CalculationType:enum'
     name: Excel.CalculationType
@@ -310,7 +310,7 @@ references:
     name: Excel.Interfaces.ApplicationLoadOptions
   - uid: 'excel!Excel.Interfaces.ApplicationUpdateData:interface'
     name: Interfaces.ApplicationUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ApplicationData:interface'
     name: Excel.Interfaces.ApplicationData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.binding.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.binding.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Binding#context:member'
@@ -357,7 +357,7 @@ items:
         type:
           - 'excel!Excel.Binding#type~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -369,7 +369,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -382,7 +382,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.BindingDataChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.BindingDataChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -396,7 +396,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.BindingSelectionChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.BindingSelectionChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.bindingcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.bindingcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.BindingCollection#add:member(1)'
@@ -493,7 +493,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.BindingCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -513,7 +513,7 @@ items:
           - 'excel!Excel.Interfaces.BindingCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Binding:class'
     name: Excel.Binding
@@ -543,7 +543,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -571,7 +571,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.BindingCollectionData:interface'
     name: Excel.Interfaces.BindingCollectionData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.cellvalueconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.cellvalueconditionalformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.CellValueConditionalFormat#context:member'
@@ -212,7 +212,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.CellValueConditionalFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -250,7 +250,7 @@ items:
           - 'excel!Excel.Interfaces.CellValueConditionalFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -264,7 +264,7 @@ references:
     name: Excel.ConditionalCellValueRule
   - uid: 'excel!Excel.Interfaces.CellValueConditionalFormatUpdateData:interface'
     name: Interfaces.CellValueConditionalFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.CellValueConditionalFormatData:interface'
     name: Excel.Interfaces.CellValueConditionalFormatData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.chart.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.chart.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Chart#axes:member'
@@ -671,7 +671,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Chart#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -944,7 +944,7 @@ items:
         type:
           - 'excel!Excel.Worksheet:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartAxes:class'
     name: Excel.ChartAxes
@@ -1004,7 +1004,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -1015,7 +1015,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -1030,7 +1030,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.ChartActivatedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.ChartActivatedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -1044,7 +1044,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.ChartDeactivatedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.ChartDeactivatedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -1069,7 +1069,7 @@ references:
     name: Excel.ChartSeriesCollection
   - uid: 'excel!Excel.Interfaces.ChartUpdateData:interface'
     name: Interfaces.ChartUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Range:class'
     name: Range

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.chartareaformat.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.chartareaformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAreaFormat#border:member'
@@ -182,7 +182,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAreaFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -220,7 +220,7 @@ items:
           - 'excel!Excel.Interfaces.ChartAreaFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartBorder:class'
     name: Excel.ChartBorder
@@ -236,7 +236,7 @@ references:
     name: Excel.Interfaces.ChartAreaFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartAreaFormatUpdateData:interface'
     name: Interfaces.ChartAreaFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartAreaFormatData:interface'
     name: Excel.Interfaces.ChartAreaFormatData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.chartaxes.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.chartaxes.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAxes#categoryAxis:member'
@@ -221,7 +221,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAxes#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -297,7 +297,7 @@ items:
           });
           ```
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartAxis:class'
     name: Excel.ChartAxis
@@ -313,7 +313,7 @@ references:
     name: Excel.Interfaces.ChartAxesLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartAxesUpdateData:interface'
     name: Interfaces.ChartAxesUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartAxesData:interface'
     name: Excel.Interfaces.ChartAxesData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.chartaxis.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.chartaxis.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAxis#alignment:member'
@@ -664,7 +664,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAxis#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -946,7 +946,7 @@ items:
         type:
           - number
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartAxis#alignment~0:complex'
     name: Excel.ChartTickLabelAlignment | "Center" | "Left" | "Right"
@@ -1063,7 +1063,7 @@ references:
         fullName: ' | "Linear" | "Logarithmic"'
   - uid: 'excel!Excel.Interfaces.ChartAxisUpdateData:interface'
     name: Interfaces.ChartAxisUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Range:class'
     name: Range

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.chartaxisformat.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.chartaxisformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAxisFormat#context:member'
@@ -182,7 +182,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAxisFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -220,7 +220,7 @@ items:
           - 'excel!Excel.Interfaces.ChartAxisFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -236,7 +236,7 @@ references:
     name: Excel.Interfaces.ChartAxisFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisFormatUpdateData:interface'
     name: Interfaces.ChartAxisFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisFormatData:interface'
     name: Excel.Interfaces.ChartAxisFormatData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.chartaxistitle.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.chartaxistitle.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAxisTitle#context:member'
@@ -172,7 +172,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAxisTitle#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -261,7 +261,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -273,7 +273,7 @@ references:
     name: Excel.Interfaces.ChartAxisTitleLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisTitleUpdateData:interface'
     name: Interfaces.ChartAxisTitleUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisTitleData:interface'
     name: Excel.Interfaces.ChartAxisTitleData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.chartaxistitleformat.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.chartaxistitleformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAxisTitleFormat#border:member'
@@ -182,7 +182,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAxisTitleFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -220,7 +220,7 @@ items:
           - 'excel!Excel.Interfaces.ChartAxisTitleFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartBorder:class'
     name: Excel.ChartBorder
@@ -236,7 +236,7 @@ references:
     name: Excel.Interfaces.ChartAxisTitleFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisTitleFormatUpdateData:interface'
     name: Interfaces.ChartAxisTitleFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisTitleFormatData:interface'
     name: Excel.Interfaces.ChartAxisTitleFormatData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.chartborder.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.chartborder.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartBorder#clear:member(1)'
@@ -186,7 +186,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartBorder#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -239,7 +239,7 @@ items:
         type:
           - number
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -262,7 +262,7 @@ references:
     name: Excel.Interfaces.ChartBorderLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartBorderUpdateData:interface'
     name: Interfaces.ChartBorderUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartBorderData:interface'
     name: Excel.Interfaces.ChartBorderData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.chartcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartCollection#add:member(1)'
@@ -387,7 +387,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.ChartCollection#onActivated:member'
     summary: |-
       Occurs when a chart is activated.
@@ -535,7 +535,7 @@ items:
           - 'excel!Excel.Interfaces.ChartCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Chart:class'
     name: Excel.Chart
@@ -551,7 +551,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -579,13 +579,13 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.ChartCollection#onActivated~0:complex'
     name: OfficeExtension.EventHandlers<Excel.ChartActivatedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.ChartActivatedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -599,7 +599,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.ChartAddedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.ChartAddedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -613,7 +613,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.ChartDeactivatedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.ChartDeactivatedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -627,7 +627,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.ChartDeletedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.ChartDeletedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.chartdatalabel.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.chartdatalabel.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartDataLabel#autoText:member'
@@ -299,7 +299,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartDataLabel#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -508,7 +508,7 @@ items:
         type:
           - number
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -542,7 +542,7 @@ references:
         fullName: ' | "Invalid" | "None" | "Center" | "InsideEnd" | "InsideBase" | "OutsideEnd" | "Left" | "Right" | "Top" | "Bottom" | "BestFit" | "Callout"'
   - uid: 'excel!Excel.Interfaces.ChartDataLabelUpdateData:interface'
     name: Interfaces.ChartDataLabelUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartDataLabelData:interface'
     name: Excel.Interfaces.ChartDataLabelData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.chartdatalabelformat.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.chartdatalabelformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartDataLabelFormat#border:member'
@@ -182,7 +182,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartDataLabelFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -220,7 +220,7 @@ items:
           - 'excel!Excel.Interfaces.ChartDataLabelFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartBorder:class'
     name: Excel.ChartBorder
@@ -236,7 +236,7 @@ references:
     name: Excel.Interfaces.ChartDataLabelFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartDataLabelFormatUpdateData:interface'
     name: Interfaces.ChartDataLabelFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartDataLabelFormatData:interface'
     name: Excel.Interfaces.ChartDataLabelFormatData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.chartdatalabels.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.chartdatalabels.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartDataLabels#autoText:member'
@@ -267,7 +267,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartDataLabels#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -429,7 +429,7 @@ items:
         type:
           - 'excel!Excel.ChartDataLabels#verticalAlignment~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -463,7 +463,7 @@ references:
         fullName: ' | "Invalid" | "None" | "Center" | "InsideEnd" | "InsideBase" | "OutsideEnd" | "Left" | "Right" | "Top" | "Bottom" | "BestFit" | "Callout"'
   - uid: 'excel!Excel.Interfaces.ChartDataLabelsUpdateData:interface'
     name: Interfaces.ChartDataLabelsUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartDataLabelsData:interface'
     name: Excel.Interfaces.ChartDataLabelsData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.chartfill.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.chartfill.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartFill#clear:member(1)'
@@ -138,7 +138,7 @@ items:
                     }
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.chartfont.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.chartfont.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     remarks: |-
 
@@ -223,7 +223,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartFont#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -291,7 +291,7 @@ items:
         type:
           - 'excel!Excel.ChartFont#underline~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -301,7 +301,7 @@ references:
     name: Excel.Interfaces.ChartFontLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartFontUpdateData:interface'
     name: Interfaces.ChartFontUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartFontData:interface'
     name: Excel.Interfaces.ChartFontData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.chartformatstring.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.chartformatstring.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartFormatString#context:member'
@@ -152,7 +152,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartFormatString#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -190,7 +190,7 @@ items:
           - 'excel!Excel.Interfaces.ChartFormatStringData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -202,7 +202,7 @@ references:
     name: Excel.Interfaces.ChartFormatStringLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartFormatStringUpdateData:interface'
     name: Interfaces.ChartFormatStringUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartFormatStringData:interface'
     name: Excel.Interfaces.ChartFormatStringData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.chartgridlines.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.chartgridlines.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartGridlines#context:member'
@@ -170,7 +170,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartGridlines#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -223,7 +223,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -235,7 +235,7 @@ references:
     name: Excel.Interfaces.ChartGridlinesLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartGridlinesUpdateData:interface'
     name: Interfaces.ChartGridlinesUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartGridlinesData:interface'
     name: Excel.Interfaces.ChartGridlinesData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.chartgridlinesformat.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.chartgridlinesformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartGridlinesFormat#context:member'
@@ -150,7 +150,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartGridlinesFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -188,7 +188,7 @@ items:
           - 'excel!Excel.Interfaces.ChartGridlinesFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -200,7 +200,7 @@ references:
     name: Excel.Interfaces.ChartGridlinesFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartGridlinesFormatUpdateData:interface'
     name: Interfaces.ChartGridlinesFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartGridlinesFormatData:interface'
     name: Excel.Interfaces.ChartGridlinesFormatData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.chartlegend.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.chartlegend.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartLegend#context:member'
@@ -254,7 +254,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartLegend#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -352,7 +352,7 @@ items:
         type:
           - number
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -375,7 +375,7 @@ references:
         fullName: ' | "Invalid" | "Top" | "Bottom" | "Left" | "Right" | "Corner" | "Custom"'
   - uid: 'excel!Excel.Interfaces.ChartLegendUpdateData:interface'
     name: Interfaces.ChartLegendUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartLegendData:interface'
     name: Excel.Interfaces.ChartLegendData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.chartlegendentry.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.chartlegendentry.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartLegendEntry#context:member'
@@ -185,7 +185,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartLegendEntry#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -268,7 +268,7 @@ items:
         type:
           - number
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -278,7 +278,7 @@ references:
     name: Excel.Interfaces.ChartLegendEntryLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartLegendEntryUpdateData:interface'
     name: Interfaces.ChartLegendEntryUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartLegendEntryData:interface'
     name: Excel.Interfaces.ChartLegendEntryData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.chartlegendentrycollection.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.chartlegendentrycollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartLegendEntryCollection#context:member'
@@ -148,7 +148,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.ChartLegendEntryCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -168,7 +168,7 @@ items:
           - 'excel!Excel.Interfaces.ChartLegendEntryCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -176,7 +176,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -206,7 +206,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.ChartLegendEntryCollectionData:interface'
     name: Excel.Interfaces.ChartLegendEntryCollectionData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.chartlegendformat.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.chartlegendformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartLegendFormat#border:member'
@@ -212,7 +212,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartLegendFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -250,7 +250,7 @@ items:
           - 'excel!Excel.Interfaces.ChartLegendFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartBorder:class'
     name: Excel.ChartBorder
@@ -266,7 +266,7 @@ references:
     name: Excel.Interfaces.ChartLegendFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartLegendFormatUpdateData:interface'
     name: Interfaces.ChartLegendFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartLegendFormatData:interface'
     name: Excel.Interfaces.ChartLegendFormatData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.chartlineformat.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.chartlineformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartLineFormat#clear:member(1)'
@@ -224,7 +224,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartLineFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -277,7 +277,7 @@ items:
         type:
           - number
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -300,7 +300,7 @@ references:
     name: Excel.Interfaces.ChartLineFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartLineFormatUpdateData:interface'
     name: Interfaces.ChartLineFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartLineFormatData:interface'
     name: Excel.Interfaces.ChartLineFormatData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.chartplotarea.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.chartplotarea.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartPlotArea#context:member'
@@ -264,7 +264,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartPlotArea#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -332,7 +332,7 @@ items:
         type:
           - number
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -353,7 +353,7 @@ references:
         fullName: ' | "Automatic" | "Custom"'
   - uid: 'excel!Excel.Interfaces.ChartPlotAreaUpdateData:interface'
     name: Interfaces.ChartPlotAreaUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartPlotAreaData:interface'
     name: Excel.Interfaces.ChartPlotAreaData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.chartplotareaformat.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.chartplotareaformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartPlotAreaFormat#border:member'
@@ -166,7 +166,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartPlotAreaFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -204,7 +204,7 @@ items:
           - 'excel!Excel.Interfaces.ChartPlotAreaFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartBorder:class'
     name: Excel.ChartBorder
@@ -218,7 +218,7 @@ references:
     name: Excel.Interfaces.ChartPlotAreaFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartPlotAreaFormatUpdateData:interface'
     name: Interfaces.ChartPlotAreaFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartPlotAreaFormatData:interface'
     name: Excel.Interfaces.ChartPlotAreaFormatData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.chartpoint.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.chartpoint.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartPoint#context:member'
@@ -249,7 +249,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartPoint#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -302,7 +302,7 @@ items:
         type:
           - any
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -329,7 +329,7 @@ references:
         fullName: ' | "Invalid" | "Automatic" | "None" | "Square" | "Diamond" | "Triangle" | "X" | "Star" | "Dot" | "Dash" | "Circle" | "Plus" | "Picture"'
   - uid: 'excel!Excel.Interfaces.ChartPointUpdateData:interface'
     name: Interfaces.ChartPointUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartPointData:interface'
     name: Excel.Interfaces.ChartPointData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.chartpointformat.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.chartpointformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartPointFormat#border:member'
@@ -168,7 +168,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartPointFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -206,7 +206,7 @@ items:
           - 'excel!Excel.Interfaces.ChartPointFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartBorder:class'
     name: Excel.ChartBorder
@@ -220,7 +220,7 @@ references:
     name: Excel.Interfaces.ChartPointFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartPointFormatUpdateData:interface'
     name: Interfaces.ChartPointFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartPointFormatData:interface'
     name: Excel.Interfaces.ChartPointFormatData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.chartpointscollection.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.chartpointscollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartPointsCollection#context:member'
@@ -219,7 +219,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.ChartPointsCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -239,7 +239,7 @@ items:
           - 'excel!Excel.Interfaces.ChartPointsCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -247,7 +247,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -277,7 +277,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.ChartPointsCollectionData:interface'
     name: Excel.Interfaces.ChartPointsCollectionData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.chartseries.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.chartseries.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartSeries#axisGroup:member'
@@ -713,7 +713,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartSeries#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -919,7 +919,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartSeries#axisGroup~0:complex'
     name: Excel.ChartAxisGroup | "Primary" | "Secondary"
@@ -994,7 +994,7 @@ references:
     name: Excel.ChartPointsCollection
   - uid: 'excel!Excel.Interfaces.ChartSeriesUpdateData:interface'
     name: Interfaces.ChartSeriesUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Range:class'
     name: Range

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.chartseriescollection.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.chartseriescollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartSeriesCollection#add:member(1)'
@@ -248,7 +248,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.ChartSeriesCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -268,7 +268,7 @@ items:
           - 'excel!Excel.Interfaces.ChartSeriesCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartSeries:class'
     name: Excel.ChartSeries
@@ -278,7 +278,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -306,7 +306,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.ChartSeriesCollectionData:interface'
     name: Excel.Interfaces.ChartSeriesCollectionData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.chartseriesformat.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.chartseriesformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartSeriesFormat#context:member'
@@ -166,7 +166,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartSeriesFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -204,7 +204,7 @@ items:
           - 'excel!Excel.Interfaces.ChartSeriesFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -218,7 +218,7 @@ references:
     name: Excel.Interfaces.ChartSeriesFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartSeriesFormatUpdateData:interface'
     name: Interfaces.ChartSeriesFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartSeriesFormatData:interface'
     name: Excel.Interfaces.ChartSeriesFormatData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.charttitle.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.charttitle.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartTitle#context:member'
@@ -328,7 +328,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartTitle#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -516,7 +516,7 @@ items:
         type:
           - number
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -548,7 +548,7 @@ references:
         fullName: ' | "Automatic" | "Top" | "Bottom" | "Left" | "Right"'
   - uid: 'excel!Excel.Interfaces.ChartTitleUpdateData:interface'
     name: Interfaces.ChartTitleUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartTitleData:interface'
     name: Excel.Interfaces.ChartTitleData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.charttitleformat.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.charttitleformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartTitleFormat#border:member'
@@ -182,7 +182,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartTitleFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -220,7 +220,7 @@ items:
           - 'excel!Excel.Interfaces.ChartTitleFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartBorder:class'
     name: Excel.ChartBorder
@@ -236,7 +236,7 @@ references:
     name: Excel.Interfaces.ChartTitleFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartTitleFormatUpdateData:interface'
     name: Interfaces.ChartTitleFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartTitleFormatData:interface'
     name: Excel.Interfaces.ChartTitleFormatData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.charttrendline.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.charttrendline.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartTrendline#backwardPeriod:member'
@@ -286,7 +286,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartTrendline#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -397,7 +397,7 @@ items:
 
           ```
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -411,7 +411,7 @@ references:
     name: Excel.Interfaces.ChartTrendlineLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartTrendlineUpdateData:interface'
     name: Interfaces.ChartTrendlineUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartTrendlineData:interface'
     name: Excel.Interfaces.ChartTrendlineData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.charttrendlinecollection.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.charttrendlinecollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartTrendlineCollection#add:member(1)'
@@ -216,7 +216,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.ChartTrendlineCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -236,7 +236,7 @@ items:
           - 'excel!Excel.Interfaces.ChartTrendlineCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartTrendline:class'
     name: Excel.ChartTrendline
@@ -248,7 +248,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -276,7 +276,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.ChartTrendlineCollectionData:interface'
     name: Excel.Interfaces.ChartTrendlineCollectionData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.charttrendlineformat.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.charttrendlineformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartTrendlineFormat#context:member'
@@ -199,7 +199,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartTrendlineFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -237,7 +237,7 @@ items:
           - 'excel!Excel.Interfaces.ChartTrendlineFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -249,7 +249,7 @@ references:
     name: Excel.Interfaces.ChartTrendlineFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartTrendlineFormatUpdateData:interface'
     name: Interfaces.ChartTrendlineFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartTrendlineFormatData:interface'
     name: Excel.Interfaces.ChartTrendlineFormatData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.charttrendlinelabel.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.charttrendlinelabel.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartTrendlineLabel#autoText:member'
@@ -259,7 +259,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartTrendlineLabel#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -380,7 +380,7 @@ items:
         type:
           - number
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -401,7 +401,7 @@ references:
     name: Excel.Interfaces.ChartTrendlineLabelLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartTrendlineLabelUpdateData:interface'
     name: Interfaces.ChartTrendlineLabelUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartTrendlineLabelData:interface'
     name: Excel.Interfaces.ChartTrendlineLabelData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.charttrendlinelabelformat.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.charttrendlinelabelformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartTrendlineLabelFormat#border:member'
@@ -182,7 +182,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartTrendlineLabelFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -220,7 +220,7 @@ items:
           - 'excel!Excel.Interfaces.ChartTrendlineLabelFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartBorder:class'
     name: Excel.ChartBorder
@@ -236,7 +236,7 @@ references:
     name: Excel.Interfaces.ChartTrendlineLabelFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartTrendlineLabelFormatUpdateData:interface'
     name: Interfaces.ChartTrendlineLabelFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartTrendlineLabelFormatData:interface'
     name: Excel.Interfaces.ChartTrendlineLabelFormatData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.colorscaleconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.colorscaleconditionalformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ColorScaleConditionalFormat#context:member'
@@ -180,7 +180,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ColorScaleConditionalFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -235,7 +235,7 @@ items:
           - 'excel!Excel.Interfaces.ColorScaleConditionalFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -247,7 +247,7 @@ references:
     name: Excel.Interfaces.ColorScaleConditionalFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ColorScaleConditionalFormatUpdateData:interface'
     name: Interfaces.ColorScaleConditionalFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ColorScaleConditionalFormatData:interface'
     name: Excel.Interfaces.ColorScaleConditionalFormatData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.conditionaldatabarnegativeformat.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.conditionaldatabarnegativeformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ConditionalDataBarNegativeFormat#borderColor:member'
@@ -206,7 +206,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ConditionalDataBarNegativeFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -244,7 +244,7 @@ items:
           - 'excel!Excel.Interfaces.ConditionalDataBarNegativeFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -254,7 +254,7 @@ references:
     name: Excel.Interfaces.ConditionalDataBarNegativeFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ConditionalDataBarNegativeFormatUpdateData:interface'
     name: Interfaces.ConditionalDataBarNegativeFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ConditionalDataBarNegativeFormatData:interface'
     name: Excel.Interfaces.ConditionalDataBarNegativeFormatData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.conditionaldatabarpositiveformat.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.conditionaldatabarpositiveformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ConditionalDataBarPositiveFormat#borderColor:member'
@@ -190,7 +190,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ConditionalDataBarPositiveFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -228,7 +228,7 @@ items:
           - 'excel!Excel.Interfaces.ConditionalDataBarPositiveFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -238,7 +238,7 @@ references:
     name: Excel.Interfaces.ConditionalDataBarPositiveFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ConditionalDataBarPositiveFormatUpdateData:interface'
     name: Interfaces.ConditionalDataBarPositiveFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ConditionalDataBarPositiveFormatData:interface'
     name: Excel.Interfaces.ConditionalDataBarPositiveFormatData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.conditionalformat.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.conditionalformat.yml
@@ -14,7 +14,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ConditionalFormat#cellValue:member'
@@ -640,7 +640,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ConditionalFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -841,7 +841,7 @@ items:
 
           ```
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.CellValueConditionalFormat:class'
     name: Excel.CellValueConditionalFormat
@@ -865,7 +865,7 @@ references:
     name: Excel.PresetCriteriaConditionalFormat
   - uid: 'excel!Excel.Interfaces.ConditionalFormatUpdateData:interface'
     name: Interfaces.ConditionalFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.TextConditionalFormat:class'
     name: Excel.TextConditionalFormat

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.conditionalformatcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.conditionalformatcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ConditionalFormatCollection#add:member(1)'
@@ -363,7 +363,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.ConditionalFormatCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -383,7 +383,7 @@ items:
           - 'excel!Excel.Interfaces.ConditionalFormatCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ConditionalFormat:class'
     name: Excel.ConditionalFormat
@@ -395,7 +395,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -423,7 +423,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.ConditionalFormatCollectionData:interface'
     name: Excel.Interfaces.ConditionalFormatCollectionData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.conditionalformatrule.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.conditionalformatrule.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ConditionalFormatRule#context:member'
@@ -204,7 +204,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ConditionalFormatRule#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -242,7 +242,7 @@ items:
           - 'excel!Excel.Interfaces.ConditionalFormatRuleData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -252,7 +252,7 @@ references:
     name: Excel.Interfaces.ConditionalFormatRuleLoadOptions
   - uid: 'excel!Excel.Interfaces.ConditionalFormatRuleUpdateData:interface'
     name: Interfaces.ConditionalFormatRuleUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ConditionalFormatRuleData:interface'
     name: Excel.Interfaces.ConditionalFormatRuleData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.conditionalrangeborder.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.conditionalrangeborder.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ConditionalRangeBorder#color:member'
@@ -154,7 +154,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ConditionalRangeBorder#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -228,7 +228,7 @@ items:
           - 'excel!Excel.Interfaces.ConditionalRangeBorderData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -238,7 +238,7 @@ references:
     name: Excel.Interfaces.ConditionalRangeBorderLoadOptions
   - uid: 'excel!Excel.Interfaces.ConditionalRangeBorderUpdateData:interface'
     name: Interfaces.ConditionalRangeBorderUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.ConditionalRangeBorder#sideIndex~0:complex'
     name: Excel.ConditionalRangeBorderIndex | "EdgeTop" | "EdgeBottom" | "EdgeLeft" | "EdgeRight"

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.conditionalrangebordercollection.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.conditionalrangebordercollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ConditionalRangeBorderCollection#bottom:member'
@@ -225,7 +225,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.ConditionalRangeBorderCollection#right:member'
     summary: |-
       Gets the right border. Read-only.
@@ -275,7 +275,7 @@ items:
         type:
           - 'excel!Excel.ConditionalRangeBorder:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ConditionalRangeBorder:class'
     name: Excel.ConditionalRangeBorder
@@ -306,7 +306,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.ConditionalRangeBorderCollectionData:interface'
     name: Excel.Interfaces.ConditionalRangeBorderCollectionData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.conditionalrangefill.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.conditionalrangefill.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ConditionalRangeFill#clear:member(1)'
@@ -169,7 +169,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ConditionalRangeFill#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -207,7 +207,7 @@ items:
           - 'excel!Excel.Interfaces.ConditionalRangeFillData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -217,7 +217,7 @@ references:
     name: Excel.Interfaces.ConditionalRangeFillLoadOptions
   - uid: 'excel!Excel.Interfaces.ConditionalRangeFillUpdateData:interface'
     name: Interfaces.ConditionalRangeFillUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ConditionalRangeFillData:interface'
     name: Excel.Interfaces.ConditionalRangeFillData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.conditionalrangefont.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.conditionalrangefont.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ConditionalRangeFont#bold:member'
@@ -201,7 +201,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ConditionalRangeFont#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -269,7 +269,7 @@ items:
         type:
           - 'excel!Excel.ConditionalRangeFont#underline~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -279,7 +279,7 @@ references:
     name: Excel.Interfaces.ConditionalRangeFontLoadOptions
   - uid: 'excel!Excel.Interfaces.ConditionalRangeFontUpdateData:interface'
     name: Interfaces.ConditionalRangeFontUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ConditionalRangeFontData:interface'
     name: Excel.Interfaces.ConditionalRangeFontData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.conditionalrangeformat.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.conditionalrangeformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ConditionalRangeFormat#borders:member'
@@ -198,7 +198,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ConditionalRangeFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -236,7 +236,7 @@ items:
           - 'excel!Excel.Interfaces.ConditionalRangeFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ConditionalRangeBorderCollection:class'
     name: Excel.ConditionalRangeBorderCollection
@@ -252,7 +252,7 @@ references:
     name: Excel.Interfaces.ConditionalRangeFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ConditionalRangeFormatUpdateData:interface'
     name: Interfaces.ConditionalRangeFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ConditionalRangeFormatData:interface'
     name: Excel.Interfaces.ConditionalRangeFormatData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.customconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.customconditionalformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.CustomConditionalFormat#context:member'
@@ -214,7 +214,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.CustomConditionalFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -252,7 +252,7 @@ items:
           - 'excel!Excel.Interfaces.CustomConditionalFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -266,7 +266,7 @@ references:
     name: Excel.ConditionalFormatRule
   - uid: 'excel!Excel.Interfaces.CustomConditionalFormatUpdateData:interface'
     name: Interfaces.CustomConditionalFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.CustomConditionalFormatData:interface'
     name: Excel.Interfaces.CustomConditionalFormatData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.customproperty.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.customproperty.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.CustomProperty#context:member'
@@ -169,7 +169,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.CustomProperty#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -237,7 +237,7 @@ items:
         type:
           - any
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -247,7 +247,7 @@ references:
     name: Excel.Interfaces.CustomPropertyLoadOptions
   - uid: 'excel!Excel.Interfaces.CustomPropertyUpdateData:interface'
     name: Interfaces.CustomPropertyUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.CustomPropertyData:interface'
     name: Excel.Interfaces.CustomPropertyData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.custompropertycollection.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.custompropertycollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.CustomPropertyCollection#add:member(1)'
@@ -215,7 +215,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.CustomPropertyCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -235,7 +235,7 @@ items:
           - 'excel!Excel.Interfaces.CustomPropertyCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.CustomProperty:class'
     name: Excel.CustomProperty
@@ -245,7 +245,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -273,7 +273,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.CustomPropertyCollectionData:interface'
     name: Excel.Interfaces.CustomPropertyCollectionData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.customxmlpart.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.customxmlpart.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.CustomXmlPart#context:member'
@@ -343,7 +343,7 @@ items:
           - 'excel!Excel.Interfaces.CustomXmlPartData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -351,7 +351,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.customxmlpartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.customxmlpartcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.CustomXmlPartCollection#add:member(1)'
@@ -317,7 +317,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.CustomXmlPartCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -337,7 +337,7 @@ items:
           - 'excel!Excel.Interfaces.CustomXmlPartCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.CustomXmlPart:class'
     name: Excel.CustomXmlPart
@@ -349,7 +349,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -377,7 +377,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.CustomXmlPartCollectionData:interface'
     name: Excel.Interfaces.CustomXmlPartCollectionData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.customxmlpartscopedcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.customxmlpartscopedcollection.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.CustomXmlPartScopedCollection#context:member'
@@ -325,7 +325,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.CustomXmlPartScopedCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -345,7 +345,7 @@ items:
           - 'excel!Excel.Interfaces.CustomXmlPartScopedCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -353,7 +353,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -383,7 +383,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.CustomXmlPartScopedCollectionData:interface'
     name: Excel.Interfaces.CustomXmlPartScopedCollectionData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.databarconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.databarconditionalformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.DataBarConditionalFormat#axisColor:member'
@@ -259,7 +259,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.DataBarConditionalFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -330,7 +330,7 @@ items:
         type:
           - 'excel!Excel.ConditionalDataBarRule:interface'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.DataBarConditionalFormat#axisFormat~0:complex'
     name: Excel.ConditionalDataBarAxisFormat | "Automatic" | "None" | "CellMidPoint"
@@ -364,7 +364,7 @@ references:
     name: Excel.ConditionalDataBarPositiveFormat
   - uid: 'excel!Excel.Interfaces.DataBarConditionalFormatUpdateData:interface'
     name: Interfaces.DataBarConditionalFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.DataBarConditionalFormatData:interface'
     name: Excel.Interfaces.DataBarConditionalFormatData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.dataconnectioncollection.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.dataconnectioncollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.DataConnectionCollection#context:member'
@@ -72,7 +72,7 @@ items:
                     }
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.datapivothierarchy.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.datapivothierarchy.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.DataPivotHierarchy#context:member'
@@ -239,7 +239,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.DataPivotHierarchy#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -359,7 +359,7 @@ items:
           - 'excel!Excel.Interfaces.DataPivotHierarchyData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -371,7 +371,7 @@ references:
     name: Excel.Interfaces.DataPivotHierarchyLoadOptions
   - uid: 'excel!Excel.Interfaces.DataPivotHierarchyUpdateData:interface'
     name: Interfaces.DataPivotHierarchyUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.ShowAsRule:interface'
     name: Excel.ShowAsRule

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.datapivothierarchycollection.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.datapivothierarchycollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.DataPivotHierarchyCollection#add:member(1)'
@@ -193,7 +193,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.DataPivotHierarchyCollection#remove:member(1)'
     summary: |-
       Removes the PivotHierarchy from the current axis.
@@ -234,7 +234,7 @@ items:
           - 'excel!Excel.Interfaces.DataPivotHierarchyCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.DataPivotHierarchy:class'
     name: Excel.DataPivotHierarchy
@@ -246,7 +246,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -274,7 +274,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.DataPivotHierarchyCollectionData:interface'
     name: Excel.Interfaces.DataPivotHierarchyCollectionData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.datavalidation.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.datavalidation.yml
@@ -14,7 +14,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.DataValidation#clear:member(1)'
@@ -338,7 +338,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.DataValidation#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -411,7 +411,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -427,7 +427,7 @@ references:
     name: Excel.DataValidationRule
   - uid: 'excel!Excel.Interfaces.DataValidationUpdateData:interface'
     name: Interfaces.DataValidationUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.DataValidationData:interface'
     name: Excel.Interfaces.DataValidationData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.documentproperties.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.documentproperties.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.DocumentProperties#author:member'
@@ -296,7 +296,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.DocumentProperties#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -364,7 +364,7 @@ items:
           - 'excel!Excel.Interfaces.DocumentPropertiesData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -378,7 +378,7 @@ references:
     name: Excel.Interfaces.DocumentPropertiesLoadOptions
   - uid: 'excel!Excel.Interfaces.DocumentPropertiesUpdateData:interface'
     name: Interfaces.DocumentPropertiesUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.DocumentPropertiesData:interface'
     name: Excel.Interfaces.DocumentPropertiesData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.filter.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.filter.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Filter#apply:member(1)'
@@ -473,7 +473,7 @@ items:
           - 'excel!Excel.Interfaces.FilterData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.FilterCriteria:interface'
     name: Excel.FilterCriteria

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.filterpivothierarchy.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.filterpivothierarchy.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.FilterPivotHierarchy#context:member'
@@ -215,7 +215,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.FilterPivotHierarchy#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -269,7 +269,7 @@ items:
           - 'excel!Excel.Interfaces.FilterPivotHierarchyData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -281,7 +281,7 @@ references:
     name: Excel.Interfaces.FilterPivotHierarchyLoadOptions
   - uid: 'excel!Excel.Interfaces.FilterPivotHierarchyUpdateData:interface'
     name: Interfaces.FilterPivotHierarchyUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.FilterPivotHierarchyData:interface'
     name: Excel.Interfaces.FilterPivotHierarchyData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.filterpivothierarchycollection.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.filterpivothierarchycollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.FilterPivotHierarchyCollection#add:member(1)'
@@ -195,7 +195,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.FilterPivotHierarchyCollection#remove:member(1)'
     summary: |-
       Removes the PivotHierarchy from the current axis.
@@ -236,7 +236,7 @@ items:
           - 'excel!Excel.Interfaces.FilterPivotHierarchyCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.FilterPivotHierarchy:class'
     name: Excel.FilterPivotHierarchy
@@ -248,7 +248,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -276,7 +276,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.FilterPivotHierarchyCollectionData:interface'
     name: Excel.Interfaces.FilterPivotHierarchyCollectionData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.formatprotection.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.formatprotection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.FormatProtection#context:member'
@@ -170,7 +170,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.FormatProtection#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -208,7 +208,7 @@ items:
           - 'excel!Excel.Interfaces.FormatProtectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -218,7 +218,7 @@ references:
     name: Excel.Interfaces.FormatProtectionLoadOptions
   - uid: 'excel!Excel.Interfaces.FormatProtectionUpdateData:interface'
     name: Interfaces.FormatProtectionUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.FormatProtectionData:interface'
     name: Excel.Interfaces.FormatProtectionData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.functionresult.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.functionresult.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.FunctionResult#context:member'
@@ -158,7 +158,7 @@ items:
         type:
           - T
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.functions.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.functions.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Functions#abs:member(1)'
@@ -11184,7 +11184,7 @@ items:
           type:
             - 'excel!Excel.Functions#z_Test~3:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Functions#abs~0:complex'
     name: FunctionResult<number>

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.iconsetconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.iconsetconditionalformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.IconSetConditionalFormat#context:member'
@@ -222,7 +222,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.IconSetConditionalFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -345,7 +345,7 @@ items:
           - 'excel!Excel.Interfaces.IconSetConditionalFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -364,7 +364,7 @@ references:
     name: Excel.Interfaces.IconSetConditionalFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.IconSetConditionalFormatUpdateData:interface'
     name: Interfaces.IconSetConditionalFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.IconSetConditionalFormat#style~0:complex'
     name: >-

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.nameditem.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.nameditem.yml
@@ -14,7 +14,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.NamedItem#arrayValues:member'
@@ -381,7 +381,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.NamedItem#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -500,7 +500,7 @@ items:
         type:
           - 'excel!Excel.Worksheet:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.NamedItemArrayValues:class'
     name: Excel.NamedItemArrayValues
@@ -523,7 +523,7 @@ references:
         fullName: ' | "Worksheet" | "Workbook"'
   - uid: 'excel!Excel.Interfaces.NamedItemUpdateData:interface'
     name: Interfaces.NamedItemUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.NamedItemData:interface'
     name: Excel.Interfaces.NamedItemData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.nameditemarrayvalues.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.nameditemarrayvalues.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.NamedItemArrayValues#context:member'
@@ -154,7 +154,7 @@ items:
         type:
           - 'any[][]'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.nameditemcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.nameditemcollection.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.NamedItemCollection#add:member(1)'
@@ -294,7 +294,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.NamedItemCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -314,7 +314,7 @@ items:
           - 'excel!Excel.Interfaces.NamedItemCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.NamedItem:class'
     name: Excel.NamedItem
@@ -333,7 +333,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -361,7 +361,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.NamedItemCollectionData:interface'
     name: Excel.Interfaces.NamedItemCollectionData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.pivotfield.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.pivotfield.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PivotField#context:member'
@@ -185,7 +185,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.PivotField#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -276,7 +276,7 @@ items:
           - 'excel!Excel.Interfaces.PivotFieldData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -288,7 +288,7 @@ references:
     name: Excel.Interfaces.PivotFieldLoadOptions
   - uid: 'excel!Excel.Interfaces.PivotFieldUpdateData:interface'
     name: Interfaces.PivotFieldUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.SortBy:enum'
     name: SortBy

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.pivotfieldcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.pivotfieldcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PivotFieldCollection#context:member'
@@ -170,7 +170,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.PivotFieldCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -190,7 +190,7 @@ items:
           - 'excel!Excel.Interfaces.PivotFieldCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -198,7 +198,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -228,7 +228,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.PivotFieldCollectionData:interface'
     name: Excel.Interfaces.PivotFieldCollectionData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.pivothierarchy.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.pivothierarchy.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PivotHierarchy#context:member'
@@ -182,7 +182,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.PivotHierarchy#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -220,7 +220,7 @@ items:
           - 'excel!Excel.Interfaces.PivotHierarchyData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -232,7 +232,7 @@ references:
     name: Excel.Interfaces.PivotHierarchyLoadOptions
   - uid: 'excel!Excel.Interfaces.PivotHierarchyUpdateData:interface'
     name: Interfaces.PivotHierarchyUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.PivotHierarchyData:interface'
     name: Excel.Interfaces.PivotHierarchyData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.pivothierarchycollection.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.pivothierarchycollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PivotHierarchyCollection#context:member'
@@ -170,7 +170,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.PivotHierarchyCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -190,7 +190,7 @@ items:
           - 'excel!Excel.Interfaces.PivotHierarchyCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -198,7 +198,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -228,7 +228,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.PivotHierarchyCollectionData:interface'
     name: Excel.Interfaces.PivotHierarchyCollectionData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.pivotitem.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.pivotitem.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PivotItem#context:member'
@@ -183,7 +183,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.PivotItem#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -236,7 +236,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -246,7 +246,7 @@ references:
     name: Excel.Interfaces.PivotItemLoadOptions
   - uid: 'excel!Excel.Interfaces.PivotItemUpdateData:interface'
     name: Interfaces.PivotItemUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.PivotItemData:interface'
     name: Excel.Interfaces.PivotItemData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.pivotitemcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.pivotitemcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PivotItemCollection#context:member'
@@ -170,7 +170,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.PivotItemCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -190,7 +190,7 @@ items:
           - 'excel!Excel.Interfaces.PivotItemCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -198,7 +198,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -228,7 +228,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.PivotItemCollectionData:interface'
     name: Excel.Interfaces.PivotItemCollectionData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.pivotlayout.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.pivotlayout.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PivotLayout#context:member'
@@ -268,7 +268,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.PivotLayout#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -353,7 +353,7 @@ items:
           - 'excel!Excel.Interfaces.PivotLayoutData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -374,7 +374,7 @@ references:
     name: Excel.Interfaces.PivotLayoutLoadOptions
   - uid: 'excel!Excel.Interfaces.PivotLayoutUpdateData:interface'
     name: Interfaces.PivotLayoutUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.PivotLayout#subtotalLocation~0:complex'
     name: Excel.SubtotalLocationType | "AtTop" | "AtBottom" | "Off"

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.pivottable.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.pivottable.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PivotTable#columnHierarchies:member'
@@ -423,7 +423,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.PivotTable#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -476,7 +476,7 @@ items:
         type:
           - 'excel!Excel.Worksheet:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RowColumnPivotHierarchyCollection:class'
     name: Excel.RowColumnPivotHierarchyCollection
@@ -496,7 +496,7 @@ references:
     name: Excel.Interfaces.PivotTableLoadOptions
   - uid: 'excel!Excel.Interfaces.PivotTableUpdateData:interface'
     name: Interfaces.PivotTableUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.PivotTableData:interface'
     name: Excel.Interfaces.PivotTableData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.pivottablecollection.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.pivottablecollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PivotTableCollection#add:member(1)'
@@ -225,7 +225,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.PivotTableCollection#refreshAll:member(1)'
     summary: |-
       Refreshes all the pivot tables in the collection.
@@ -261,7 +261,7 @@ items:
           - 'excel!Excel.Interfaces.PivotTableCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.PivotTable:class'
     name: Excel.PivotTable
@@ -292,7 +292,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -320,7 +320,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.PivotTableCollectionData:interface'
     name: Excel.Interfaces.PivotTableCollectionData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.presetcriteriaconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.presetcriteriaconditionalformat.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PresetCriteriaConditionalFormat#context:member'
@@ -212,7 +212,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.PresetCriteriaConditionalFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -250,7 +250,7 @@ items:
           - 'excel!Excel.Interfaces.PresetCriteriaConditionalFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -264,7 +264,7 @@ references:
     name: Excel.ConditionalPresetCriteriaRule
   - uid: 'excel!Excel.Interfaces.PresetCriteriaConditionalFormatUpdateData:interface'
     name: Interfaces.PresetCriteriaConditionalFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.PresetCriteriaConditionalFormatData:interface'
     name: Excel.Interfaces.PresetCriteriaConditionalFormatData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.range.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.range.yml
@@ -16,7 +16,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Range#address:member'
@@ -1905,7 +1905,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Range#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -2209,7 +2209,7 @@ items:
         type:
           - 'excel!Excel.Worksheet:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ClearApplyTo:enum'
     name: Excel.ClearApplyTo
@@ -2238,7 +2238,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -2280,7 +2280,7 @@ references:
         fullName: ' | string'
   - uid: 'excel!Excel.Interfaces.RangeUpdateData:interface'
     name: Interfaces.RangeUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.RangeSort:class'
     name: Excel.RangeSort

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.rangeborder.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.rangeborder.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeBorder#color:member'
@@ -155,7 +155,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.RangeBorder#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -269,7 +269,7 @@ items:
         type:
           - 'excel!Excel.RangeBorder#weight~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -279,7 +279,7 @@ references:
     name: Excel.Interfaces.RangeBorderLoadOptions
   - uid: 'excel!Excel.Interfaces.RangeBorderUpdateData:interface'
     name: Interfaces.RangeBorderUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.RangeBorder#sideIndex~0:complex'
     name: >-

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.rangebordercollection.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.rangebordercollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeBorderCollection#context:member'
@@ -265,7 +265,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.RangeBorderCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -285,7 +285,7 @@ items:
           - 'excel!Excel.Interfaces.RangeBorderCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -316,7 +316,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.RangeBorderCollectionData:interface'
     name: Excel.Interfaces.RangeBorderCollectionData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.rangefill.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.rangefill.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeFill#clear:member(1)'
@@ -226,7 +226,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.RangeFill#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -264,7 +264,7 @@ items:
           - 'excel!Excel.Interfaces.RangeFillData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -274,7 +274,7 @@ references:
     name: Excel.Interfaces.RangeFillLoadOptions
   - uid: 'excel!Excel.Interfaces.RangeFillUpdateData:interface'
     name: Interfaces.RangeFillUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.RangeFillData:interface'
     name: Excel.Interfaces.RangeFillData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.rangefont.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.rangefont.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeFont#bold:member'
@@ -237,7 +237,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.RangeFont#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -305,7 +305,7 @@ items:
         type:
           - 'excel!Excel.RangeFont#underline~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -315,7 +315,7 @@ references:
     name: Excel.Interfaces.RangeFontLoadOptions
   - uid: 'excel!Excel.Interfaces.RangeFontUpdateData:interface'
     name: Interfaces.RangeFontUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.RangeFontData:interface'
     name: Excel.Interfaces.RangeFontData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.rangeformat.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.rangeformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeFormat#adjustIndent:member(1)'
@@ -381,7 +381,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.RangeFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -528,7 +528,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RangeBorderCollection:class'
     name: Excel.RangeBorderCollection
@@ -559,7 +559,7 @@ references:
     name: Excel.FormatProtection
   - uid: 'excel!Excel.Interfaces.RangeFormatUpdateData:interface'
     name: Interfaces.RangeFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.RangeFormatData:interface'
     name: Excel.Interfaces.RangeFormatData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.rangesort.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.rangesort.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeSort#apply:member(1)'
@@ -135,7 +135,7 @@ items:
                     }
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RangeSort#apply~0:complex'
     name: 'Excel.SortField[]'

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.rangeview.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.rangeview.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeView#cellAddresses:member'
@@ -300,7 +300,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.RangeView#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -387,7 +387,7 @@ items:
         type:
           - 'excel!Excel.RangeView#valueTypes~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -401,7 +401,7 @@ references:
     name: Excel.RangeViewCollection
   - uid: 'excel!Excel.Interfaces.RangeViewUpdateData:interface'
     name: Interfaces.RangeViewUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.RangeViewData:interface'
     name: Excel.Interfaces.RangeViewData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.rangeviewcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.rangeviewcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeViewCollection#context:member'
@@ -148,7 +148,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.RangeViewCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -168,7 +168,7 @@ items:
           - 'excel!Excel.Interfaces.RangeViewCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -176,7 +176,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -206,7 +206,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.RangeViewCollectionData:interface'
     name: Excel.Interfaces.RangeViewCollectionData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.requestcontext.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.requestcontext.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientRequestContext:class'
+      - 'office!OfficeExtension.ClientRequestContext:class'
     package: excel!
     children:
       - 'excel!Excel.RequestContext:constructor(1)'
@@ -67,7 +67,7 @@ items:
         type:
           - 'excel!Excel.Workbook:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientRequestContext:class'
+  - uid: 'office!OfficeExtension.ClientRequestContext:class'
     name: OfficeExtension.ClientRequestContext
   - uid: 'excel!Excel.RequestContext~0:complex'
     name: string | Session

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.rowcolumnpivothierarchy.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.rowcolumnpivothierarchy.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RowColumnPivotHierarchy#context:member'
@@ -199,7 +199,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.RowColumnPivotHierarchy#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -253,7 +253,7 @@ items:
           - 'excel!Excel.Interfaces.RowColumnPivotHierarchyData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -265,7 +265,7 @@ references:
     name: Excel.Interfaces.RowColumnPivotHierarchyLoadOptions
   - uid: 'excel!Excel.Interfaces.RowColumnPivotHierarchyUpdateData:interface'
     name: Interfaces.RowColumnPivotHierarchyUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.RowColumnPivotHierarchyData:interface'
     name: Excel.Interfaces.RowColumnPivotHierarchyData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.rowcolumnpivothierarchycollection.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.rowcolumnpivothierarchycollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RowColumnPivotHierarchyCollection#add:member(1)'
@@ -195,7 +195,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.RowColumnPivotHierarchyCollection#remove:member(1)'
     summary: |-
       Removes the PivotHierarchy from the current axis.
@@ -237,7 +237,7 @@ items:
           - 'excel!Excel.Interfaces.RowColumnPivotHierarchyCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RowColumnPivotHierarchy:class'
     name: Excel.RowColumnPivotHierarchy
@@ -249,7 +249,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -277,7 +277,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.RowColumnPivotHierarchyCollectionData:interface'
     name: Excel.Interfaces.RowColumnPivotHierarchyCollectionData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.runoptions.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.runoptions.yml
@@ -34,7 +34,7 @@ references:
     name: OfficeExtension.RunOptions<Session>
     fullName: OfficeExtension.RunOptions<Excel.Session>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.RunOptions:interface'
+      - uid: 'office!OfficeExtension.RunOptions:interface'
         name: OfficeExtension.RunOptions
         fullName: OfficeExtension.RunOptions
       - name: <

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.runtime.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.runtime.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Runtime#context:member'
@@ -178,7 +178,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Runtime#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -216,7 +216,7 @@ items:
           - 'excel!Excel.Interfaces.RuntimeData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -226,7 +226,7 @@ references:
     name: Excel.Interfaces.RuntimeLoadOptions
   - uid: 'excel!Excel.Interfaces.RuntimeUpdateData:interface'
     name: Interfaces.RuntimeUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.RuntimeData:interface'
     name: Excel.Interfaces.RuntimeData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.setting.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.setting.yml
@@ -15,7 +15,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Setting#context:member'
@@ -200,7 +200,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Setting#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -253,7 +253,7 @@ items:
         type:
           - any
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -263,7 +263,7 @@ references:
     name: Excel.Interfaces.SettingLoadOptions
   - uid: 'excel!Excel.Interfaces.SettingUpdateData:interface'
     name: Interfaces.SettingUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.SettingData:interface'
     name: Excel.Interfaces.SettingData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.settingcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.settingcollection.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.SettingCollection#add:member(1)'
@@ -246,7 +246,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.SettingCollection#onSettingsChanged:member'
     summary: |-
       Occurs when the Settings in the document are changed.
@@ -301,7 +301,7 @@ items:
           - 'excel!Excel.Interfaces.SettingCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Setting:class'
     name: Excel.Setting
@@ -327,7 +327,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -355,13 +355,13 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.SettingCollection#onSettingsChanged~0:complex'
     name: OfficeExtension.EventHandlers<Excel.SettingsChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.SettingsChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.style.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.style.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Style#autoIndent:member'
@@ -568,7 +568,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Style#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -666,7 +666,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RangeBorderCollection:class'
     name: Excel.RangeBorderCollection
@@ -704,7 +704,7 @@ references:
         fullName: ' | "Context" | "LeftToRight" | "RightToLeft"'
   - uid: 'excel!Excel.Interfaces.StyleUpdateData:interface'
     name: Interfaces.StyleUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.StyleData:interface'
     name: Excel.Interfaces.StyleData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.stylecollection.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.stylecollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.StyleCollection#add:member(1)'
@@ -217,7 +217,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.StyleCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -237,7 +237,7 @@ items:
           - 'excel!Excel.Interfaces.StyleCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -266,7 +266,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.StyleCollectionData:interface'
     name: Excel.Interfaces.StyleCollectionData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.table.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.table.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Table#clearFilters:member(1)'
@@ -621,7 +621,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Table#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -812,7 +812,7 @@ items:
         type:
           - 'excel!Excel.Worksheet:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.TableColumnCollection:class'
     name: Excel.TableColumnCollection
@@ -828,7 +828,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.TableChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.TableChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -842,7 +842,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.TableSelectionChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.TableSelectionChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -856,7 +856,7 @@ references:
     name: Excel.TableRowCollection
   - uid: 'excel!Excel.Interfaces.TableUpdateData:interface'
     name: Interfaces.TableUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.TableSort:class'
     name: Excel.TableSort

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.tablecollection.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.tablecollection.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableCollection#add:member(1)'
@@ -339,7 +339,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.TableCollection#onChanged:member'
     summary: |-
       Occurs when data changes on any table in a workbook, or a worksheet.
@@ -394,7 +394,7 @@ items:
           - 'excel!Excel.Interfaces.TableCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Table:class'
     name: Excel.Table
@@ -413,7 +413,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -441,13 +441,13 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.TableCollection#onChanged~0:complex'
     name: OfficeExtension.EventHandlers<Excel.TableChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.TableChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.tablecolumn.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.tablecolumn.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableColumn#context:member'
@@ -401,7 +401,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.TableColumn#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -456,7 +456,7 @@ items:
         type:
           - 'any[][]'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -470,7 +470,7 @@ references:
     name: Excel.Interfaces.TableColumnLoadOptions
   - uid: 'excel!Excel.Interfaces.TableColumnUpdateData:interface'
     name: Interfaces.TableColumnUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.TableColumnData:interface'
     name: Excel.Interfaces.TableColumnData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.tablecolumncollection.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.tablecolumncollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableColumnCollection#add:member(1)'
@@ -322,7 +322,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.TableColumnCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -342,7 +342,7 @@ items:
           - 'excel!Excel.Interfaces.TableColumnCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.TableColumn:class'
     name: Excel.TableColumn
@@ -366,7 +366,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -394,7 +394,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.TableColumnCollectionData:interface'
     name: Excel.Interfaces.TableColumnCollectionData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.tablerow.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.tablerow.yml
@@ -17,7 +17,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableRow#context:member'
@@ -247,7 +247,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.TableRow#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -302,7 +302,7 @@ items:
         type:
           - 'any[][]'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -314,7 +314,7 @@ references:
     name: Excel.Interfaces.TableRowLoadOptions
   - uid: 'excel!Excel.Interfaces.TableRowUpdateData:interface'
     name: Interfaces.TableRowUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.TableRowData:interface'
     name: Excel.Interfaces.TableRowData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.tablerowcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.tablerowcollection.yml
@@ -17,7 +17,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableRowCollection#add:member(1)'
@@ -290,7 +290,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.TableRowCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -310,7 +310,7 @@ items:
           - 'excel!Excel.Interfaces.TableRowCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.TableRow:class'
     name: Excel.TableRow
@@ -334,7 +334,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -362,7 +362,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.TableRowCollectionData:interface'
     name: Excel.Interfaces.TableRowCollectionData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.tablesort.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.tablesort.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableSort#apply:member(1)'
@@ -288,7 +288,7 @@ items:
           - 'excel!Excel.Interfaces.TableSortData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.TableSort#apply~0:complex'
     name: 'Excel.SortField[]'

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.textconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.textconditionalformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TextConditionalFormat#context:member'
@@ -214,7 +214,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.TextConditionalFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -252,7 +252,7 @@ items:
           - 'excel!Excel.Interfaces.TextConditionalFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -266,7 +266,7 @@ references:
     name: Excel.ConditionalTextComparisonRule
   - uid: 'excel!Excel.Interfaces.TextConditionalFormatUpdateData:interface'
     name: Interfaces.TextConditionalFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.TextConditionalFormatData:interface'
     name: Excel.Interfaces.TextConditionalFormatData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.topbottomconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.topbottomconditionalformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TopBottomConditionalFormat#context:member'
@@ -168,7 +168,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.TopBottomConditionalFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -206,7 +206,7 @@ items:
           - 'excel!Excel.Interfaces.TopBottomConditionalFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -220,7 +220,7 @@ references:
     name: Excel.ConditionalTopBottomRule
   - uid: 'excel!Excel.Interfaces.TopBottomConditionalFormatUpdateData:interface'
     name: Interfaces.TopBottomConditionalFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.TopBottomConditionalFormatData:interface'
     name: Excel.Interfaces.TopBottomConditionalFormatData

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.workbook.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.workbook.yml
@@ -14,7 +14,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Workbook#application:member'
@@ -446,7 +446,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Workbook#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -577,7 +577,7 @@ items:
         type:
           - 'excel!Excel.WorksheetCollection:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Application:class'
     name: Excel.Application
@@ -603,7 +603,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.SelectionChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.SelectionChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -621,7 +621,7 @@ references:
     name: Excel.WorkbookProtection
   - uid: 'excel!Excel.Interfaces.WorkbookUpdateData:interface'
     name: Interfaces.WorkbookUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.SettingCollection:class'
     name: Excel.SettingCollection

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.workbookcreated.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.workbookcreated.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.WorkbookCreated#context:member'
@@ -103,7 +103,7 @@ items:
           - 'excel!Excel.Interfaces.WorkbookCreatedData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.workbookprotection.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.workbookprotection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.WorkbookProtection#context:member'
@@ -258,7 +258,7 @@ items:
           type:
             - string
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.worksheet.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.worksheet.yml
@@ -14,7 +14,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Worksheet#activate:member(1)'
@@ -1078,7 +1078,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Worksheet#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -1268,7 +1268,7 @@ items:
         type:
           - 'excel!Excel.Worksheet#visibility~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartCollection:class'
     name: Excel.ChartCollection
@@ -1290,7 +1290,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetActivatedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetActivatedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -1304,7 +1304,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetCalculatedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetCalculatedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -1318,7 +1318,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -1332,7 +1332,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetDeactivatedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetDeactivatedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -1346,7 +1346,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetSelectionChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetSelectionChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -1362,7 +1362,7 @@ references:
     name: Excel.WorksheetProtection
   - uid: 'excel!Excel.Interfaces.WorksheetUpdateData:interface'
     name: Interfaces.WorksheetUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.TableCollection:class'
     name: Excel.TableCollection

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.worksheetcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.worksheetcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.WorksheetCollection#add:member(1)'
@@ -398,7 +398,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.WorksheetCollection#onActivated:member'
     summary: |-
       Occurs when any worksheet in the workbook is activated.
@@ -553,7 +553,7 @@ items:
           - 'excel!Excel.Interfaces.WorksheetCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Worksheet:class'
     name: Excel.Worksheet
@@ -563,7 +563,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -591,13 +591,13 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.WorksheetCollection#onActivated~0:complex'
     name: OfficeExtension.EventHandlers<Excel.WorksheetActivatedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetActivatedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -611,7 +611,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetAddedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetAddedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -625,7 +625,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetCalculatedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetCalculatedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -639,7 +639,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetDeactivatedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetDeactivatedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -653,7 +653,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetDeletedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetDeletedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.worksheetfreezepanes.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.worksheetfreezepanes.yml
@@ -8,7 +8,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.WorksheetFreezePanes#context:member'
@@ -278,7 +278,7 @@ items:
 
           ```
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel_1_8/excel/excel.worksheetprotection.yml
+++ b/docs/docs-ref-autogen/excel_1_8/excel/excel.worksheetprotection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.WorksheetProtection#context:member'
@@ -282,7 +282,7 @@ items:
           type:
             - string
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel_1_9/excel.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel.yml
@@ -960,7 +960,7 @@ items:
             A previously-created API object. The batch will use the same RequestContext as the passed-in object, which
             means that any changes applied to the object will be picked up by "context.sync()".
           type:
-            - 'excel!OfficeExtension.ClientObject:class'
+            - 'office!OfficeExtension.ClientObject:class'
         - id: batch
           description: >-
             A function that takes in a RequestContext and returns a promise (typically, just the result of
@@ -1065,7 +1065,7 @@ items:
             A previously-created object. The batch will use the same RequestContext as the passed-in object, which means
             that any changes applied to the object will be picked up by "context.sync()".
           type:
-            - 'excel!OfficeExtension.ClientRequestContext:class'
+            - 'office!OfficeExtension.ClientRequestContext:class'
         - id: batch
           description: >-
             A function that takes in a RequestContext and returns a promise (typically, just the result of
@@ -2560,7 +2560,7 @@ references:
         fullName: Promise
       - name: <T>
         fullName: <T>
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.run~3:complex'
     name: '(context: Excel.RequestContext) => Promise<T>'
@@ -2591,7 +2591,7 @@ references:
     name: 'OfficeExtension.ClientObject[]'
     fullName: 'OfficeExtension.ClientObject[]'
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientObject:class'
+      - uid: 'office!OfficeExtension.ClientObject:class'
         name: OfficeExtension.ClientObject
         fullName: OfficeExtension.ClientObject
       - name: '[]'
@@ -2648,7 +2648,7 @@ references:
         fullName: Promise
       - name: <T>
         fullName: <T>
-  - uid: 'excel!OfficeExtension.ClientRequestContext:class'
+  - uid: 'office!OfficeExtension.ClientRequestContext:class'
     name: OfficeExtension.ClientRequestContext
   - uid: 'excel!Excel.run~10:complex'
     name: '(context: Excel.RequestContext) => Promise<T>'

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.application.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.application.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Application#calculate:member(1)'
@@ -284,7 +284,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Application#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -401,7 +401,7 @@ items:
           - 'excel!Excel.Interfaces.ApplicationData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.CalculationType:enum'
     name: Excel.CalculationType
@@ -433,7 +433,7 @@ references:
     name: Excel.Interfaces.ApplicationLoadOptions
   - uid: 'excel!Excel.Interfaces.ApplicationUpdateData:interface'
     name: Interfaces.ApplicationUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ApplicationData:interface'
     name: Excel.Interfaces.ApplicationData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.autofilter.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.autofilter.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.AutoFilter#apply:member(1)'
@@ -309,7 +309,7 @@ items:
           - 'excel!Excel.Interfaces.AutoFilterData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.AutoFilter#apply~0:complex'
     name: Range | string

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.binding.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.binding.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Binding#context:member'
@@ -357,7 +357,7 @@ items:
         type:
           - 'excel!Excel.Binding#type~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -369,7 +369,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -382,7 +382,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.BindingDataChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.BindingDataChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -396,7 +396,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.BindingSelectionChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.BindingSelectionChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.bindingcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.bindingcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.BindingCollection#add:member(1)'
@@ -493,7 +493,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.BindingCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -513,7 +513,7 @@ items:
           - 'excel!Excel.Interfaces.BindingCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Binding:class'
     name: Excel.Binding
@@ -543,7 +543,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -571,7 +571,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.BindingCollectionData:interface'
     name: Excel.Interfaces.BindingCollectionData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.cellvalueconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.cellvalueconditionalformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.CellValueConditionalFormat#context:member'
@@ -212,7 +212,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.CellValueConditionalFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -250,7 +250,7 @@ items:
           - 'excel!Excel.Interfaces.CellValueConditionalFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -264,7 +264,7 @@ references:
     name: Excel.ConditionalCellValueRule
   - uid: 'excel!Excel.Interfaces.CellValueConditionalFormatUpdateData:interface'
     name: Interfaces.CellValueConditionalFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.CellValueConditionalFormatData:interface'
     name: Excel.Interfaces.CellValueConditionalFormatData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chart.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chart.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Chart#activate:member(1)'
@@ -704,7 +704,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Chart#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -977,7 +977,7 @@ items:
         type:
           - 'excel!Excel.Worksheet:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartAxes:class'
     name: Excel.ChartAxes
@@ -1037,7 +1037,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -1048,7 +1048,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -1063,7 +1063,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.ChartActivatedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.ChartActivatedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -1077,7 +1077,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.ChartDeactivatedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.ChartDeactivatedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -1104,7 +1104,7 @@ references:
     name: Excel.ChartSeriesCollection
   - uid: 'excel!Excel.Interfaces.ChartUpdateData:interface'
     name: Interfaces.ChartUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Range:class'
     name: Range

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chartareaformat.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chartareaformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAreaFormat#border:member'
@@ -219,7 +219,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAreaFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -257,7 +257,7 @@ items:
           - 'excel!Excel.Interfaces.ChartAreaFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartBorder:class'
     name: Excel.ChartBorder
@@ -292,7 +292,7 @@ references:
     name: Excel.Interfaces.ChartAreaFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartAreaFormatUpdateData:interface'
     name: Interfaces.ChartAreaFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartAreaFormatData:interface'
     name: Excel.Interfaces.ChartAreaFormatData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chartaxes.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chartaxes.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAxes#categoryAxis:member'
@@ -221,7 +221,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAxes#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -297,7 +297,7 @@ items:
           });
           ```
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartAxis:class'
     name: Excel.ChartAxis
@@ -313,7 +313,7 @@ references:
     name: Excel.Interfaces.ChartAxesLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartAxesUpdateData:interface'
     name: Interfaces.ChartAxesUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartAxesData:interface'
     name: Excel.Interfaces.ChartAxesData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chartaxis.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chartaxis.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAxis#alignment:member'
@@ -682,7 +682,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAxis#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -964,7 +964,7 @@ items:
         type:
           - number
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartAxis#alignment~0:complex'
     name: Excel.ChartTickLabelAlignment | "Center" | "Left" | "Right"
@@ -1081,7 +1081,7 @@ references:
         fullName: ' | "Linear" | "Logarithmic"'
   - uid: 'excel!Excel.Interfaces.ChartAxisUpdateData:interface'
     name: Interfaces.ChartAxisUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Range:class'
     name: Range

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chartaxisformat.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chartaxisformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAxisFormat#context:member'
@@ -182,7 +182,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAxisFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -220,7 +220,7 @@ items:
           - 'excel!Excel.Interfaces.ChartAxisFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -236,7 +236,7 @@ references:
     name: Excel.Interfaces.ChartAxisFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisFormatUpdateData:interface'
     name: Interfaces.ChartAxisFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisFormatData:interface'
     name: Excel.Interfaces.ChartAxisFormatData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chartaxistitle.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chartaxistitle.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAxisTitle#context:member'
@@ -172,7 +172,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAxisTitle#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -261,7 +261,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -273,7 +273,7 @@ references:
     name: Excel.Interfaces.ChartAxisTitleLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisTitleUpdateData:interface'
     name: Interfaces.ChartAxisTitleUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisTitleData:interface'
     name: Excel.Interfaces.ChartAxisTitleData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chartaxistitleformat.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chartaxistitleformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAxisTitleFormat#border:member'
@@ -182,7 +182,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAxisTitleFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -220,7 +220,7 @@ items:
           - 'excel!Excel.Interfaces.ChartAxisTitleFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartBorder:class'
     name: Excel.ChartBorder
@@ -236,7 +236,7 @@ references:
     name: Excel.Interfaces.ChartAxisTitleFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisTitleFormatUpdateData:interface'
     name: Interfaces.ChartAxisTitleFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisTitleFormatData:interface'
     name: Excel.Interfaces.ChartAxisTitleFormatData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chartbinoptions.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chartbinoptions.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartBinOptions#allowOverflow:member'
@@ -201,7 +201,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartBinOptions#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -284,7 +284,7 @@ items:
         type:
           - number
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -294,7 +294,7 @@ references:
     name: Excel.Interfaces.ChartBinOptionsLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartBinOptionsUpdateData:interface'
     name: Interfaces.ChartBinOptionsUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartBinOptionsData:interface'
     name: Excel.Interfaces.ChartBinOptionsData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chartborder.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chartborder.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartBorder#clear:member(1)'
@@ -186,7 +186,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartBorder#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -239,7 +239,7 @@ items:
         type:
           - number
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -262,7 +262,7 @@ references:
     name: Excel.Interfaces.ChartBorderLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartBorderUpdateData:interface'
     name: Interfaces.ChartBorderUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartBorderData:interface'
     name: Excel.Interfaces.ChartBorderData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chartboxwhiskeroptions.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chartboxwhiskeroptions.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartBoxwhiskerOptions#context:member'
@@ -154,7 +154,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartBoxwhiskerOptions#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -252,7 +252,7 @@ items:
           - 'excel!Excel.Interfaces.ChartBoxwhiskerOptionsData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -271,7 +271,7 @@ references:
         fullName: ' | "Inclusive" | "Exclusive"'
   - uid: 'excel!Excel.Interfaces.ChartBoxwhiskerOptionsUpdateData:interface'
     name: Interfaces.ChartBoxwhiskerOptionsUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartBoxwhiskerOptionsData:interface'
     name: Excel.Interfaces.ChartBoxwhiskerOptionsData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chartcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartCollection#add:member(1)'
@@ -387,7 +387,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.ChartCollection#onActivated:member'
     summary: |-
       Occurs when a chart is activated.
@@ -535,7 +535,7 @@ items:
           - 'excel!Excel.Interfaces.ChartCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Chart:class'
     name: Excel.Chart
@@ -551,7 +551,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -579,13 +579,13 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.ChartCollection#onActivated~0:complex'
     name: OfficeExtension.EventHandlers<Excel.ChartActivatedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.ChartActivatedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -599,7 +599,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.ChartAddedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.ChartAddedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -613,7 +613,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.ChartDeactivatedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.ChartDeactivatedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -627,7 +627,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.ChartDeletedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.ChartDeletedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chartdatalabel.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chartdatalabel.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartDataLabel#autoText:member'
@@ -317,7 +317,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartDataLabel#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -526,7 +526,7 @@ items:
         type:
           - number
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -560,7 +560,7 @@ references:
         fullName: ' | "Invalid" | "None" | "Center" | "InsideEnd" | "InsideBase" | "OutsideEnd" | "Left" | "Right" | "Top" | "Bottom" | "BestFit" | "Callout"'
   - uid: 'excel!Excel.Interfaces.ChartDataLabelUpdateData:interface'
     name: Interfaces.ChartDataLabelUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartDataLabelData:interface'
     name: Excel.Interfaces.ChartDataLabelData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chartdatalabelformat.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chartdatalabelformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartDataLabelFormat#border:member'
@@ -182,7 +182,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartDataLabelFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -220,7 +220,7 @@ items:
           - 'excel!Excel.Interfaces.ChartDataLabelFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartBorder:class'
     name: Excel.ChartBorder
@@ -236,7 +236,7 @@ references:
     name: Excel.Interfaces.ChartDataLabelFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartDataLabelFormatUpdateData:interface'
     name: Interfaces.ChartDataLabelFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartDataLabelFormatData:interface'
     name: Excel.Interfaces.ChartDataLabelFormatData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chartdatalabels.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chartdatalabels.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartDataLabels#autoText:member'
@@ -285,7 +285,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartDataLabels#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -447,7 +447,7 @@ items:
         type:
           - 'excel!Excel.ChartDataLabels#verticalAlignment~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -481,7 +481,7 @@ references:
         fullName: ' | "Invalid" | "None" | "Center" | "InsideEnd" | "InsideBase" | "OutsideEnd" | "Left" | "Right" | "Top" | "Bottom" | "BestFit" | "Callout"'
   - uid: 'excel!Excel.Interfaces.ChartDataLabelsUpdateData:interface'
     name: Interfaces.ChartDataLabelsUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartDataLabelsData:interface'
     name: Excel.Interfaces.ChartDataLabelsData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.charterrorbars.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.charterrorbars.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartErrorBars#context:member'
@@ -184,7 +184,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartErrorBars#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -252,7 +252,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -273,7 +273,7 @@ references:
     name: Excel.Interfaces.ChartErrorBarsLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartErrorBarsUpdateData:interface'
     name: Interfaces.ChartErrorBarsUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartErrorBarsData:interface'
     name: Excel.Interfaces.ChartErrorBarsData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.charterrorbarsformat.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.charterrorbarsformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartErrorBarsFormat#context:member'
@@ -150,7 +150,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartErrorBarsFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -188,7 +188,7 @@ items:
           - 'excel!Excel.Interfaces.ChartErrorBarsFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -200,7 +200,7 @@ references:
     name: Excel.Interfaces.ChartErrorBarsFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartErrorBarsFormatUpdateData:interface'
     name: Interfaces.ChartErrorBarsFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartErrorBarsFormatData:interface'
     name: Excel.Interfaces.ChartErrorBarsFormatData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chartfill.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chartfill.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartFill#clear:member(1)'
@@ -138,7 +138,7 @@ items:
                     }
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chartfont.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chartfont.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     remarks: |-
 
@@ -223,7 +223,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartFont#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -291,7 +291,7 @@ items:
         type:
           - 'excel!Excel.ChartFont#underline~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -301,7 +301,7 @@ references:
     name: Excel.Interfaces.ChartFontLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartFontUpdateData:interface'
     name: Interfaces.ChartFontUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartFontData:interface'
     name: Excel.Interfaces.ChartFontData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chartformatstring.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chartformatstring.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartFormatString#context:member'
@@ -152,7 +152,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartFormatString#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -190,7 +190,7 @@ items:
           - 'excel!Excel.Interfaces.ChartFormatStringData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -202,7 +202,7 @@ references:
     name: Excel.Interfaces.ChartFormatStringLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartFormatStringUpdateData:interface'
     name: Interfaces.ChartFormatStringUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartFormatStringData:interface'
     name: Excel.Interfaces.ChartFormatStringData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chartgridlines.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chartgridlines.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartGridlines#context:member'
@@ -170,7 +170,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartGridlines#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -223,7 +223,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -235,7 +235,7 @@ references:
     name: Excel.Interfaces.ChartGridlinesLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartGridlinesUpdateData:interface'
     name: Interfaces.ChartGridlinesUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartGridlinesData:interface'
     name: Excel.Interfaces.ChartGridlinesData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chartgridlinesformat.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chartgridlinesformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartGridlinesFormat#context:member'
@@ -150,7 +150,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartGridlinesFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -188,7 +188,7 @@ items:
           - 'excel!Excel.Interfaces.ChartGridlinesFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -200,7 +200,7 @@ references:
     name: Excel.Interfaces.ChartGridlinesFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartGridlinesFormatUpdateData:interface'
     name: Interfaces.ChartGridlinesFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartGridlinesFormatData:interface'
     name: Excel.Interfaces.ChartGridlinesFormatData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chartlegend.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chartlegend.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartLegend#context:member'
@@ -254,7 +254,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartLegend#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -352,7 +352,7 @@ items:
         type:
           - number
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -375,7 +375,7 @@ references:
         fullName: ' | "Invalid" | "Top" | "Bottom" | "Left" | "Right" | "Corner" | "Custom"'
   - uid: 'excel!Excel.Interfaces.ChartLegendUpdateData:interface'
     name: Interfaces.ChartLegendUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartLegendData:interface'
     name: Excel.Interfaces.ChartLegendData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chartlegendentry.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chartlegendentry.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartLegendEntry#context:member'
@@ -185,7 +185,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartLegendEntry#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -268,7 +268,7 @@ items:
         type:
           - number
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -278,7 +278,7 @@ references:
     name: Excel.Interfaces.ChartLegendEntryLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartLegendEntryUpdateData:interface'
     name: Interfaces.ChartLegendEntryUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartLegendEntryData:interface'
     name: Excel.Interfaces.ChartLegendEntryData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chartlegendentrycollection.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chartlegendentrycollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartLegendEntryCollection#context:member'
@@ -148,7 +148,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.ChartLegendEntryCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -168,7 +168,7 @@ items:
           - 'excel!Excel.Interfaces.ChartLegendEntryCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -176,7 +176,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -206,7 +206,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.ChartLegendEntryCollectionData:interface'
     name: Excel.Interfaces.ChartLegendEntryCollectionData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chartlegendformat.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chartlegendformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartLegendFormat#border:member'
@@ -212,7 +212,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartLegendFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -250,7 +250,7 @@ items:
           - 'excel!Excel.Interfaces.ChartLegendFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartBorder:class'
     name: Excel.ChartBorder
@@ -266,7 +266,7 @@ references:
     name: Excel.Interfaces.ChartLegendFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartLegendFormatUpdateData:interface'
     name: Interfaces.ChartLegendFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartLegendFormatData:interface'
     name: Excel.Interfaces.ChartLegendFormatData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chartlineformat.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chartlineformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartLineFormat#clear:member(1)'
@@ -224,7 +224,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartLineFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -277,7 +277,7 @@ items:
         type:
           - number
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -300,7 +300,7 @@ references:
     name: Excel.Interfaces.ChartLineFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartLineFormatUpdateData:interface'
     name: Interfaces.ChartLineFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartLineFormatData:interface'
     name: Excel.Interfaces.ChartLineFormatData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chartmapoptions.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chartmapoptions.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartMapOptions#context:member'
@@ -184,7 +184,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartMapOptions#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -222,7 +222,7 @@ items:
           - 'excel!Excel.Interfaces.ChartMapOptionsData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -263,7 +263,7 @@ references:
         fullName: ' | "Automatic" | "Mercator" | "Miller" | "Robinson" | "Albers"'
   - uid: 'excel!Excel.Interfaces.ChartMapOptionsUpdateData:interface'
     name: Interfaces.ChartMapOptionsUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartMapOptionsData:interface'
     name: Excel.Interfaces.ChartMapOptionsData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chartpivotoptions.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chartpivotoptions.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartPivotOptions#context:member'
@@ -138,7 +138,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartPivotOptions#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -239,7 +239,7 @@ items:
           - 'excel!Excel.Interfaces.ChartPivotOptionsData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -249,7 +249,7 @@ references:
     name: Excel.Interfaces.ChartPivotOptionsLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartPivotOptionsUpdateData:interface'
     name: Interfaces.ChartPivotOptionsUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartPivotOptionsData:interface'
     name: Excel.Interfaces.ChartPivotOptionsData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chartplotarea.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chartplotarea.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartPlotArea#context:member'
@@ -264,7 +264,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartPlotArea#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -332,7 +332,7 @@ items:
         type:
           - number
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -353,7 +353,7 @@ references:
         fullName: ' | "Automatic" | "Custom"'
   - uid: 'excel!Excel.Interfaces.ChartPlotAreaUpdateData:interface'
     name: Interfaces.ChartPlotAreaUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartPlotAreaData:interface'
     name: Excel.Interfaces.ChartPlotAreaData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chartplotareaformat.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chartplotareaformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartPlotAreaFormat#border:member'
@@ -166,7 +166,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartPlotAreaFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -204,7 +204,7 @@ items:
           - 'excel!Excel.Interfaces.ChartPlotAreaFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartBorder:class'
     name: Excel.ChartBorder
@@ -218,7 +218,7 @@ references:
     name: Excel.Interfaces.ChartPlotAreaFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartPlotAreaFormatUpdateData:interface'
     name: Interfaces.ChartPlotAreaFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartPlotAreaFormatData:interface'
     name: Excel.Interfaces.ChartPlotAreaFormatData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chartpoint.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chartpoint.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartPoint#context:member'
@@ -249,7 +249,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartPoint#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -302,7 +302,7 @@ items:
         type:
           - any
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -329,7 +329,7 @@ references:
         fullName: ' | "Invalid" | "Automatic" | "None" | "Square" | "Diamond" | "Triangle" | "X" | "Star" | "Dot" | "Dash" | "Circle" | "Plus" | "Picture"'
   - uid: 'excel!Excel.Interfaces.ChartPointUpdateData:interface'
     name: Interfaces.ChartPointUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartPointData:interface'
     name: Excel.Interfaces.ChartPointData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chartpointformat.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chartpointformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartPointFormat#border:member'
@@ -168,7 +168,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartPointFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -206,7 +206,7 @@ items:
           - 'excel!Excel.Interfaces.ChartPointFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartBorder:class'
     name: Excel.ChartBorder
@@ -220,7 +220,7 @@ references:
     name: Excel.Interfaces.ChartPointFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartPointFormatUpdateData:interface'
     name: Interfaces.ChartPointFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartPointFormatData:interface'
     name: Excel.Interfaces.ChartPointFormatData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chartpointscollection.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chartpointscollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartPointsCollection#context:member'
@@ -219,7 +219,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.ChartPointsCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -239,7 +239,7 @@ items:
           - 'excel!Excel.Interfaces.ChartPointsCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -247,7 +247,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -277,7 +277,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.ChartPointsCollectionData:interface'
     name: Excel.Interfaces.ChartPointsCollectionData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chartseries.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chartseries.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartSeries#axisGroup:member'
@@ -976,7 +976,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartSeries#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -1259,7 +1259,7 @@ items:
         type:
           - 'excel!Excel.ChartErrorBars:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartSeries#axisGroup~0:complex'
     name: Excel.ChartAxisGroup | "Primary" | "Secondary"
@@ -1385,7 +1385,7 @@ references:
     name: Excel.ChartPointsCollection
   - uid: 'excel!Excel.Interfaces.ChartSeriesUpdateData:interface'
     name: Interfaces.ChartSeriesUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Range:class'
     name: Range

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chartseriescollection.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chartseriescollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartSeriesCollection#add:member(1)'
@@ -248,7 +248,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.ChartSeriesCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -268,7 +268,7 @@ items:
           - 'excel!Excel.Interfaces.ChartSeriesCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartSeries:class'
     name: Excel.ChartSeries
@@ -278,7 +278,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -306,7 +306,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.ChartSeriesCollectionData:interface'
     name: Excel.Interfaces.ChartSeriesCollectionData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.chartseriesformat.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.chartseriesformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartSeriesFormat#context:member'
@@ -166,7 +166,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartSeriesFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -204,7 +204,7 @@ items:
           - 'excel!Excel.Interfaces.ChartSeriesFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -218,7 +218,7 @@ references:
     name: Excel.Interfaces.ChartSeriesFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartSeriesFormatUpdateData:interface'
     name: Interfaces.ChartSeriesFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartSeriesFormatData:interface'
     name: Excel.Interfaces.ChartSeriesFormatData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.charttitle.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.charttitle.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartTitle#context:member'
@@ -328,7 +328,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartTitle#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -516,7 +516,7 @@ items:
         type:
           - number
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -548,7 +548,7 @@ references:
         fullName: ' | "Automatic" | "Top" | "Bottom" | "Left" | "Right"'
   - uid: 'excel!Excel.Interfaces.ChartTitleUpdateData:interface'
     name: Interfaces.ChartTitleUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartTitleData:interface'
     name: Excel.Interfaces.ChartTitleData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.charttitleformat.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.charttitleformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartTitleFormat#border:member'
@@ -182,7 +182,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartTitleFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -220,7 +220,7 @@ items:
           - 'excel!Excel.Interfaces.ChartTitleFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartBorder:class'
     name: Excel.ChartBorder
@@ -236,7 +236,7 @@ references:
     name: Excel.Interfaces.ChartTitleFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartTitleFormatUpdateData:interface'
     name: Interfaces.ChartTitleFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartTitleFormatData:interface'
     name: Excel.Interfaces.ChartTitleFormatData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.charttrendline.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.charttrendline.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartTrendline#backwardPeriod:member'
@@ -286,7 +286,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartTrendline#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -397,7 +397,7 @@ items:
 
           ```
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -411,7 +411,7 @@ references:
     name: Excel.Interfaces.ChartTrendlineLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartTrendlineUpdateData:interface'
     name: Interfaces.ChartTrendlineUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartTrendlineData:interface'
     name: Excel.Interfaces.ChartTrendlineData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.charttrendlinecollection.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.charttrendlinecollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartTrendlineCollection#add:member(1)'
@@ -216,7 +216,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.ChartTrendlineCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -236,7 +236,7 @@ items:
           - 'excel!Excel.Interfaces.ChartTrendlineCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartTrendline:class'
     name: Excel.ChartTrendline
@@ -248,7 +248,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -276,7 +276,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.ChartTrendlineCollectionData:interface'
     name: Excel.Interfaces.ChartTrendlineCollectionData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.charttrendlineformat.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.charttrendlineformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartTrendlineFormat#context:member'
@@ -199,7 +199,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartTrendlineFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -237,7 +237,7 @@ items:
           - 'excel!Excel.Interfaces.ChartTrendlineFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -249,7 +249,7 @@ references:
     name: Excel.Interfaces.ChartTrendlineFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartTrendlineFormatUpdateData:interface'
     name: Interfaces.ChartTrendlineFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartTrendlineFormatData:interface'
     name: Excel.Interfaces.ChartTrendlineFormatData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.charttrendlinelabel.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.charttrendlinelabel.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartTrendlineLabel#autoText:member'
@@ -277,7 +277,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartTrendlineLabel#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -398,7 +398,7 @@ items:
         type:
           - number
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -419,7 +419,7 @@ references:
     name: Excel.Interfaces.ChartTrendlineLabelLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartTrendlineLabelUpdateData:interface'
     name: Interfaces.ChartTrendlineLabelUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartTrendlineLabelData:interface'
     name: Excel.Interfaces.ChartTrendlineLabelData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.charttrendlinelabelformat.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.charttrendlinelabelformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartTrendlineLabelFormat#border:member'
@@ -182,7 +182,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartTrendlineLabelFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -220,7 +220,7 @@ items:
           - 'excel!Excel.Interfaces.ChartTrendlineLabelFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartBorder:class'
     name: Excel.ChartBorder
@@ -236,7 +236,7 @@ references:
     name: Excel.Interfaces.ChartTrendlineLabelFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartTrendlineLabelFormatUpdateData:interface'
     name: Interfaces.ChartTrendlineLabelFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartTrendlineLabelFormatData:interface'
     name: Excel.Interfaces.ChartTrendlineLabelFormatData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.colorscaleconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.colorscaleconditionalformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ColorScaleConditionalFormat#context:member'
@@ -180,7 +180,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ColorScaleConditionalFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -235,7 +235,7 @@ items:
           - 'excel!Excel.Interfaces.ColorScaleConditionalFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -247,7 +247,7 @@ references:
     name: Excel.Interfaces.ColorScaleConditionalFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ColorScaleConditionalFormatUpdateData:interface'
     name: Interfaces.ColorScaleConditionalFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ColorScaleConditionalFormatData:interface'
     name: Excel.Interfaces.ColorScaleConditionalFormatData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.conditionaldatabarnegativeformat.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.conditionaldatabarnegativeformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ConditionalDataBarNegativeFormat#borderColor:member'
@@ -206,7 +206,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ConditionalDataBarNegativeFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -244,7 +244,7 @@ items:
           - 'excel!Excel.Interfaces.ConditionalDataBarNegativeFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -254,7 +254,7 @@ references:
     name: Excel.Interfaces.ConditionalDataBarNegativeFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ConditionalDataBarNegativeFormatUpdateData:interface'
     name: Interfaces.ConditionalDataBarNegativeFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ConditionalDataBarNegativeFormatData:interface'
     name: Excel.Interfaces.ConditionalDataBarNegativeFormatData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.conditionaldatabarpositiveformat.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.conditionaldatabarpositiveformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ConditionalDataBarPositiveFormat#borderColor:member'
@@ -190,7 +190,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ConditionalDataBarPositiveFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -228,7 +228,7 @@ items:
           - 'excel!Excel.Interfaces.ConditionalDataBarPositiveFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -238,7 +238,7 @@ references:
     name: Excel.Interfaces.ConditionalDataBarPositiveFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ConditionalDataBarPositiveFormatUpdateData:interface'
     name: Interfaces.ConditionalDataBarPositiveFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ConditionalDataBarPositiveFormatData:interface'
     name: Excel.Interfaces.ConditionalDataBarPositiveFormatData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.conditionalformat.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.conditionalformat.yml
@@ -14,7 +14,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ConditionalFormat#cellValue:member'
@@ -657,7 +657,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ConditionalFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -858,7 +858,7 @@ items:
 
           ```
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.CellValueConditionalFormat:class'
     name: Excel.CellValueConditionalFormat
@@ -884,7 +884,7 @@ references:
     name: Excel.PresetCriteriaConditionalFormat
   - uid: 'excel!Excel.Interfaces.ConditionalFormatUpdateData:interface'
     name: Interfaces.ConditionalFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.TextConditionalFormat:class'
     name: Excel.TextConditionalFormat

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.conditionalformatcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.conditionalformatcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ConditionalFormatCollection#add:member(1)'
@@ -363,7 +363,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.ConditionalFormatCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -383,7 +383,7 @@ items:
           - 'excel!Excel.Interfaces.ConditionalFormatCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ConditionalFormat:class'
     name: Excel.ConditionalFormat
@@ -395,7 +395,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -423,7 +423,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.ConditionalFormatCollectionData:interface'
     name: Excel.Interfaces.ConditionalFormatCollectionData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.conditionalformatrule.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.conditionalformatrule.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ConditionalFormatRule#context:member'
@@ -204,7 +204,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ConditionalFormatRule#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -242,7 +242,7 @@ items:
           - 'excel!Excel.Interfaces.ConditionalFormatRuleData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -252,7 +252,7 @@ references:
     name: Excel.Interfaces.ConditionalFormatRuleLoadOptions
   - uid: 'excel!Excel.Interfaces.ConditionalFormatRuleUpdateData:interface'
     name: Interfaces.ConditionalFormatRuleUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ConditionalFormatRuleData:interface'
     name: Excel.Interfaces.ConditionalFormatRuleData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.conditionalrangeborder.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.conditionalrangeborder.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ConditionalRangeBorder#color:member'
@@ -154,7 +154,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ConditionalRangeBorder#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -228,7 +228,7 @@ items:
           - 'excel!Excel.Interfaces.ConditionalRangeBorderData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -238,7 +238,7 @@ references:
     name: Excel.Interfaces.ConditionalRangeBorderLoadOptions
   - uid: 'excel!Excel.Interfaces.ConditionalRangeBorderUpdateData:interface'
     name: Interfaces.ConditionalRangeBorderUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.ConditionalRangeBorder#sideIndex~0:complex'
     name: Excel.ConditionalRangeBorderIndex | "EdgeTop" | "EdgeBottom" | "EdgeLeft" | "EdgeRight"

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.conditionalrangebordercollection.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.conditionalrangebordercollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ConditionalRangeBorderCollection#bottom:member'
@@ -225,7 +225,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.ConditionalRangeBorderCollection#right:member'
     summary: |-
       Gets the right border. Read-only.
@@ -275,7 +275,7 @@ items:
         type:
           - 'excel!Excel.ConditionalRangeBorder:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ConditionalRangeBorder:class'
     name: Excel.ConditionalRangeBorder
@@ -306,7 +306,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.ConditionalRangeBorderCollectionData:interface'
     name: Excel.Interfaces.ConditionalRangeBorderCollectionData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.conditionalrangefill.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.conditionalrangefill.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ConditionalRangeFill#clear:member(1)'
@@ -169,7 +169,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ConditionalRangeFill#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -207,7 +207,7 @@ items:
           - 'excel!Excel.Interfaces.ConditionalRangeFillData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -217,7 +217,7 @@ references:
     name: Excel.Interfaces.ConditionalRangeFillLoadOptions
   - uid: 'excel!Excel.Interfaces.ConditionalRangeFillUpdateData:interface'
     name: Interfaces.ConditionalRangeFillUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ConditionalRangeFillData:interface'
     name: Excel.Interfaces.ConditionalRangeFillData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.conditionalrangefont.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.conditionalrangefont.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ConditionalRangeFont#bold:member'
@@ -201,7 +201,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ConditionalRangeFont#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -269,7 +269,7 @@ items:
         type:
           - 'excel!Excel.ConditionalRangeFont#underline~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -279,7 +279,7 @@ references:
     name: Excel.Interfaces.ConditionalRangeFontLoadOptions
   - uid: 'excel!Excel.Interfaces.ConditionalRangeFontUpdateData:interface'
     name: Interfaces.ConditionalRangeFontUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ConditionalRangeFontData:interface'
     name: Excel.Interfaces.ConditionalRangeFontData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.conditionalrangeformat.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.conditionalrangeformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ConditionalRangeFormat#borders:member'
@@ -198,7 +198,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ConditionalRangeFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -236,7 +236,7 @@ items:
           - 'excel!Excel.Interfaces.ConditionalRangeFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ConditionalRangeBorderCollection:class'
     name: Excel.ConditionalRangeBorderCollection
@@ -252,7 +252,7 @@ references:
     name: Excel.Interfaces.ConditionalRangeFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ConditionalRangeFormatUpdateData:interface'
     name: Interfaces.ConditionalRangeFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ConditionalRangeFormatData:interface'
     name: Excel.Interfaces.ConditionalRangeFormatData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.customconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.customconditionalformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.CustomConditionalFormat#context:member'
@@ -214,7 +214,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.CustomConditionalFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -252,7 +252,7 @@ items:
           - 'excel!Excel.Interfaces.CustomConditionalFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -266,7 +266,7 @@ references:
     name: Excel.ConditionalFormatRule
   - uid: 'excel!Excel.Interfaces.CustomConditionalFormatUpdateData:interface'
     name: Interfaces.CustomConditionalFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.CustomConditionalFormatData:interface'
     name: Excel.Interfaces.CustomConditionalFormatData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.customproperty.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.customproperty.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.CustomProperty#context:member'
@@ -169,7 +169,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.CustomProperty#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -237,7 +237,7 @@ items:
         type:
           - any
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -247,7 +247,7 @@ references:
     name: Excel.Interfaces.CustomPropertyLoadOptions
   - uid: 'excel!Excel.Interfaces.CustomPropertyUpdateData:interface'
     name: Interfaces.CustomPropertyUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.CustomPropertyData:interface'
     name: Excel.Interfaces.CustomPropertyData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.custompropertycollection.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.custompropertycollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.CustomPropertyCollection#add:member(1)'
@@ -215,7 +215,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.CustomPropertyCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -235,7 +235,7 @@ items:
           - 'excel!Excel.Interfaces.CustomPropertyCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.CustomProperty:class'
     name: Excel.CustomProperty
@@ -245,7 +245,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -273,7 +273,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.CustomPropertyCollectionData:interface'
     name: Excel.Interfaces.CustomPropertyCollectionData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.customxmlpart.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.customxmlpart.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.CustomXmlPart#context:member'
@@ -343,7 +343,7 @@ items:
           - 'excel!Excel.Interfaces.CustomXmlPartData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -351,7 +351,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.customxmlpartcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.customxmlpartcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.CustomXmlPartCollection#add:member(1)'
@@ -317,7 +317,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.CustomXmlPartCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -337,7 +337,7 @@ items:
           - 'excel!Excel.Interfaces.CustomXmlPartCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.CustomXmlPart:class'
     name: Excel.CustomXmlPart
@@ -349,7 +349,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -377,7 +377,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.CustomXmlPartCollectionData:interface'
     name: Excel.Interfaces.CustomXmlPartCollectionData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.customxmlpartscopedcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.customxmlpartscopedcollection.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.CustomXmlPartScopedCollection#context:member'
@@ -325,7 +325,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.CustomXmlPartScopedCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -345,7 +345,7 @@ items:
           - 'excel!Excel.Interfaces.CustomXmlPartScopedCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -353,7 +353,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -383,7 +383,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.CustomXmlPartScopedCollectionData:interface'
     name: Excel.Interfaces.CustomXmlPartScopedCollectionData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.databarconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.databarconditionalformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.DataBarConditionalFormat#axisColor:member'
@@ -259,7 +259,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.DataBarConditionalFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -330,7 +330,7 @@ items:
         type:
           - 'excel!Excel.ConditionalDataBarRule:interface'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.DataBarConditionalFormat#axisFormat~0:complex'
     name: Excel.ConditionalDataBarAxisFormat | "Automatic" | "None" | "CellMidPoint"
@@ -364,7 +364,7 @@ references:
     name: Excel.ConditionalDataBarPositiveFormat
   - uid: 'excel!Excel.Interfaces.DataBarConditionalFormatUpdateData:interface'
     name: Interfaces.DataBarConditionalFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.DataBarConditionalFormatData:interface'
     name: Excel.Interfaces.DataBarConditionalFormatData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.dataconnectioncollection.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.dataconnectioncollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.DataConnectionCollection#context:member'
@@ -72,7 +72,7 @@ items:
                     }
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.datapivothierarchy.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.datapivothierarchy.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.DataPivotHierarchy#context:member'
@@ -239,7 +239,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.DataPivotHierarchy#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -359,7 +359,7 @@ items:
           - 'excel!Excel.Interfaces.DataPivotHierarchyData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -371,7 +371,7 @@ references:
     name: Excel.Interfaces.DataPivotHierarchyLoadOptions
   - uid: 'excel!Excel.Interfaces.DataPivotHierarchyUpdateData:interface'
     name: Interfaces.DataPivotHierarchyUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.ShowAsRule:interface'
     name: Excel.ShowAsRule

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.datapivothierarchycollection.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.datapivothierarchycollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.DataPivotHierarchyCollection#add:member(1)'
@@ -193,7 +193,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.DataPivotHierarchyCollection#remove:member(1)'
     summary: |-
       Removes the PivotHierarchy from the current axis.
@@ -234,7 +234,7 @@ items:
           - 'excel!Excel.Interfaces.DataPivotHierarchyCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.DataPivotHierarchy:class'
     name: Excel.DataPivotHierarchy
@@ -246,7 +246,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -274,7 +274,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.DataPivotHierarchyCollectionData:interface'
     name: Excel.Interfaces.DataPivotHierarchyCollectionData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.datavalidation.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.datavalidation.yml
@@ -14,7 +14,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.DataValidation#clear:member(1)'
@@ -376,7 +376,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.DataValidation#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -449,7 +449,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -467,7 +467,7 @@ references:
     name: Excel.DataValidationRule
   - uid: 'excel!Excel.Interfaces.DataValidationUpdateData:interface'
     name: Interfaces.DataValidationUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.DataValidationData:interface'
     name: Excel.Interfaces.DataValidationData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.documentproperties.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.documentproperties.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.DocumentProperties#author:member'
@@ -296,7 +296,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.DocumentProperties#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -364,7 +364,7 @@ items:
           - 'excel!Excel.Interfaces.DocumentPropertiesData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -378,7 +378,7 @@ references:
     name: Excel.Interfaces.DocumentPropertiesLoadOptions
   - uid: 'excel!Excel.Interfaces.DocumentPropertiesUpdateData:interface'
     name: Interfaces.DocumentPropertiesUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.DocumentPropertiesData:interface'
     name: Excel.Interfaces.DocumentPropertiesData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.filter.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.filter.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Filter#apply:member(1)'
@@ -473,7 +473,7 @@ items:
           - 'excel!Excel.Interfaces.FilterData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.FilterCriteria:interface'
     name: Excel.FilterCriteria

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.filterpivothierarchy.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.filterpivothierarchy.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.FilterPivotHierarchy#context:member'
@@ -215,7 +215,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.FilterPivotHierarchy#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -269,7 +269,7 @@ items:
           - 'excel!Excel.Interfaces.FilterPivotHierarchyData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -281,7 +281,7 @@ references:
     name: Excel.Interfaces.FilterPivotHierarchyLoadOptions
   - uid: 'excel!Excel.Interfaces.FilterPivotHierarchyUpdateData:interface'
     name: Interfaces.FilterPivotHierarchyUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.FilterPivotHierarchyData:interface'
     name: Excel.Interfaces.FilterPivotHierarchyData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.filterpivothierarchycollection.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.filterpivothierarchycollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.FilterPivotHierarchyCollection#add:member(1)'
@@ -195,7 +195,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.FilterPivotHierarchyCollection#remove:member(1)'
     summary: |-
       Removes the PivotHierarchy from the current axis.
@@ -236,7 +236,7 @@ items:
           - 'excel!Excel.Interfaces.FilterPivotHierarchyCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.FilterPivotHierarchy:class'
     name: Excel.FilterPivotHierarchy
@@ -248,7 +248,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -276,7 +276,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.FilterPivotHierarchyCollectionData:interface'
     name: Excel.Interfaces.FilterPivotHierarchyCollectionData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.formatprotection.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.formatprotection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.FormatProtection#context:member'
@@ -170,7 +170,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.FormatProtection#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -208,7 +208,7 @@ items:
           - 'excel!Excel.Interfaces.FormatProtectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -218,7 +218,7 @@ references:
     name: Excel.Interfaces.FormatProtectionLoadOptions
   - uid: 'excel!Excel.Interfaces.FormatProtectionUpdateData:interface'
     name: Interfaces.FormatProtectionUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.FormatProtectionData:interface'
     name: Excel.Interfaces.FormatProtectionData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.functionresult.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.functionresult.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.FunctionResult#context:member'
@@ -158,7 +158,7 @@ items:
         type:
           - T
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.functions.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.functions.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Functions#abs:member(1)'
@@ -11184,7 +11184,7 @@ items:
           type:
             - 'excel!Excel.Functions#z_Test~3:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Functions#abs~0:complex'
     name: FunctionResult<number>

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.geometricshape.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.geometricshape.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.GeometricShape#context:member'
@@ -156,7 +156,7 @@ items:
           - 'excel!Excel.Interfaces.GeometricShapeData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.groupshapecollection.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.groupshapecollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.GroupShapeCollection#context:member'
@@ -170,7 +170,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.GroupShapeCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -190,7 +190,7 @@ items:
           - 'excel!Excel.Interfaces.GroupShapeCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -198,7 +198,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -228,7 +228,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.GroupShapeCollectionData:interface'
     name: Excel.Interfaces.GroupShapeCollectionData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.headerfooter.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.headerfooter.yml
@@ -8,7 +8,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.HeaderFooter#centerFooter:member'
@@ -239,7 +239,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.HeaderFooter#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -277,7 +277,7 @@ items:
           - 'excel!Excel.Interfaces.HeaderFooterData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -287,7 +287,7 @@ references:
     name: Excel.Interfaces.HeaderFooterLoadOptions
   - uid: 'excel!Excel.Interfaces.HeaderFooterUpdateData:interface'
     name: Interfaces.HeaderFooterUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.HeaderFooterData:interface'
     name: Excel.Interfaces.HeaderFooterData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.headerfootergroup.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.headerfootergroup.yml
@@ -8,7 +8,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.HeaderFooterGroup#context:member'
@@ -198,7 +198,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.HeaderFooterGroup#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -285,7 +285,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -297,7 +297,7 @@ references:
     name: Excel.Interfaces.HeaderFooterGroupLoadOptions
   - uid: 'excel!Excel.Interfaces.HeaderFooterGroupUpdateData:interface'
     name: Interfaces.HeaderFooterGroupUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.HeaderFooterGroup#state~0:complex'
     name: Excel.HeaderFooterState | "Default" | "FirstAndDefault" | "OddAndEven" | "FirstOddAndEven"

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.iconsetconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.iconsetconditionalformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.IconSetConditionalFormat#context:member'
@@ -222,7 +222,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.IconSetConditionalFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -345,7 +345,7 @@ items:
           - 'excel!Excel.Interfaces.IconSetConditionalFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -364,7 +364,7 @@ references:
     name: Excel.Interfaces.IconSetConditionalFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.IconSetConditionalFormatUpdateData:interface'
     name: Interfaces.IconSetConditionalFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.IconSetConditionalFormat#style~0:complex'
     name: >-

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.image.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.image.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Image#context:member'
@@ -192,7 +192,7 @@ items:
           - 'excel!Excel.Interfaces.ImageData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.iterativecalculation.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.iterativecalculation.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.IterativeCalculation#context:member'
@@ -182,7 +182,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.IterativeCalculation#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -220,7 +220,7 @@ items:
           - 'excel!Excel.Interfaces.IterativeCalculationData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -230,7 +230,7 @@ references:
     name: Excel.Interfaces.IterativeCalculationLoadOptions
   - uid: 'excel!Excel.Interfaces.IterativeCalculationUpdateData:interface'
     name: Interfaces.IterativeCalculationUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.IterativeCalculationData:interface'
     name: Excel.Interfaces.IterativeCalculationData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.line.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.line.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Line#beginArrowheadLength:member'
@@ -529,7 +529,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Line#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -582,7 +582,7 @@ items:
           - 'excel!Excel.Interfaces.LineData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Line#beginArrowheadLength~0:complex'
     name: Excel.ArrowheadLength | "Short" | "Medium" | "Long"
@@ -657,7 +657,7 @@ references:
     name: Excel.Interfaces.LineLoadOptions
   - uid: 'excel!Excel.Interfaces.LineUpdateData:interface'
     name: Interfaces.LineUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.LineData:interface'
     name: Excel.Interfaces.LineData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.nameditem.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.nameditem.yml
@@ -14,7 +14,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.NamedItem#arrayValues:member'
@@ -381,7 +381,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.NamedItem#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -500,7 +500,7 @@ items:
         type:
           - 'excel!Excel.Worksheet:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.NamedItemArrayValues:class'
     name: Excel.NamedItemArrayValues
@@ -523,7 +523,7 @@ references:
         fullName: ' | "Worksheet" | "Workbook"'
   - uid: 'excel!Excel.Interfaces.NamedItemUpdateData:interface'
     name: Interfaces.NamedItemUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.NamedItemData:interface'
     name: Excel.Interfaces.NamedItemData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.nameditemarrayvalues.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.nameditemarrayvalues.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.NamedItemArrayValues#context:member'
@@ -154,7 +154,7 @@ items:
         type:
           - 'any[][]'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.nameditemcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.nameditemcollection.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.NamedItemCollection#add:member(1)'
@@ -294,7 +294,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.NamedItemCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -314,7 +314,7 @@ items:
           - 'excel!Excel.Interfaces.NamedItemCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.NamedItem:class'
     name: Excel.NamedItem
@@ -333,7 +333,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -361,7 +361,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.NamedItemCollectionData:interface'
     name: Excel.Interfaces.NamedItemCollectionData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.pagebreak.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.pagebreak.yml
@@ -8,7 +8,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PageBreak#columnIndex:member'
@@ -185,7 +185,7 @@ items:
           - 'excel!Excel.Interfaces.PageBreakData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.pagebreakcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.pagebreakcollection.yml
@@ -8,7 +8,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PageBreakCollection#add:member(1)'
@@ -185,7 +185,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.PageBreakCollection#removePageBreaks:member(1)'
     summary: |-
       Resets all manual page breaks in the collection.
@@ -221,7 +221,7 @@ items:
           - 'excel!Excel.Interfaces.PageBreakCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.PageBreak:class'
     name: Excel.PageBreak
@@ -240,7 +240,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -268,7 +268,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.PageBreakCollectionData:interface'
     name: Excel.Interfaces.PageBreakCollectionData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.pagelayout.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.pagelayout.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PageLayout#blackAndWhite:member'
@@ -605,7 +605,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.PageLayout#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -842,7 +842,7 @@ items:
 
           ```
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -915,7 +915,7 @@ references:
         fullName: ' | "DownThenOver" | "OverThenDown"'
   - uid: 'excel!Excel.Interfaces.PageLayoutUpdateData:interface'
     name: Interfaces.PageLayoutUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.PageLayout#setPrintArea~0:complex'
     name: Range | RangeAreas | string

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.pivotfield.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.pivotfield.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PivotField#context:member'
@@ -187,7 +187,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.PivotField#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -352,7 +352,7 @@ items:
           - 'excel!Excel.Interfaces.PivotFieldData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -364,7 +364,7 @@ references:
     name: Excel.Interfaces.PivotFieldLoadOptions
   - uid: 'excel!Excel.Interfaces.PivotFieldUpdateData:interface'
     name: Interfaces.PivotFieldUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.SortBy:enum'
     name: SortBy

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.pivotfieldcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.pivotfieldcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PivotFieldCollection#context:member'
@@ -170,7 +170,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.PivotFieldCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -190,7 +190,7 @@ items:
           - 'excel!Excel.Interfaces.PivotFieldCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -198,7 +198,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -228,7 +228,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.PivotFieldCollectionData:interface'
     name: Excel.Interfaces.PivotFieldCollectionData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.pivothierarchy.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.pivothierarchy.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PivotHierarchy#context:member'
@@ -182,7 +182,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.PivotHierarchy#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -220,7 +220,7 @@ items:
           - 'excel!Excel.Interfaces.PivotHierarchyData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -232,7 +232,7 @@ references:
     name: Excel.Interfaces.PivotHierarchyLoadOptions
   - uid: 'excel!Excel.Interfaces.PivotHierarchyUpdateData:interface'
     name: Interfaces.PivotHierarchyUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.PivotHierarchyData:interface'
     name: Excel.Interfaces.PivotHierarchyData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.pivothierarchycollection.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.pivothierarchycollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PivotHierarchyCollection#context:member'
@@ -170,7 +170,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.PivotHierarchyCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -190,7 +190,7 @@ items:
           - 'excel!Excel.Interfaces.PivotHierarchyCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -198,7 +198,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -228,7 +228,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.PivotHierarchyCollectionData:interface'
     name: Excel.Interfaces.PivotHierarchyCollectionData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.pivotitem.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.pivotitem.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PivotItem#context:member'
@@ -183,7 +183,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.PivotItem#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -236,7 +236,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -246,7 +246,7 @@ references:
     name: Excel.Interfaces.PivotItemLoadOptions
   - uid: 'excel!Excel.Interfaces.PivotItemUpdateData:interface'
     name: Interfaces.PivotItemUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.PivotItemData:interface'
     name: Excel.Interfaces.PivotItemData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.pivotitemcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.pivotitemcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PivotItemCollection#context:member'
@@ -170,7 +170,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.PivotItemCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -190,7 +190,7 @@ items:
           - 'excel!Excel.Interfaces.PivotItemCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -198,7 +198,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -228,7 +228,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.PivotItemCollectionData:interface'
     name: Excel.Interfaces.PivotItemCollectionData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.pivotlayout.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.pivotlayout.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PivotLayout#autoFormat:member'
@@ -380,7 +380,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.PivotLayout#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -519,7 +519,7 @@ items:
           - 'excel!Excel.Interfaces.PivotLayoutData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -540,7 +540,7 @@ references:
     name: 'OfficeExtension.ClientResult<Excel.PivotItem[]>'
     fullName: 'OfficeExtension.ClientResult<Excel.PivotItem[]>'
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <
@@ -565,7 +565,7 @@ references:
     name: 'OfficeExtension.ClientResult<Excel.PivotItem[]>'
     fullName: 'OfficeExtension.ClientResult<Excel.PivotItem[]>'
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <
@@ -599,7 +599,7 @@ references:
     name: Excel.Interfaces.PivotLayoutLoadOptions
   - uid: 'excel!Excel.Interfaces.PivotLayoutUpdateData:interface'
     name: Interfaces.PivotLayoutUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.PivotLayout#setAutoSortOnCell~0:complex'
     name: Range | string

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.pivottable.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.pivottable.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PivotTable#columnHierarchies:member'
@@ -440,7 +440,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.PivotTable#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -508,7 +508,7 @@ items:
         type:
           - 'excel!Excel.Worksheet:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RowColumnPivotHierarchyCollection:class'
     name: Excel.RowColumnPivotHierarchyCollection
@@ -528,7 +528,7 @@ references:
     name: Excel.Interfaces.PivotTableLoadOptions
   - uid: 'excel!Excel.Interfaces.PivotTableUpdateData:interface'
     name: Interfaces.PivotTableUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.PivotTableData:interface'
     name: Excel.Interfaces.PivotTableData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.pivottablecollection.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.pivottablecollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PivotTableCollection#add:member(1)'
@@ -225,7 +225,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.PivotTableCollection#refreshAll:member(1)'
     summary: |-
       Refreshes all the pivot tables in the collection.
@@ -261,7 +261,7 @@ items:
           - 'excel!Excel.Interfaces.PivotTableCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.PivotTable:class'
     name: Excel.PivotTable
@@ -292,7 +292,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -320,7 +320,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.PivotTableCollectionData:interface'
     name: Excel.Interfaces.PivotTableCollectionData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.presetcriteriaconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.presetcriteriaconditionalformat.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PresetCriteriaConditionalFormat#context:member'
@@ -212,7 +212,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.PresetCriteriaConditionalFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -250,7 +250,7 @@ items:
           - 'excel!Excel.Interfaces.PresetCriteriaConditionalFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -264,7 +264,7 @@ references:
     name: Excel.ConditionalPresetCriteriaRule
   - uid: 'excel!Excel.Interfaces.PresetCriteriaConditionalFormatUpdateData:interface'
     name: Interfaces.PresetCriteriaConditionalFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.PresetCriteriaConditionalFormatData:interface'
     name: Excel.Interfaces.PresetCriteriaConditionalFormatData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.range.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.range.yml
@@ -16,7 +16,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Range#address:member'
@@ -2708,7 +2708,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Range#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -3180,7 +3180,7 @@ items:
         type:
           - 'excel!Excel.Worksheet:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Range#autoFill~0:complex'
     name: Range | string
@@ -3261,7 +3261,7 @@ references:
     name: 'OfficeExtension.ClientResult<CellProperties[][]>'
     fullName: 'OfficeExtension.ClientResult<Excel.CellProperties[][]>'
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <
@@ -3277,7 +3277,7 @@ references:
     name: 'OfficeExtension.ClientResult<ColumnProperties[]>'
     fullName: 'OfficeExtension.ClientResult<Excel.ColumnProperties[]>'
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <
@@ -3293,7 +3293,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -3320,7 +3320,7 @@ references:
     name: 'OfficeExtension.ClientResult<RowProperties[]>'
     fullName: 'OfficeExtension.ClientResult<Excel.RowProperties[]>'
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <
@@ -3372,7 +3372,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -3381,7 +3381,7 @@ references:
     name: Excel.ReplaceCriteria
   - uid: 'excel!Excel.Interfaces.RangeUpdateData:interface'
     name: Interfaces.RangeUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Range#setCellProperties~0:complex'
     name: 'SettableCellProperties[][]'

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.rangeareas.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.rangeareas.yml
@@ -14,7 +14,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeAreas#address:member'
@@ -852,7 +852,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.RangeAreas#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -974,7 +974,7 @@ items:
         type:
           - 'excel!Excel.Worksheet:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RangeCollection:class'
     name: Excel.RangeCollection
@@ -1058,7 +1058,7 @@ references:
     name: Excel.Interfaces.RangeAreasLoadOptions
   - uid: 'excel!Excel.Interfaces.RangeAreasUpdateData:interface'
     name: Interfaces.RangeAreasUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.RangeAreasData:interface'
     name: Excel.Interfaces.RangeAreasData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.rangeborder.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.rangeborder.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeBorder#color:member'
@@ -156,7 +156,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.RangeBorder#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -288,7 +288,7 @@ items:
         type:
           - 'excel!Excel.RangeBorder#weight~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -298,7 +298,7 @@ references:
     name: Excel.Interfaces.RangeBorderLoadOptions
   - uid: 'excel!Excel.Interfaces.RangeBorderUpdateData:interface'
     name: Interfaces.RangeBorderUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.RangeBorder#sideIndex~0:complex'
     name: >-

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.rangebordercollection.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.rangebordercollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeBorderCollection#context:member'
@@ -266,7 +266,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.RangeBorderCollection#tintAndShade:member'
     summary: >-
       Returns or sets a double that lightens or darkens a color for Range Borders, the value is between -1 (darkest) and
@@ -304,7 +304,7 @@ items:
           - 'excel!Excel.Interfaces.RangeBorderCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -335,7 +335,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.RangeBorderCollectionData:interface'
     name: Excel.Interfaces.RangeBorderCollectionData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.rangecollection.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.rangecollection.yml
@@ -8,7 +8,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeCollection#context:member'
@@ -145,7 +145,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.RangeCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -165,7 +165,7 @@ items:
           - 'excel!Excel.Interfaces.RangeCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -173,7 +173,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -203,7 +203,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.RangeCollectionData:interface'
     name: Excel.Interfaces.RangeCollectionData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.rangefill.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.rangefill.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeFill#clear:member(1)'
@@ -286,7 +286,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.RangeFill#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -341,7 +341,7 @@ items:
           - 'excel!Excel.Interfaces.RangeFillData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -366,7 +366,7 @@ references:
         fullName: ' | "None" | "Solid" | "Gray50" | "Gray75" | "Gray25" | "Horizontal" | "Vertical" | "Down" | "Up" | "Checker" | "SemiGray75" | "LightHorizontal" | "LightVertical" | "LightDown" | "LightUp" | "Grid" | "CrissCross" | "Gray16" | "Gray8" | "LinearGradient" | "RectangularGradient"'
   - uid: 'excel!Excel.Interfaces.RangeFillUpdateData:interface'
     name: Interfaces.RangeFillUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.RangeFillData:interface'
     name: Excel.Interfaces.RangeFillData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.rangefont.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.rangefont.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeFont#bold:member'
@@ -241,7 +241,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.RangeFont#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -380,7 +380,7 @@ items:
         type:
           - 'excel!Excel.RangeFont#underline~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -390,7 +390,7 @@ references:
     name: Excel.Interfaces.RangeFontLoadOptions
   - uid: 'excel!Excel.Interfaces.RangeFontUpdateData:interface'
     name: Interfaces.RangeFontUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.RangeFontData:interface'
     name: Excel.Interfaces.RangeFontData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.rangeformat.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.rangeformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeFormat#adjustIndent:member(1)'
@@ -430,7 +430,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.RangeFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -592,7 +592,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RangeBorderCollection:class'
     name: Excel.RangeBorderCollection
@@ -632,7 +632,7 @@ references:
         fullName: ' | "Context" | "LeftToRight" | "RightToLeft"'
   - uid: 'excel!Excel.Interfaces.RangeFormatUpdateData:interface'
     name: Interfaces.RangeFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.RangeFormatData:interface'
     name: Excel.Interfaces.RangeFormatData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.rangesort.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.rangesort.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeSort#apply:member(1)'
@@ -135,7 +135,7 @@ items:
                     }
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RangeSort#apply~0:complex'
     name: 'Excel.SortField[]'

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.rangeview.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.rangeview.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeView#cellAddresses:member'
@@ -300,7 +300,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.RangeView#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -387,7 +387,7 @@ items:
         type:
           - 'excel!Excel.RangeView#valueTypes~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -401,7 +401,7 @@ references:
     name: Excel.RangeViewCollection
   - uid: 'excel!Excel.Interfaces.RangeViewUpdateData:interface'
     name: Interfaces.RangeViewUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.RangeViewData:interface'
     name: Excel.Interfaces.RangeViewData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.rangeviewcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.rangeviewcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeViewCollection#context:member'
@@ -148,7 +148,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.RangeViewCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -168,7 +168,7 @@ items:
           - 'excel!Excel.Interfaces.RangeViewCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -176,7 +176,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -206,7 +206,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.RangeViewCollectionData:interface'
     name: Excel.Interfaces.RangeViewCollectionData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.removeduplicatesresult.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.removeduplicatesresult.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RemoveDuplicatesResult#context:member'
@@ -178,7 +178,7 @@ items:
 
           ```
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.requestcontext.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.requestcontext.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientRequestContext:class'
+      - 'office!OfficeExtension.ClientRequestContext:class'
     package: excel!
     children:
       - 'excel!Excel.RequestContext:constructor(1)'
@@ -67,7 +67,7 @@ items:
         type:
           - 'excel!Excel.Workbook:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientRequestContext:class'
+  - uid: 'office!OfficeExtension.ClientRequestContext:class'
     name: OfficeExtension.ClientRequestContext
   - uid: 'excel!Excel.RequestContext~0:complex'
     name: string | Session

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.rowcolumnpivothierarchy.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.rowcolumnpivothierarchy.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RowColumnPivotHierarchy#context:member'
@@ -199,7 +199,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.RowColumnPivotHierarchy#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -253,7 +253,7 @@ items:
           - 'excel!Excel.Interfaces.RowColumnPivotHierarchyData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -265,7 +265,7 @@ references:
     name: Excel.Interfaces.RowColumnPivotHierarchyLoadOptions
   - uid: 'excel!Excel.Interfaces.RowColumnPivotHierarchyUpdateData:interface'
     name: Interfaces.RowColumnPivotHierarchyUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.RowColumnPivotHierarchyData:interface'
     name: Excel.Interfaces.RowColumnPivotHierarchyData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.rowcolumnpivothierarchycollection.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.rowcolumnpivothierarchycollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RowColumnPivotHierarchyCollection#add:member(1)'
@@ -195,7 +195,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.RowColumnPivotHierarchyCollection#remove:member(1)'
     summary: |-
       Removes the PivotHierarchy from the current axis.
@@ -237,7 +237,7 @@ items:
           - 'excel!Excel.Interfaces.RowColumnPivotHierarchyCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RowColumnPivotHierarchy:class'
     name: Excel.RowColumnPivotHierarchy
@@ -249,7 +249,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -277,7 +277,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.RowColumnPivotHierarchyCollectionData:interface'
     name: Excel.Interfaces.RowColumnPivotHierarchyCollectionData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.runoptions.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.runoptions.yml
@@ -34,7 +34,7 @@ references:
     name: OfficeExtension.RunOptions<Session>
     fullName: OfficeExtension.RunOptions<Excel.Session>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.RunOptions:interface'
+      - uid: 'office!OfficeExtension.RunOptions:interface'
         name: OfficeExtension.RunOptions
         fullName: OfficeExtension.RunOptions
       - name: <

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.runtime.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.runtime.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Runtime#context:member'
@@ -178,7 +178,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Runtime#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -216,7 +216,7 @@ items:
           - 'excel!Excel.Interfaces.RuntimeData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -226,7 +226,7 @@ references:
     name: Excel.Interfaces.RuntimeLoadOptions
   - uid: 'excel!Excel.Interfaces.RuntimeUpdateData:interface'
     name: Interfaces.RuntimeUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.RuntimeData:interface'
     name: Excel.Interfaces.RuntimeData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.setting.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.setting.yml
@@ -15,7 +15,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Setting#context:member'
@@ -200,7 +200,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Setting#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -253,7 +253,7 @@ items:
         type:
           - any
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -263,7 +263,7 @@ references:
     name: Excel.Interfaces.SettingLoadOptions
   - uid: 'excel!Excel.Interfaces.SettingUpdateData:interface'
     name: Interfaces.SettingUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.SettingData:interface'
     name: Excel.Interfaces.SettingData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.settingcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.settingcollection.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.SettingCollection#add:member(1)'
@@ -246,7 +246,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.SettingCollection#onSettingsChanged:member'
     summary: |-
       Occurs when the Settings in the document are changed.
@@ -301,7 +301,7 @@ items:
           - 'excel!Excel.Interfaces.SettingCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Setting:class'
     name: Excel.Setting
@@ -327,7 +327,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -355,13 +355,13 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.SettingCollection#onSettingsChanged~0:complex'
     name: OfficeExtension.EventHandlers<Excel.SettingsChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.SettingsChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.shape.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.shape.yml
@@ -14,7 +14,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Shape#altTextDescription:member'
@@ -1038,7 +1038,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Shape#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -1236,7 +1236,7 @@ items:
         type:
           - number
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -1317,7 +1317,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -1328,7 +1328,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -1349,7 +1349,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.ShapeActivatedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.ShapeActivatedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -1363,7 +1363,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.ShapeDeactivatedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.ShapeDeactivatedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -1379,7 +1379,7 @@ references:
     name: Excel.ShapeScaleFrom
   - uid: 'excel!Excel.Interfaces.ShapeUpdateData:interface'
     name: Interfaces.ShapeUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.ShapeZOrder:enum'
     name: Excel.ShapeZOrder

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.shapecollection.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.shapecollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ShapeCollection#addGeometricShape:member(1)'
@@ -546,7 +546,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.ShapeCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -566,7 +566,7 @@ items:
           - 'excel!Excel.Interfaces.ShapeCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Shape:class'
     name: Excel.Shape
@@ -594,7 +594,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -622,7 +622,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.ShapeCollectionData:interface'
     name: Excel.Interfaces.ShapeCollectionData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.shapefill.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.shapefill.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ShapeFill#clear:member(1)'
@@ -172,7 +172,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ShapeFill#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -268,7 +268,7 @@ items:
         type:
           - 'excel!Excel.ShapeFill#type~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -278,7 +278,7 @@ references:
     name: Excel.Interfaces.ShapeFillLoadOptions
   - uid: 'excel!Excel.Interfaces.ShapeFillUpdateData:interface'
     name: Interfaces.ShapeFillUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ShapeFillData:interface'
     name: Excel.Interfaces.ShapeFillData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.shapefont.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.shapefont.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ShapeFont#bold:member'
@@ -206,7 +206,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ShapeFont#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -281,7 +281,7 @@ items:
         type:
           - 'excel!Excel.ShapeFont#underline~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -291,7 +291,7 @@ references:
     name: Excel.Interfaces.ShapeFontLoadOptions
   - uid: 'excel!Excel.Interfaces.ShapeFontUpdateData:interface'
     name: Interfaces.ShapeFontUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ShapeFontData:interface'
     name: Excel.Interfaces.ShapeFontData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.shapegroup.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.shapegroup.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ShapeGroup#context:member'
@@ -210,7 +210,7 @@ items:
 
           ```
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.shapelineformat.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.shapelineformat.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ShapeLineFormat#color:member'
@@ -178,7 +178,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ShapeLineFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -284,7 +284,7 @@ items:
         type:
           - number
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -307,7 +307,7 @@ references:
     name: Excel.Interfaces.ShapeLineFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ShapeLineFormatUpdateData:interface'
     name: Interfaces.ShapeLineFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.ShapeLineFormat#style~0:complex'
     name: Excel.ShapeLineStyle | "Single" | "ThickBetweenThin" | "ThickThin" | "ThinThick" | "ThinThin"

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.style.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.style.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Style#autoIndent:member'
@@ -568,7 +568,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Style#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -666,7 +666,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RangeBorderCollection:class'
     name: Excel.RangeBorderCollection
@@ -704,7 +704,7 @@ references:
         fullName: ' | "Context" | "LeftToRight" | "RightToLeft"'
   - uid: 'excel!Excel.Interfaces.StyleUpdateData:interface'
     name: Interfaces.StyleUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.StyleData:interface'
     name: Excel.Interfaces.StyleData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.stylecollection.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.stylecollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.StyleCollection#add:member(1)'
@@ -256,7 +256,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.StyleCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -276,7 +276,7 @@ items:
           - 'excel!Excel.Interfaces.StyleCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -284,7 +284,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -314,7 +314,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.StyleCollectionData:interface'
     name: Excel.Interfaces.StyleCollectionData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.table.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.table.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Table#autoFilter:member'
@@ -637,7 +637,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Table#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -828,7 +828,7 @@ items:
         type:
           - 'excel!Excel.Worksheet:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.AutoFilter:class'
     name: Excel.AutoFilter
@@ -846,7 +846,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.TableChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.TableChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -860,7 +860,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.TableSelectionChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.TableSelectionChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -874,7 +874,7 @@ references:
     name: Excel.TableRowCollection
   - uid: 'excel!Excel.Interfaces.TableUpdateData:interface'
     name: Interfaces.TableUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.TableSort:class'
     name: Excel.TableSort

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.tablecollection.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.tablecollection.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableCollection#add:member(1)'
@@ -341,7 +341,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.TableCollection#onAdded:member'
     summary: |-
       Occurs when new table is added in a workbook.
@@ -426,7 +426,7 @@ items:
           - 'excel!Excel.Interfaces.TableCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Table:class'
     name: Excel.Table
@@ -445,7 +445,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -473,13 +473,13 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.TableCollection#onAdded~0:complex'
     name: OfficeExtension.EventHandlers<Excel.TableAddedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.TableAddedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -493,7 +493,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.TableChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.TableChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -507,7 +507,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.TableDeletedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.TableDeletedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.tablecolumn.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.tablecolumn.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableColumn#context:member'
@@ -401,7 +401,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.TableColumn#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -456,7 +456,7 @@ items:
         type:
           - 'any[][]'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -470,7 +470,7 @@ references:
     name: Excel.Interfaces.TableColumnLoadOptions
   - uid: 'excel!Excel.Interfaces.TableColumnUpdateData:interface'
     name: Interfaces.TableColumnUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.TableColumnData:interface'
     name: Excel.Interfaces.TableColumnData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.tablecolumncollection.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.tablecolumncollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableColumnCollection#add:member(1)'
@@ -322,7 +322,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.TableColumnCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -342,7 +342,7 @@ items:
           - 'excel!Excel.Interfaces.TableColumnCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.TableColumn:class'
     name: Excel.TableColumn
@@ -366,7 +366,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -394,7 +394,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.TableColumnCollectionData:interface'
     name: Excel.Interfaces.TableColumnCollectionData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.tablerow.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.tablerow.yml
@@ -17,7 +17,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableRow#context:member'
@@ -247,7 +247,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.TableRow#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -302,7 +302,7 @@ items:
         type:
           - 'any[][]'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -314,7 +314,7 @@ references:
     name: Excel.Interfaces.TableRowLoadOptions
   - uid: 'excel!Excel.Interfaces.TableRowUpdateData:interface'
     name: Interfaces.TableRowUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.TableRowData:interface'
     name: Excel.Interfaces.TableRowData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.tablerowcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.tablerowcollection.yml
@@ -17,7 +17,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableRowCollection#add:member(1)'
@@ -290,7 +290,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.TableRowCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -310,7 +310,7 @@ items:
           - 'excel!Excel.Interfaces.TableRowCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.TableRow:class'
     name: Excel.TableRow
@@ -334,7 +334,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -362,7 +362,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.TableRowCollectionData:interface'
     name: Excel.Interfaces.TableRowCollectionData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.tablescopedcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.tablescopedcollection.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableScopedCollection#context:member'
@@ -169,7 +169,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.TableScopedCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -189,7 +189,7 @@ items:
           - 'excel!Excel.Interfaces.TableScopedCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -197,7 +197,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -227,7 +227,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.TableScopedCollectionData:interface'
     name: Excel.Interfaces.TableScopedCollectionData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.tablesort.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.tablesort.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableSort#apply:member(1)'
@@ -288,7 +288,7 @@ items:
           - 'excel!Excel.Interfaces.TableSortData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.TableSort#apply~0:complex'
     name: 'Excel.SortField[]'

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.textconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.textconditionalformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TextConditionalFormat#context:member'
@@ -214,7 +214,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.TextConditionalFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -252,7 +252,7 @@ items:
           - 'excel!Excel.Interfaces.TextConditionalFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -266,7 +266,7 @@ references:
     name: Excel.ConditionalTextComparisonRule
   - uid: 'excel!Excel.Interfaces.TextConditionalFormatUpdateData:interface'
     name: Interfaces.TextConditionalFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.TextConditionalFormatData:interface'
     name: Excel.Interfaces.TextConditionalFormatData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.textframe.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.textframe.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TextFrame#autoSizeSetting:member'
@@ -327,7 +327,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.TextFrame#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -427,7 +427,7 @@ items:
         type:
           - 'excel!Excel.TextFrame#verticalOverflow~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.TextFrame#autoSizeSetting~0:complex'
     name: Excel.ShapeAutoSize | "AutoSizeNone" | "AutoSizeTextToFitShape" | "AutoSizeShapeToFitText" | "AutoSizeMixed"
@@ -490,7 +490,7 @@ references:
         fullName: ' | "LeftToRight" | "RightToLeft"'
   - uid: 'excel!Excel.Interfaces.TextFrameUpdateData:interface'
     name: Interfaces.TextFrameUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.TextRange:class'
     name: Excel.TextRange

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.textrange.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.textrange.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TextRange#context:member'
@@ -179,7 +179,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.TextRange#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -232,7 +232,7 @@ items:
           - 'excel!Excel.Interfaces.TextRangeData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -244,7 +244,7 @@ references:
     name: Excel.Interfaces.TextRangeLoadOptions
   - uid: 'excel!Excel.Interfaces.TextRangeUpdateData:interface'
     name: Interfaces.TextRangeUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.TextRangeData:interface'
     name: Excel.Interfaces.TextRangeData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.topbottomconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.topbottomconditionalformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TopBottomConditionalFormat#context:member'
@@ -168,7 +168,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.TopBottomConditionalFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -206,7 +206,7 @@ items:
           - 'excel!Excel.Interfaces.TopBottomConditionalFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -220,7 +220,7 @@ references:
     name: Excel.ConditionalTopBottomRule
   - uid: 'excel!Excel.Interfaces.TopBottomConditionalFormatUpdateData:interface'
     name: Interfaces.TopBottomConditionalFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.TopBottomConditionalFormatData:interface'
     name: Excel.Interfaces.TopBottomConditionalFormatData

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.workbook.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.workbook.yml
@@ -14,7 +14,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Workbook#application:member'
@@ -640,7 +640,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Workbook#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -788,7 +788,7 @@ items:
         type:
           - 'excel!Excel.WorksheetCollection:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Application:class'
     name: Excel.Application
@@ -810,7 +810,7 @@ references:
     name: OfficeExtension.ClientResult<boolean>
     fullName: OfficeExtension.ClientResult<boolean>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <boolean>
@@ -827,7 +827,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorkbookAutoSaveSettingChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorkbookAutoSaveSettingChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -841,7 +841,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.SelectionChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.SelectionChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -859,7 +859,7 @@ references:
     name: Excel.WorkbookProtection
   - uid: 'excel!Excel.Interfaces.WorkbookUpdateData:interface'
     name: Interfaces.WorkbookUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.SettingCollection:class'
     name: Excel.SettingCollection

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.workbookcreated.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.workbookcreated.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.WorkbookCreated#context:member'
@@ -103,7 +103,7 @@ items:
           - 'excel!Excel.Interfaces.WorkbookCreatedData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.workbookprotection.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.workbookprotection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.WorkbookProtection#context:member'
@@ -258,7 +258,7 @@ items:
           type:
             - string
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.worksheet.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.worksheet.yml
@@ -14,7 +14,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Worksheet#activate:member(1)'
@@ -1352,7 +1352,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Worksheet#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -1572,7 +1572,7 @@ items:
         type:
           - 'excel!Excel.Worksheet#visibility~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.AutoFilter:class'
     name: Excel.AutoFilter
@@ -1602,7 +1602,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetActivatedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetActivatedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -1616,7 +1616,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetCalculatedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetCalculatedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -1630,7 +1630,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -1644,7 +1644,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetDeactivatedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetDeactivatedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -1658,7 +1658,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetFormatChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetFormatChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -1672,7 +1672,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetSelectionChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetSelectionChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -1692,7 +1692,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -1701,7 +1701,7 @@ references:
     name: Excel.ReplaceCriteria
   - uid: 'excel!Excel.Interfaces.WorksheetUpdateData:interface'
     name: Interfaces.WorksheetUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.ShapeCollection:class'
     name: Excel.ShapeCollection

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.worksheetcollection.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.worksheetcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.WorksheetCollection#add:member(1)'
@@ -401,7 +401,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.WorksheetCollection#onActivated:member'
     summary: |-
       Occurs when any worksheet in the workbook is activated.
@@ -601,7 +601,7 @@ items:
           - 'excel!Excel.Interfaces.WorksheetCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Worksheet:class'
     name: Excel.Worksheet
@@ -611,7 +611,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -639,13 +639,13 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.WorksheetCollection#onActivated~0:complex'
     name: OfficeExtension.EventHandlers<Excel.WorksheetActivatedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetActivatedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -659,7 +659,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetAddedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetAddedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -673,7 +673,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetCalculatedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetCalculatedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -687,7 +687,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -701,7 +701,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetDeactivatedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetDeactivatedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -715,7 +715,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetDeletedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetDeletedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -729,7 +729,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetFormatChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetFormatChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -743,7 +743,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetSelectionChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetSelectionChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.worksheetfreezepanes.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.worksheetfreezepanes.yml
@@ -8,7 +8,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.WorksheetFreezePanes#context:member'
@@ -278,7 +278,7 @@ items:
 
           ```
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel_1_9/excel/excel.worksheetprotection.yml
+++ b/docs/docs-ref-autogen/excel_1_9/excel/excel.worksheetprotection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.WorksheetProtection#context:member'
@@ -282,7 +282,7 @@ items:
           type:
             - string
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel_online/excel.yml
+++ b/docs/docs-ref-autogen/excel_online/excel.yml
@@ -998,7 +998,7 @@ items:
             A previously-created API object. The batch will use the same RequestContext as the passed-in object, which
             means that any changes applied to the object will be picked up by "context.sync()".
           type:
-            - 'excel!OfficeExtension.ClientObject:class'
+            - 'office!OfficeExtension.ClientObject:class'
         - id: batch
           description: >-
             A function that takes in a RequestContext and returns a promise (typically, just the result of
@@ -1103,7 +1103,7 @@ items:
             A previously-created object. The batch will use the same RequestContext as the passed-in object, which means
             that any changes applied to the object will be picked up by "context.sync()".
           type:
-            - 'excel!OfficeExtension.ClientRequestContext:class'
+            - 'office!OfficeExtension.ClientRequestContext:class'
         - id: batch
           description: >-
             A function that takes in a RequestContext and returns a promise (typically, just the result of
@@ -2646,7 +2646,7 @@ references:
         fullName: Promise
       - name: <T>
         fullName: <T>
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.run~3:complex'
     name: '(context: Excel.RequestContext) => Promise<T>'
@@ -2677,7 +2677,7 @@ references:
     name: 'OfficeExtension.ClientObject[]'
     fullName: 'OfficeExtension.ClientObject[]'
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientObject:class'
+      - uid: 'office!OfficeExtension.ClientObject:class'
         name: OfficeExtension.ClientObject
         fullName: OfficeExtension.ClientObject
       - name: '[]'
@@ -2734,7 +2734,7 @@ references:
         fullName: Promise
       - name: <T>
         fullName: <T>
-  - uid: 'excel!OfficeExtension.ClientRequestContext:class'
+  - uid: 'office!OfficeExtension.ClientRequestContext:class'
     name: OfficeExtension.ClientRequestContext
   - uid: 'excel!Excel.run~10:complex'
     name: '(context: Excel.RequestContext) => Promise<T>'

--- a/docs/docs-ref-autogen/excel_online/excel/excel.application.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.application.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Application#calculate:member(1)'
@@ -284,7 +284,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Application#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -401,7 +401,7 @@ items:
           - 'excel!Excel.Interfaces.ApplicationData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.CalculationType:enum'
     name: Excel.CalculationType
@@ -433,7 +433,7 @@ references:
     name: Excel.Interfaces.ApplicationLoadOptions
   - uid: 'excel!Excel.Interfaces.ApplicationUpdateData:interface'
     name: Interfaces.ApplicationUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ApplicationData:interface'
     name: Excel.Interfaces.ApplicationData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.autofilter.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.autofilter.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.AutoFilter#apply:member(1)'
@@ -309,7 +309,7 @@ items:
           - 'excel!Excel.Interfaces.AutoFilterData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.AutoFilter#apply~0:complex'
     name: Range | string

--- a/docs/docs-ref-autogen/excel_online/excel/excel.binding.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.binding.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Binding#context:member'
@@ -357,7 +357,7 @@ items:
         type:
           - 'excel!Excel.Binding#type~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -369,7 +369,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -382,7 +382,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.BindingDataChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.BindingDataChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -396,7 +396,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.BindingSelectionChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.BindingSelectionChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <

--- a/docs/docs-ref-autogen/excel_online/excel/excel.bindingcollection.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.bindingcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.BindingCollection#add:member(1)'
@@ -493,7 +493,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.BindingCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -513,7 +513,7 @@ items:
           - 'excel!Excel.Interfaces.BindingCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Binding:class'
     name: Excel.Binding
@@ -543,7 +543,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -571,7 +571,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.BindingCollectionData:interface'
     name: Excel.Interfaces.BindingCollectionData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.cellvalueconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.cellvalueconditionalformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.CellValueConditionalFormat#context:member'
@@ -212,7 +212,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.CellValueConditionalFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -250,7 +250,7 @@ items:
           - 'excel!Excel.Interfaces.CellValueConditionalFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -264,7 +264,7 @@ references:
     name: Excel.ConditionalCellValueRule
   - uid: 'excel!Excel.Interfaces.CellValueConditionalFormatUpdateData:interface'
     name: Interfaces.CellValueConditionalFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.CellValueConditionalFormatData:interface'
     name: Excel.Interfaces.CellValueConditionalFormatData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chart.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chart.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Chart#activate:member(1)'
@@ -704,7 +704,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Chart#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -977,7 +977,7 @@ items:
         type:
           - 'excel!Excel.Worksheet:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartAxes:class'
     name: Excel.ChartAxes
@@ -1037,7 +1037,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -1048,7 +1048,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -1063,7 +1063,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.ChartActivatedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.ChartActivatedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -1077,7 +1077,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.ChartDeactivatedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.ChartDeactivatedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -1104,7 +1104,7 @@ references:
     name: Excel.ChartSeriesCollection
   - uid: 'excel!Excel.Interfaces.ChartUpdateData:interface'
     name: Interfaces.ChartUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Range:class'
     name: Range

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chartareaformat.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chartareaformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAreaFormat#border:member'
@@ -219,7 +219,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAreaFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -257,7 +257,7 @@ items:
           - 'excel!Excel.Interfaces.ChartAreaFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartBorder:class'
     name: Excel.ChartBorder
@@ -292,7 +292,7 @@ references:
     name: Excel.Interfaces.ChartAreaFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartAreaFormatUpdateData:interface'
     name: Interfaces.ChartAreaFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartAreaFormatData:interface'
     name: Excel.Interfaces.ChartAreaFormatData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chartaxes.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chartaxes.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAxes#categoryAxis:member'
@@ -221,7 +221,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAxes#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -297,7 +297,7 @@ items:
           });
           ```
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartAxis:class'
     name: Excel.ChartAxis
@@ -313,7 +313,7 @@ references:
     name: Excel.Interfaces.ChartAxesLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartAxesUpdateData:interface'
     name: Interfaces.ChartAxesUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartAxesData:interface'
     name: Excel.Interfaces.ChartAxesData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chartaxis.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chartaxis.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAxis#alignment:member'
@@ -682,7 +682,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAxis#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -964,7 +964,7 @@ items:
         type:
           - number
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartAxis#alignment~0:complex'
     name: Excel.ChartTickLabelAlignment | "Center" | "Left" | "Right"
@@ -1081,7 +1081,7 @@ references:
         fullName: ' | "Linear" | "Logarithmic"'
   - uid: 'excel!Excel.Interfaces.ChartAxisUpdateData:interface'
     name: Interfaces.ChartAxisUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Range:class'
     name: Range

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chartaxisformat.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chartaxisformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAxisFormat#context:member'
@@ -182,7 +182,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAxisFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -220,7 +220,7 @@ items:
           - 'excel!Excel.Interfaces.ChartAxisFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -236,7 +236,7 @@ references:
     name: Excel.Interfaces.ChartAxisFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisFormatUpdateData:interface'
     name: Interfaces.ChartAxisFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisFormatData:interface'
     name: Excel.Interfaces.ChartAxisFormatData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chartaxistitle.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chartaxistitle.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAxisTitle#context:member'
@@ -172,7 +172,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAxisTitle#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -261,7 +261,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -273,7 +273,7 @@ references:
     name: Excel.Interfaces.ChartAxisTitleLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisTitleUpdateData:interface'
     name: Interfaces.ChartAxisTitleUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisTitleData:interface'
     name: Excel.Interfaces.ChartAxisTitleData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chartaxistitleformat.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chartaxistitleformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartAxisTitleFormat#border:member'
@@ -182,7 +182,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartAxisTitleFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -220,7 +220,7 @@ items:
           - 'excel!Excel.Interfaces.ChartAxisTitleFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartBorder:class'
     name: Excel.ChartBorder
@@ -236,7 +236,7 @@ references:
     name: Excel.Interfaces.ChartAxisTitleFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisTitleFormatUpdateData:interface'
     name: Interfaces.ChartAxisTitleFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartAxisTitleFormatData:interface'
     name: Excel.Interfaces.ChartAxisTitleFormatData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chartbinoptions.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chartbinoptions.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartBinOptions#allowOverflow:member'
@@ -201,7 +201,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartBinOptions#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -284,7 +284,7 @@ items:
         type:
           - number
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -294,7 +294,7 @@ references:
     name: Excel.Interfaces.ChartBinOptionsLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartBinOptionsUpdateData:interface'
     name: Interfaces.ChartBinOptionsUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartBinOptionsData:interface'
     name: Excel.Interfaces.ChartBinOptionsData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chartborder.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chartborder.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartBorder#clear:member(1)'
@@ -186,7 +186,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartBorder#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -239,7 +239,7 @@ items:
         type:
           - number
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -262,7 +262,7 @@ references:
     name: Excel.Interfaces.ChartBorderLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartBorderUpdateData:interface'
     name: Interfaces.ChartBorderUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartBorderData:interface'
     name: Excel.Interfaces.ChartBorderData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chartboxwhiskeroptions.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chartboxwhiskeroptions.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartBoxwhiskerOptions#context:member'
@@ -154,7 +154,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartBoxwhiskerOptions#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -252,7 +252,7 @@ items:
           - 'excel!Excel.Interfaces.ChartBoxwhiskerOptionsData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -271,7 +271,7 @@ references:
         fullName: ' | "Inclusive" | "Exclusive"'
   - uid: 'excel!Excel.Interfaces.ChartBoxwhiskerOptionsUpdateData:interface'
     name: Interfaces.ChartBoxwhiskerOptionsUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartBoxwhiskerOptionsData:interface'
     name: Excel.Interfaces.ChartBoxwhiskerOptionsData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chartcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartCollection#add:member(1)'
@@ -387,7 +387,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.ChartCollection#onActivated:member'
     summary: |-
       Occurs when a chart is activated.
@@ -535,7 +535,7 @@ items:
           - 'excel!Excel.Interfaces.ChartCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Chart:class'
     name: Excel.Chart
@@ -551,7 +551,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -579,13 +579,13 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.ChartCollection#onActivated~0:complex'
     name: OfficeExtension.EventHandlers<Excel.ChartActivatedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.ChartActivatedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -599,7 +599,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.ChartAddedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.ChartAddedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -613,7 +613,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.ChartDeactivatedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.ChartDeactivatedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -627,7 +627,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.ChartDeletedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.ChartDeletedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chartdatalabel.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chartdatalabel.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartDataLabel#autoText:member'
@@ -317,7 +317,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartDataLabel#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -526,7 +526,7 @@ items:
         type:
           - number
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -560,7 +560,7 @@ references:
         fullName: ' | "Invalid" | "None" | "Center" | "InsideEnd" | "InsideBase" | "OutsideEnd" | "Left" | "Right" | "Top" | "Bottom" | "BestFit" | "Callout"'
   - uid: 'excel!Excel.Interfaces.ChartDataLabelUpdateData:interface'
     name: Interfaces.ChartDataLabelUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartDataLabelData:interface'
     name: Excel.Interfaces.ChartDataLabelData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chartdatalabelformat.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chartdatalabelformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartDataLabelFormat#border:member'
@@ -182,7 +182,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartDataLabelFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -220,7 +220,7 @@ items:
           - 'excel!Excel.Interfaces.ChartDataLabelFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartBorder:class'
     name: Excel.ChartBorder
@@ -236,7 +236,7 @@ references:
     name: Excel.Interfaces.ChartDataLabelFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartDataLabelFormatUpdateData:interface'
     name: Interfaces.ChartDataLabelFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartDataLabelFormatData:interface'
     name: Excel.Interfaces.ChartDataLabelFormatData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chartdatalabels.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chartdatalabels.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartDataLabels#autoText:member'
@@ -285,7 +285,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartDataLabels#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -447,7 +447,7 @@ items:
         type:
           - 'excel!Excel.ChartDataLabels#verticalAlignment~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -481,7 +481,7 @@ references:
         fullName: ' | "Invalid" | "None" | "Center" | "InsideEnd" | "InsideBase" | "OutsideEnd" | "Left" | "Right" | "Top" | "Bottom" | "BestFit" | "Callout"'
   - uid: 'excel!Excel.Interfaces.ChartDataLabelsUpdateData:interface'
     name: Interfaces.ChartDataLabelsUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartDataLabelsData:interface'
     name: Excel.Interfaces.ChartDataLabelsData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.charterrorbars.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.charterrorbars.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartErrorBars#context:member'
@@ -184,7 +184,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartErrorBars#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -252,7 +252,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -273,7 +273,7 @@ references:
     name: Excel.Interfaces.ChartErrorBarsLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartErrorBarsUpdateData:interface'
     name: Interfaces.ChartErrorBarsUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartErrorBarsData:interface'
     name: Excel.Interfaces.ChartErrorBarsData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.charterrorbarsformat.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.charterrorbarsformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartErrorBarsFormat#context:member'
@@ -150,7 +150,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartErrorBarsFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -188,7 +188,7 @@ items:
           - 'excel!Excel.Interfaces.ChartErrorBarsFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -200,7 +200,7 @@ references:
     name: Excel.Interfaces.ChartErrorBarsFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartErrorBarsFormatUpdateData:interface'
     name: Interfaces.ChartErrorBarsFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartErrorBarsFormatData:interface'
     name: Excel.Interfaces.ChartErrorBarsFormatData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chartfill.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chartfill.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartFill#clear:member(1)'
@@ -138,7 +138,7 @@ items:
                     }
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chartfont.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chartfont.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     remarks: |-
 
@@ -223,7 +223,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartFont#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -291,7 +291,7 @@ items:
         type:
           - 'excel!Excel.ChartFont#underline~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -301,7 +301,7 @@ references:
     name: Excel.Interfaces.ChartFontLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartFontUpdateData:interface'
     name: Interfaces.ChartFontUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartFontData:interface'
     name: Excel.Interfaces.ChartFontData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chartformatstring.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chartformatstring.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartFormatString#context:member'
@@ -152,7 +152,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartFormatString#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -190,7 +190,7 @@ items:
           - 'excel!Excel.Interfaces.ChartFormatStringData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -202,7 +202,7 @@ references:
     name: Excel.Interfaces.ChartFormatStringLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartFormatStringUpdateData:interface'
     name: Interfaces.ChartFormatStringUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartFormatStringData:interface'
     name: Excel.Interfaces.ChartFormatStringData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chartgridlines.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chartgridlines.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartGridlines#context:member'
@@ -170,7 +170,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartGridlines#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -223,7 +223,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -235,7 +235,7 @@ references:
     name: Excel.Interfaces.ChartGridlinesLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartGridlinesUpdateData:interface'
     name: Interfaces.ChartGridlinesUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartGridlinesData:interface'
     name: Excel.Interfaces.ChartGridlinesData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chartgridlinesformat.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chartgridlinesformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartGridlinesFormat#context:member'
@@ -150,7 +150,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartGridlinesFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -188,7 +188,7 @@ items:
           - 'excel!Excel.Interfaces.ChartGridlinesFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -200,7 +200,7 @@ references:
     name: Excel.Interfaces.ChartGridlinesFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartGridlinesFormatUpdateData:interface'
     name: Interfaces.ChartGridlinesFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartGridlinesFormatData:interface'
     name: Excel.Interfaces.ChartGridlinesFormatData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chartlegend.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chartlegend.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartLegend#context:member'
@@ -254,7 +254,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartLegend#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -352,7 +352,7 @@ items:
         type:
           - number
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -375,7 +375,7 @@ references:
         fullName: ' | "Invalid" | "Top" | "Bottom" | "Left" | "Right" | "Corner" | "Custom"'
   - uid: 'excel!Excel.Interfaces.ChartLegendUpdateData:interface'
     name: Interfaces.ChartLegendUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartLegendData:interface'
     name: Excel.Interfaces.ChartLegendData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chartlegendentry.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chartlegendentry.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartLegendEntry#context:member'
@@ -185,7 +185,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartLegendEntry#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -268,7 +268,7 @@ items:
         type:
           - number
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -278,7 +278,7 @@ references:
     name: Excel.Interfaces.ChartLegendEntryLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartLegendEntryUpdateData:interface'
     name: Interfaces.ChartLegendEntryUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartLegendEntryData:interface'
     name: Excel.Interfaces.ChartLegendEntryData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chartlegendentrycollection.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chartlegendentrycollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartLegendEntryCollection#context:member'
@@ -148,7 +148,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.ChartLegendEntryCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -168,7 +168,7 @@ items:
           - 'excel!Excel.Interfaces.ChartLegendEntryCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -176,7 +176,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -206,7 +206,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.ChartLegendEntryCollectionData:interface'
     name: Excel.Interfaces.ChartLegendEntryCollectionData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chartlegendformat.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chartlegendformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartLegendFormat#border:member'
@@ -212,7 +212,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartLegendFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -250,7 +250,7 @@ items:
           - 'excel!Excel.Interfaces.ChartLegendFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartBorder:class'
     name: Excel.ChartBorder
@@ -266,7 +266,7 @@ references:
     name: Excel.Interfaces.ChartLegendFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartLegendFormatUpdateData:interface'
     name: Interfaces.ChartLegendFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartLegendFormatData:interface'
     name: Excel.Interfaces.ChartLegendFormatData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chartlineformat.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chartlineformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartLineFormat#clear:member(1)'
@@ -224,7 +224,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartLineFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -277,7 +277,7 @@ items:
         type:
           - number
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -300,7 +300,7 @@ references:
     name: Excel.Interfaces.ChartLineFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartLineFormatUpdateData:interface'
     name: Interfaces.ChartLineFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartLineFormatData:interface'
     name: Excel.Interfaces.ChartLineFormatData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chartmapoptions.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chartmapoptions.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartMapOptions#context:member'
@@ -184,7 +184,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartMapOptions#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -222,7 +222,7 @@ items:
           - 'excel!Excel.Interfaces.ChartMapOptionsData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -263,7 +263,7 @@ references:
         fullName: ' | "Automatic" | "Mercator" | "Miller" | "Robinson" | "Albers"'
   - uid: 'excel!Excel.Interfaces.ChartMapOptionsUpdateData:interface'
     name: Interfaces.ChartMapOptionsUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartMapOptionsData:interface'
     name: Excel.Interfaces.ChartMapOptionsData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chartpivotoptions.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chartpivotoptions.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartPivotOptions#context:member'
@@ -138,7 +138,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartPivotOptions#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -239,7 +239,7 @@ items:
           - 'excel!Excel.Interfaces.ChartPivotOptionsData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -249,7 +249,7 @@ references:
     name: Excel.Interfaces.ChartPivotOptionsLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartPivotOptionsUpdateData:interface'
     name: Interfaces.ChartPivotOptionsUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartPivotOptionsData:interface'
     name: Excel.Interfaces.ChartPivotOptionsData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chartplotarea.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chartplotarea.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartPlotArea#context:member'
@@ -264,7 +264,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartPlotArea#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -332,7 +332,7 @@ items:
         type:
           - number
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -353,7 +353,7 @@ references:
         fullName: ' | "Automatic" | "Custom"'
   - uid: 'excel!Excel.Interfaces.ChartPlotAreaUpdateData:interface'
     name: Interfaces.ChartPlotAreaUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartPlotAreaData:interface'
     name: Excel.Interfaces.ChartPlotAreaData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chartplotareaformat.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chartplotareaformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartPlotAreaFormat#border:member'
@@ -166,7 +166,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartPlotAreaFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -204,7 +204,7 @@ items:
           - 'excel!Excel.Interfaces.ChartPlotAreaFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartBorder:class'
     name: Excel.ChartBorder
@@ -218,7 +218,7 @@ references:
     name: Excel.Interfaces.ChartPlotAreaFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartPlotAreaFormatUpdateData:interface'
     name: Interfaces.ChartPlotAreaFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartPlotAreaFormatData:interface'
     name: Excel.Interfaces.ChartPlotAreaFormatData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chartpoint.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chartpoint.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartPoint#context:member'
@@ -249,7 +249,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartPoint#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -302,7 +302,7 @@ items:
         type:
           - any
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -329,7 +329,7 @@ references:
         fullName: ' | "Invalid" | "Automatic" | "None" | "Square" | "Diamond" | "Triangle" | "X" | "Star" | "Dot" | "Dash" | "Circle" | "Plus" | "Picture"'
   - uid: 'excel!Excel.Interfaces.ChartPointUpdateData:interface'
     name: Interfaces.ChartPointUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartPointData:interface'
     name: Excel.Interfaces.ChartPointData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chartpointformat.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chartpointformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartPointFormat#border:member'
@@ -168,7 +168,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartPointFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -206,7 +206,7 @@ items:
           - 'excel!Excel.Interfaces.ChartPointFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartBorder:class'
     name: Excel.ChartBorder
@@ -220,7 +220,7 @@ references:
     name: Excel.Interfaces.ChartPointFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartPointFormatUpdateData:interface'
     name: Interfaces.ChartPointFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartPointFormatData:interface'
     name: Excel.Interfaces.ChartPointFormatData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chartpointscollection.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chartpointscollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartPointsCollection#context:member'
@@ -219,7 +219,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.ChartPointsCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -239,7 +239,7 @@ items:
           - 'excel!Excel.Interfaces.ChartPointsCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -247,7 +247,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -277,7 +277,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.ChartPointsCollectionData:interface'
     name: Excel.Interfaces.ChartPointsCollectionData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chartseries.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chartseries.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartSeries#axisGroup:member'
@@ -976,7 +976,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartSeries#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -1259,7 +1259,7 @@ items:
         type:
           - 'excel!Excel.ChartErrorBars:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartSeries#axisGroup~0:complex'
     name: Excel.ChartAxisGroup | "Primary" | "Secondary"
@@ -1385,7 +1385,7 @@ references:
     name: Excel.ChartPointsCollection
   - uid: 'excel!Excel.Interfaces.ChartSeriesUpdateData:interface'
     name: Interfaces.ChartSeriesUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Range:class'
     name: Range

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chartseriescollection.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chartseriescollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartSeriesCollection#add:member(1)'
@@ -248,7 +248,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.ChartSeriesCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -268,7 +268,7 @@ items:
           - 'excel!Excel.Interfaces.ChartSeriesCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartSeries:class'
     name: Excel.ChartSeries
@@ -278,7 +278,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -306,7 +306,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.ChartSeriesCollectionData:interface'
     name: Excel.Interfaces.ChartSeriesCollectionData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.chartseriesformat.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.chartseriesformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartSeriesFormat#context:member'
@@ -166,7 +166,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartSeriesFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -204,7 +204,7 @@ items:
           - 'excel!Excel.Interfaces.ChartSeriesFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -218,7 +218,7 @@ references:
     name: Excel.Interfaces.ChartSeriesFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartSeriesFormatUpdateData:interface'
     name: Interfaces.ChartSeriesFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartSeriesFormatData:interface'
     name: Excel.Interfaces.ChartSeriesFormatData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.charttitle.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.charttitle.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartTitle#context:member'
@@ -328,7 +328,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartTitle#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -516,7 +516,7 @@ items:
         type:
           - number
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -548,7 +548,7 @@ references:
         fullName: ' | "Automatic" | "Top" | "Bottom" | "Left" | "Right"'
   - uid: 'excel!Excel.Interfaces.ChartTitleUpdateData:interface'
     name: Interfaces.ChartTitleUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartTitleData:interface'
     name: Excel.Interfaces.ChartTitleData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.charttitleformat.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.charttitleformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartTitleFormat#border:member'
@@ -182,7 +182,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartTitleFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -220,7 +220,7 @@ items:
           - 'excel!Excel.Interfaces.ChartTitleFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartBorder:class'
     name: Excel.ChartBorder
@@ -236,7 +236,7 @@ references:
     name: Excel.Interfaces.ChartTitleFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartTitleFormatUpdateData:interface'
     name: Interfaces.ChartTitleFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartTitleFormatData:interface'
     name: Excel.Interfaces.ChartTitleFormatData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.charttrendline.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.charttrendline.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartTrendline#backwardPeriod:member'
@@ -286,7 +286,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartTrendline#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -397,7 +397,7 @@ items:
 
           ```
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -411,7 +411,7 @@ references:
     name: Excel.Interfaces.ChartTrendlineLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartTrendlineUpdateData:interface'
     name: Interfaces.ChartTrendlineUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartTrendlineData:interface'
     name: Excel.Interfaces.ChartTrendlineData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.charttrendlinecollection.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.charttrendlinecollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartTrendlineCollection#add:member(1)'
@@ -216,7 +216,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.ChartTrendlineCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -236,7 +236,7 @@ items:
           - 'excel!Excel.Interfaces.ChartTrendlineCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartTrendline:class'
     name: Excel.ChartTrendline
@@ -248,7 +248,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -276,7 +276,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.ChartTrendlineCollectionData:interface'
     name: Excel.Interfaces.ChartTrendlineCollectionData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.charttrendlineformat.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.charttrendlineformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartTrendlineFormat#context:member'
@@ -199,7 +199,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartTrendlineFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -237,7 +237,7 @@ items:
           - 'excel!Excel.Interfaces.ChartTrendlineFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -249,7 +249,7 @@ references:
     name: Excel.Interfaces.ChartTrendlineFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartTrendlineFormatUpdateData:interface'
     name: Interfaces.ChartTrendlineFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartTrendlineFormatData:interface'
     name: Excel.Interfaces.ChartTrendlineFormatData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.charttrendlinelabel.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.charttrendlinelabel.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartTrendlineLabel#autoText:member'
@@ -277,7 +277,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartTrendlineLabel#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -398,7 +398,7 @@ items:
         type:
           - number
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -419,7 +419,7 @@ references:
     name: Excel.Interfaces.ChartTrendlineLabelLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartTrendlineLabelUpdateData:interface'
     name: Interfaces.ChartTrendlineLabelUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartTrendlineLabelData:interface'
     name: Excel.Interfaces.ChartTrendlineLabelData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.charttrendlinelabelformat.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.charttrendlinelabelformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ChartTrendlineLabelFormat#border:member'
@@ -182,7 +182,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ChartTrendlineLabelFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -220,7 +220,7 @@ items:
           - 'excel!Excel.Interfaces.ChartTrendlineLabelFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ChartBorder:class'
     name: Excel.ChartBorder
@@ -236,7 +236,7 @@ references:
     name: Excel.Interfaces.ChartTrendlineLabelFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ChartTrendlineLabelFormatUpdateData:interface'
     name: Interfaces.ChartTrendlineLabelFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ChartTrendlineLabelFormatData:interface'
     name: Excel.Interfaces.ChartTrendlineLabelFormatData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.colorscaleconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.colorscaleconditionalformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ColorScaleConditionalFormat#context:member'
@@ -180,7 +180,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ColorScaleConditionalFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -235,7 +235,7 @@ items:
           - 'excel!Excel.Interfaces.ColorScaleConditionalFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -247,7 +247,7 @@ references:
     name: Excel.Interfaces.ColorScaleConditionalFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ColorScaleConditionalFormatUpdateData:interface'
     name: Interfaces.ColorScaleConditionalFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ColorScaleConditionalFormatData:interface'
     name: Excel.Interfaces.ColorScaleConditionalFormatData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.comment.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.comment.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Comment#authorEmail:member'
@@ -356,7 +356,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Comment#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -417,7 +417,7 @@ items:
           type:
             - 'excel!Excel.CommentRichContent:interface'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -442,7 +442,7 @@ references:
     name: Excel.CommentReplyCollection
   - uid: 'excel!Excel.Interfaces.CommentUpdateData:interface'
     name: Interfaces.CommentUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.CommentData:interface'
     name: Excel.Interfaces.CommentData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.commentcollection.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.commentcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.CommentCollection#add:member(1)'
@@ -322,7 +322,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.CommentCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -342,7 +342,7 @@ items:
           - 'excel!Excel.Interfaces.CommentCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Comment:class'
     name: Excel.Comment
@@ -390,7 +390,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -427,7 +427,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.CommentCollectionData:interface'
     name: Excel.Interfaces.CommentCollectionData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.commentreply.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.commentreply.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.CommentReply#authorEmail:member'
@@ -344,7 +344,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.CommentReply#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -405,7 +405,7 @@ items:
           type:
             - 'excel!Excel.CommentRichContent:interface'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -430,7 +430,7 @@ references:
         fullName: '[]'
   - uid: 'excel!Excel.Interfaces.CommentReplyUpdateData:interface'
     name: Interfaces.CommentReplyUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.CommentReplyData:interface'
     name: Excel.Interfaces.CommentReplyData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.commentreplycollection.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.commentreplycollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.CommentReplyCollection#add:member(1)'
@@ -251,7 +251,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.CommentReplyCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -271,7 +271,7 @@ items:
           - 'excel!Excel.Interfaces.CommentReplyCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.CommentReply:class'
     name: Excel.CommentReply
@@ -301,7 +301,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -329,7 +329,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.CommentReplyCollectionData:interface'
     name: Excel.Interfaces.CommentReplyCollectionData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.conditionaldatabarnegativeformat.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.conditionaldatabarnegativeformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ConditionalDataBarNegativeFormat#borderColor:member'
@@ -206,7 +206,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ConditionalDataBarNegativeFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -244,7 +244,7 @@ items:
           - 'excel!Excel.Interfaces.ConditionalDataBarNegativeFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -254,7 +254,7 @@ references:
     name: Excel.Interfaces.ConditionalDataBarNegativeFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ConditionalDataBarNegativeFormatUpdateData:interface'
     name: Interfaces.ConditionalDataBarNegativeFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ConditionalDataBarNegativeFormatData:interface'
     name: Excel.Interfaces.ConditionalDataBarNegativeFormatData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.conditionaldatabarpositiveformat.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.conditionaldatabarpositiveformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ConditionalDataBarPositiveFormat#borderColor:member'
@@ -190,7 +190,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ConditionalDataBarPositiveFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -228,7 +228,7 @@ items:
           - 'excel!Excel.Interfaces.ConditionalDataBarPositiveFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -238,7 +238,7 @@ references:
     name: Excel.Interfaces.ConditionalDataBarPositiveFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ConditionalDataBarPositiveFormatUpdateData:interface'
     name: Interfaces.ConditionalDataBarPositiveFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ConditionalDataBarPositiveFormatData:interface'
     name: Excel.Interfaces.ConditionalDataBarPositiveFormatData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.conditionalformat.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.conditionalformat.yml
@@ -14,7 +14,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ConditionalFormat#cellValue:member'
@@ -657,7 +657,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ConditionalFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -858,7 +858,7 @@ items:
 
           ```
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.CellValueConditionalFormat:class'
     name: Excel.CellValueConditionalFormat
@@ -884,7 +884,7 @@ references:
     name: Excel.PresetCriteriaConditionalFormat
   - uid: 'excel!Excel.Interfaces.ConditionalFormatUpdateData:interface'
     name: Interfaces.ConditionalFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.TextConditionalFormat:class'
     name: Excel.TextConditionalFormat

--- a/docs/docs-ref-autogen/excel_online/excel/excel.conditionalformatcollection.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.conditionalformatcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ConditionalFormatCollection#add:member(1)'
@@ -363,7 +363,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.ConditionalFormatCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -383,7 +383,7 @@ items:
           - 'excel!Excel.Interfaces.ConditionalFormatCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ConditionalFormat:class'
     name: Excel.ConditionalFormat
@@ -395,7 +395,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -423,7 +423,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.ConditionalFormatCollectionData:interface'
     name: Excel.Interfaces.ConditionalFormatCollectionData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.conditionalformatrule.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.conditionalformatrule.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ConditionalFormatRule#context:member'
@@ -204,7 +204,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ConditionalFormatRule#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -242,7 +242,7 @@ items:
           - 'excel!Excel.Interfaces.ConditionalFormatRuleData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -252,7 +252,7 @@ references:
     name: Excel.Interfaces.ConditionalFormatRuleLoadOptions
   - uid: 'excel!Excel.Interfaces.ConditionalFormatRuleUpdateData:interface'
     name: Interfaces.ConditionalFormatRuleUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ConditionalFormatRuleData:interface'
     name: Excel.Interfaces.ConditionalFormatRuleData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.conditionalrangeborder.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.conditionalrangeborder.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ConditionalRangeBorder#color:member'
@@ -154,7 +154,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ConditionalRangeBorder#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -228,7 +228,7 @@ items:
           - 'excel!Excel.Interfaces.ConditionalRangeBorderData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -238,7 +238,7 @@ references:
     name: Excel.Interfaces.ConditionalRangeBorderLoadOptions
   - uid: 'excel!Excel.Interfaces.ConditionalRangeBorderUpdateData:interface'
     name: Interfaces.ConditionalRangeBorderUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.ConditionalRangeBorder#sideIndex~0:complex'
     name: Excel.ConditionalRangeBorderIndex | "EdgeTop" | "EdgeBottom" | "EdgeLeft" | "EdgeRight"

--- a/docs/docs-ref-autogen/excel_online/excel/excel.conditionalrangebordercollection.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.conditionalrangebordercollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ConditionalRangeBorderCollection#bottom:member'
@@ -225,7 +225,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.ConditionalRangeBorderCollection#right:member'
     summary: |-
       Gets the right border. Read-only.
@@ -275,7 +275,7 @@ items:
         type:
           - 'excel!Excel.ConditionalRangeBorder:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ConditionalRangeBorder:class'
     name: Excel.ConditionalRangeBorder
@@ -306,7 +306,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.ConditionalRangeBorderCollectionData:interface'
     name: Excel.Interfaces.ConditionalRangeBorderCollectionData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.conditionalrangefill.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.conditionalrangefill.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ConditionalRangeFill#clear:member(1)'
@@ -169,7 +169,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ConditionalRangeFill#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -207,7 +207,7 @@ items:
           - 'excel!Excel.Interfaces.ConditionalRangeFillData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -217,7 +217,7 @@ references:
     name: Excel.Interfaces.ConditionalRangeFillLoadOptions
   - uid: 'excel!Excel.Interfaces.ConditionalRangeFillUpdateData:interface'
     name: Interfaces.ConditionalRangeFillUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ConditionalRangeFillData:interface'
     name: Excel.Interfaces.ConditionalRangeFillData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.conditionalrangefont.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.conditionalrangefont.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ConditionalRangeFont#bold:member'
@@ -201,7 +201,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ConditionalRangeFont#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -269,7 +269,7 @@ items:
         type:
           - 'excel!Excel.ConditionalRangeFont#underline~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -279,7 +279,7 @@ references:
     name: Excel.Interfaces.ConditionalRangeFontLoadOptions
   - uid: 'excel!Excel.Interfaces.ConditionalRangeFontUpdateData:interface'
     name: Interfaces.ConditionalRangeFontUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ConditionalRangeFontData:interface'
     name: Excel.Interfaces.ConditionalRangeFontData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.conditionalrangeformat.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.conditionalrangeformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ConditionalRangeFormat#borders:member'
@@ -198,7 +198,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ConditionalRangeFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -236,7 +236,7 @@ items:
           - 'excel!Excel.Interfaces.ConditionalRangeFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.ConditionalRangeBorderCollection:class'
     name: Excel.ConditionalRangeBorderCollection
@@ -252,7 +252,7 @@ references:
     name: Excel.Interfaces.ConditionalRangeFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ConditionalRangeFormatUpdateData:interface'
     name: Interfaces.ConditionalRangeFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ConditionalRangeFormatData:interface'
     name: Excel.Interfaces.ConditionalRangeFormatData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.customconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.customconditionalformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.CustomConditionalFormat#context:member'
@@ -214,7 +214,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.CustomConditionalFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -252,7 +252,7 @@ items:
           - 'excel!Excel.Interfaces.CustomConditionalFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -266,7 +266,7 @@ references:
     name: Excel.ConditionalFormatRule
   - uid: 'excel!Excel.Interfaces.CustomConditionalFormatUpdateData:interface'
     name: Interfaces.CustomConditionalFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.CustomConditionalFormatData:interface'
     name: Excel.Interfaces.CustomConditionalFormatData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.customproperty.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.customproperty.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.CustomProperty#context:member'
@@ -169,7 +169,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.CustomProperty#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -237,7 +237,7 @@ items:
         type:
           - any
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -247,7 +247,7 @@ references:
     name: Excel.Interfaces.CustomPropertyLoadOptions
   - uid: 'excel!Excel.Interfaces.CustomPropertyUpdateData:interface'
     name: Interfaces.CustomPropertyUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.CustomPropertyData:interface'
     name: Excel.Interfaces.CustomPropertyData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.custompropertycollection.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.custompropertycollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.CustomPropertyCollection#add:member(1)'
@@ -215,7 +215,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.CustomPropertyCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -235,7 +235,7 @@ items:
           - 'excel!Excel.Interfaces.CustomPropertyCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.CustomProperty:class'
     name: Excel.CustomProperty
@@ -245,7 +245,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -273,7 +273,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.CustomPropertyCollectionData:interface'
     name: Excel.Interfaces.CustomPropertyCollectionData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.customxmlpart.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.customxmlpart.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.CustomXmlPart#context:member'
@@ -343,7 +343,7 @@ items:
           - 'excel!Excel.Interfaces.CustomXmlPartData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -351,7 +351,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>

--- a/docs/docs-ref-autogen/excel_online/excel/excel.customxmlpartcollection.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.customxmlpartcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.CustomXmlPartCollection#add:member(1)'
@@ -317,7 +317,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.CustomXmlPartCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -337,7 +337,7 @@ items:
           - 'excel!Excel.Interfaces.CustomXmlPartCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.CustomXmlPart:class'
     name: Excel.CustomXmlPart
@@ -349,7 +349,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -377,7 +377,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.CustomXmlPartCollectionData:interface'
     name: Excel.Interfaces.CustomXmlPartCollectionData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.customxmlpartscopedcollection.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.customxmlpartscopedcollection.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.CustomXmlPartScopedCollection#context:member'
@@ -325,7 +325,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.CustomXmlPartScopedCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -345,7 +345,7 @@ items:
           - 'excel!Excel.Interfaces.CustomXmlPartScopedCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -353,7 +353,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -383,7 +383,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.CustomXmlPartScopedCollectionData:interface'
     name: Excel.Interfaces.CustomXmlPartScopedCollectionData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.databarconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.databarconditionalformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.DataBarConditionalFormat#axisColor:member'
@@ -259,7 +259,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.DataBarConditionalFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -330,7 +330,7 @@ items:
         type:
           - 'excel!Excel.ConditionalDataBarRule:interface'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.DataBarConditionalFormat#axisFormat~0:complex'
     name: Excel.ConditionalDataBarAxisFormat | "Automatic" | "None" | "CellMidPoint"
@@ -364,7 +364,7 @@ references:
     name: Excel.ConditionalDataBarPositiveFormat
   - uid: 'excel!Excel.Interfaces.DataBarConditionalFormatUpdateData:interface'
     name: Interfaces.DataBarConditionalFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.DataBarConditionalFormatData:interface'
     name: Excel.Interfaces.DataBarConditionalFormatData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.dataconnectioncollection.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.dataconnectioncollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.DataConnectionCollection#context:member'
@@ -72,7 +72,7 @@ items:
                     }
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel_online/excel/excel.datapivothierarchy.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.datapivothierarchy.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.DataPivotHierarchy#context:member'
@@ -239,7 +239,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.DataPivotHierarchy#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -359,7 +359,7 @@ items:
           - 'excel!Excel.Interfaces.DataPivotHierarchyData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -371,7 +371,7 @@ references:
     name: Excel.Interfaces.DataPivotHierarchyLoadOptions
   - uid: 'excel!Excel.Interfaces.DataPivotHierarchyUpdateData:interface'
     name: Interfaces.DataPivotHierarchyUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.ShowAsRule:interface'
     name: Excel.ShowAsRule

--- a/docs/docs-ref-autogen/excel_online/excel/excel.datapivothierarchycollection.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.datapivothierarchycollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.DataPivotHierarchyCollection#add:member(1)'
@@ -193,7 +193,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.DataPivotHierarchyCollection#remove:member(1)'
     summary: |-
       Removes the PivotHierarchy from the current axis.
@@ -234,7 +234,7 @@ items:
           - 'excel!Excel.Interfaces.DataPivotHierarchyCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.DataPivotHierarchy:class'
     name: Excel.DataPivotHierarchy
@@ -246,7 +246,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -274,7 +274,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.DataPivotHierarchyCollectionData:interface'
     name: Excel.Interfaces.DataPivotHierarchyCollectionData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.datavalidation.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.datavalidation.yml
@@ -14,7 +14,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.DataValidation#clear:member(1)'
@@ -376,7 +376,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.DataValidation#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -449,7 +449,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -467,7 +467,7 @@ references:
     name: Excel.DataValidationRule
   - uid: 'excel!Excel.Interfaces.DataValidationUpdateData:interface'
     name: Interfaces.DataValidationUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.DataValidationData:interface'
     name: Excel.Interfaces.DataValidationData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.documentproperties.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.documentproperties.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.DocumentProperties#author:member'
@@ -296,7 +296,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.DocumentProperties#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -364,7 +364,7 @@ items:
           - 'excel!Excel.Interfaces.DocumentPropertiesData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -378,7 +378,7 @@ references:
     name: Excel.Interfaces.DocumentPropertiesLoadOptions
   - uid: 'excel!Excel.Interfaces.DocumentPropertiesUpdateData:interface'
     name: Interfaces.DocumentPropertiesUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.DocumentPropertiesData:interface'
     name: Excel.Interfaces.DocumentPropertiesData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.filter.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.filter.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Filter#apply:member(1)'
@@ -473,7 +473,7 @@ items:
           - 'excel!Excel.Interfaces.FilterData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.FilterCriteria:interface'
     name: Excel.FilterCriteria

--- a/docs/docs-ref-autogen/excel_online/excel/excel.filterpivothierarchy.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.filterpivothierarchy.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.FilterPivotHierarchy#context:member'
@@ -215,7 +215,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.FilterPivotHierarchy#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -269,7 +269,7 @@ items:
           - 'excel!Excel.Interfaces.FilterPivotHierarchyData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -281,7 +281,7 @@ references:
     name: Excel.Interfaces.FilterPivotHierarchyLoadOptions
   - uid: 'excel!Excel.Interfaces.FilterPivotHierarchyUpdateData:interface'
     name: Interfaces.FilterPivotHierarchyUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.FilterPivotHierarchyData:interface'
     name: Excel.Interfaces.FilterPivotHierarchyData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.filterpivothierarchycollection.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.filterpivothierarchycollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.FilterPivotHierarchyCollection#add:member(1)'
@@ -195,7 +195,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.FilterPivotHierarchyCollection#remove:member(1)'
     summary: |-
       Removes the PivotHierarchy from the current axis.
@@ -236,7 +236,7 @@ items:
           - 'excel!Excel.Interfaces.FilterPivotHierarchyCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.FilterPivotHierarchy:class'
     name: Excel.FilterPivotHierarchy
@@ -248,7 +248,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -276,7 +276,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.FilterPivotHierarchyCollectionData:interface'
     name: Excel.Interfaces.FilterPivotHierarchyCollectionData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.formatprotection.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.formatprotection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.FormatProtection#context:member'
@@ -170,7 +170,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.FormatProtection#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -208,7 +208,7 @@ items:
           - 'excel!Excel.Interfaces.FormatProtectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -218,7 +218,7 @@ references:
     name: Excel.Interfaces.FormatProtectionLoadOptions
   - uid: 'excel!Excel.Interfaces.FormatProtectionUpdateData:interface'
     name: Interfaces.FormatProtectionUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.FormatProtectionData:interface'
     name: Excel.Interfaces.FormatProtectionData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.functionresult.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.functionresult.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.FunctionResult#context:member'
@@ -158,7 +158,7 @@ items:
         type:
           - T
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel_online/excel/excel.functions.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.functions.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Functions#abs:member(1)'
@@ -11184,7 +11184,7 @@ items:
           type:
             - 'excel!Excel.Functions#z_Test~3:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Functions#abs~0:complex'
     name: FunctionResult<number>

--- a/docs/docs-ref-autogen/excel_online/excel/excel.geometricshape.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.geometricshape.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.GeometricShape#context:member'
@@ -156,7 +156,7 @@ items:
           - 'excel!Excel.Interfaces.GeometricShapeData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel_online/excel/excel.groupshapecollection.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.groupshapecollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.GroupShapeCollection#context:member'
@@ -170,7 +170,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.GroupShapeCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -190,7 +190,7 @@ items:
           - 'excel!Excel.Interfaces.GroupShapeCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -198,7 +198,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -228,7 +228,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.GroupShapeCollectionData:interface'
     name: Excel.Interfaces.GroupShapeCollectionData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.headerfooter.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.headerfooter.yml
@@ -8,7 +8,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.HeaderFooter#centerFooter:member'
@@ -239,7 +239,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.HeaderFooter#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -277,7 +277,7 @@ items:
           - 'excel!Excel.Interfaces.HeaderFooterData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -287,7 +287,7 @@ references:
     name: Excel.Interfaces.HeaderFooterLoadOptions
   - uid: 'excel!Excel.Interfaces.HeaderFooterUpdateData:interface'
     name: Interfaces.HeaderFooterUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.HeaderFooterData:interface'
     name: Excel.Interfaces.HeaderFooterData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.headerfootergroup.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.headerfootergroup.yml
@@ -8,7 +8,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.HeaderFooterGroup#context:member'
@@ -198,7 +198,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.HeaderFooterGroup#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -285,7 +285,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -297,7 +297,7 @@ references:
     name: Excel.Interfaces.HeaderFooterGroupLoadOptions
   - uid: 'excel!Excel.Interfaces.HeaderFooterGroupUpdateData:interface'
     name: Interfaces.HeaderFooterGroupUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.HeaderFooterGroup#state~0:complex'
     name: Excel.HeaderFooterState | "Default" | "FirstAndDefault" | "OddAndEven" | "FirstOddAndEven"

--- a/docs/docs-ref-autogen/excel_online/excel/excel.iconsetconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.iconsetconditionalformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.IconSetConditionalFormat#context:member'
@@ -222,7 +222,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.IconSetConditionalFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -345,7 +345,7 @@ items:
           - 'excel!Excel.Interfaces.IconSetConditionalFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -364,7 +364,7 @@ references:
     name: Excel.Interfaces.IconSetConditionalFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.IconSetConditionalFormatUpdateData:interface'
     name: Interfaces.IconSetConditionalFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.IconSetConditionalFormat#style~0:complex'
     name: >-

--- a/docs/docs-ref-autogen/excel_online/excel/excel.image.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.image.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Image#context:member'
@@ -192,7 +192,7 @@ items:
           - 'excel!Excel.Interfaces.ImageData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel_online/excel/excel.iterativecalculation.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.iterativecalculation.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.IterativeCalculation#context:member'
@@ -182,7 +182,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.IterativeCalculation#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -220,7 +220,7 @@ items:
           - 'excel!Excel.Interfaces.IterativeCalculationData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -230,7 +230,7 @@ references:
     name: Excel.Interfaces.IterativeCalculationLoadOptions
   - uid: 'excel!Excel.Interfaces.IterativeCalculationUpdateData:interface'
     name: Interfaces.IterativeCalculationUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.IterativeCalculationData:interface'
     name: Excel.Interfaces.IterativeCalculationData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.line.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.line.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Line#beginArrowheadLength:member'
@@ -529,7 +529,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Line#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -582,7 +582,7 @@ items:
           - 'excel!Excel.Interfaces.LineData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Line#beginArrowheadLength~0:complex'
     name: Excel.ArrowheadLength | "Short" | "Medium" | "Long"
@@ -657,7 +657,7 @@ references:
     name: Excel.Interfaces.LineLoadOptions
   - uid: 'excel!Excel.Interfaces.LineUpdateData:interface'
     name: Interfaces.LineUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.LineData:interface'
     name: Excel.Interfaces.LineData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.nameditem.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.nameditem.yml
@@ -14,7 +14,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.NamedItem#arrayValues:member'
@@ -381,7 +381,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.NamedItem#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -500,7 +500,7 @@ items:
         type:
           - 'excel!Excel.Worksheet:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.NamedItemArrayValues:class'
     name: Excel.NamedItemArrayValues
@@ -523,7 +523,7 @@ references:
         fullName: ' | "Worksheet" | "Workbook"'
   - uid: 'excel!Excel.Interfaces.NamedItemUpdateData:interface'
     name: Interfaces.NamedItemUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.NamedItemData:interface'
     name: Excel.Interfaces.NamedItemData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.nameditemarrayvalues.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.nameditemarrayvalues.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.NamedItemArrayValues#context:member'
@@ -154,7 +154,7 @@ items:
         type:
           - 'any[][]'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel_online/excel/excel.nameditemcollection.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.nameditemcollection.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.NamedItemCollection#add:member(1)'
@@ -294,7 +294,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.NamedItemCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -314,7 +314,7 @@ items:
           - 'excel!Excel.Interfaces.NamedItemCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.NamedItem:class'
     name: Excel.NamedItem
@@ -333,7 +333,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -361,7 +361,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.NamedItemCollectionData:interface'
     name: Excel.Interfaces.NamedItemCollectionData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.pagebreak.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.pagebreak.yml
@@ -8,7 +8,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PageBreak#columnIndex:member'
@@ -185,7 +185,7 @@ items:
           - 'excel!Excel.Interfaces.PageBreakData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel_online/excel/excel.pagebreakcollection.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.pagebreakcollection.yml
@@ -8,7 +8,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PageBreakCollection#add:member(1)'
@@ -185,7 +185,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.PageBreakCollection#removePageBreaks:member(1)'
     summary: |-
       Resets all manual page breaks in the collection.
@@ -221,7 +221,7 @@ items:
           - 'excel!Excel.Interfaces.PageBreakCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.PageBreak:class'
     name: Excel.PageBreak
@@ -240,7 +240,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -268,7 +268,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.PageBreakCollectionData:interface'
     name: Excel.Interfaces.PageBreakCollectionData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.pagelayout.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.pagelayout.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PageLayout#blackAndWhite:member'
@@ -605,7 +605,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.PageLayout#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -842,7 +842,7 @@ items:
 
           ```
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -915,7 +915,7 @@ references:
         fullName: ' | "DownThenOver" | "OverThenDown"'
   - uid: 'excel!Excel.Interfaces.PageLayoutUpdateData:interface'
     name: Interfaces.PageLayoutUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.PageLayout#setPrintArea~0:complex'
     name: Range | RangeAreas | string

--- a/docs/docs-ref-autogen/excel_online/excel/excel.pivotfield.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.pivotfield.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PivotField#context:member'
@@ -187,7 +187,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.PivotField#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -352,7 +352,7 @@ items:
           - 'excel!Excel.Interfaces.PivotFieldData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -364,7 +364,7 @@ references:
     name: Excel.Interfaces.PivotFieldLoadOptions
   - uid: 'excel!Excel.Interfaces.PivotFieldUpdateData:interface'
     name: Interfaces.PivotFieldUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.SortBy:enum'
     name: SortBy

--- a/docs/docs-ref-autogen/excel_online/excel/excel.pivotfieldcollection.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.pivotfieldcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PivotFieldCollection#context:member'
@@ -170,7 +170,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.PivotFieldCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -190,7 +190,7 @@ items:
           - 'excel!Excel.Interfaces.PivotFieldCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -198,7 +198,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -228,7 +228,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.PivotFieldCollectionData:interface'
     name: Excel.Interfaces.PivotFieldCollectionData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.pivothierarchy.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.pivothierarchy.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PivotHierarchy#context:member'
@@ -182,7 +182,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.PivotHierarchy#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -220,7 +220,7 @@ items:
           - 'excel!Excel.Interfaces.PivotHierarchyData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -232,7 +232,7 @@ references:
     name: Excel.Interfaces.PivotHierarchyLoadOptions
   - uid: 'excel!Excel.Interfaces.PivotHierarchyUpdateData:interface'
     name: Interfaces.PivotHierarchyUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.PivotHierarchyData:interface'
     name: Excel.Interfaces.PivotHierarchyData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.pivothierarchycollection.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.pivothierarchycollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PivotHierarchyCollection#context:member'
@@ -170,7 +170,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.PivotHierarchyCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -190,7 +190,7 @@ items:
           - 'excel!Excel.Interfaces.PivotHierarchyCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -198,7 +198,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -228,7 +228,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.PivotHierarchyCollectionData:interface'
     name: Excel.Interfaces.PivotHierarchyCollectionData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.pivotitem.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.pivotitem.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PivotItem#context:member'
@@ -183,7 +183,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.PivotItem#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -236,7 +236,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -246,7 +246,7 @@ references:
     name: Excel.Interfaces.PivotItemLoadOptions
   - uid: 'excel!Excel.Interfaces.PivotItemUpdateData:interface'
     name: Interfaces.PivotItemUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.PivotItemData:interface'
     name: Excel.Interfaces.PivotItemData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.pivotitemcollection.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.pivotitemcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PivotItemCollection#context:member'
@@ -170,7 +170,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.PivotItemCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -190,7 +190,7 @@ items:
           - 'excel!Excel.Interfaces.PivotItemCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -198,7 +198,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -228,7 +228,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.PivotItemCollectionData:interface'
     name: Excel.Interfaces.PivotItemCollectionData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.pivotlayout.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.pivotlayout.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PivotLayout#autoFormat:member'
@@ -396,7 +396,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.PivotLayout#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -535,7 +535,7 @@ items:
           - 'excel!Excel.Interfaces.PivotLayoutData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -556,7 +556,7 @@ references:
     name: 'OfficeExtension.ClientResult<Excel.PivotItem[]>'
     fullName: 'OfficeExtension.ClientResult<Excel.PivotItem[]>'
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <
@@ -581,7 +581,7 @@ references:
     name: 'OfficeExtension.ClientResult<Excel.PivotItem[]>'
     fullName: 'OfficeExtension.ClientResult<Excel.PivotItem[]>'
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <
@@ -615,7 +615,7 @@ references:
     name: Excel.Interfaces.PivotLayoutLoadOptions
   - uid: 'excel!Excel.Interfaces.PivotLayoutUpdateData:interface'
     name: Interfaces.PivotLayoutUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.PivotLayout#setAutoSortOnCell~0:complex'
     name: Range | string

--- a/docs/docs-ref-autogen/excel_online/excel/excel.pivottable.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.pivottable.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PivotTable#columnHierarchies:member'
@@ -440,7 +440,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.PivotTable#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -508,7 +508,7 @@ items:
         type:
           - 'excel!Excel.Worksheet:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RowColumnPivotHierarchyCollection:class'
     name: Excel.RowColumnPivotHierarchyCollection
@@ -528,7 +528,7 @@ references:
     name: Excel.Interfaces.PivotTableLoadOptions
   - uid: 'excel!Excel.Interfaces.PivotTableUpdateData:interface'
     name: Interfaces.PivotTableUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.PivotTableData:interface'
     name: Excel.Interfaces.PivotTableData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.pivottablecollection.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.pivottablecollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PivotTableCollection#add:member(1)'
@@ -225,7 +225,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.PivotTableCollection#refreshAll:member(1)'
     summary: |-
       Refreshes all the pivot tables in the collection.
@@ -261,7 +261,7 @@ items:
           - 'excel!Excel.Interfaces.PivotTableCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.PivotTable:class'
     name: Excel.PivotTable
@@ -292,7 +292,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -320,7 +320,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.PivotTableCollectionData:interface'
     name: Excel.Interfaces.PivotTableCollectionData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.pivottablestyle.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.pivottablestyle.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PivotTableStyle#context:member'
@@ -200,7 +200,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.PivotTableStyle#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -238,7 +238,7 @@ items:
           - 'excel!Excel.Interfaces.PivotTableStyleData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -248,7 +248,7 @@ references:
     name: Excel.Interfaces.PivotTableStyleLoadOptions
   - uid: 'excel!Excel.Interfaces.PivotTableStyleUpdateData:interface'
     name: Interfaces.PivotTableStyleUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.PivotTableStyleData:interface'
     name: Excel.Interfaces.PivotTableStyleData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.pivottablestylecollection.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.pivottablestylecollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PivotTableStyleCollection#add:member(1)'
@@ -216,7 +216,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.PivotTableStyleCollection#setDefault:member(1)'
     summary: |-
       Sets the default PivotTableStyle for use in the parent object's scope.
@@ -257,7 +257,7 @@ items:
           - 'excel!Excel.Interfaces.PivotTableStyleCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.PivotTableStyle:class'
     name: Excel.PivotTableStyle
@@ -267,7 +267,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -295,7 +295,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.PivotTableStyleCollection#setDefault~0:complex'
     name: PivotTableStyle | string

--- a/docs/docs-ref-autogen/excel_online/excel/excel.presetcriteriaconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.presetcriteriaconditionalformat.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.PresetCriteriaConditionalFormat#context:member'
@@ -212,7 +212,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.PresetCriteriaConditionalFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -250,7 +250,7 @@ items:
           - 'excel!Excel.Interfaces.PresetCriteriaConditionalFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -264,7 +264,7 @@ references:
     name: Excel.ConditionalPresetCriteriaRule
   - uid: 'excel!Excel.Interfaces.PresetCriteriaConditionalFormatUpdateData:interface'
     name: Interfaces.PresetCriteriaConditionalFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.PresetCriteriaConditionalFormatData:interface'
     name: Excel.Interfaces.PresetCriteriaConditionalFormatData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.range.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.range.yml
@@ -16,7 +16,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Range#address:member'
@@ -2867,7 +2867,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Range#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -3476,7 +3476,7 @@ items:
         type:
           - 'excel!Excel.Worksheet:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Range#autoFill~0:complex'
     name: Range | string
@@ -3557,7 +3557,7 @@ references:
     name: 'OfficeExtension.ClientResult<CellProperties[][]>'
     fullName: 'OfficeExtension.ClientResult<Excel.CellProperties[][]>'
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <
@@ -3573,7 +3573,7 @@ references:
     name: 'OfficeExtension.ClientResult<ColumnProperties[]>'
     fullName: 'OfficeExtension.ClientResult<Excel.ColumnProperties[]>'
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <
@@ -3589,7 +3589,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -3616,7 +3616,7 @@ references:
     name: 'OfficeExtension.ClientResult<RowProperties[]>'
     fullName: 'OfficeExtension.ClientResult<Excel.RowProperties[]>'
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <
@@ -3670,7 +3670,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -3679,7 +3679,7 @@ references:
     name: Excel.ReplaceCriteria
   - uid: 'excel!Excel.Interfaces.RangeUpdateData:interface'
     name: Interfaces.RangeUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Range#setCellProperties~0:complex'
     name: 'SettableCellProperties[][]'

--- a/docs/docs-ref-autogen/excel_online/excel/excel.rangeareas.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.rangeareas.yml
@@ -14,7 +14,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeAreas#address:member'
@@ -852,7 +852,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.RangeAreas#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -974,7 +974,7 @@ items:
         type:
           - 'excel!Excel.Worksheet:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RangeCollection:class'
     name: Excel.RangeCollection
@@ -1058,7 +1058,7 @@ references:
     name: Excel.Interfaces.RangeAreasLoadOptions
   - uid: 'excel!Excel.Interfaces.RangeAreasUpdateData:interface'
     name: Interfaces.RangeAreasUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.RangeAreasData:interface'
     name: Excel.Interfaces.RangeAreasData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.rangeborder.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.rangeborder.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeBorder#color:member'
@@ -156,7 +156,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.RangeBorder#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -288,7 +288,7 @@ items:
         type:
           - 'excel!Excel.RangeBorder#weight~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -298,7 +298,7 @@ references:
     name: Excel.Interfaces.RangeBorderLoadOptions
   - uid: 'excel!Excel.Interfaces.RangeBorderUpdateData:interface'
     name: Interfaces.RangeBorderUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.RangeBorder#sideIndex~0:complex'
     name: >-

--- a/docs/docs-ref-autogen/excel_online/excel/excel.rangebordercollection.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.rangebordercollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeBorderCollection#context:member'
@@ -266,7 +266,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.RangeBorderCollection#tintAndShade:member'
     summary: >-
       Returns or sets a double that lightens or darkens a color for Range Borders, the value is between -1 (darkest) and
@@ -304,7 +304,7 @@ items:
           - 'excel!Excel.Interfaces.RangeBorderCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -335,7 +335,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.RangeBorderCollectionData:interface'
     name: Excel.Interfaces.RangeBorderCollectionData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.rangecollection.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.rangecollection.yml
@@ -8,7 +8,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeCollection#context:member'
@@ -145,7 +145,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.RangeCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -165,7 +165,7 @@ items:
           - 'excel!Excel.Interfaces.RangeCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -173,7 +173,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -203,7 +203,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.RangeCollectionData:interface'
     name: Excel.Interfaces.RangeCollectionData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.rangefill.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.rangefill.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeFill#clear:member(1)'
@@ -286,7 +286,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.RangeFill#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -341,7 +341,7 @@ items:
           - 'excel!Excel.Interfaces.RangeFillData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -366,7 +366,7 @@ references:
         fullName: ' | "None" | "Solid" | "Gray50" | "Gray75" | "Gray25" | "Horizontal" | "Vertical" | "Down" | "Up" | "Checker" | "SemiGray75" | "LightHorizontal" | "LightVertical" | "LightDown" | "LightUp" | "Grid" | "CrissCross" | "Gray16" | "Gray8" | "LinearGradient" | "RectangularGradient"'
   - uid: 'excel!Excel.Interfaces.RangeFillUpdateData:interface'
     name: Interfaces.RangeFillUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.RangeFillData:interface'
     name: Excel.Interfaces.RangeFillData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.rangefont.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.rangefont.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeFont#bold:member'
@@ -241,7 +241,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.RangeFont#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -380,7 +380,7 @@ items:
         type:
           - 'excel!Excel.RangeFont#underline~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -390,7 +390,7 @@ references:
     name: Excel.Interfaces.RangeFontLoadOptions
   - uid: 'excel!Excel.Interfaces.RangeFontUpdateData:interface'
     name: Interfaces.RangeFontUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.RangeFontData:interface'
     name: Excel.Interfaces.RangeFontData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.rangeformat.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.rangeformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeFormat#adjustIndent:member(1)'
@@ -430,7 +430,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.RangeFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -592,7 +592,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RangeBorderCollection:class'
     name: Excel.RangeBorderCollection
@@ -632,7 +632,7 @@ references:
         fullName: ' | "Context" | "LeftToRight" | "RightToLeft"'
   - uid: 'excel!Excel.Interfaces.RangeFormatUpdateData:interface'
     name: Interfaces.RangeFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.RangeFormatData:interface'
     name: Excel.Interfaces.RangeFormatData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.rangesort.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.rangesort.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeSort#apply:member(1)'
@@ -135,7 +135,7 @@ items:
                     }
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RangeSort#apply~0:complex'
     name: 'Excel.SortField[]'

--- a/docs/docs-ref-autogen/excel_online/excel/excel.rangeview.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.rangeview.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeView#cellAddresses:member'
@@ -300,7 +300,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.RangeView#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -387,7 +387,7 @@ items:
         type:
           - 'excel!Excel.RangeView#valueTypes~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -401,7 +401,7 @@ references:
     name: Excel.RangeViewCollection
   - uid: 'excel!Excel.Interfaces.RangeViewUpdateData:interface'
     name: Interfaces.RangeViewUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.RangeViewData:interface'
     name: Excel.Interfaces.RangeViewData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.rangeviewcollection.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.rangeviewcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RangeViewCollection#context:member'
@@ -148,7 +148,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.RangeViewCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -168,7 +168,7 @@ items:
           - 'excel!Excel.Interfaces.RangeViewCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -176,7 +176,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -206,7 +206,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.RangeViewCollectionData:interface'
     name: Excel.Interfaces.RangeViewCollectionData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.removeduplicatesresult.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.removeduplicatesresult.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RemoveDuplicatesResult#context:member'
@@ -178,7 +178,7 @@ items:
 
           ```
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel_online/excel/excel.requestcontext.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.requestcontext.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientRequestContext:class'
+      - 'office!OfficeExtension.ClientRequestContext:class'
     package: excel!
     children:
       - 'excel!Excel.RequestContext:constructor(1)'
@@ -67,7 +67,7 @@ items:
         type:
           - 'excel!Excel.Workbook:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientRequestContext:class'
+  - uid: 'office!OfficeExtension.ClientRequestContext:class'
     name: OfficeExtension.ClientRequestContext
   - uid: 'excel!Excel.RequestContext~0:complex'
     name: string | Session

--- a/docs/docs-ref-autogen/excel_online/excel/excel.rowcolumnpivothierarchy.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.rowcolumnpivothierarchy.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RowColumnPivotHierarchy#context:member'
@@ -199,7 +199,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.RowColumnPivotHierarchy#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -253,7 +253,7 @@ items:
           - 'excel!Excel.Interfaces.RowColumnPivotHierarchyData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -265,7 +265,7 @@ references:
     name: Excel.Interfaces.RowColumnPivotHierarchyLoadOptions
   - uid: 'excel!Excel.Interfaces.RowColumnPivotHierarchyUpdateData:interface'
     name: Interfaces.RowColumnPivotHierarchyUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.RowColumnPivotHierarchyData:interface'
     name: Excel.Interfaces.RowColumnPivotHierarchyData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.rowcolumnpivothierarchycollection.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.rowcolumnpivothierarchycollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.RowColumnPivotHierarchyCollection#add:member(1)'
@@ -195,7 +195,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.RowColumnPivotHierarchyCollection#remove:member(1)'
     summary: |-
       Removes the PivotHierarchy from the current axis.
@@ -237,7 +237,7 @@ items:
           - 'excel!Excel.Interfaces.RowColumnPivotHierarchyCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RowColumnPivotHierarchy:class'
     name: Excel.RowColumnPivotHierarchy
@@ -249,7 +249,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -277,7 +277,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.RowColumnPivotHierarchyCollectionData:interface'
     name: Excel.Interfaces.RowColumnPivotHierarchyCollectionData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.runoptions.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.runoptions.yml
@@ -34,7 +34,7 @@ references:
     name: OfficeExtension.RunOptions<Session>
     fullName: OfficeExtension.RunOptions<Excel.Session>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.RunOptions:interface'
+      - uid: 'office!OfficeExtension.RunOptions:interface'
         name: OfficeExtension.RunOptions
         fullName: OfficeExtension.RunOptions
       - name: <

--- a/docs/docs-ref-autogen/excel_online/excel/excel.runtime.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.runtime.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Runtime#context:member'
@@ -178,7 +178,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Runtime#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -216,7 +216,7 @@ items:
           - 'excel!Excel.Interfaces.RuntimeData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -226,7 +226,7 @@ references:
     name: Excel.Interfaces.RuntimeLoadOptions
   - uid: 'excel!Excel.Interfaces.RuntimeUpdateData:interface'
     name: Interfaces.RuntimeUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.RuntimeData:interface'
     name: Excel.Interfaces.RuntimeData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.setting.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.setting.yml
@@ -15,7 +15,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Setting#context:member'
@@ -200,7 +200,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Setting#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -253,7 +253,7 @@ items:
         type:
           - any
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -263,7 +263,7 @@ references:
     name: Excel.Interfaces.SettingLoadOptions
   - uid: 'excel!Excel.Interfaces.SettingUpdateData:interface'
     name: Interfaces.SettingUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.SettingData:interface'
     name: Excel.Interfaces.SettingData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.settingcollection.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.settingcollection.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.SettingCollection#add:member(1)'
@@ -246,7 +246,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.SettingCollection#onSettingsChanged:member'
     summary: |-
       Occurs when the Settings in the document are changed.
@@ -301,7 +301,7 @@ items:
           - 'excel!Excel.Interfaces.SettingCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Setting:class'
     name: Excel.Setting
@@ -327,7 +327,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -355,13 +355,13 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.SettingCollection#onSettingsChanged~0:complex'
     name: OfficeExtension.EventHandlers<Excel.SettingsChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.SettingsChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <

--- a/docs/docs-ref-autogen/excel_online/excel/excel.shape.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.shape.yml
@@ -14,7 +14,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Shape#altTextDescription:member'
@@ -1076,7 +1076,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Shape#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -1274,7 +1274,7 @@ items:
         type:
           - number
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -1366,7 +1366,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -1377,7 +1377,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -1396,7 +1396,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.ShapeActivatedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.ShapeActivatedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -1410,7 +1410,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.ShapeDeactivatedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.ShapeDeactivatedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -1435,7 +1435,7 @@ references:
     name: Excel.ShapeScaleFrom
   - uid: 'excel!Excel.Interfaces.ShapeUpdateData:interface'
     name: Interfaces.ShapeUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.ShapeZOrder:enum'
     name: Excel.ShapeZOrder

--- a/docs/docs-ref-autogen/excel_online/excel/excel.shapecollection.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.shapecollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ShapeCollection#addGeometricShape:member(1)'
@@ -546,7 +546,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.ShapeCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -566,7 +566,7 @@ items:
           - 'excel!Excel.Interfaces.ShapeCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Shape:class'
     name: Excel.Shape
@@ -594,7 +594,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -622,7 +622,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.ShapeCollectionData:interface'
     name: Excel.Interfaces.ShapeCollectionData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.shapefill.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.shapefill.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ShapeFill#clear:member(1)'
@@ -172,7 +172,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ShapeFill#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -268,7 +268,7 @@ items:
         type:
           - 'excel!Excel.ShapeFill#type~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -278,7 +278,7 @@ references:
     name: Excel.Interfaces.ShapeFillLoadOptions
   - uid: 'excel!Excel.Interfaces.ShapeFillUpdateData:interface'
     name: Interfaces.ShapeFillUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ShapeFillData:interface'
     name: Excel.Interfaces.ShapeFillData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.shapefont.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.shapefont.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ShapeFont#bold:member'
@@ -206,7 +206,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ShapeFont#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -281,7 +281,7 @@ items:
         type:
           - 'excel!Excel.ShapeFont#underline~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -291,7 +291,7 @@ references:
     name: Excel.Interfaces.ShapeFontLoadOptions
   - uid: 'excel!Excel.Interfaces.ShapeFontUpdateData:interface'
     name: Interfaces.ShapeFontUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.ShapeFontData:interface'
     name: Excel.Interfaces.ShapeFontData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.shapegroup.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.shapegroup.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ShapeGroup#context:member'
@@ -210,7 +210,7 @@ items:
 
           ```
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel_online/excel/excel.shapelineformat.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.shapelineformat.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.ShapeLineFormat#color:member'
@@ -178,7 +178,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.ShapeLineFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -284,7 +284,7 @@ items:
         type:
           - number
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -307,7 +307,7 @@ references:
     name: Excel.Interfaces.ShapeLineFormatLoadOptions
   - uid: 'excel!Excel.Interfaces.ShapeLineFormatUpdateData:interface'
     name: Interfaces.ShapeLineFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.ShapeLineFormat#style~0:complex'
     name: Excel.ShapeLineStyle | "Single" | "ThickBetweenThin" | "ThickThin" | "ThinThick" | "ThinThin"

--- a/docs/docs-ref-autogen/excel_online/excel/excel.slicer.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.slicer.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Slicer#caption:member'
@@ -366,7 +366,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Slicer#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -521,7 +521,7 @@ items:
         type:
           - 'excel!Excel.Worksheet:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -529,7 +529,7 @@ references:
     name: 'OfficeExtension.ClientResult<string[]>'
     fullName: 'OfficeExtension.ClientResult<string[]>'
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: '<string[]>'
@@ -540,7 +540,7 @@ references:
     name: Excel.Interfaces.SlicerLoadOptions
   - uid: 'excel!Excel.Interfaces.SlicerUpdateData:interface'
     name: Interfaces.SlicerUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.SlicerItemCollection:class'
     name: Excel.SlicerItemCollection

--- a/docs/docs-ref-autogen/excel_online/excel/excel.slicercollection.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.slicercollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.SlicerCollection#add:member(1)'
@@ -275,7 +275,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.SlicerCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -295,7 +295,7 @@ items:
           - 'excel!Excel.Interfaces.SlicerCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Slicer:class'
     name: Excel.Slicer
@@ -342,7 +342,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -370,7 +370,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.SlicerCollectionData:interface'
     name: Excel.Interfaces.SlicerCollectionData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.sliceritem.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.sliceritem.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.SlicerItem#context:member'
@@ -200,7 +200,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.SlicerItem#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -238,7 +238,7 @@ items:
           - 'excel!Excel.Interfaces.SlicerItemData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -248,7 +248,7 @@ references:
     name: Excel.Interfaces.SlicerItemLoadOptions
   - uid: 'excel!Excel.Interfaces.SlicerItemUpdateData:interface'
     name: Interfaces.SlicerItemUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.SlicerItemData:interface'
     name: Excel.Interfaces.SlicerItemData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.sliceritemcollection.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.sliceritemcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.SlicerItemCollection#context:member'
@@ -192,7 +192,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.SlicerItemCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -212,7 +212,7 @@ items:
           - 'excel!Excel.Interfaces.SlicerItemCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -220,7 +220,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -250,7 +250,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.SlicerItemCollectionData:interface'
     name: Excel.Interfaces.SlicerItemCollectionData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.slicerstyle.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.slicerstyle.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.SlicerStyle#context:member'
@@ -200,7 +200,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.SlicerStyle#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -238,7 +238,7 @@ items:
           - 'excel!Excel.Interfaces.SlicerStyleData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -248,7 +248,7 @@ references:
     name: Excel.Interfaces.SlicerStyleLoadOptions
   - uid: 'excel!Excel.Interfaces.SlicerStyleUpdateData:interface'
     name: Interfaces.SlicerStyleUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.SlicerStyleData:interface'
     name: Excel.Interfaces.SlicerStyleData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.slicerstylecollection.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.slicerstylecollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.SlicerStyleCollection#add:member(1)'
@@ -216,7 +216,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.SlicerStyleCollection#setDefault:member(1)'
     summary: |-
       Sets the default SlicerStyle for use in the parent object's scope.
@@ -257,7 +257,7 @@ items:
           - 'excel!Excel.Interfaces.SlicerStyleCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.SlicerStyle:class'
     name: Excel.SlicerStyle
@@ -267,7 +267,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -295,7 +295,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.SlicerStyleCollection#setDefault~0:complex'
     name: SlicerStyle | string

--- a/docs/docs-ref-autogen/excel_online/excel/excel.style.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.style.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Style#autoIndent:member'
@@ -568,7 +568,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Style#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -666,7 +666,7 @@ items:
         type:
           - boolean
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RangeBorderCollection:class'
     name: Excel.RangeBorderCollection
@@ -704,7 +704,7 @@ references:
         fullName: ' | "Context" | "LeftToRight" | "RightToLeft"'
   - uid: 'excel!Excel.Interfaces.StyleUpdateData:interface'
     name: Interfaces.StyleUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.StyleData:interface'
     name: Excel.Interfaces.StyleData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.stylecollection.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.stylecollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.StyleCollection#add:member(1)'
@@ -256,7 +256,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.StyleCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -276,7 +276,7 @@ items:
           - 'excel!Excel.Interfaces.StyleCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -284,7 +284,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -314,7 +314,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.StyleCollectionData:interface'
     name: Excel.Interfaces.StyleCollectionData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.table.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.table.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Table#autoFilter:member'
@@ -637,7 +637,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Table#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -828,7 +828,7 @@ items:
         type:
           - 'excel!Excel.Worksheet:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.AutoFilter:class'
     name: Excel.AutoFilter
@@ -846,7 +846,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.TableChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.TableChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -860,7 +860,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.TableSelectionChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.TableSelectionChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -874,7 +874,7 @@ references:
     name: Excel.TableRowCollection
   - uid: 'excel!Excel.Interfaces.TableUpdateData:interface'
     name: Interfaces.TableUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.TableSort:class'
     name: Excel.TableSort

--- a/docs/docs-ref-autogen/excel_online/excel/excel.tablecollection.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.tablecollection.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableCollection#add:member(1)'
@@ -341,7 +341,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.TableCollection#onAdded:member'
     summary: |-
       Occurs when new table is added in a workbook.
@@ -426,7 +426,7 @@ items:
           - 'excel!Excel.Interfaces.TableCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Table:class'
     name: Excel.Table
@@ -445,7 +445,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -473,13 +473,13 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.TableCollection#onAdded~0:complex'
     name: OfficeExtension.EventHandlers<Excel.TableAddedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.TableAddedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -493,7 +493,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.TableChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.TableChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -507,7 +507,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.TableDeletedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.TableDeletedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <

--- a/docs/docs-ref-autogen/excel_online/excel/excel.tablecolumn.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.tablecolumn.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableColumn#context:member'
@@ -401,7 +401,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.TableColumn#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -456,7 +456,7 @@ items:
         type:
           - 'any[][]'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -470,7 +470,7 @@ references:
     name: Excel.Interfaces.TableColumnLoadOptions
   - uid: 'excel!Excel.Interfaces.TableColumnUpdateData:interface'
     name: Interfaces.TableColumnUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.TableColumnData:interface'
     name: Excel.Interfaces.TableColumnData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.tablecolumncollection.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.tablecolumncollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableColumnCollection#add:member(1)'
@@ -322,7 +322,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.TableColumnCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -342,7 +342,7 @@ items:
           - 'excel!Excel.Interfaces.TableColumnCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.TableColumn:class'
     name: Excel.TableColumn
@@ -366,7 +366,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -394,7 +394,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.TableColumnCollectionData:interface'
     name: Excel.Interfaces.TableColumnCollectionData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.tablerow.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.tablerow.yml
@@ -17,7 +17,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableRow#context:member'
@@ -247,7 +247,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.TableRow#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -302,7 +302,7 @@ items:
         type:
           - 'any[][]'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -314,7 +314,7 @@ references:
     name: Excel.Interfaces.TableRowLoadOptions
   - uid: 'excel!Excel.Interfaces.TableRowUpdateData:interface'
     name: Interfaces.TableRowUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.TableRowData:interface'
     name: Excel.Interfaces.TableRowData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.tablerowcollection.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.tablerowcollection.yml
@@ -17,7 +17,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableRowCollection#add:member(1)'
@@ -290,7 +290,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.TableRowCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -310,7 +310,7 @@ items:
           - 'excel!Excel.Interfaces.TableRowCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.TableRow:class'
     name: Excel.TableRow
@@ -334,7 +334,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -362,7 +362,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.TableRowCollectionData:interface'
     name: Excel.Interfaces.TableRowCollectionData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.tablescopedcollection.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.tablescopedcollection.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableScopedCollection#context:member'
@@ -169,7 +169,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.TableScopedCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -189,7 +189,7 @@ items:
           - 'excel!Excel.Interfaces.TableScopedCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -197,7 +197,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -227,7 +227,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.Interfaces.TableScopedCollectionData:interface'
     name: Excel.Interfaces.TableScopedCollectionData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.tablesort.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.tablesort.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableSort#apply:member(1)'
@@ -288,7 +288,7 @@ items:
           - 'excel!Excel.Interfaces.TableSortData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.TableSort#apply~0:complex'
     name: 'Excel.SortField[]'

--- a/docs/docs-ref-autogen/excel_online/excel/excel.tablestyle.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.tablestyle.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableStyle#context:member'
@@ -200,7 +200,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.TableStyle#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -238,7 +238,7 @@ items:
           - 'excel!Excel.Interfaces.TableStyleData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -248,7 +248,7 @@ references:
     name: Excel.Interfaces.TableStyleLoadOptions
   - uid: 'excel!Excel.Interfaces.TableStyleUpdateData:interface'
     name: Interfaces.TableStyleUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.TableStyleData:interface'
     name: Excel.Interfaces.TableStyleData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.tablestylecollection.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.tablestylecollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TableStyleCollection#add:member(1)'
@@ -216,7 +216,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.TableStyleCollection#setDefault:member(1)'
     summary: |-
       Sets the default TableStyle for use in the parent object's scope.
@@ -257,7 +257,7 @@ items:
           - 'excel!Excel.Interfaces.TableStyleCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.TableStyle:class'
     name: Excel.TableStyle
@@ -267,7 +267,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -295,7 +295,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.TableStyleCollection#setDefault~0:complex'
     name: TableStyle | string

--- a/docs/docs-ref-autogen/excel_online/excel/excel.textconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.textconditionalformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TextConditionalFormat#context:member'
@@ -214,7 +214,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.TextConditionalFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -252,7 +252,7 @@ items:
           - 'excel!Excel.Interfaces.TextConditionalFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -266,7 +266,7 @@ references:
     name: Excel.ConditionalTextComparisonRule
   - uid: 'excel!Excel.Interfaces.TextConditionalFormatUpdateData:interface'
     name: Interfaces.TextConditionalFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.TextConditionalFormatData:interface'
     name: Excel.Interfaces.TextConditionalFormatData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.textframe.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.textframe.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TextFrame#autoSizeSetting:member'
@@ -327,7 +327,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.TextFrame#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -427,7 +427,7 @@ items:
         type:
           - 'excel!Excel.TextFrame#verticalOverflow~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.TextFrame#autoSizeSetting~0:complex'
     name: Excel.ShapeAutoSize | "AutoSizeNone" | "AutoSizeTextToFitShape" | "AutoSizeShapeToFitText" | "AutoSizeMixed"
@@ -490,7 +490,7 @@ references:
         fullName: ' | "LeftToRight" | "RightToLeft"'
   - uid: 'excel!Excel.Interfaces.TextFrameUpdateData:interface'
     name: Interfaces.TextFrameUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.TextRange:class'
     name: Excel.TextRange

--- a/docs/docs-ref-autogen/excel_online/excel/excel.textrange.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.textrange.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TextRange#context:member'
@@ -179,7 +179,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.TextRange#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -232,7 +232,7 @@ items:
           - 'excel!Excel.Interfaces.TextRangeData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -244,7 +244,7 @@ references:
     name: Excel.Interfaces.TextRangeLoadOptions
   - uid: 'excel!Excel.Interfaces.TextRangeUpdateData:interface'
     name: Interfaces.TextRangeUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.TextRangeData:interface'
     name: Excel.Interfaces.TextRangeData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.timelinestyle.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.timelinestyle.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TimelineStyle#context:member'
@@ -200,7 +200,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.TimelineStyle#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -238,7 +238,7 @@ items:
           - 'excel!Excel.Interfaces.TimelineStyleData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -248,7 +248,7 @@ references:
     name: Excel.Interfaces.TimelineStyleLoadOptions
   - uid: 'excel!Excel.Interfaces.TimelineStyleUpdateData:interface'
     name: Interfaces.TimelineStyleUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.TimelineStyleData:interface'
     name: Excel.Interfaces.TimelineStyleData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.timelinestylecollection.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.timelinestylecollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TimelineStyleCollection#add:member(1)'
@@ -216,7 +216,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.TimelineStyleCollection#setDefault:member(1)'
     summary: |-
       Sets the default TimelineStyle for use in the parent object's scope.
@@ -257,7 +257,7 @@ items:
           - 'excel!Excel.Interfaces.TimelineStyleCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.TimelineStyle:class'
     name: Excel.TimelineStyle
@@ -267,7 +267,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -295,7 +295,7 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.TimelineStyleCollection#setDefault~0:complex'
     name: TimelineStyle | string

--- a/docs/docs-ref-autogen/excel_online/excel/excel.topbottomconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.topbottomconditionalformat.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.TopBottomConditionalFormat#context:member'
@@ -168,7 +168,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.TopBottomConditionalFormat#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -206,7 +206,7 @@ items:
           - 'excel!Excel.Interfaces.TopBottomConditionalFormatData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext
@@ -220,7 +220,7 @@ references:
     name: Excel.ConditionalTopBottomRule
   - uid: 'excel!Excel.Interfaces.TopBottomConditionalFormatUpdateData:interface'
     name: Interfaces.TopBottomConditionalFormatUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.Interfaces.TopBottomConditionalFormatData:interface'
     name: Excel.Interfaces.TopBottomConditionalFormatData

--- a/docs/docs-ref-autogen/excel_online/excel/excel.workbook.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.workbook.yml
@@ -14,7 +14,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Workbook#application:member'
@@ -712,7 +712,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Workbook#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -920,7 +920,7 @@ items:
         type:
           - 'excel!Excel.WorksheetCollection:class'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Application:class'
     name: Excel.Application
@@ -946,7 +946,7 @@ references:
     name: OfficeExtension.ClientResult<boolean>
     fullName: OfficeExtension.ClientResult<boolean>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <boolean>
@@ -963,7 +963,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorkbookAutoSaveSettingChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorkbookAutoSaveSettingChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -977,7 +977,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.SelectionChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.SelectionChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -997,7 +997,7 @@ references:
     name: Excel.WorkbookProtection
   - uid: 'excel!Excel.Interfaces.WorkbookUpdateData:interface'
     name: Interfaces.WorkbookUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.SettingCollection:class'
     name: Excel.SettingCollection

--- a/docs/docs-ref-autogen/excel_online/excel/excel.workbookcreated.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.workbookcreated.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.WorkbookCreated#context:member'
@@ -103,7 +103,7 @@ items:
           - 'excel!Excel.Interfaces.WorkbookCreatedData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel_online/excel/excel.workbookprotection.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.workbookprotection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.WorkbookProtection#context:member'
@@ -258,7 +258,7 @@ items:
           type:
             - string
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel_online/excel/excel.worksheet.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.worksheet.yml
@@ -14,7 +14,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.Worksheet#activate:member(1)'
@@ -1518,7 +1518,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'excel!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'excel!Excel.Worksheet#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -1838,7 +1838,7 @@ items:
         type:
           - 'excel!Excel.Worksheet#visibility~0:complex'
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.AutoFilter:class'
     name: Excel.AutoFilter
@@ -1870,7 +1870,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetActivatedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetActivatedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -1884,7 +1884,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetCalculatedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetCalculatedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -1898,7 +1898,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -1912,7 +1912,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetColumnSortedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetColumnSortedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -1926,7 +1926,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetDeactivatedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetDeactivatedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -1940,7 +1940,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetFormatChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetFormatChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -1954,7 +1954,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetRowSortedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetRowSortedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -1968,7 +1968,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetSelectionChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetSelectionChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -1982,7 +1982,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetSingleClickedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetSingleClickedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -2002,7 +2002,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -2011,7 +2011,7 @@ references:
     name: Excel.ReplaceCriteria
   - uid: 'excel!Excel.Interfaces.WorksheetUpdateData:interface'
     name: Interfaces.WorksheetUpdateData
-  - uid: 'excel!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'excel!Excel.ShapeCollection:class'
     name: Excel.ShapeCollection

--- a/docs/docs-ref-autogen/excel_online/excel/excel.worksheetcollection.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.worksheetcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.WorksheetCollection#add:member(1)'
@@ -404,7 +404,7 @@ items:
             `propertyNamesAndPaths.select` is a comma-delimited string that specifies the properties to load, and
             `propertyNamesAndPaths.expand` is a comma-delimited string that specifies the navigation properties to load.
           type:
-            - 'excel!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'excel!Excel.WorksheetCollection#onActivated:member'
     summary: |-
       Occurs when any worksheet in the workbook is activated.
@@ -652,7 +652,7 @@ items:
           - 'excel!Excel.Interfaces.WorksheetCollectionData:interface'
         description: ''
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.Worksheet:class'
     name: Excel.Worksheet
@@ -662,7 +662,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -690,13 +690,13 @@ references:
       - uid: 'excel!Excel.Interfaces.CollectionLoadOptions:interface'
         name: Excel.Interfaces.CollectionLoadOptions
         fullName: Excel.Interfaces.CollectionLoadOptions
-  - uid: 'excel!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'excel!Excel.WorksheetCollection#onActivated~0:complex'
     name: OfficeExtension.EventHandlers<Excel.WorksheetActivatedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetActivatedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -710,7 +710,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetAddedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetAddedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -724,7 +724,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetCalculatedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetCalculatedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -738,7 +738,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -752,7 +752,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetColumnSortedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetColumnSortedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -766,7 +766,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetDeactivatedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetDeactivatedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -780,7 +780,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetDeletedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetDeletedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -794,7 +794,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetFormatChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetFormatChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -808,7 +808,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetRowSortedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetRowSortedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -822,7 +822,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetSelectionChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetSelectionChangedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -836,7 +836,7 @@ references:
     name: OfficeExtension.EventHandlers<Excel.WorksheetSingleClickedEventArgs>
     fullName: OfficeExtension.EventHandlers<Excel.WorksheetSingleClickedEventArgs>
     spec.typeScript:
-      - uid: 'excel!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <

--- a/docs/docs-ref-autogen/excel_online/excel/excel.worksheetfreezepanes.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.worksheetfreezepanes.yml
@@ -8,7 +8,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.WorksheetFreezePanes#context:member'
@@ -278,7 +278,7 @@ items:
 
           ```
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/excel_online/excel/excel.worksheetprotection.yml
+++ b/docs/docs-ref-autogen/excel_online/excel/excel.worksheetprotection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'excel!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: excel!
     children:
       - 'excel!Excel.WorksheetProtection#context:member'
@@ -282,7 +282,7 @@ items:
           type:
             - string
 references:
-  - uid: 'excel!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'excel!Excel.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/onenote/onenote.yml
+++ b/docs/docs-ref-autogen/onenote/onenote.yml
@@ -197,7 +197,7 @@ items:
             A previously-created API object. The batch will use the same request context as the passed-in object, which
             means that any changes applied to the object will be picked up by "context.sync()".
           type:
-            - 'onenote!OfficeExtension.ClientObject:class'
+            - 'office!OfficeExtension.ClientObject:class'
         - id: batch
           description: >-
             A function that takes in an OneNote.RequestContext and returns a promise (typically, just the result of
@@ -531,7 +531,7 @@ references:
         fullName: Promise
       - name: <T>
         fullName: <T>
-  - uid: 'onenote!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'onenote!OneNote.run~3:complex'
     name: '(context: OneNote.RequestContext) => Promise<T>'
@@ -562,7 +562,7 @@ references:
     name: 'OfficeExtension.ClientObject[]'
     fullName: 'OfficeExtension.ClientObject[]'
     spec.typeScript:
-      - uid: 'onenote!OfficeExtension.ClientObject:class'
+      - uid: 'office!OfficeExtension.ClientObject:class'
         name: OfficeExtension.ClientObject
         fullName: OfficeExtension.ClientObject
       - name: '[]'

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.application.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.application.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'onenote!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: onenote!
     children:
       - 'onenote!OneNote.Application#context:member'
@@ -725,7 +725,7 @@ items:
           - 'onenote!OneNote.Interfaces.ApplicationData:interface'
         description: ''
 references:
-  - uid: 'onenote!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'onenote!OneNote.RequestContext:class'
     name: RequestContext
@@ -743,7 +743,7 @@ references:
     name: 'OfficeExtension.ClientResult<number[]>'
     fullName: 'OfficeExtension.ClientResult<number[]>'
     spec.typeScript:
-      - uid: 'onenote!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: '<number[]>'
@@ -752,7 +752,7 @@ references:
     name: OfficeExtension.ClientResult<boolean>
     fullName: OfficeExtension.ClientResult<boolean>
     spec.typeScript:
-      - uid: 'onenote!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <boolean>

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.floatingink.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.floatingink.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'onenote!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: onenote!
     children:
       - 'onenote!OneNote.FloatingInk#context:member'
@@ -260,7 +260,7 @@ items:
           - 'onenote!OneNote.FloatingInk:class'
         description: ''
 references:
-  - uid: 'onenote!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'onenote!OneNote.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.image.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.image.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'onenote!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: onenote!
     children:
       - 'onenote!OneNote.Image#context:member'
@@ -484,7 +484,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'onenote!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'onenote!OneNote.Image#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -572,7 +572,7 @@ items:
         type:
           - number
 references:
-  - uid: 'onenote!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'onenote!OneNote.RequestContext:class'
     name: RequestContext
@@ -580,7 +580,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'onenote!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -597,7 +597,7 @@ references:
     name: OneNote.Paragraph
   - uid: 'onenote!OneNote.Interfaces.ImageUpdateData:interface'
     name: Interfaces.ImageUpdateData
-  - uid: 'onenote!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'onenote!OneNote.Interfaces.ImageData:interface'
     name: OneNote.Interfaces.ImageData

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.inkanalysis.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.inkanalysis.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'onenote!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: onenote!
     children:
       - 'onenote!OneNote.InkAnalysis#context:member'
@@ -204,7 +204,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'onenote!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'onenote!OneNote.InkAnalysis#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -277,7 +277,7 @@ items:
           - 'onenote!OneNote.InkAnalysis:class'
         description: ''
 references:
-  - uid: 'onenote!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'onenote!OneNote.RequestContext:class'
     name: RequestContext
@@ -289,7 +289,7 @@ references:
     name: OneNote.Page
   - uid: 'onenote!OneNote.Interfaces.InkAnalysisUpdateData:interface'
     name: Interfaces.InkAnalysisUpdateData
-  - uid: 'onenote!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'onenote!OneNote.Interfaces.InkAnalysisData:interface'
     name: OneNote.Interfaces.InkAnalysisData

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.inkanalysisline.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.inkanalysisline.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'onenote!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: onenote!
     children:
       - 'onenote!OneNote.InkAnalysisLine#context:member'
@@ -210,7 +210,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'onenote!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'onenote!OneNote.InkAnalysisLine#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -298,7 +298,7 @@ items:
         type:
           - 'onenote!OneNote.InkAnalysisWordCollection:class'
 references:
-  - uid: 'onenote!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'onenote!OneNote.RequestContext:class'
     name: RequestContext
@@ -310,7 +310,7 @@ references:
     name: OneNote.InkAnalysisParagraph
   - uid: 'onenote!OneNote.Interfaces.InkAnalysisLineUpdateData:interface'
     name: Interfaces.InkAnalysisLineUpdateData
-  - uid: 'onenote!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'onenote!OneNote.Interfaces.InkAnalysisLineData:interface'
     name: OneNote.Interfaces.InkAnalysisLineData

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.inkanalysislinecollection.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.inkanalysislinecollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'onenote!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: onenote!
     children:
       - 'onenote!OneNote.InkAnalysisLineCollection#context:member'
@@ -184,7 +184,7 @@ items:
         - id: option
           description: ''
           type:
-            - 'onenote!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'onenote!OneNote.InkAnalysisLineCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -239,7 +239,7 @@ items:
           - 'onenote!OneNote.InkAnalysisLineCollection:class'
         description: ''
 references:
-  - uid: 'onenote!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'onenote!OneNote.RequestContext:class'
     name: RequestContext
@@ -268,7 +268,7 @@ references:
       - uid: 'onenote!OneNote.Interfaces.CollectionLoadOptions:interface'
         name: OneNote.Interfaces.CollectionLoadOptions
         fullName: OneNote.Interfaces.CollectionLoadOptions
-  - uid: 'onenote!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'onenote!OneNote.Interfaces.InkAnalysisLineCollectionData:interface'
     name: OneNote.Interfaces.InkAnalysisLineCollectionData

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.inkanalysisparagraph.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.inkanalysisparagraph.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'onenote!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: onenote!
     children:
       - 'onenote!OneNote.InkAnalysisParagraph#context:member'
@@ -228,7 +228,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'onenote!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'onenote!OneNote.InkAnalysisParagraph#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -301,7 +301,7 @@ items:
           - 'onenote!OneNote.InkAnalysisParagraph:class'
         description: ''
 references:
-  - uid: 'onenote!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'onenote!OneNote.RequestContext:class'
     name: RequestContext
@@ -315,7 +315,7 @@ references:
     name: OneNote.Interfaces.InkAnalysisParagraphLoadOptions
   - uid: 'onenote!OneNote.Interfaces.InkAnalysisParagraphUpdateData:interface'
     name: Interfaces.InkAnalysisParagraphUpdateData
-  - uid: 'onenote!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'onenote!OneNote.Interfaces.InkAnalysisParagraphData:interface'
     name: OneNote.Interfaces.InkAnalysisParagraphData

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.inkanalysisparagraphcollection.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.inkanalysisparagraphcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'onenote!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: onenote!
     children:
       - 'onenote!OneNote.InkAnalysisParagraphCollection#context:member'
@@ -186,7 +186,7 @@ items:
         - id: option
           description: ''
           type:
-            - 'onenote!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'onenote!OneNote.InkAnalysisParagraphCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -241,7 +241,7 @@ items:
           - 'onenote!OneNote.InkAnalysisParagraphCollection:class'
         description: ''
 references:
-  - uid: 'onenote!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'onenote!OneNote.RequestContext:class'
     name: RequestContext
@@ -270,7 +270,7 @@ references:
       - uid: 'onenote!OneNote.Interfaces.CollectionLoadOptions:interface'
         name: OneNote.Interfaces.CollectionLoadOptions
         fullName: OneNote.Interfaces.CollectionLoadOptions
-  - uid: 'onenote!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'onenote!OneNote.Interfaces.InkAnalysisParagraphCollectionData:interface'
     name: OneNote.Interfaces.InkAnalysisParagraphCollectionData

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.inkanalysisword.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.inkanalysisword.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'onenote!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: onenote!
     children:
       - 'onenote!OneNote.InkAnalysisWord#context:member'
@@ -236,7 +236,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'onenote!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'onenote!OneNote.InkAnalysisWord#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -339,7 +339,7 @@ items:
         type:
           - 'string[]'
 references:
-  - uid: 'onenote!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'onenote!OneNote.RequestContext:class'
     name: RequestContext
@@ -351,7 +351,7 @@ references:
     name: OneNote.Interfaces.InkAnalysisWordLoadOptions
   - uid: 'onenote!OneNote.Interfaces.InkAnalysisWordUpdateData:interface'
     name: Interfaces.InkAnalysisWordUpdateData
-  - uid: 'onenote!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'onenote!OneNote.InkAnalysisWord#strokePointers~0:complex'
     name: 'OneNote.InkStrokePointer[]'

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.inkanalysiswordcollection.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.inkanalysiswordcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'onenote!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: onenote!
     children:
       - 'onenote!OneNote.InkAnalysisWordCollection#context:member'
@@ -184,7 +184,7 @@ items:
         - id: option
           description: ''
           type:
-            - 'onenote!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'onenote!OneNote.InkAnalysisWordCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -239,7 +239,7 @@ items:
           - 'onenote!OneNote.InkAnalysisWordCollection:class'
         description: ''
 references:
-  - uid: 'onenote!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'onenote!OneNote.RequestContext:class'
     name: RequestContext
@@ -268,7 +268,7 @@ references:
       - uid: 'onenote!OneNote.Interfaces.CollectionLoadOptions:interface'
         name: OneNote.Interfaces.CollectionLoadOptions
         fullName: OneNote.Interfaces.CollectionLoadOptions
-  - uid: 'onenote!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'onenote!OneNote.Interfaces.InkAnalysisWordCollectionData:interface'
     name: OneNote.Interfaces.InkAnalysisWordCollectionData

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.inkstroke.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.inkstroke.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'onenote!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: onenote!
     children:
       - 'onenote!OneNote.InkStroke#context:member'
@@ -201,7 +201,7 @@ items:
           - 'onenote!OneNote.InkStroke:class'
         description: ''
 references:
-  - uid: 'onenote!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'onenote!OneNote.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.inkstrokecollection.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.inkstrokecollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'onenote!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: onenote!
     children:
       - 'onenote!OneNote.InkStrokeCollection#context:member'
@@ -184,7 +184,7 @@ items:
         - id: option
           description: ''
           type:
-            - 'onenote!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'onenote!OneNote.InkStrokeCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -239,7 +239,7 @@ items:
           - 'onenote!OneNote.InkStrokeCollection:class'
         description: ''
 references:
-  - uid: 'onenote!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'onenote!OneNote.RequestContext:class'
     name: RequestContext
@@ -268,7 +268,7 @@ references:
       - uid: 'onenote!OneNote.Interfaces.CollectionLoadOptions:interface'
         name: OneNote.Interfaces.CollectionLoadOptions
         fullName: OneNote.Interfaces.CollectionLoadOptions
-  - uid: 'onenote!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'onenote!OneNote.Interfaces.InkStrokeCollectionData:interface'
     name: OneNote.Interfaces.InkStrokeCollectionData

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.inkword.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.inkword.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'onenote!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: onenote!
     children:
       - 'onenote!OneNote.InkWord#context:member'
@@ -233,7 +233,7 @@ items:
         type:
           - 'string[]'
 references:
-  - uid: 'onenote!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'onenote!OneNote.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.inkwordcollection.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.inkwordcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'onenote!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: onenote!
     children:
       - 'onenote!OneNote.InkWordCollection#context:member'
@@ -184,7 +184,7 @@ items:
         - id: option
           description: ''
           type:
-            - 'onenote!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'onenote!OneNote.InkWordCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -239,7 +239,7 @@ items:
           - 'onenote!OneNote.InkWordCollection:class'
         description: ''
 references:
-  - uid: 'onenote!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'onenote!OneNote.RequestContext:class'
     name: RequestContext
@@ -268,7 +268,7 @@ references:
       - uid: 'onenote!OneNote.Interfaces.CollectionLoadOptions:interface'
         name: OneNote.Interfaces.CollectionLoadOptions
         fullName: OneNote.Interfaces.CollectionLoadOptions
-  - uid: 'onenote!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'onenote!OneNote.Interfaces.InkWordCollectionData:interface'
     name: OneNote.Interfaces.InkWordCollectionData

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.notebook.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.notebook.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'onenote!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: onenote!
     children:
       - 'onenote!OneNote.Notebook#addSection:member(1)'
@@ -550,7 +550,7 @@ items:
           - 'onenote!OneNote.Notebook:class'
         description: ''
 references:
-  - uid: 'onenote!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'onenote!OneNote.Section:class'
     name: OneNote.Section
@@ -562,7 +562,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'onenote!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.notebookcollection.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.notebookcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'onenote!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: onenote!
     children:
       - 'onenote!OneNote.NotebookCollection#context:member'
@@ -276,7 +276,7 @@ items:
         - id: option
           description: ''
           type:
-            - 'onenote!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'onenote!OneNote.NotebookCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -331,7 +331,7 @@ items:
           - 'onenote!OneNote.NotebookCollection:class'
         description: ''
 references:
-  - uid: 'onenote!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'onenote!OneNote.RequestContext:class'
     name: RequestContext
@@ -360,7 +360,7 @@ references:
       - uid: 'onenote!OneNote.Interfaces.CollectionLoadOptions:interface'
         name: OneNote.Interfaces.CollectionLoadOptions
         fullName: OneNote.Interfaces.CollectionLoadOptions
-  - uid: 'onenote!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'onenote!OneNote.Interfaces.NotebookCollectionData:interface'
     name: OneNote.Interfaces.NotebookCollectionData

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.notetag.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.notetag.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'onenote!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: onenote!
     children:
       - 'onenote!OneNote.NoteTag#context:member'
@@ -221,7 +221,7 @@ items:
           - 'onenote!OneNote.NoteTag:class'
         description: ''
 references:
-  - uid: 'onenote!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'onenote!OneNote.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.outline.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.outline.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'onenote!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: onenote!
     children:
       - 'onenote!OneNote.Outline#appendHtml:member(1)'
@@ -420,7 +420,7 @@ items:
           - 'onenote!OneNote.Outline:class'
         description: ''
 references:
-  - uid: 'onenote!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'onenote!OneNote.Image:class'
     name: OneNote.Image
@@ -434,7 +434,7 @@ references:
     name: OfficeExtension.ClientResult<boolean>
     fullName: OfficeExtension.ClientResult<boolean>
     spec.typeScript:
-      - uid: 'onenote!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <boolean>

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.page.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.page.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'onenote!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: onenote!
     children:
       - 'onenote!OneNote.Page#addOutline:member(1)'
@@ -682,7 +682,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'onenote!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'onenote!OneNote.Page#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -785,7 +785,7 @@ items:
         type:
           - string
 references:
-  - uid: 'onenote!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'onenote!OneNote.Outline:class'
     name: OneNote.Outline
@@ -793,7 +793,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'onenote!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -810,7 +810,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'onenote!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -819,7 +819,7 @@ references:
     name: OfficeExtension.ClientResult<boolean>
     fullName: OfficeExtension.ClientResult<boolean>
     spec.typeScript:
-      - uid: 'onenote!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <boolean>
@@ -832,7 +832,7 @@ references:
     name: OneNote.Interfaces.PageLoadOptions
   - uid: 'onenote!OneNote.Interfaces.PageUpdateData:interface'
     name: Interfaces.PageUpdateData
-  - uid: 'onenote!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'onenote!OneNote.Interfaces.PageData:interface'
     name: OneNote.Interfaces.PageData

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.pagecollection.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.pagecollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'onenote!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: onenote!
     children:
       - 'onenote!OneNote.PageCollection#context:member'
@@ -280,7 +280,7 @@ items:
         - id: option
           description: ''
           type:
-            - 'onenote!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'onenote!OneNote.PageCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -335,7 +335,7 @@ items:
           - 'onenote!OneNote.PageCollection:class'
         description: ''
 references:
-  - uid: 'onenote!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'onenote!OneNote.RequestContext:class'
     name: RequestContext
@@ -364,7 +364,7 @@ references:
       - uid: 'onenote!OneNote.Interfaces.CollectionLoadOptions:interface'
         name: OneNote.Interfaces.CollectionLoadOptions
         fullName: OneNote.Interfaces.CollectionLoadOptions
-  - uid: 'onenote!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'onenote!OneNote.Interfaces.PageCollectionData:interface'
     name: OneNote.Interfaces.PageCollectionData

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.pagecontent.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.pagecontent.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'onenote!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: onenote!
     children:
       - 'onenote!OneNote.PageContent#context:member'
@@ -292,7 +292,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'onenote!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'onenote!OneNote.PageContent#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -395,7 +395,7 @@ items:
           - 'onenote!OneNote.PageContent:class'
         description: ''
 references:
-  - uid: 'onenote!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'onenote!OneNote.RequestContext:class'
     name: RequestContext
@@ -413,7 +413,7 @@ references:
     name: OneNote.Page
   - uid: 'onenote!OneNote.Interfaces.PageContentUpdateData:interface'
     name: Interfaces.PageContentUpdateData
-  - uid: 'onenote!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'onenote!OneNote.Interfaces.PageContentData:interface'
     name: OneNote.Interfaces.PageContentData

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.pagecontentcollection.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.pagecontentcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'onenote!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: onenote!
     children:
       - 'onenote!OneNote.PageContentCollection#context:member'
@@ -266,7 +266,7 @@ items:
         - id: option
           description: ''
           type:
-            - 'onenote!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'onenote!OneNote.PageContentCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -321,7 +321,7 @@ items:
           - 'onenote!OneNote.PageContentCollection:class'
         description: ''
 references:
-  - uid: 'onenote!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'onenote!OneNote.RequestContext:class'
     name: RequestContext
@@ -350,7 +350,7 @@ references:
       - uid: 'onenote!OneNote.Interfaces.CollectionLoadOptions:interface'
         name: OneNote.Interfaces.CollectionLoadOptions
         fullName: OneNote.Interfaces.CollectionLoadOptions
-  - uid: 'onenote!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'onenote!OneNote.Interfaces.PageContentCollectionData:interface'
     name: OneNote.Interfaces.PageContentCollectionData

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.paragraph.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.paragraph.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'onenote!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: onenote!
     children:
       - 'onenote!OneNote.Paragraph#addNoteTag:member(1)'
@@ -882,7 +882,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'onenote!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'onenote!OneNote.Paragraph#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -985,7 +985,7 @@ items:
           - 'onenote!OneNote.Paragraph:class'
         description: ''
 references:
-  - uid: 'onenote!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'onenote!OneNote.NoteTag:class'
     name: OneNote.NoteTag
@@ -999,7 +999,7 @@ references:
     name: OfficeExtension.ClientResult<OneNote.ParagraphInfo>
     fullName: OfficeExtension.ClientResult<OneNote.ParagraphInfo>
     spec.typeScript:
-      - uid: 'onenote!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <
@@ -1031,7 +1031,7 @@ references:
     name: OneNote.TableCell
   - uid: 'onenote!OneNote.Interfaces.ParagraphUpdateData:interface'
     name: Interfaces.ParagraphUpdateData
-  - uid: 'onenote!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'onenote!OneNote.Interfaces.ParagraphData:interface'
     name: OneNote.Interfaces.ParagraphData

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.paragraphcollection.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.paragraphcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'onenote!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: onenote!
     children:
       - 'onenote!OneNote.ParagraphCollection#context:member'
@@ -313,7 +313,7 @@ items:
         - id: option
           description: ''
           type:
-            - 'onenote!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'onenote!OneNote.ParagraphCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -368,7 +368,7 @@ items:
           - 'onenote!OneNote.ParagraphCollection:class'
         description: ''
 references:
-  - uid: 'onenote!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'onenote!OneNote.RequestContext:class'
     name: RequestContext
@@ -397,7 +397,7 @@ references:
       - uid: 'onenote!OneNote.Interfaces.CollectionLoadOptions:interface'
         name: OneNote.Interfaces.CollectionLoadOptions
         fullName: OneNote.Interfaces.CollectionLoadOptions
-  - uid: 'onenote!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'onenote!OneNote.Interfaces.ParagraphCollectionData:interface'
     name: OneNote.Interfaces.ParagraphCollectionData

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.requestcontext.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.requestcontext.yml
@@ -7,7 +7,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'onenote!OfficeExtension.ClientRequestContext:class'
+      - 'office!OfficeExtension.ClientRequestContext:class'
     package: onenote!
     children:
       - 'onenote!OneNote.RequestContext:constructor(1)'
@@ -38,7 +38,7 @@ items:
         type:
           - 'onenote!OneNote.Application:class'
 references:
-  - uid: 'onenote!OfficeExtension.ClientRequestContext:class'
+  - uid: 'office!OfficeExtension.ClientRequestContext:class'
     name: OfficeExtension.ClientRequestContext
   - uid: 'onenote!OneNote.Application:class'
     name: Application

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.richtext.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.richtext.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'onenote!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: onenote!
     children:
       - 'onenote!OneNote.RichText#context:member'
@@ -313,7 +313,7 @@ items:
           - 'onenote!OneNote.RichText:class'
         description: ''
 references:
-  - uid: 'onenote!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'onenote!OneNote.RequestContext:class'
     name: RequestContext
@@ -321,7 +321,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'onenote!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.section.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.section.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'onenote!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: onenote!
     children:
       - 'onenote!OneNote.Section#addPage:member(1)'
@@ -692,7 +692,7 @@ items:
         type:
           - string
 references:
-  - uid: 'onenote!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'onenote!OneNote.Page:class'
     name: OneNote.Page
@@ -708,7 +708,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'onenote!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.sectioncollection.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.sectioncollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'onenote!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: onenote!
     children:
       - 'onenote!OneNote.SectionCollection#context:member'
@@ -280,7 +280,7 @@ items:
         - id: option
           description: ''
           type:
-            - 'onenote!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'onenote!OneNote.SectionCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -335,7 +335,7 @@ items:
           - 'onenote!OneNote.SectionCollection:class'
         description: ''
 references:
-  - uid: 'onenote!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'onenote!OneNote.RequestContext:class'
     name: RequestContext
@@ -364,7 +364,7 @@ references:
       - uid: 'onenote!OneNote.Interfaces.CollectionLoadOptions:interface'
         name: OneNote.Interfaces.CollectionLoadOptions
         fullName: OneNote.Interfaces.CollectionLoadOptions
-  - uid: 'onenote!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'onenote!OneNote.Interfaces.SectionCollectionData:interface'
     name: OneNote.Interfaces.SectionCollectionData

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.sectiongroup.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.sectiongroup.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'onenote!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: onenote!
     children:
       - 'onenote!OneNote.SectionGroup#addSection:member(1)'
@@ -555,7 +555,7 @@ items:
           - 'onenote!OneNote.SectionGroup:class'
         description: ''
 references:
-  - uid: 'onenote!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'onenote!OneNote.Section:class'
     name: OneNote.Section
@@ -567,7 +567,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'onenote!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.sectiongroupcollection.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.sectiongroupcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'onenote!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: onenote!
     children:
       - 'onenote!OneNote.SectionGroupCollection#context:member'
@@ -277,7 +277,7 @@ items:
         - id: option
           description: ''
           type:
-            - 'onenote!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'onenote!OneNote.SectionGroupCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -332,7 +332,7 @@ items:
           - 'onenote!OneNote.SectionGroupCollection:class'
         description: ''
 references:
-  - uid: 'onenote!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'onenote!OneNote.RequestContext:class'
     name: RequestContext
@@ -361,7 +361,7 @@ references:
       - uid: 'onenote!OneNote.Interfaces.CollectionLoadOptions:interface'
         name: OneNote.Interfaces.CollectionLoadOptions
         fullName: OneNote.Interfaces.CollectionLoadOptions
-  - uid: 'onenote!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'onenote!OneNote.Interfaces.SectionGroupCollectionData:interface'
     name: OneNote.Interfaces.SectionGroupCollectionData

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.table.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.table.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'onenote!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: onenote!
     children:
       - 'onenote!OneNote.Table#appendColumn:member(1)'
@@ -644,7 +644,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'onenote!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'onenote!OneNote.Table#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -738,7 +738,7 @@ items:
           - 'onenote!OneNote.Table:class'
         description: ''
 references:
-  - uid: 'onenote!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'onenote!OneNote.TableRow:class'
     name: OneNote.TableRow
@@ -756,7 +756,7 @@ references:
     name: OneNote.TableRowCollection
   - uid: 'onenote!OneNote.Interfaces.TableUpdateData:interface'
     name: Interfaces.TableUpdateData
-  - uid: 'onenote!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'onenote!OneNote.Interfaces.TableData:interface'
     name: OneNote.Interfaces.TableData

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.tablecell.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.tablecell.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'onenote!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: onenote!
     children:
       - 'onenote!OneNote.TableCell#appendHtml:member(1)'
@@ -508,7 +508,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'onenote!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'onenote!OneNote.TableCell#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -596,7 +596,7 @@ items:
           - 'onenote!OneNote.TableCell:class'
         description: ''
 references:
-  - uid: 'onenote!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'onenote!OneNote.Image:class'
     name: OneNote.Image
@@ -616,7 +616,7 @@ references:
     name: OneNote.TableRow
   - uid: 'onenote!OneNote.Interfaces.TableCellUpdateData:interface'
     name: Interfaces.TableCellUpdateData
-  - uid: 'onenote!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'onenote!OneNote.Interfaces.TableCellData:interface'
     name: OneNote.Interfaces.TableCellData

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.tablecellcollection.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.tablecellcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'onenote!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: onenote!
     children:
       - 'onenote!OneNote.TableCellCollection#context:member'
@@ -184,7 +184,7 @@ items:
         - id: option
           description: ''
           type:
-            - 'onenote!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'onenote!OneNote.TableCellCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -239,7 +239,7 @@ items:
           - 'onenote!OneNote.TableCellCollection:class'
         description: ''
 references:
-  - uid: 'onenote!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'onenote!OneNote.RequestContext:class'
     name: RequestContext
@@ -268,7 +268,7 @@ references:
       - uid: 'onenote!OneNote.Interfaces.CollectionLoadOptions:interface'
         name: OneNote.Interfaces.CollectionLoadOptions
         fullName: OneNote.Interfaces.CollectionLoadOptions
-  - uid: 'onenote!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'onenote!OneNote.Interfaces.TableCellCollectionData:interface'
     name: OneNote.Interfaces.TableCellCollectionData

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.tablerow.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.tablerow.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'onenote!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: onenote!
     children:
       - 'onenote!OneNote.TableRow#cellCount:member'
@@ -476,7 +476,7 @@ items:
           - 'onenote!OneNote.TableRow:class'
         description: ''
 references:
-  - uid: 'onenote!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'onenote!OneNote.TableCellCollection:class'
     name: OneNote.TableCellCollection

--- a/docs/docs-ref-autogen/onenote/onenote/onenote.tablerowcollection.yml
+++ b/docs/docs-ref-autogen/onenote/onenote/onenote.tablerowcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'onenote!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: onenote!
     children:
       - 'onenote!OneNote.TableRowCollection#context:member'
@@ -184,7 +184,7 @@ items:
         - id: option
           description: ''
           type:
-            - 'onenote!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'onenote!OneNote.TableRowCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -239,7 +239,7 @@ items:
           - 'onenote!OneNote.TableRowCollection:class'
         description: ''
 references:
-  - uid: 'onenote!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'onenote!OneNote.RequestContext:class'
     name: RequestContext
@@ -268,7 +268,7 @@ references:
       - uid: 'onenote!OneNote.Interfaces.CollectionLoadOptions:interface'
         name: OneNote.Interfaces.CollectionLoadOptions
         fullName: OneNote.Interfaces.CollectionLoadOptions
-  - uid: 'onenote!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'onenote!OneNote.Interfaces.TableRowCollectionData:interface'
     name: OneNote.Interfaces.TableRowCollectionData

--- a/docs/docs-ref-autogen/visio/visio.yml
+++ b/docs/docs-ref-autogen/visio/visio.yml
@@ -219,7 +219,7 @@ items:
             having a new context created). This means that the batch will be able to pick up changes made to existing
             API objects, if those objects were derived from this same context.
           type:
-            - 'visio!OfficeExtension.ClientRequestContext:class'
+            - 'office!OfficeExtension.ClientRequestContext:class'
         - id: batch
           description: >-
             A function that takes in a RequestContext and returns a promise (typically, just the result of
@@ -403,12 +403,12 @@ references:
     name: OfficeExtension.ClientObject | OfficeExtension.EmbeddedSession
     fullName: OfficeExtension.ClientObject | OfficeExtension.EmbeddedSession
     spec.typeScript:
-      - uid: 'visio!OfficeExtension.ClientObject:class'
+      - uid: 'office!OfficeExtension.ClientObject:class'
         name: OfficeExtension.ClientObject
         fullName: OfficeExtension.ClientObject
       - name: ' | '
         fullName: ' | '
-      - uid: 'visio!OfficeExtension.EmbeddedSession:class'
+      - uid: 'office!OfficeExtension.EmbeddedSession:class'
         name: OfficeExtension.EmbeddedSession
         fullName: OfficeExtension.EmbeddedSession
   - uid: 'visio!Visio.run~4:complex'
@@ -440,7 +440,7 @@ references:
     name: 'OfficeExtension.ClientObject[]'
     fullName: 'OfficeExtension.ClientObject[]'
     spec.typeScript:
-      - uid: 'visio!OfficeExtension.ClientObject:class'
+      - uid: 'office!OfficeExtension.ClientObject:class'
         name: OfficeExtension.ClientObject
         fullName: OfficeExtension.ClientObject
       - name: '[]'
@@ -470,7 +470,7 @@ references:
         fullName: Promise
       - name: <T>
         fullName: <T>
-  - uid: 'visio!OfficeExtension.ClientRequestContext:class'
+  - uid: 'office!OfficeExtension.ClientRequestContext:class'
     name: OfficeExtension.ClientRequestContext
   - uid: 'visio!Visio.run~9:complex'
     name: '(context: Visio.RequestContext) => Promise<T>'

--- a/docs/docs-ref-autogen/visio/visio/visio.application.yml
+++ b/docs/docs-ref-autogen/visio/visio/visio.application.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'visio!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: visio!
     children:
       - 'visio!Visio.Application#context:member'
@@ -148,7 +148,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'visio!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'visio!Visio.Application#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -284,7 +284,7 @@ items:
           - 'visio!Visio.Interfaces.ApplicationData:interface'
         description: ''
 references:
-  - uid: 'visio!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'visio!Visio.RequestContext:class'
     name: RequestContext
@@ -294,7 +294,7 @@ references:
     name: Visio.Interfaces.ApplicationLoadOptions
   - uid: 'visio!Visio.Interfaces.ApplicationUpdateData:interface'
     name: Interfaces.ApplicationUpdateData
-  - uid: 'visio!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'visio!Visio.ToolBarType:enum'
     name: Visio.ToolBarType

--- a/docs/docs-ref-autogen/visio/visio/visio.comment.yml
+++ b/docs/docs-ref-autogen/visio/visio/visio.comment.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'visio!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: visio!
     children:
       - 'visio!Visio.Comment#author:member'
@@ -207,7 +207,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'visio!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'visio!Visio.Comment#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -260,7 +260,7 @@ items:
           - 'visio!Visio.Interfaces.CommentData:interface'
         description: ''
 references:
-  - uid: 'visio!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'visio!Visio.RequestContext:class'
     name: RequestContext
@@ -270,7 +270,7 @@ references:
     name: Visio.Interfaces.CommentLoadOptions
   - uid: 'visio!Visio.Interfaces.CommentUpdateData:interface'
     name: Interfaces.CommentUpdateData
-  - uid: 'visio!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'visio!Visio.Interfaces.CommentData:interface'
     name: Visio.Interfaces.CommentData

--- a/docs/docs-ref-autogen/visio/visio/visio.commentcollection.yml
+++ b/docs/docs-ref-autogen/visio/visio/visio.commentcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'visio!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: visio!
     children:
       - 'visio!Visio.CommentCollection#context:member'
@@ -191,7 +191,7 @@ items:
         - id: option
           description: ''
           type:
-            - 'visio!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'visio!Visio.CommentCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -211,7 +211,7 @@ items:
           - 'visio!Visio.Interfaces.CommentCollectionData:interface'
         description: ''
 references:
-  - uid: 'visio!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'visio!Visio.RequestContext:class'
     name: RequestContext
@@ -219,7 +219,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'visio!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -249,7 +249,7 @@ references:
       - uid: 'visio!Visio.Interfaces.CollectionLoadOptions:interface'
         name: Visio.Interfaces.CollectionLoadOptions
         fullName: Visio.Interfaces.CollectionLoadOptions
-  - uid: 'visio!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'visio!Visio.Interfaces.CommentCollectionData:interface'
     name: Visio.Interfaces.CommentCollectionData

--- a/docs/docs-ref-autogen/visio/visio/visio.document.yml
+++ b/docs/docs-ref-autogen/visio/visio/visio.document.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'visio!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: visio!
     children:
       - 'visio!Visio.Document#application:member'
@@ -330,7 +330,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'visio!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'visio!Visio.Document#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -453,7 +453,7 @@ items:
         type:
           - 'visio!Visio.DocumentView:class'
 references:
-  - uid: 'visio!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'visio!Visio.Application:class'
     name: Visio.Application
@@ -469,7 +469,7 @@ references:
     name: OfficeExtension.EventHandlers<Visio.DataRefreshCompleteEventArgs>
     fullName: OfficeExtension.EventHandlers<Visio.DataRefreshCompleteEventArgs>
     spec.typeScript:
-      - uid: 'visio!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -483,7 +483,7 @@ references:
     name: OfficeExtension.EventHandlers<Visio.DocumentLoadCompleteEventArgs>
     fullName: OfficeExtension.EventHandlers<Visio.DocumentLoadCompleteEventArgs>
     spec.typeScript:
-      - uid: 'visio!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -497,7 +497,7 @@ references:
     name: OfficeExtension.EventHandlers<Visio.PageLoadCompleteEventArgs>
     fullName: OfficeExtension.EventHandlers<Visio.PageLoadCompleteEventArgs>
     spec.typeScript:
-      - uid: 'visio!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -511,7 +511,7 @@ references:
     name: OfficeExtension.EventHandlers<Visio.SelectionChangedEventArgs>
     fullName: OfficeExtension.EventHandlers<Visio.SelectionChangedEventArgs>
     spec.typeScript:
-      - uid: 'visio!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -525,7 +525,7 @@ references:
     name: OfficeExtension.EventHandlers<Visio.ShapeMouseEnterEventArgs>
     fullName: OfficeExtension.EventHandlers<Visio.ShapeMouseEnterEventArgs>
     spec.typeScript:
-      - uid: 'visio!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -539,7 +539,7 @@ references:
     name: OfficeExtension.EventHandlers<Visio.ShapeMouseLeaveEventArgs>
     fullName: OfficeExtension.EventHandlers<Visio.ShapeMouseLeaveEventArgs>
     spec.typeScript:
-      - uid: 'visio!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -553,7 +553,7 @@ references:
     name: Visio.PageCollection
   - uid: 'visio!Visio.Interfaces.DocumentUpdateData:interface'
     name: Interfaces.DocumentUpdateData
-  - uid: 'visio!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'visio!Visio.Interfaces.DocumentData:interface'
     name: Visio.Interfaces.DocumentData

--- a/docs/docs-ref-autogen/visio/visio/visio.documentview.yml
+++ b/docs/docs-ref-autogen/visio/visio/visio.documentview.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'visio!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: visio!
     children:
       - 'visio!Visio.DocumentView#context:member'
@@ -241,7 +241,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'visio!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'visio!Visio.DocumentView#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -279,7 +279,7 @@ items:
           - 'visio!Visio.Interfaces.DocumentViewData:interface'
         description: ''
 references:
-  - uid: 'visio!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'visio!Visio.RequestContext:class'
     name: RequestContext
@@ -289,7 +289,7 @@ references:
     name: Visio.Interfaces.DocumentViewLoadOptions
   - uid: 'visio!Visio.Interfaces.DocumentViewUpdateData:interface'
     name: Interfaces.DocumentViewUpdateData
-  - uid: 'visio!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'visio!Visio.Interfaces.DocumentViewData:interface'
     name: Visio.Interfaces.DocumentViewData

--- a/docs/docs-ref-autogen/visio/visio/visio.hyperlink.yml
+++ b/docs/docs-ref-autogen/visio/visio/visio.hyperlink.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'visio!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: visio!
     children:
       - 'visio!Visio.Hyperlink#address:member'
@@ -222,7 +222,7 @@ items:
           - 'visio!Visio.Interfaces.HyperlinkData:interface'
         description: ''
 references:
-  - uid: 'visio!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'visio!Visio.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/visio/visio/visio.hyperlinkcollection.yml
+++ b/docs/docs-ref-autogen/visio/visio/visio.hyperlinkcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'visio!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: visio!
     children:
       - 'visio!Visio.HyperlinkCollection#context:member'
@@ -190,7 +190,7 @@ items:
         - id: option
           description: ''
           type:
-            - 'visio!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'visio!Visio.HyperlinkCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -210,7 +210,7 @@ items:
           - 'visio!Visio.Interfaces.HyperlinkCollectionData:interface'
         description: ''
 references:
-  - uid: 'visio!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'visio!Visio.RequestContext:class'
     name: RequestContext
@@ -218,7 +218,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'visio!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -248,7 +248,7 @@ references:
       - uid: 'visio!Visio.Interfaces.CollectionLoadOptions:interface'
         name: Visio.Interfaces.CollectionLoadOptions
         fullName: Visio.Interfaces.CollectionLoadOptions
-  - uid: 'visio!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'visio!Visio.Interfaces.HyperlinkCollectionData:interface'
     name: Visio.Interfaces.HyperlinkCollectionData

--- a/docs/docs-ref-autogen/visio/visio/visio.page.yml
+++ b/docs/docs-ref-autogen/visio/visio/visio.page.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'visio!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: visio!
     children:
       - 'visio!Visio.Page#activate:member(1)'
@@ -260,7 +260,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'visio!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'visio!Visio.Page#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -343,7 +343,7 @@ items:
         type:
           - number
 references:
-  - uid: 'visio!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'visio!Visio.ShapeCollection:class'
     name: Visio.ShapeCollection
@@ -357,7 +357,7 @@ references:
     name: Visio.Interfaces.PageLoadOptions
   - uid: 'visio!Visio.Interfaces.PageUpdateData:interface'
     name: Interfaces.PageUpdateData
-  - uid: 'visio!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'visio!Visio.Interfaces.PageData:interface'
     name: Visio.Interfaces.PageData

--- a/docs/docs-ref-autogen/visio/visio/visio.pagecollection.yml
+++ b/docs/docs-ref-autogen/visio/visio/visio.pagecollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'visio!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: visio!
     children:
       - 'visio!Visio.PageCollection#context:member'
@@ -178,7 +178,7 @@ items:
         - id: option
           description: ''
           type:
-            - 'visio!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'visio!Visio.PageCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -198,7 +198,7 @@ items:
           - 'visio!Visio.Interfaces.PageCollectionData:interface'
         description: ''
 references:
-  - uid: 'visio!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'visio!Visio.RequestContext:class'
     name: RequestContext
@@ -206,7 +206,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'visio!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -236,7 +236,7 @@ references:
       - uid: 'visio!Visio.Interfaces.CollectionLoadOptions:interface'
         name: Visio.Interfaces.CollectionLoadOptions
         fullName: Visio.Interfaces.CollectionLoadOptions
-  - uid: 'visio!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'visio!Visio.Interfaces.PageCollectionData:interface'
     name: Visio.Interfaces.PageCollectionData

--- a/docs/docs-ref-autogen/visio/visio/visio.pageview.yml
+++ b/docs/docs-ref-autogen/visio/visio/visio.pageview.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'visio!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: visio!
     children:
       - 'visio!Visio.PageView#centerViewportOnShape:member(1)'
@@ -258,7 +258,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'visio!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'visio!Visio.PageView#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -349,7 +349,7 @@ items:
           });
           ```
 references:
-  - uid: 'visio!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'visio!Visio.RequestContext:class'
     name: RequestContext
@@ -357,7 +357,7 @@ references:
     name: OfficeExtension.ClientResult<Visio.Position>
     fullName: OfficeExtension.ClientResult<Visio.Position>
     spec.typeScript:
-      - uid: 'visio!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <
@@ -373,7 +373,7 @@ references:
     name: OfficeExtension.ClientResult<boolean>
     fullName: OfficeExtension.ClientResult<boolean>
     spec.typeScript:
-      - uid: 'visio!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <boolean>
@@ -386,7 +386,7 @@ references:
     name: Visio.Interfaces.PageViewLoadOptions
   - uid: 'visio!Visio.Interfaces.PageViewUpdateData:interface'
     name: Interfaces.PageViewUpdateData
-  - uid: 'visio!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'visio!Visio.Position:interface'
     name: Visio.Position

--- a/docs/docs-ref-autogen/visio/visio/visio.requestcontext.yml
+++ b/docs/docs-ref-autogen/visio/visio/visio.requestcontext.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'visio!OfficeExtension.ClientRequestContext:class'
+      - 'office!OfficeExtension.ClientRequestContext:class'
     package: visio!
     children:
       - 'visio!Visio.RequestContext:constructor(1)'
@@ -42,7 +42,7 @@ items:
         type:
           - 'visio!Visio.Document:class'
 references:
-  - uid: 'visio!OfficeExtension.ClientRequestContext:class'
+  - uid: 'office!OfficeExtension.ClientRequestContext:class'
     name: OfficeExtension.ClientRequestContext
   - uid: 'visio!Visio.RequestContext~0:complex'
     name: string | OfficeExtension.EmbeddedSession
@@ -50,7 +50,7 @@ references:
     spec.typeScript:
       - name: 'string | '
         fullName: 'string | '
-      - uid: 'visio!OfficeExtension.EmbeddedSession:class'
+      - uid: 'office!OfficeExtension.EmbeddedSession:class'
         name: OfficeExtension.EmbeddedSession
         fullName: OfficeExtension.EmbeddedSession
   - uid: 'visio!Visio.Document:class'

--- a/docs/docs-ref-autogen/visio/visio/visio.selection.yml
+++ b/docs/docs-ref-autogen/visio/visio/visio.selection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'visio!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: visio!
     children:
       - 'visio!Visio.Selection#context:member'
@@ -109,7 +109,7 @@ items:
           - 'visio!Visio.Interfaces.SelectionData:interface'
         description: ''
 references:
-  - uid: 'visio!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'visio!Visio.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/visio/visio/visio.shape.yml
+++ b/docs/docs-ref-autogen/visio/visio/visio.shape.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'visio!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: visio!
     children:
       - 'visio!Visio.Shape#comments:member'
@@ -281,7 +281,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'visio!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'visio!Visio.Shape#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -379,7 +379,7 @@ items:
         type:
           - 'visio!Visio.ShapeView:class'
 references:
-  - uid: 'visio!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'visio!Visio.CommentCollection:class'
     name: Visio.CommentCollection
@@ -389,7 +389,7 @@ references:
     name: OfficeExtension.ClientResult<Visio.BoundingBox>
     fullName: OfficeExtension.ClientResult<Visio.BoundingBox>
     spec.typeScript:
-      - uid: 'visio!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <
@@ -407,7 +407,7 @@ references:
     name: Visio.Interfaces.ShapeLoadOptions
   - uid: 'visio!Visio.Interfaces.ShapeUpdateData:interface'
     name: Interfaces.ShapeUpdateData
-  - uid: 'visio!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'visio!Visio.ShapeDataItemCollection:class'
     name: Visio.ShapeDataItemCollection

--- a/docs/docs-ref-autogen/visio/visio/visio.shapecollection.yml
+++ b/docs/docs-ref-autogen/visio/visio/visio.shapecollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'visio!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: visio!
     children:
       - 'visio!Visio.ShapeCollection#context:member'
@@ -179,7 +179,7 @@ items:
         - id: option
           description: ''
           type:
-            - 'visio!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'visio!Visio.ShapeCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -199,7 +199,7 @@ items:
           - 'visio!Visio.Interfaces.ShapeCollectionData:interface'
         description: ''
 references:
-  - uid: 'visio!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'visio!Visio.RequestContext:class'
     name: RequestContext
@@ -207,7 +207,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'visio!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -237,7 +237,7 @@ references:
       - uid: 'visio!Visio.Interfaces.CollectionLoadOptions:interface'
         name: Visio.Interfaces.CollectionLoadOptions
         fullName: Visio.Interfaces.CollectionLoadOptions
-  - uid: 'visio!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'visio!Visio.Interfaces.ShapeCollectionData:interface'
     name: Visio.Interfaces.ShapeCollectionData

--- a/docs/docs-ref-autogen/visio/visio/visio.shapedataitem.yml
+++ b/docs/docs-ref-autogen/visio/visio/visio.shapedataitem.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'visio!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: visio!
     children:
       - 'visio!Visio.ShapeDataItem#context:member'
@@ -220,7 +220,7 @@ items:
         type:
           - string
 references:
-  - uid: 'visio!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'visio!Visio.RequestContext:class'
     name: RequestContext

--- a/docs/docs-ref-autogen/visio/visio/visio.shapedataitemcollection.yml
+++ b/docs/docs-ref-autogen/visio/visio/visio.shapedataitemcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'visio!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: visio!
     children:
       - 'visio!Visio.ShapeDataItemCollection#context:member'
@@ -187,7 +187,7 @@ items:
         - id: option
           description: ''
           type:
-            - 'visio!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'visio!Visio.ShapeDataItemCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -207,7 +207,7 @@ items:
           - 'visio!Visio.Interfaces.ShapeDataItemCollectionData:interface'
         description: ''
 references:
-  - uid: 'visio!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'visio!Visio.RequestContext:class'
     name: RequestContext
@@ -215,7 +215,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'visio!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -245,7 +245,7 @@ references:
       - uid: 'visio!Visio.Interfaces.CollectionLoadOptions:interface'
         name: Visio.Interfaces.CollectionLoadOptions
         fullName: Visio.Interfaces.CollectionLoadOptions
-  - uid: 'visio!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'visio!Visio.Interfaces.ShapeDataItemCollectionData:interface'
     name: Visio.Interfaces.ShapeDataItemCollectionData

--- a/docs/docs-ref-autogen/visio/visio/visio.shapeview.yml
+++ b/docs/docs-ref-autogen/visio/visio/visio.shapeview.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'visio!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: visio!
     children:
       - 'visio!Visio.ShapeView#addOverlay:member(1)'
@@ -325,7 +325,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'visio!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'visio!Visio.ShapeView#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -388,13 +388,13 @@ items:
           - 'visio!Visio.Interfaces.ShapeViewData:interface'
         description: ''
 references:
-  - uid: 'visio!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'visio!Visio.ShapeView#addOverlay~0:complex'
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'visio!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -409,7 +409,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'visio!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -424,7 +424,7 @@ references:
     name: Visio.Interfaces.ShapeViewLoadOptions
   - uid: 'visio!Visio.Interfaces.ShapeViewUpdateData:interface'
     name: Interfaces.ShapeViewUpdateData
-  - uid: 'visio!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'visio!Visio.Interfaces.ShapeViewData:interface'
     name: Visio.Interfaces.ShapeViewData

--- a/docs/docs-ref-autogen/word/word.yml
+++ b/docs/docs-ref-autogen/word/word.yml
@@ -228,7 +228,7 @@ items:
             A previously created API object. The batch will use the same RequestContext as the passed-in object, which
             means that any changes applied to the object will be picked up by "context.sync()".
           type:
-            - 'word!OfficeExtension.ClientObject:class'
+            - 'office!OfficeExtension.ClientObject:class'
         - id: batch
           description: >-
             A function that takes in a RequestContext and returns a promise (typically, just the result of
@@ -574,7 +574,7 @@ references:
     name: 'OfficeExtension.ClientObject[]'
     fullName: 'OfficeExtension.ClientObject[]'
     spec.typeScript:
-      - uid: 'word!OfficeExtension.ClientObject:class'
+      - uid: 'office!OfficeExtension.ClientObject:class'
         name: OfficeExtension.ClientObject
         fullName: OfficeExtension.ClientObject
       - name: '[]'
@@ -604,7 +604,7 @@ references:
         fullName: Promise
       - name: <T>
         fullName: <T>
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.run~4:complex'
     name: '(context: Word.RequestContext) => Promise<T>'

--- a/docs/docs-ref-autogen/word/word/word.application.yml
+++ b/docs/docs-ref-autogen/word/word/word.application.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.Application#context:member'
@@ -70,7 +70,7 @@ items:
         - id: context
           description: ''
           type:
-            - 'word!OfficeExtension.ClientRequestContext:class'
+            - 'office!OfficeExtension.ClientRequestContext:class'
   - uid: 'word!Word.Application#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -96,7 +96,7 @@ items:
                     }
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.RequestContext:class'
     name: RequestContext
@@ -104,5 +104,5 @@ references:
     name: Word.DocumentCreated
   - uid: 'word!Word.Application:class'
     name: Word.Application
-  - uid: 'word!OfficeExtension.ClientRequestContext:class'
+  - uid: 'office!OfficeExtension.ClientRequestContext:class'
     name: OfficeExtension.ClientRequestContext

--- a/docs/docs-ref-autogen/word/word/word.body.yml
+++ b/docs/docs-ref-autogen/word/word/word.body.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.Body#clear:member(1)'
@@ -1519,7 +1519,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'word!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'word!Word.Body#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -1731,7 +1731,7 @@ items:
           - 'word!Word.Body:class'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.ContentControlCollection:class'
     name: Word.ContentControlCollection
@@ -1743,7 +1743,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'word!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -1752,7 +1752,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'word!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -1836,7 +1836,7 @@ references:
     name: Word.SelectionMode
   - uid: 'word!Word.Interfaces.BodyUpdateData:interface'
     name: Interfaces.BodyUpdateData
-  - uid: 'word!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'word!Word.Body#styleBuiltIn~0:complex'
     name: >-

--- a/docs/docs-ref-autogen/word/word/word.contentcontrol.yml
+++ b/docs/docs-ref-autogen/word/word/word.contentcontrol.yml
@@ -14,7 +14,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.ContentControl#appearance:member'
@@ -1784,7 +1784,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'word!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'word!Word.ContentControl#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -2099,7 +2099,7 @@ items:
           - 'word!Word.ContentControl:class'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.ContentControl#appearance~0:complex'
     name: Word.ContentControlAppearance | "BoundingBox" | "Tags" | "Hidden"
@@ -2120,7 +2120,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'word!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -2129,7 +2129,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'word!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -2162,7 +2162,7 @@ references:
     name: OfficeExtension.EventHandlers<Word.ContentControlEventArgs>
     fullName: OfficeExtension.EventHandlers<Word.ContentControlEventArgs>
     spec.typeScript:
-      - uid: 'word!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -2176,7 +2176,7 @@ references:
     name: OfficeExtension.EventHandlers<Word.ContentControlEventArgs>
     fullName: OfficeExtension.EventHandlers<Word.ContentControlEventArgs>
     spec.typeScript:
-      - uid: 'word!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -2190,7 +2190,7 @@ references:
     name: OfficeExtension.EventHandlers<Word.ContentControlEventArgs>
     fullName: OfficeExtension.EventHandlers<Word.ContentControlEventArgs>
     spec.typeScript:
-      - uid: 'word!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -2255,7 +2255,7 @@ references:
     name: Word.SelectionMode
   - uid: 'word!Word.Interfaces.ContentControlUpdateData:interface'
     name: Interfaces.ContentControlUpdateData
-  - uid: 'word!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'word!Word.ContentControl#styleBuiltIn~0:complex'
     name: >-

--- a/docs/docs-ref-autogen/word/word/word.contentcontrolcollection.yml
+++ b/docs/docs-ref-autogen/word/word/word.contentcontrolcollection.yml
@@ -15,7 +15,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.ContentControlCollection#context:member'
@@ -530,7 +530,7 @@ items:
         - id: option
           description: ''
           type:
-            - 'word!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'word!Word.ContentControlCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -585,7 +585,7 @@ items:
           - 'word!Word.ContentControlCollection:class'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.RequestContext:class'
     name: RequestContext
@@ -623,7 +623,7 @@ references:
       - uid: 'word!Word.Interfaces.CollectionLoadOptions:interface'
         name: Word.Interfaces.CollectionLoadOptions
         fullName: Word.Interfaces.CollectionLoadOptions
-  - uid: 'word!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'word!Word.Interfaces.ContentControlCollectionData:interface'
     name: Word.Interfaces.ContentControlCollectionData

--- a/docs/docs-ref-autogen/word/word/word.customproperty.yml
+++ b/docs/docs-ref-autogen/word/word/word.customproperty.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.CustomProperty#context:member'
@@ -181,7 +181,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'word!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'word!Word.CustomProperty#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -287,7 +287,7 @@ items:
         type:
           - any
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.RequestContext:class'
     name: RequestContext
@@ -297,7 +297,7 @@ references:
     name: Word.Interfaces.CustomPropertyLoadOptions
   - uid: 'word!Word.Interfaces.CustomPropertyUpdateData:interface'
     name: Interfaces.CustomPropertyUpdateData
-  - uid: 'word!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'word!Word.Interfaces.CustomPropertyData:interface'
     name: Word.Interfaces.CustomPropertyData

--- a/docs/docs-ref-autogen/word/word/word.custompropertycollection.yml
+++ b/docs/docs-ref-autogen/word/word/word.custompropertycollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.CustomPropertyCollection#add:member(1)'
@@ -285,7 +285,7 @@ items:
         - id: option
           description: ''
           type:
-            - 'word!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'word!Word.CustomPropertyCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -340,7 +340,7 @@ items:
           - 'word!Word.CustomPropertyCollection:class'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.CustomProperty:class'
     name: Word.CustomProperty
@@ -350,7 +350,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'word!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -378,7 +378,7 @@ references:
       - uid: 'word!Word.Interfaces.CollectionLoadOptions:interface'
         name: Word.Interfaces.CollectionLoadOptions
         fullName: Word.Interfaces.CollectionLoadOptions
-  - uid: 'word!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'word!Word.Interfaces.CustomPropertyCollectionData:interface'
     name: Word.Interfaces.CustomPropertyCollectionData

--- a/docs/docs-ref-autogen/word/word/word.customxmlpart.yml
+++ b/docs/docs-ref-autogen/word/word/word.customxmlpart.yml
@@ -14,7 +14,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.CustomXmlPart#context:member'
@@ -533,7 +533,7 @@ items:
           type:
             - any
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.RequestContext:class'
     name: RequestContext
@@ -541,7 +541,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'word!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -554,7 +554,7 @@ references:
     name: 'OfficeExtension.ClientResult<string[]>'
     fullName: 'OfficeExtension.ClientResult<string[]>'
     spec.typeScript:
-      - uid: 'word!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: '<string[]>'

--- a/docs/docs-ref-autogen/word/word/word.customxmlpartcollection.yml
+++ b/docs/docs-ref-autogen/word/word/word.customxmlpartcollection.yml
@@ -14,7 +14,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.CustomXmlPartCollection#add:member(1)'
@@ -252,7 +252,7 @@ items:
         - id: option
           description: ''
           type:
-            - 'word!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'word!Word.CustomXmlPartCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -310,7 +310,7 @@ items:
           - 'word!Word.CustomXmlPartCollection:class'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.CustomXmlPart:class'
     name: Word.CustomXmlPart
@@ -322,7 +322,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'word!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -350,7 +350,7 @@ references:
       - uid: 'word!Word.Interfaces.CollectionLoadOptions:interface'
         name: Word.Interfaces.CollectionLoadOptions
         fullName: Word.Interfaces.CollectionLoadOptions
-  - uid: 'word!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'word!Word.Interfaces.CustomXmlPartCollectionData:interface'
     name: Word.Interfaces.CustomXmlPartCollectionData

--- a/docs/docs-ref-autogen/word/word/word.customxmlpartscopedcollection.yml
+++ b/docs/docs-ref-autogen/word/word/word.customxmlpartscopedcollection.yml
@@ -15,7 +15,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.CustomXmlPartScopedCollection#context:member'
@@ -244,7 +244,7 @@ items:
         - id: option
           description: ''
           type:
-            - 'word!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'word!Word.CustomXmlPartScopedCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -302,7 +302,7 @@ items:
           - 'word!Word.CustomXmlPartScopedCollection:class'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.RequestContext:class'
     name: RequestContext
@@ -310,7 +310,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'word!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -340,7 +340,7 @@ references:
       - uid: 'word!Word.Interfaces.CollectionLoadOptions:interface'
         name: Word.Interfaces.CollectionLoadOptions
         fullName: Word.Interfaces.CollectionLoadOptions
-  - uid: 'word!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'word!Word.Interfaces.CustomXmlPartScopedCollectionData:interface'
     name: Word.Interfaces.CustomXmlPartScopedCollectionData

--- a/docs/docs-ref-autogen/word/word/word.document.yml
+++ b/docs/docs-ref-autogen/word/word/word.document.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.Document#body:member'
@@ -515,7 +515,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'word!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'word!Word.Document#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -606,7 +606,7 @@ items:
           - 'word!Word.Document:class'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.Body:class'
     name: Word.Body
@@ -626,7 +626,7 @@ references:
     name: OfficeExtension.EventHandlers<Word.ContentControlEventArgs>
     fullName: OfficeExtension.EventHandlers<Word.ContentControlEventArgs>
     spec.typeScript:
-      - uid: 'word!OfficeExtension.EventHandlers:class'
+      - uid: 'office!OfficeExtension.EventHandlers:class'
         name: OfficeExtension.EventHandlers
         fullName: OfficeExtension.EventHandlers
       - name: <
@@ -642,7 +642,7 @@ references:
     name: Word.SectionCollection
   - uid: 'word!Word.Interfaces.DocumentUpdateData:interface'
     name: Interfaces.DocumentUpdateData
-  - uid: 'word!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'word!Word.SettingCollection:class'
     name: Word.SettingCollection

--- a/docs/docs-ref-autogen/word/word/word.documentcreated.yml
+++ b/docs/docs-ref-autogen/word/word/word.documentcreated.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.DocumentCreated#body:member'
@@ -378,7 +378,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'word!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'word!Word.DocumentCreated#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -469,7 +469,7 @@ items:
           - 'word!Word.DocumentCreated:class'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.Body:class'
     name: Word.Body
@@ -491,7 +491,7 @@ references:
     name: Word.SectionCollection
   - uid: 'word!Word.Interfaces.DocumentCreatedUpdateData:interface'
     name: Interfaces.DocumentCreatedUpdateData
-  - uid: 'word!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'word!Word.SettingCollection:class'
     name: Word.SettingCollection

--- a/docs/docs-ref-autogen/word/word/word.documentproperties.yml
+++ b/docs/docs-ref-autogen/word/word/word.documentproperties.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.DocumentProperties#applicationName:member'
@@ -396,7 +396,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'word!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'word!Word.DocumentProperties#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -514,7 +514,7 @@ items:
           - 'word!Word.DocumentProperties:class'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.RequestContext:class'
     name: RequestContext
@@ -528,7 +528,7 @@ references:
     name: Word.Interfaces.DocumentPropertiesLoadOptions
   - uid: 'word!Word.Interfaces.DocumentPropertiesUpdateData:interface'
     name: Interfaces.DocumentPropertiesUpdateData
-  - uid: 'word!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'word!Word.Interfaces.DocumentPropertiesData:interface'
     name: Word.Interfaces.DocumentPropertiesData

--- a/docs/docs-ref-autogen/word/word/word.font.yml
+++ b/docs/docs-ref-autogen/word/word/word.font.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.Font#bold:member'
@@ -377,7 +377,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'word!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'word!Word.Font#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -621,7 +621,7 @@ items:
           - 'word!Word.Font:class'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.RequestContext:class'
     name: RequestContext
@@ -631,7 +631,7 @@ references:
     name: Word.Interfaces.FontLoadOptions
   - uid: 'word!Word.Interfaces.FontUpdateData:interface'
     name: Interfaces.FontUpdateData
-  - uid: 'word!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'word!Word.Interfaces.FontData:interface'
     name: Word.Interfaces.FontData

--- a/docs/docs-ref-autogen/word/word/word.inlinepicture.yml
+++ b/docs/docs-ref-autogen/word/word/word.inlinepicture.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.InlinePicture#altTextDescription:member'
@@ -1003,7 +1003,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'word!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'word!Word.InlinePicture#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -1091,7 +1091,7 @@ items:
         type:
           - number
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.RequestContext:class'
     name: RequestContext
@@ -1099,7 +1099,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'word!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -1141,7 +1141,7 @@ references:
     name: Word.SelectionMode
   - uid: 'word!Word.Interfaces.InlinePictureUpdateData:interface'
     name: Interfaces.InlinePictureUpdateData
-  - uid: 'word!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'word!Word.Interfaces.InlinePictureData:interface'
     name: Word.Interfaces.InlinePictureData

--- a/docs/docs-ref-autogen/word/word/word.inlinepicturecollection.yml
+++ b/docs/docs-ref-autogen/word/word/word.inlinepicturecollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.InlinePictureCollection#context:member'
@@ -158,7 +158,7 @@ items:
         - id: option
           description: ''
           type:
-            - 'word!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'word!Word.InlinePictureCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -213,7 +213,7 @@ items:
           - 'word!Word.InlinePictureCollection:class'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.RequestContext:class'
     name: RequestContext
@@ -242,7 +242,7 @@ references:
       - uid: 'word!Word.Interfaces.CollectionLoadOptions:interface'
         name: Word.Interfaces.CollectionLoadOptions
         fullName: Word.Interfaces.CollectionLoadOptions
-  - uid: 'word!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'word!Word.Interfaces.InlinePictureCollectionData:interface'
     name: Word.Interfaces.InlinePictureCollectionData

--- a/docs/docs-ref-autogen/word/word/word.list.yml
+++ b/docs/docs-ref-autogen/word/word/word.list.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.List#context:member'
@@ -697,7 +697,7 @@ items:
           - 'word!Word.List:class'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.RequestContext:class'
     name: RequestContext
@@ -709,7 +709,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'word!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -718,7 +718,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'word!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>

--- a/docs/docs-ref-autogen/word/word/word.listcollection.yml
+++ b/docs/docs-ref-autogen/word/word/word.listcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.ListCollection#context:member'
@@ -224,7 +224,7 @@ items:
         - id: option
           description: ''
           type:
-            - 'word!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'word!Word.ListCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -279,7 +279,7 @@ items:
           - 'word!Word.ListCollection:class'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.RequestContext:class'
     name: RequestContext
@@ -308,7 +308,7 @@ references:
       - uid: 'word!Word.Interfaces.CollectionLoadOptions:interface'
         name: Word.Interfaces.CollectionLoadOptions
         fullName: Word.Interfaces.CollectionLoadOptions
-  - uid: 'word!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'word!Word.Interfaces.ListCollectionData:interface'
     name: Word.Interfaces.ListCollectionData

--- a/docs/docs-ref-autogen/word/word/word.listitem.yml
+++ b/docs/docs-ref-autogen/word/word/word.listitem.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.ListItem#context:member'
@@ -255,7 +255,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'word!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'word!Word.ListItem#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -343,7 +343,7 @@ items:
           - 'word!Word.ListItem:class'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.RequestContext:class'
     name: RequestContext
@@ -357,7 +357,7 @@ references:
     name: Word.Interfaces.ListItemLoadOptions
   - uid: 'word!Word.Interfaces.ListItemUpdateData:interface'
     name: Interfaces.ListItemUpdateData
-  - uid: 'word!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'word!Word.Interfaces.ListItemData:interface'
     name: Word.Interfaces.ListItemData

--- a/docs/docs-ref-autogen/word/word/word.paragraph.yml
+++ b/docs/docs-ref-autogen/word/word/word.paragraph.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.Paragraph#alignment:member'
@@ -1894,7 +1894,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'word!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'word!Word.Paragraph#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -2245,7 +2245,7 @@ items:
           - 'word!Word.Paragraph:class'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.Paragraph#alignment~0:complex'
     name: Word.Alignment | "Mixed" | "Unknown" | "Left" | "Centered" | "Right" | "Justified"
@@ -2268,7 +2268,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'word!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -2279,7 +2279,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'word!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -2359,7 +2359,7 @@ references:
     name: Word.SelectionMode
   - uid: 'word!Word.Interfaces.ParagraphUpdateData:interface'
     name: Interfaces.ParagraphUpdateData
-  - uid: 'word!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'word!Word.Paragraph#styleBuiltIn~0:complex'
     name: >-

--- a/docs/docs-ref-autogen/word/word/word.paragraphcollection.yml
+++ b/docs/docs-ref-autogen/word/word/word.paragraphcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.ParagraphCollection#context:member'
@@ -233,7 +233,7 @@ items:
         - id: option
           description: ''
           type:
-            - 'word!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'word!Word.ParagraphCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -288,7 +288,7 @@ items:
           - 'word!Word.ParagraphCollection:class'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.RequestContext:class'
     name: RequestContext
@@ -317,7 +317,7 @@ references:
       - uid: 'word!Word.Interfaces.CollectionLoadOptions:interface'
         name: Word.Interfaces.CollectionLoadOptions
         fullName: Word.Interfaces.CollectionLoadOptions
-  - uid: 'word!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'word!Word.Interfaces.ParagraphCollectionData:interface'
     name: Word.Interfaces.ParagraphCollectionData

--- a/docs/docs-ref-autogen/word/word/word.range.yml
+++ b/docs/docs-ref-autogen/word/word/word.range.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.Range#clear:member(1)'
@@ -1716,7 +1716,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'word!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'word!Word.Range#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -1926,13 +1926,13 @@ items:
           - 'word!Word.Range:class'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.Range#compareLocationWith~0:complex'
     name: OfficeExtension.ClientResult<Word.LocationRelation>
     fullName: OfficeExtension.ClientResult<Word.LocationRelation>
     spec.typeScript:
-      - uid: 'word!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <
@@ -1954,7 +1954,7 @@ references:
     name: 'OfficeExtension.ClientResult<string[]>'
     fullName: 'OfficeExtension.ClientResult<string[]>'
     spec.typeScript:
-      - uid: 'word!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: '<string[]>'
@@ -1963,7 +1963,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'word!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -1974,7 +1974,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'word!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -2054,7 +2054,7 @@ references:
     name: Word.SelectionMode
   - uid: 'word!Word.Interfaces.RangeUpdateData:interface'
     name: Interfaces.RangeUpdateData
-  - uid: 'word!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'word!Word.Range#styleBuiltIn~0:complex'
     name: >-

--- a/docs/docs-ref-autogen/word/word/word.rangecollection.yml
+++ b/docs/docs-ref-autogen/word/word/word.rangecollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.RangeCollection#context:member'
@@ -158,7 +158,7 @@ items:
         - id: option
           description: ''
           type:
-            - 'word!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'word!Word.RangeCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -213,7 +213,7 @@ items:
           - 'word!Word.RangeCollection:class'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.RequestContext:class'
     name: RequestContext
@@ -242,7 +242,7 @@ references:
       - uid: 'word!Word.Interfaces.CollectionLoadOptions:interface'
         name: Word.Interfaces.CollectionLoadOptions
         fullName: Word.Interfaces.CollectionLoadOptions
-  - uid: 'word!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'word!Word.Interfaces.RangeCollectionData:interface'
     name: Word.Interfaces.RangeCollectionData

--- a/docs/docs-ref-autogen/word/word/word.requestcontext.yml
+++ b/docs/docs-ref-autogen/word/word/word.requestcontext.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientRequestContext:class'
+      - 'office!OfficeExtension.ClientRequestContext:class'
     package: word!
     children:
       - 'word!Word.RequestContext:constructor(1)'
@@ -55,7 +55,7 @@ items:
         type:
           - 'word!Word.Document:class'
 references:
-  - uid: 'word!OfficeExtension.ClientRequestContext:class'
+  - uid: 'office!OfficeExtension.ClientRequestContext:class'
     name: OfficeExtension.ClientRequestContext
   - uid: 'word!Word.Application:class'
     name: Application

--- a/docs/docs-ref-autogen/word/word/word.searchoptions.yml
+++ b/docs/docs-ref-autogen/word/word/word.searchoptions.yml
@@ -16,7 +16,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.SearchOptions#context:member'
@@ -445,7 +445,7 @@ items:
         - id: context
           description: ''
           type:
-            - 'word!OfficeExtension.ClientRequestContext:class'
+            - 'office!OfficeExtension.ClientRequestContext:class'
   - uid: 'word!Word.SearchOptions#set:member(1)'
     summary: >-
       Sets multiple properties of an object at the same time. You can pass either a plain object with the appropriate
@@ -475,7 +475,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'word!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'word!Word.SearchOptions#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -513,7 +513,7 @@ items:
           - 'word!Word.Interfaces.SearchOptionsData:interface'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.RequestContext:class'
     name: RequestContext
@@ -521,11 +521,11 @@ references:
     name: Word.SearchOptions
   - uid: 'word!Word.Interfaces.SearchOptionsLoadOptions:interface'
     name: Word.Interfaces.SearchOptionsLoadOptions
-  - uid: 'word!OfficeExtension.ClientRequestContext:class'
+  - uid: 'office!OfficeExtension.ClientRequestContext:class'
     name: OfficeExtension.ClientRequestContext
   - uid: 'word!Word.Interfaces.SearchOptionsUpdateData:interface'
     name: Interfaces.SearchOptionsUpdateData
-  - uid: 'word!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'word!Word.Interfaces.SearchOptionsData:interface'
     name: Word.Interfaces.SearchOptionsData

--- a/docs/docs-ref-autogen/word/word/word.section.yml
+++ b/docs/docs-ref-autogen/word/word/word.section.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.Section#body:member'
@@ -406,7 +406,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'word!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'word!Word.Section#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -479,7 +479,7 @@ items:
           - 'word!Word.Section:class'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.Body:class'
     name: Word.Body
@@ -493,7 +493,7 @@ references:
     name: Word.Interfaces.SectionLoadOptions
   - uid: 'word!Word.Interfaces.SectionUpdateData:interface'
     name: Interfaces.SectionUpdateData
-  - uid: 'word!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'word!Word.Interfaces.SectionData:interface'
     name: Word.Interfaces.SectionData

--- a/docs/docs-ref-autogen/word/word/word.sectioncollection.yml
+++ b/docs/docs-ref-autogen/word/word/word.sectioncollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.SectionCollection#context:member'
@@ -158,7 +158,7 @@ items:
         - id: option
           description: ''
           type:
-            - 'word!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'word!Word.SectionCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -213,7 +213,7 @@ items:
           - 'word!Word.SectionCollection:class'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.RequestContext:class'
     name: RequestContext
@@ -242,7 +242,7 @@ references:
       - uid: 'word!Word.Interfaces.CollectionLoadOptions:interface'
         name: Word.Interfaces.CollectionLoadOptions
         fullName: Word.Interfaces.CollectionLoadOptions
-  - uid: 'word!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'word!Word.Interfaces.SectionCollectionData:interface'
     name: Word.Interfaces.SectionCollectionData

--- a/docs/docs-ref-autogen/word/word/word.setting.yml
+++ b/docs/docs-ref-autogen/word/word/word.setting.yml
@@ -14,7 +14,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.Setting._replaceDateWithStringDate:member(1)'
@@ -254,7 +254,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'word!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'word!Word.Setting#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     isPreview: true
@@ -349,7 +349,7 @@ items:
         type:
           - any
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.RequestContext:class'
     name: RequestContext
@@ -359,7 +359,7 @@ references:
     name: Word.Interfaces.SettingLoadOptions
   - uid: 'word!Word.Interfaces.SettingUpdateData:interface'
     name: Interfaces.SettingUpdateData
-  - uid: 'word!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'word!Word.Interfaces.SettingData:interface'
     name: Word.Interfaces.SettingData

--- a/docs/docs-ref-autogen/word/word/word.settingcollection.yml
+++ b/docs/docs-ref-autogen/word/word/word.settingcollection.yml
@@ -14,7 +14,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.SettingCollection#add:member(1)'
@@ -408,7 +408,7 @@ items:
         - id: option
           description: ''
           type:
-            - 'word!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'word!Word.SettingCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -466,7 +466,7 @@ items:
           - 'word!Word.SettingCollection:class'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.Setting:class'
     name: Word.Setting
@@ -476,7 +476,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'word!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -504,7 +504,7 @@ references:
       - uid: 'word!Word.Interfaces.CollectionLoadOptions:interface'
         name: Word.Interfaces.CollectionLoadOptions
         fullName: Word.Interfaces.CollectionLoadOptions
-  - uid: 'word!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'word!Word.Interfaces.SettingCollectionData:interface'
     name: Word.Interfaces.SettingCollectionData

--- a/docs/docs-ref-autogen/word/word/word.table.yml
+++ b/docs/docs-ref-autogen/word/word/word.table.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.Table#addColumns:member(1)'
@@ -1232,7 +1232,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'word!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'word!Word.Table#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -1570,7 +1570,7 @@ items:
         type:
           - number
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.InsertLocation:enum'
     name: Word.InsertLocation
@@ -1599,7 +1599,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'word!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -1610,7 +1610,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'word!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -1689,7 +1689,7 @@ references:
     name: Word.SelectionMode
   - uid: 'word!Word.Interfaces.TableUpdateData:interface'
     name: Interfaces.TableUpdateData
-  - uid: 'word!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'word!Word.Table#styleBuiltIn~0:complex'
     name: >-

--- a/docs/docs-ref-autogen/word/word/word.tableborder.yml
+++ b/docs/docs-ref-autogen/word/word/word.tableborder.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.TableBorder#color:member'
@@ -164,7 +164,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'word!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'word!Word.TableBorder#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -273,7 +273,7 @@ items:
         type:
           - number
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.RequestContext:class'
     name: RequestContext
@@ -283,7 +283,7 @@ references:
     name: Word.Interfaces.TableBorderLoadOptions
   - uid: 'word!Word.Interfaces.TableBorderUpdateData:interface'
     name: Interfaces.TableBorderUpdateData
-  - uid: 'word!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'word!Word.Interfaces.TableBorderData:interface'
     name: Word.Interfaces.TableBorderData

--- a/docs/docs-ref-autogen/word/word/word.tablecell.yml
+++ b/docs/docs-ref-autogen/word/word/word.tablecell.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.TableCell#body:member'
@@ -557,7 +557,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'word!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'word!Word.TableCell#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -768,7 +768,7 @@ items:
         type:
           - number
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.Body:class'
     name: Word.Body
@@ -782,7 +782,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'word!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -793,7 +793,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'word!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -821,7 +821,7 @@ references:
     name: Word.Table
   - uid: 'word!Word.Interfaces.TableCellUpdateData:interface'
     name: Interfaces.TableCellUpdateData
-  - uid: 'word!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'word!Word.Interfaces.TableCellData:interface'
     name: Word.Interfaces.TableCellData

--- a/docs/docs-ref-autogen/word/word/word.tablecellcollection.yml
+++ b/docs/docs-ref-autogen/word/word/word.tablecellcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.TableCellCollection#context:member'
@@ -158,7 +158,7 @@ items:
         - id: option
           description: ''
           type:
-            - 'word!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'word!Word.TableCellCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -213,7 +213,7 @@ items:
           - 'word!Word.TableCellCollection:class'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.RequestContext:class'
     name: RequestContext
@@ -242,7 +242,7 @@ references:
       - uid: 'word!Word.Interfaces.CollectionLoadOptions:interface'
         name: Word.Interfaces.CollectionLoadOptions
         fullName: Word.Interfaces.CollectionLoadOptions
-  - uid: 'word!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'word!Word.Interfaces.TableCellCollectionData:interface'
     name: Word.Interfaces.TableCellCollectionData

--- a/docs/docs-ref-autogen/word/word/word.tablecollection.yml
+++ b/docs/docs-ref-autogen/word/word/word.tablecollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.TableCollection#context:member'
@@ -158,7 +158,7 @@ items:
         - id: option
           description: ''
           type:
-            - 'word!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'word!Word.TableCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -213,7 +213,7 @@ items:
           - 'word!Word.TableCollection:class'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.RequestContext:class'
     name: RequestContext
@@ -242,7 +242,7 @@ references:
       - uid: 'word!Word.Interfaces.CollectionLoadOptions:interface'
         name: Word.Interfaces.CollectionLoadOptions
         fullName: Word.Interfaces.CollectionLoadOptions
-  - uid: 'word!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'word!Word.Interfaces.TableCollectionData:interface'
     name: Word.Interfaces.TableCollectionData

--- a/docs/docs-ref-autogen/word/word/word.tablerow.yml
+++ b/docs/docs-ref-autogen/word/word/word.tablerow.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.TableRow#cellCount:member'
@@ -630,7 +630,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'word!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'word!Word.TableRow#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -798,7 +798,7 @@ items:
         type:
           - 'word!Word.TableRow#verticalAlignment~0:complex'
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.TableCellCollection:class'
     name: Word.TableCellCollection
@@ -814,7 +814,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'word!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -825,7 +825,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'word!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -904,7 +904,7 @@ references:
     name: Word.SelectionMode
   - uid: 'word!Word.Interfaces.TableRowUpdateData:interface'
     name: Interfaces.TableRowUpdateData
-  - uid: 'word!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'word!Word.Interfaces.TableRowData:interface'
     name: Word.Interfaces.TableRowData

--- a/docs/docs-ref-autogen/word/word/word.tablerowcollection.yml
+++ b/docs/docs-ref-autogen/word/word/word.tablerowcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.TableRowCollection#context:member'
@@ -158,7 +158,7 @@ items:
         - id: option
           description: ''
           type:
-            - 'word!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'word!Word.TableRowCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -213,7 +213,7 @@ items:
           - 'word!Word.TableRowCollection:class'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.RequestContext:class'
     name: RequestContext
@@ -242,7 +242,7 @@ references:
       - uid: 'word!Word.Interfaces.CollectionLoadOptions:interface'
         name: Word.Interfaces.CollectionLoadOptions
         fullName: Word.Interfaces.CollectionLoadOptions
-  - uid: 'word!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'word!Word.Interfaces.TableRowCollectionData:interface'
     name: Word.Interfaces.TableRowCollectionData

--- a/docs/docs-ref-autogen/word_1_1/word.yml
+++ b/docs/docs-ref-autogen/word_1_1/word.yml
@@ -179,7 +179,7 @@ items:
             A previously created API object. The batch will use the same RequestContext as the passed-in object, which
             means that any changes applied to the object will be picked up by "context.sync()".
           type:
-            - 'word!OfficeExtension.ClientObject:class'
+            - 'office!OfficeExtension.ClientObject:class'
         - id: batch
           description: >-
             A function that takes in a RequestContext and returns a promise (typically, just the result of
@@ -445,7 +445,7 @@ references:
     name: 'OfficeExtension.ClientObject[]'
     fullName: 'OfficeExtension.ClientObject[]'
     spec.typeScript:
-      - uid: 'word!OfficeExtension.ClientObject:class'
+      - uid: 'office!OfficeExtension.ClientObject:class'
         name: OfficeExtension.ClientObject
         fullName: OfficeExtension.ClientObject
       - name: '[]'
@@ -475,7 +475,7 @@ references:
         fullName: Promise
       - name: <T>
         fullName: <T>
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.run~4:complex'
     name: '(context: Word.RequestContext) => Promise<T>'

--- a/docs/docs-ref-autogen/word_1_1/word/word.body.yml
+++ b/docs/docs-ref-autogen/word_1_1/word/word.body.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.Body#clear:member(1)'
@@ -1185,7 +1185,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'word!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'word!Word.Body#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -1319,7 +1319,7 @@ items:
           - 'word!Word.Body:class'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.ContentControlCollection:class'
     name: Word.ContentControlCollection
@@ -1331,7 +1331,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'word!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -1340,7 +1340,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'word!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -1414,7 +1414,7 @@ references:
     name: Word.SelectionMode
   - uid: 'word!Word.Interfaces.BodyUpdateData:interface'
     name: Interfaces.BodyUpdateData
-  - uid: 'word!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'word!Word.Interfaces.BodyData:interface'
     name: Word.Interfaces.BodyData

--- a/docs/docs-ref-autogen/word_1_1/word/word.contentcontrol.yml
+++ b/docs/docs-ref-autogen/word_1_1/word/word.contentcontrol.yml
@@ -14,7 +14,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.ContentControl#appearance:member'
@@ -1392,7 +1392,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'word!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'word!Word.ContentControl#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -1581,7 +1581,7 @@ items:
           - 'word!Word.ContentControl:class'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.ContentControl#appearance~0:complex'
     name: Word.ContentControlAppearance | "BoundingBox" | "Tags" | "Hidden"
@@ -1602,7 +1602,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'word!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -1611,7 +1611,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'word!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -1683,7 +1683,7 @@ references:
     name: Word.SelectionMode
   - uid: 'word!Word.Interfaces.ContentControlUpdateData:interface'
     name: Interfaces.ContentControlUpdateData
-  - uid: 'word!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'word!Word.Interfaces.ContentControlData:interface'
     name: Word.Interfaces.ContentControlData

--- a/docs/docs-ref-autogen/word_1_1/word/word.contentcontrolcollection.yml
+++ b/docs/docs-ref-autogen/word_1_1/word/word.contentcontrolcollection.yml
@@ -15,7 +15,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.ContentControlCollection#context:member'
@@ -388,7 +388,7 @@ items:
         - id: option
           description: ''
           type:
-            - 'word!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'word!Word.ContentControlCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -443,7 +443,7 @@ items:
           - 'word!Word.ContentControlCollection:class'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.RequestContext:class'
     name: RequestContext
@@ -472,7 +472,7 @@ references:
       - uid: 'word!Word.Interfaces.CollectionLoadOptions:interface'
         name: Word.Interfaces.CollectionLoadOptions
         fullName: Word.Interfaces.CollectionLoadOptions
-  - uid: 'word!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'word!Word.Interfaces.ContentControlCollectionData:interface'
     name: Word.Interfaces.ContentControlCollectionData

--- a/docs/docs-ref-autogen/word_1_1/word/word.document.yml
+++ b/docs/docs-ref-autogen/word_1_1/word/word.document.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.Document#body:member'
@@ -364,7 +364,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'word!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'word!Word.Document#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -437,7 +437,7 @@ items:
           - 'word!Word.Document:class'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.Body:class'
     name: Word.Body
@@ -455,7 +455,7 @@ references:
     name: Word.SectionCollection
   - uid: 'word!Word.Interfaces.DocumentUpdateData:interface'
     name: Interfaces.DocumentUpdateData
-  - uid: 'word!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'word!Word.Interfaces.DocumentData:interface'
     name: Word.Interfaces.DocumentData

--- a/docs/docs-ref-autogen/word_1_1/word/word.font.yml
+++ b/docs/docs-ref-autogen/word_1_1/word/word.font.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.Font#bold:member'
@@ -377,7 +377,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'word!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'word!Word.Font#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -621,7 +621,7 @@ items:
           - 'word!Word.Font:class'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.RequestContext:class'
     name: RequestContext
@@ -631,7 +631,7 @@ references:
     name: Word.Interfaces.FontLoadOptions
   - uid: 'word!Word.Interfaces.FontUpdateData:interface'
     name: Interfaces.FontUpdateData
-  - uid: 'word!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'word!Word.Interfaces.FontData:interface'
     name: Word.Interfaces.FontData

--- a/docs/docs-ref-autogen/word_1_1/word/word.inlinepicture.yml
+++ b/docs/docs-ref-autogen/word_1_1/word/word.inlinepicture.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.InlinePicture#altTextDescription:member'
@@ -303,7 +303,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'word!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'word!Word.InlinePicture#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -391,7 +391,7 @@ items:
         type:
           - number
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.RequestContext:class'
     name: RequestContext
@@ -399,7 +399,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'word!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -412,7 +412,7 @@ references:
     name: Word.Interfaces.InlinePictureLoadOptions
   - uid: 'word!Word.Interfaces.InlinePictureUpdateData:interface'
     name: Interfaces.InlinePictureUpdateData
-  - uid: 'word!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'word!Word.Interfaces.InlinePictureData:interface'
     name: Word.Interfaces.InlinePictureData

--- a/docs/docs-ref-autogen/word_1_1/word/word.inlinepicturecollection.yml
+++ b/docs/docs-ref-autogen/word_1_1/word/word.inlinepicturecollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.InlinePictureCollection#context:member'
@@ -124,7 +124,7 @@ items:
         - id: option
           description: ''
           type:
-            - 'word!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'word!Word.InlinePictureCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -179,7 +179,7 @@ items:
           - 'word!Word.InlinePictureCollection:class'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.RequestContext:class'
     name: RequestContext
@@ -206,7 +206,7 @@ references:
       - uid: 'word!Word.Interfaces.CollectionLoadOptions:interface'
         name: Word.Interfaces.CollectionLoadOptions
         fullName: Word.Interfaces.CollectionLoadOptions
-  - uid: 'word!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'word!Word.Interfaces.InlinePictureCollectionData:interface'
     name: Word.Interfaces.InlinePictureCollectionData

--- a/docs/docs-ref-autogen/word_1_1/word/word.paragraph.yml
+++ b/docs/docs-ref-autogen/word_1_1/word/word.paragraph.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.Paragraph#alignment:member'
@@ -1392,7 +1392,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'word!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'word!Word.Paragraph#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -1567,7 +1567,7 @@ items:
           - 'word!Word.Paragraph:class'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.Paragraph#alignment~0:complex'
     name: Word.Alignment | "Mixed" | "Unknown" | "Left" | "Centered" | "Right" | "Justified"
@@ -1588,7 +1588,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'word!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -1597,7 +1597,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'word!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -1669,7 +1669,7 @@ references:
     name: Word.SelectionMode
   - uid: 'word!Word.Interfaces.ParagraphUpdateData:interface'
     name: Interfaces.ParagraphUpdateData
-  - uid: 'word!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'word!Word.Interfaces.ParagraphData:interface'
     name: Word.Interfaces.ParagraphData

--- a/docs/docs-ref-autogen/word_1_1/word/word.paragraphcollection.yml
+++ b/docs/docs-ref-autogen/word_1_1/word/word.paragraphcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.ParagraphCollection#context:member'
@@ -165,7 +165,7 @@ items:
         - id: option
           description: ''
           type:
-            - 'word!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'word!Word.ParagraphCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -220,7 +220,7 @@ items:
           - 'word!Word.ParagraphCollection:class'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.RequestContext:class'
     name: RequestContext
@@ -247,7 +247,7 @@ references:
       - uid: 'word!Word.Interfaces.CollectionLoadOptions:interface'
         name: Word.Interfaces.CollectionLoadOptions
         fullName: Word.Interfaces.CollectionLoadOptions
-  - uid: 'word!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'word!Word.Interfaces.ParagraphCollectionData:interface'
     name: Word.Interfaces.ParagraphCollectionData

--- a/docs/docs-ref-autogen/word_1_1/word/word.range.yml
+++ b/docs/docs-ref-autogen/word_1_1/word/word.range.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.Range#clear:member(1)'
@@ -1050,7 +1050,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'word!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'word!Word.Range#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -1155,7 +1155,7 @@ items:
           - 'word!Word.Range:class'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.ContentControlCollection:class'
     name: Word.ContentControlCollection
@@ -1167,7 +1167,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'word!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -1176,7 +1176,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'word!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -1246,7 +1246,7 @@ references:
     name: Word.SelectionMode
   - uid: 'word!Word.Interfaces.RangeUpdateData:interface'
     name: Interfaces.RangeUpdateData
-  - uid: 'word!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'word!Word.Interfaces.RangeData:interface'
     name: Word.Interfaces.RangeData

--- a/docs/docs-ref-autogen/word_1_1/word/word.rangecollection.yml
+++ b/docs/docs-ref-autogen/word_1_1/word/word.rangecollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.RangeCollection#context:member'
@@ -124,7 +124,7 @@ items:
         - id: option
           description: ''
           type:
-            - 'word!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'word!Word.RangeCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -179,7 +179,7 @@ items:
           - 'word!Word.RangeCollection:class'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.RequestContext:class'
     name: RequestContext
@@ -206,7 +206,7 @@ references:
       - uid: 'word!Word.Interfaces.CollectionLoadOptions:interface'
         name: Word.Interfaces.CollectionLoadOptions
         fullName: Word.Interfaces.CollectionLoadOptions
-  - uid: 'word!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'word!Word.Interfaces.RangeCollectionData:interface'
     name: Word.Interfaces.RangeCollectionData

--- a/docs/docs-ref-autogen/word_1_1/word/word.requestcontext.yml
+++ b/docs/docs-ref-autogen/word_1_1/word/word.requestcontext.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientRequestContext:class'
+      - 'office!OfficeExtension.ClientRequestContext:class'
     package: word!
     children:
       - 'word!Word.RequestContext:constructor(1)'
@@ -42,7 +42,7 @@ items:
         type:
           - 'word!Word.Document:class'
 references:
-  - uid: 'word!OfficeExtension.ClientRequestContext:class'
+  - uid: 'office!OfficeExtension.ClientRequestContext:class'
     name: OfficeExtension.ClientRequestContext
   - uid: 'word!Word.Document:class'
     name: Document

--- a/docs/docs-ref-autogen/word_1_1/word/word.searchoptions.yml
+++ b/docs/docs-ref-autogen/word_1_1/word/word.searchoptions.yml
@@ -16,7 +16,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.SearchOptions#context:member'
@@ -445,7 +445,7 @@ items:
         - id: context
           description: ''
           type:
-            - 'word!OfficeExtension.ClientRequestContext:class'
+            - 'office!OfficeExtension.ClientRequestContext:class'
   - uid: 'word!Word.SearchOptions#set:member(1)'
     summary: >-
       Sets multiple properties of an object at the same time. You can pass either a plain object with the appropriate
@@ -475,7 +475,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'word!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'word!Word.SearchOptions#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -513,7 +513,7 @@ items:
           - 'word!Word.Interfaces.SearchOptionsData:interface'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.RequestContext:class'
     name: RequestContext
@@ -521,11 +521,11 @@ references:
     name: Word.SearchOptions
   - uid: 'word!Word.Interfaces.SearchOptionsLoadOptions:interface'
     name: Word.Interfaces.SearchOptionsLoadOptions
-  - uid: 'word!OfficeExtension.ClientRequestContext:class'
+  - uid: 'office!OfficeExtension.ClientRequestContext:class'
     name: OfficeExtension.ClientRequestContext
   - uid: 'word!Word.Interfaces.SearchOptionsUpdateData:interface'
     name: Interfaces.SearchOptionsUpdateData
-  - uid: 'word!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'word!Word.Interfaces.SearchOptionsData:interface'
     name: Word.Interfaces.SearchOptionsData

--- a/docs/docs-ref-autogen/word_1_1/word/word.section.yml
+++ b/docs/docs-ref-autogen/word_1_1/word/word.section.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.Section#body:member'
@@ -372,7 +372,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'word!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'word!Word.Section#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -445,7 +445,7 @@ items:
           - 'word!Word.Section:class'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.Body:class'
     name: Word.Body
@@ -459,7 +459,7 @@ references:
     name: Word.Interfaces.SectionLoadOptions
   - uid: 'word!Word.Interfaces.SectionUpdateData:interface'
     name: Interfaces.SectionUpdateData
-  - uid: 'word!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'word!Word.Interfaces.SectionData:interface'
     name: Word.Interfaces.SectionData

--- a/docs/docs-ref-autogen/word_1_1/word/word.sectioncollection.yml
+++ b/docs/docs-ref-autogen/word_1_1/word/word.sectioncollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.SectionCollection#context:member'
@@ -124,7 +124,7 @@ items:
         - id: option
           description: ''
           type:
-            - 'word!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'word!Word.SectionCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -179,7 +179,7 @@ items:
           - 'word!Word.SectionCollection:class'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.RequestContext:class'
     name: RequestContext
@@ -206,7 +206,7 @@ references:
       - uid: 'word!Word.Interfaces.CollectionLoadOptions:interface'
         name: Word.Interfaces.CollectionLoadOptions
         fullName: Word.Interfaces.CollectionLoadOptions
-  - uid: 'word!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'word!Word.Interfaces.SectionCollectionData:interface'
     name: Word.Interfaces.SectionCollectionData

--- a/docs/docs-ref-autogen/word_1_2/word.yml
+++ b/docs/docs-ref-autogen/word_1_2/word.yml
@@ -179,7 +179,7 @@ items:
             A previously created API object. The batch will use the same RequestContext as the passed-in object, which
             means that any changes applied to the object will be picked up by "context.sync()".
           type:
-            - 'word!OfficeExtension.ClientObject:class'
+            - 'office!OfficeExtension.ClientObject:class'
         - id: batch
           description: >-
             A function that takes in a RequestContext and returns a promise (typically, just the result of
@@ -445,7 +445,7 @@ references:
     name: 'OfficeExtension.ClientObject[]'
     fullName: 'OfficeExtension.ClientObject[]'
     spec.typeScript:
-      - uid: 'word!OfficeExtension.ClientObject:class'
+      - uid: 'office!OfficeExtension.ClientObject:class'
         name: OfficeExtension.ClientObject
         fullName: OfficeExtension.ClientObject
       - name: '[]'
@@ -475,7 +475,7 @@ references:
         fullName: Promise
       - name: <T>
         fullName: <T>
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.run~4:complex'
     name: '(context: Word.RequestContext) => Promise<T>'

--- a/docs/docs-ref-autogen/word_1_2/word/word.body.yml
+++ b/docs/docs-ref-autogen/word_1_2/word/word.body.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.Body#clear:member(1)'
@@ -1274,7 +1274,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'word!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'word!Word.Body#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -1408,7 +1408,7 @@ items:
           - 'word!Word.Body:class'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.ContentControlCollection:class'
     name: Word.ContentControlCollection
@@ -1420,7 +1420,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'word!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -1429,7 +1429,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'word!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -1505,7 +1505,7 @@ references:
     name: Word.SelectionMode
   - uid: 'word!Word.Interfaces.BodyUpdateData:interface'
     name: Interfaces.BodyUpdateData
-  - uid: 'word!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'word!Word.Interfaces.BodyData:interface'
     name: Word.Interfaces.BodyData

--- a/docs/docs-ref-autogen/word_1_2/word/word.contentcontrol.yml
+++ b/docs/docs-ref-autogen/word_1_2/word/word.contentcontrol.yml
@@ -14,7 +14,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.ContentControl#appearance:member'
@@ -1452,7 +1452,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'word!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'word!Word.ContentControl#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -1641,7 +1641,7 @@ items:
           - 'word!Word.ContentControl:class'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.ContentControl#appearance~0:complex'
     name: Word.ContentControlAppearance | "BoundingBox" | "Tags" | "Hidden"
@@ -1662,7 +1662,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'word!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -1671,7 +1671,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'word!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -1745,7 +1745,7 @@ references:
     name: Word.SelectionMode
   - uid: 'word!Word.Interfaces.ContentControlUpdateData:interface'
     name: Interfaces.ContentControlUpdateData
-  - uid: 'word!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'word!Word.Interfaces.ContentControlData:interface'
     name: Word.Interfaces.ContentControlData

--- a/docs/docs-ref-autogen/word_1_2/word/word.contentcontrolcollection.yml
+++ b/docs/docs-ref-autogen/word_1_2/word/word.contentcontrolcollection.yml
@@ -15,7 +15,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.ContentControlCollection#context:member'
@@ -388,7 +388,7 @@ items:
         - id: option
           description: ''
           type:
-            - 'word!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'word!Word.ContentControlCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -443,7 +443,7 @@ items:
           - 'word!Word.ContentControlCollection:class'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.RequestContext:class'
     name: RequestContext
@@ -472,7 +472,7 @@ references:
       - uid: 'word!Word.Interfaces.CollectionLoadOptions:interface'
         name: Word.Interfaces.CollectionLoadOptions
         fullName: Word.Interfaces.CollectionLoadOptions
-  - uid: 'word!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'word!Word.Interfaces.ContentControlCollectionData:interface'
     name: Word.Interfaces.ContentControlCollectionData

--- a/docs/docs-ref-autogen/word_1_2/word/word.document.yml
+++ b/docs/docs-ref-autogen/word_1_2/word/word.document.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.Document#body:member'
@@ -364,7 +364,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'word!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'word!Word.Document#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -437,7 +437,7 @@ items:
           - 'word!Word.Document:class'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.Body:class'
     name: Word.Body
@@ -455,7 +455,7 @@ references:
     name: Word.SectionCollection
   - uid: 'word!Word.Interfaces.DocumentUpdateData:interface'
     name: Interfaces.DocumentUpdateData
-  - uid: 'word!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'word!Word.Interfaces.DocumentData:interface'
     name: Word.Interfaces.DocumentData

--- a/docs/docs-ref-autogen/word_1_2/word/word.font.yml
+++ b/docs/docs-ref-autogen/word_1_2/word/word.font.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.Font#bold:member'
@@ -377,7 +377,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'word!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'word!Word.Font#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -621,7 +621,7 @@ items:
           - 'word!Word.Font:class'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.RequestContext:class'
     name: RequestContext
@@ -631,7 +631,7 @@ references:
     name: Word.Interfaces.FontLoadOptions
   - uid: 'word!Word.Interfaces.FontUpdateData:interface'
     name: Interfaces.FontUpdateData
-  - uid: 'word!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'word!Word.Interfaces.FontData:interface'
     name: Word.Interfaces.FontData

--- a/docs/docs-ref-autogen/word_1_2/word/word.inlinepicture.yml
+++ b/docs/docs-ref-autogen/word_1_2/word/word.inlinepicture.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.InlinePicture#altTextDescription:member'
@@ -754,7 +754,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'word!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'word!Word.InlinePicture#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -842,7 +842,7 @@ items:
         type:
           - number
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.RequestContext:class'
     name: RequestContext
@@ -850,7 +850,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'word!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -873,7 +873,7 @@ references:
     name: Word.SelectionMode
   - uid: 'word!Word.Interfaces.InlinePictureUpdateData:interface'
     name: Interfaces.InlinePictureUpdateData
-  - uid: 'word!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'word!Word.Interfaces.InlinePictureData:interface'
     name: Word.Interfaces.InlinePictureData

--- a/docs/docs-ref-autogen/word_1_2/word/word.inlinepicturecollection.yml
+++ b/docs/docs-ref-autogen/word_1_2/word/word.inlinepicturecollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.InlinePictureCollection#context:member'
@@ -124,7 +124,7 @@ items:
         - id: option
           description: ''
           type:
-            - 'word!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'word!Word.InlinePictureCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -179,7 +179,7 @@ items:
           - 'word!Word.InlinePictureCollection:class'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.RequestContext:class'
     name: RequestContext
@@ -206,7 +206,7 @@ references:
       - uid: 'word!Word.Interfaces.CollectionLoadOptions:interface'
         name: Word.Interfaces.CollectionLoadOptions
         fullName: Word.Interfaces.CollectionLoadOptions
-  - uid: 'word!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'word!Word.Interfaces.InlinePictureCollectionData:interface'
     name: Word.Interfaces.InlinePictureCollectionData

--- a/docs/docs-ref-autogen/word_1_2/word/word.paragraph.yml
+++ b/docs/docs-ref-autogen/word_1_2/word/word.paragraph.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.Paragraph#alignment:member'
@@ -1392,7 +1392,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'word!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'word!Word.Paragraph#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -1567,7 +1567,7 @@ items:
           - 'word!Word.Paragraph:class'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.Paragraph#alignment~0:complex'
     name: Word.Alignment | "Mixed" | "Unknown" | "Left" | "Centered" | "Right" | "Justified"
@@ -1588,7 +1588,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'word!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -1597,7 +1597,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'word!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -1669,7 +1669,7 @@ references:
     name: Word.SelectionMode
   - uid: 'word!Word.Interfaces.ParagraphUpdateData:interface'
     name: Interfaces.ParagraphUpdateData
-  - uid: 'word!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'word!Word.Interfaces.ParagraphData:interface'
     name: Word.Interfaces.ParagraphData

--- a/docs/docs-ref-autogen/word_1_2/word/word.paragraphcollection.yml
+++ b/docs/docs-ref-autogen/word_1_2/word/word.paragraphcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.ParagraphCollection#context:member'
@@ -165,7 +165,7 @@ items:
         - id: option
           description: ''
           type:
-            - 'word!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'word!Word.ParagraphCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -220,7 +220,7 @@ items:
           - 'word!Word.ParagraphCollection:class'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.RequestContext:class'
     name: RequestContext
@@ -247,7 +247,7 @@ references:
       - uid: 'word!Word.Interfaces.CollectionLoadOptions:interface'
         name: Word.Interfaces.CollectionLoadOptions
         fullName: Word.Interfaces.CollectionLoadOptions
-  - uid: 'word!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'word!Word.Interfaces.ParagraphCollectionData:interface'
     name: Word.Interfaces.ParagraphCollectionData

--- a/docs/docs-ref-autogen/word_1_2/word/word.range.yml
+++ b/docs/docs-ref-autogen/word_1_2/word/word.range.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.Range#clear:member(1)'
@@ -1122,7 +1122,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'word!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'word!Word.Range#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -1227,7 +1227,7 @@ items:
           - 'word!Word.Range:class'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.ContentControlCollection:class'
     name: Word.ContentControlCollection
@@ -1239,7 +1239,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'word!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -1248,7 +1248,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'word!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -1322,7 +1322,7 @@ references:
     name: Word.SelectionMode
   - uid: 'word!Word.Interfaces.RangeUpdateData:interface'
     name: Interfaces.RangeUpdateData
-  - uid: 'word!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'word!Word.Interfaces.RangeData:interface'
     name: Word.Interfaces.RangeData

--- a/docs/docs-ref-autogen/word_1_2/word/word.rangecollection.yml
+++ b/docs/docs-ref-autogen/word_1_2/word/word.rangecollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.RangeCollection#context:member'
@@ -124,7 +124,7 @@ items:
         - id: option
           description: ''
           type:
-            - 'word!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'word!Word.RangeCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -179,7 +179,7 @@ items:
           - 'word!Word.RangeCollection:class'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.RequestContext:class'
     name: RequestContext
@@ -206,7 +206,7 @@ references:
       - uid: 'word!Word.Interfaces.CollectionLoadOptions:interface'
         name: Word.Interfaces.CollectionLoadOptions
         fullName: Word.Interfaces.CollectionLoadOptions
-  - uid: 'word!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'word!Word.Interfaces.RangeCollectionData:interface'
     name: Word.Interfaces.RangeCollectionData

--- a/docs/docs-ref-autogen/word_1_2/word/word.requestcontext.yml
+++ b/docs/docs-ref-autogen/word_1_2/word/word.requestcontext.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientRequestContext:class'
+      - 'office!OfficeExtension.ClientRequestContext:class'
     package: word!
     children:
       - 'word!Word.RequestContext:constructor(1)'
@@ -42,7 +42,7 @@ items:
         type:
           - 'word!Word.Document:class'
 references:
-  - uid: 'word!OfficeExtension.ClientRequestContext:class'
+  - uid: 'office!OfficeExtension.ClientRequestContext:class'
     name: OfficeExtension.ClientRequestContext
   - uid: 'word!Word.Document:class'
     name: Document

--- a/docs/docs-ref-autogen/word_1_2/word/word.searchoptions.yml
+++ b/docs/docs-ref-autogen/word_1_2/word/word.searchoptions.yml
@@ -16,7 +16,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.SearchOptions#context:member'
@@ -445,7 +445,7 @@ items:
         - id: context
           description: ''
           type:
-            - 'word!OfficeExtension.ClientRequestContext:class'
+            - 'office!OfficeExtension.ClientRequestContext:class'
   - uid: 'word!Word.SearchOptions#set:member(1)'
     summary: >-
       Sets multiple properties of an object at the same time. You can pass either a plain object with the appropriate
@@ -475,7 +475,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'word!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'word!Word.SearchOptions#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -513,7 +513,7 @@ items:
           - 'word!Word.Interfaces.SearchOptionsData:interface'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.RequestContext:class'
     name: RequestContext
@@ -521,11 +521,11 @@ references:
     name: Word.SearchOptions
   - uid: 'word!Word.Interfaces.SearchOptionsLoadOptions:interface'
     name: Word.Interfaces.SearchOptionsLoadOptions
-  - uid: 'word!OfficeExtension.ClientRequestContext:class'
+  - uid: 'office!OfficeExtension.ClientRequestContext:class'
     name: OfficeExtension.ClientRequestContext
   - uid: 'word!Word.Interfaces.SearchOptionsUpdateData:interface'
     name: Interfaces.SearchOptionsUpdateData
-  - uid: 'word!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'word!Word.Interfaces.SearchOptionsData:interface'
     name: Word.Interfaces.SearchOptionsData

--- a/docs/docs-ref-autogen/word_1_2/word/word.section.yml
+++ b/docs/docs-ref-autogen/word_1_2/word/word.section.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.Section#body:member'
@@ -372,7 +372,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'word!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'word!Word.Section#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -445,7 +445,7 @@ items:
           - 'word!Word.Section:class'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.Body:class'
     name: Word.Body
@@ -459,7 +459,7 @@ references:
     name: Word.Interfaces.SectionLoadOptions
   - uid: 'word!Word.Interfaces.SectionUpdateData:interface'
     name: Interfaces.SectionUpdateData
-  - uid: 'word!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'word!Word.Interfaces.SectionData:interface'
     name: Word.Interfaces.SectionData

--- a/docs/docs-ref-autogen/word_1_2/word/word.sectioncollection.yml
+++ b/docs/docs-ref-autogen/word_1_2/word/word.sectioncollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.SectionCollection#context:member'
@@ -124,7 +124,7 @@ items:
         - id: option
           description: ''
           type:
-            - 'word!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'word!Word.SectionCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -179,7 +179,7 @@ items:
           - 'word!Word.SectionCollection:class'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.RequestContext:class'
     name: RequestContext
@@ -206,7 +206,7 @@ references:
       - uid: 'word!Word.Interfaces.CollectionLoadOptions:interface'
         name: Word.Interfaces.CollectionLoadOptions
         fullName: Word.Interfaces.CollectionLoadOptions
-  - uid: 'word!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'word!Word.Interfaces.SectionCollectionData:interface'
     name: Word.Interfaces.SectionCollectionData

--- a/docs/docs-ref-autogen/word_1_3/word.yml
+++ b/docs/docs-ref-autogen/word_1_3/word.yml
@@ -208,7 +208,7 @@ items:
             A previously created API object. The batch will use the same RequestContext as the passed-in object, which
             means that any changes applied to the object will be picked up by "context.sync()".
           type:
-            - 'word!OfficeExtension.ClientObject:class'
+            - 'office!OfficeExtension.ClientObject:class'
         - id: batch
           description: >-
             A function that takes in a RequestContext and returns a promise (typically, just the result of
@@ -518,7 +518,7 @@ references:
     name: 'OfficeExtension.ClientObject[]'
     fullName: 'OfficeExtension.ClientObject[]'
     spec.typeScript:
-      - uid: 'word!OfficeExtension.ClientObject:class'
+      - uid: 'office!OfficeExtension.ClientObject:class'
         name: OfficeExtension.ClientObject
         fullName: OfficeExtension.ClientObject
       - name: '[]'
@@ -548,7 +548,7 @@ references:
         fullName: Promise
       - name: <T>
         fullName: <T>
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.run~4:complex'
     name: '(context: Word.RequestContext) => Promise<T>'

--- a/docs/docs-ref-autogen/word_1_3/word/word.application.yml
+++ b/docs/docs-ref-autogen/word_1_3/word/word.application.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.Application#context:member'
@@ -70,7 +70,7 @@ items:
         - id: context
           description: ''
           type:
-            - 'word!OfficeExtension.ClientRequestContext:class'
+            - 'office!OfficeExtension.ClientRequestContext:class'
   - uid: 'word!Word.Application#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -96,7 +96,7 @@ items:
                     }
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.RequestContext:class'
     name: RequestContext
@@ -104,5 +104,5 @@ references:
     name: Word.DocumentCreated
   - uid: 'word!Word.Application:class'
     name: Word.Application
-  - uid: 'word!OfficeExtension.ClientRequestContext:class'
+  - uid: 'office!OfficeExtension.ClientRequestContext:class'
     name: OfficeExtension.ClientRequestContext

--- a/docs/docs-ref-autogen/word_1_3/word/word.body.yml
+++ b/docs/docs-ref-autogen/word_1_3/word/word.body.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.Body#clear:member(1)'
@@ -1519,7 +1519,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'word!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'word!Word.Body#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -1731,7 +1731,7 @@ items:
           - 'word!Word.Body:class'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.ContentControlCollection:class'
     name: Word.ContentControlCollection
@@ -1743,7 +1743,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'word!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -1752,7 +1752,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'word!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -1836,7 +1836,7 @@ references:
     name: Word.SelectionMode
   - uid: 'word!Word.Interfaces.BodyUpdateData:interface'
     name: Interfaces.BodyUpdateData
-  - uid: 'word!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'word!Word.Body#styleBuiltIn~0:complex'
     name: >-

--- a/docs/docs-ref-autogen/word_1_3/word/word.contentcontrol.yml
+++ b/docs/docs-ref-autogen/word_1_3/word/word.contentcontrol.yml
@@ -14,7 +14,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.ContentControl#appearance:member'
@@ -1725,7 +1725,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'word!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'word!Word.ContentControl#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -2040,7 +2040,7 @@ items:
           - 'word!Word.ContentControl:class'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.ContentControl#appearance~0:complex'
     name: Word.ContentControlAppearance | "BoundingBox" | "Tags" | "Hidden"
@@ -2061,7 +2061,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'word!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -2070,7 +2070,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'word!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -2154,7 +2154,7 @@ references:
     name: Word.SelectionMode
   - uid: 'word!Word.Interfaces.ContentControlUpdateData:interface'
     name: Interfaces.ContentControlUpdateData
-  - uid: 'word!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'word!Word.ContentControl#styleBuiltIn~0:complex'
     name: >-

--- a/docs/docs-ref-autogen/word_1_3/word/word.contentcontrolcollection.yml
+++ b/docs/docs-ref-autogen/word_1_3/word/word.contentcontrolcollection.yml
@@ -15,7 +15,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.ContentControlCollection#context:member'
@@ -530,7 +530,7 @@ items:
         - id: option
           description: ''
           type:
-            - 'word!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'word!Word.ContentControlCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -585,7 +585,7 @@ items:
           - 'word!Word.ContentControlCollection:class'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.RequestContext:class'
     name: RequestContext
@@ -623,7 +623,7 @@ references:
       - uid: 'word!Word.Interfaces.CollectionLoadOptions:interface'
         name: Word.Interfaces.CollectionLoadOptions
         fullName: Word.Interfaces.CollectionLoadOptions
-  - uid: 'word!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'word!Word.Interfaces.ContentControlCollectionData:interface'
     name: Word.Interfaces.ContentControlCollectionData

--- a/docs/docs-ref-autogen/word_1_3/word/word.customproperty.yml
+++ b/docs/docs-ref-autogen/word_1_3/word/word.customproperty.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.CustomProperty#context:member'
@@ -181,7 +181,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'word!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'word!Word.CustomProperty#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -287,7 +287,7 @@ items:
         type:
           - any
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.RequestContext:class'
     name: RequestContext
@@ -297,7 +297,7 @@ references:
     name: Word.Interfaces.CustomPropertyLoadOptions
   - uid: 'word!Word.Interfaces.CustomPropertyUpdateData:interface'
     name: Interfaces.CustomPropertyUpdateData
-  - uid: 'word!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'word!Word.Interfaces.CustomPropertyData:interface'
     name: Word.Interfaces.CustomPropertyData

--- a/docs/docs-ref-autogen/word_1_3/word/word.custompropertycollection.yml
+++ b/docs/docs-ref-autogen/word_1_3/word/word.custompropertycollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.CustomPropertyCollection#add:member(1)'
@@ -285,7 +285,7 @@ items:
         - id: option
           description: ''
           type:
-            - 'word!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'word!Word.CustomPropertyCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -340,7 +340,7 @@ items:
           - 'word!Word.CustomPropertyCollection:class'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.CustomProperty:class'
     name: Word.CustomProperty
@@ -350,7 +350,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'word!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -378,7 +378,7 @@ references:
       - uid: 'word!Word.Interfaces.CollectionLoadOptions:interface'
         name: Word.Interfaces.CollectionLoadOptions
         fullName: Word.Interfaces.CollectionLoadOptions
-  - uid: 'word!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'word!Word.Interfaces.CustomPropertyCollectionData:interface'
     name: Word.Interfaces.CustomPropertyCollectionData

--- a/docs/docs-ref-autogen/word_1_3/word/word.document.yml
+++ b/docs/docs-ref-autogen/word_1_3/word/word.document.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.Document#body:member'
@@ -400,7 +400,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'word!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'word!Word.Document#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -473,7 +473,7 @@ items:
           - 'word!Word.Document:class'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.Body:class'
     name: Word.Body
@@ -493,7 +493,7 @@ references:
     name: Word.SectionCollection
   - uid: 'word!Word.Interfaces.DocumentUpdateData:interface'
     name: Interfaces.DocumentUpdateData
-  - uid: 'word!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'word!Word.Interfaces.DocumentData:interface'
     name: Word.Interfaces.DocumentData

--- a/docs/docs-ref-autogen/word_1_3/word/word.documentcreated.yml
+++ b/docs/docs-ref-autogen/word_1_3/word/word.documentcreated.yml
@@ -13,7 +13,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.DocumentCreated#body:member'
@@ -277,7 +277,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'word!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'word!Word.DocumentCreated#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -350,7 +350,7 @@ items:
           - 'word!Word.DocumentCreated:class'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.Body:class'
     name: Word.Body
@@ -368,7 +368,7 @@ references:
     name: Word.SectionCollection
   - uid: 'word!Word.Interfaces.DocumentCreatedUpdateData:interface'
     name: Interfaces.DocumentCreatedUpdateData
-  - uid: 'word!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'word!Word.Interfaces.DocumentCreatedData:interface'
     name: Word.Interfaces.DocumentCreatedData

--- a/docs/docs-ref-autogen/word_1_3/word/word.documentproperties.yml
+++ b/docs/docs-ref-autogen/word_1_3/word/word.documentproperties.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.DocumentProperties#applicationName:member'
@@ -396,7 +396,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'word!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'word!Word.DocumentProperties#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -514,7 +514,7 @@ items:
           - 'word!Word.DocumentProperties:class'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.RequestContext:class'
     name: RequestContext
@@ -528,7 +528,7 @@ references:
     name: Word.Interfaces.DocumentPropertiesLoadOptions
   - uid: 'word!Word.Interfaces.DocumentPropertiesUpdateData:interface'
     name: Interfaces.DocumentPropertiesUpdateData
-  - uid: 'word!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'word!Word.Interfaces.DocumentPropertiesData:interface'
     name: Word.Interfaces.DocumentPropertiesData

--- a/docs/docs-ref-autogen/word_1_3/word/word.font.yml
+++ b/docs/docs-ref-autogen/word_1_3/word/word.font.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.Font#bold:member'
@@ -377,7 +377,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'word!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'word!Word.Font#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -621,7 +621,7 @@ items:
           - 'word!Word.Font:class'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.RequestContext:class'
     name: RequestContext
@@ -631,7 +631,7 @@ references:
     name: Word.Interfaces.FontLoadOptions
   - uid: 'word!Word.Interfaces.FontUpdateData:interface'
     name: Interfaces.FontUpdateData
-  - uid: 'word!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'word!Word.Interfaces.FontData:interface'
     name: Word.Interfaces.FontData

--- a/docs/docs-ref-autogen/word_1_3/word/word.inlinepicture.yml
+++ b/docs/docs-ref-autogen/word_1_3/word/word.inlinepicture.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.InlinePicture#altTextDescription:member'
@@ -982,7 +982,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'word!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'word!Word.InlinePicture#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -1070,7 +1070,7 @@ items:
         type:
           - number
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.RequestContext:class'
     name: RequestContext
@@ -1078,7 +1078,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'word!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -1107,7 +1107,7 @@ references:
     name: Word.SelectionMode
   - uid: 'word!Word.Interfaces.InlinePictureUpdateData:interface'
     name: Interfaces.InlinePictureUpdateData
-  - uid: 'word!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'word!Word.Interfaces.InlinePictureData:interface'
     name: Word.Interfaces.InlinePictureData

--- a/docs/docs-ref-autogen/word_1_3/word/word.inlinepicturecollection.yml
+++ b/docs/docs-ref-autogen/word_1_3/word/word.inlinepicturecollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.InlinePictureCollection#context:member'
@@ -158,7 +158,7 @@ items:
         - id: option
           description: ''
           type:
-            - 'word!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'word!Word.InlinePictureCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -213,7 +213,7 @@ items:
           - 'word!Word.InlinePictureCollection:class'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.RequestContext:class'
     name: RequestContext
@@ -242,7 +242,7 @@ references:
       - uid: 'word!Word.Interfaces.CollectionLoadOptions:interface'
         name: Word.Interfaces.CollectionLoadOptions
         fullName: Word.Interfaces.CollectionLoadOptions
-  - uid: 'word!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'word!Word.Interfaces.InlinePictureCollectionData:interface'
     name: Word.Interfaces.InlinePictureCollectionData

--- a/docs/docs-ref-autogen/word_1_3/word/word.list.yml
+++ b/docs/docs-ref-autogen/word_1_3/word/word.list.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.List#context:member'
@@ -587,7 +587,7 @@ items:
           - 'word!Word.List:class'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.RequestContext:class'
     name: RequestContext
@@ -597,7 +597,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'word!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>

--- a/docs/docs-ref-autogen/word_1_3/word/word.listcollection.yml
+++ b/docs/docs-ref-autogen/word_1_3/word/word.listcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.ListCollection#context:member'
@@ -224,7 +224,7 @@ items:
         - id: option
           description: ''
           type:
-            - 'word!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'word!Word.ListCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -279,7 +279,7 @@ items:
           - 'word!Word.ListCollection:class'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.RequestContext:class'
     name: RequestContext
@@ -308,7 +308,7 @@ references:
       - uid: 'word!Word.Interfaces.CollectionLoadOptions:interface'
         name: Word.Interfaces.CollectionLoadOptions
         fullName: Word.Interfaces.CollectionLoadOptions
-  - uid: 'word!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'word!Word.Interfaces.ListCollectionData:interface'
     name: Word.Interfaces.ListCollectionData

--- a/docs/docs-ref-autogen/word_1_3/word/word.listitem.yml
+++ b/docs/docs-ref-autogen/word_1_3/word/word.listitem.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.ListItem#context:member'
@@ -255,7 +255,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'word!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'word!Word.ListItem#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -343,7 +343,7 @@ items:
           - 'word!Word.ListItem:class'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.RequestContext:class'
     name: RequestContext
@@ -357,7 +357,7 @@ references:
     name: Word.Interfaces.ListItemLoadOptions
   - uid: 'word!Word.Interfaces.ListItemUpdateData:interface'
     name: Interfaces.ListItemUpdateData
-  - uid: 'word!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'word!Word.Interfaces.ListItemData:interface'
     name: Word.Interfaces.ListItemData

--- a/docs/docs-ref-autogen/word_1_3/word/word.paragraph.yml
+++ b/docs/docs-ref-autogen/word_1_3/word/word.paragraph.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.Paragraph#alignment:member'
@@ -1894,7 +1894,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'word!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'word!Word.Paragraph#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -2245,7 +2245,7 @@ items:
           - 'word!Word.Paragraph:class'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.Paragraph#alignment~0:complex'
     name: Word.Alignment | "Mixed" | "Unknown" | "Left" | "Centered" | "Right" | "Justified"
@@ -2268,7 +2268,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'word!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -2279,7 +2279,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'word!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -2359,7 +2359,7 @@ references:
     name: Word.SelectionMode
   - uid: 'word!Word.Interfaces.ParagraphUpdateData:interface'
     name: Interfaces.ParagraphUpdateData
-  - uid: 'word!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'word!Word.Paragraph#styleBuiltIn~0:complex'
     name: >-

--- a/docs/docs-ref-autogen/word_1_3/word/word.paragraphcollection.yml
+++ b/docs/docs-ref-autogen/word_1_3/word/word.paragraphcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.ParagraphCollection#context:member'
@@ -233,7 +233,7 @@ items:
         - id: option
           description: ''
           type:
-            - 'word!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'word!Word.ParagraphCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -288,7 +288,7 @@ items:
           - 'word!Word.ParagraphCollection:class'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.RequestContext:class'
     name: RequestContext
@@ -317,7 +317,7 @@ references:
       - uid: 'word!Word.Interfaces.CollectionLoadOptions:interface'
         name: Word.Interfaces.CollectionLoadOptions
         fullName: Word.Interfaces.CollectionLoadOptions
-  - uid: 'word!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'word!Word.Interfaces.ParagraphCollectionData:interface'
     name: Word.Interfaces.ParagraphCollectionData

--- a/docs/docs-ref-autogen/word_1_3/word/word.range.yml
+++ b/docs/docs-ref-autogen/word_1_3/word/word.range.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.Range#clear:member(1)'
@@ -1655,7 +1655,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'word!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'word!Word.Range#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -1865,13 +1865,13 @@ items:
           - 'word!Word.Range:class'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.Range#compareLocationWith~0:complex'
     name: OfficeExtension.ClientResult<Word.LocationRelation>
     fullName: OfficeExtension.ClientResult<Word.LocationRelation>
     spec.typeScript:
-      - uid: 'word!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <
@@ -1893,7 +1893,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'word!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -1904,7 +1904,7 @@ references:
     name: OfficeExtension.ClientResult<string>
     fullName: OfficeExtension.ClientResult<string>
     spec.typeScript:
-      - uid: 'word!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <string>
@@ -1984,7 +1984,7 @@ references:
     name: Word.SelectionMode
   - uid: 'word!Word.Interfaces.RangeUpdateData:interface'
     name: Interfaces.RangeUpdateData
-  - uid: 'word!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'word!Word.Range#styleBuiltIn~0:complex'
     name: >-

--- a/docs/docs-ref-autogen/word_1_3/word/word.rangecollection.yml
+++ b/docs/docs-ref-autogen/word_1_3/word/word.rangecollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.RangeCollection#context:member'
@@ -158,7 +158,7 @@ items:
         - id: option
           description: ''
           type:
-            - 'word!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'word!Word.RangeCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -213,7 +213,7 @@ items:
           - 'word!Word.RangeCollection:class'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.RequestContext:class'
     name: RequestContext
@@ -242,7 +242,7 @@ references:
       - uid: 'word!Word.Interfaces.CollectionLoadOptions:interface'
         name: Word.Interfaces.CollectionLoadOptions
         fullName: Word.Interfaces.CollectionLoadOptions
-  - uid: 'word!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'word!Word.Interfaces.RangeCollectionData:interface'
     name: Word.Interfaces.RangeCollectionData

--- a/docs/docs-ref-autogen/word_1_3/word/word.requestcontext.yml
+++ b/docs/docs-ref-autogen/word_1_3/word/word.requestcontext.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientRequestContext:class'
+      - 'office!OfficeExtension.ClientRequestContext:class'
     package: word!
     children:
       - 'word!Word.RequestContext:constructor(1)'
@@ -55,7 +55,7 @@ items:
         type:
           - 'word!Word.Document:class'
 references:
-  - uid: 'word!OfficeExtension.ClientRequestContext:class'
+  - uid: 'office!OfficeExtension.ClientRequestContext:class'
     name: OfficeExtension.ClientRequestContext
   - uid: 'word!Word.Application:class'
     name: Application

--- a/docs/docs-ref-autogen/word_1_3/word/word.searchoptions.yml
+++ b/docs/docs-ref-autogen/word_1_3/word/word.searchoptions.yml
@@ -16,7 +16,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.SearchOptions#context:member'
@@ -445,7 +445,7 @@ items:
         - id: context
           description: ''
           type:
-            - 'word!OfficeExtension.ClientRequestContext:class'
+            - 'office!OfficeExtension.ClientRequestContext:class'
   - uid: 'word!Word.SearchOptions#set:member(1)'
     summary: >-
       Sets multiple properties of an object at the same time. You can pass either a plain object with the appropriate
@@ -475,7 +475,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'word!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'word!Word.SearchOptions#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -513,7 +513,7 @@ items:
           - 'word!Word.Interfaces.SearchOptionsData:interface'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.RequestContext:class'
     name: RequestContext
@@ -521,11 +521,11 @@ references:
     name: Word.SearchOptions
   - uid: 'word!Word.Interfaces.SearchOptionsLoadOptions:interface'
     name: Word.Interfaces.SearchOptionsLoadOptions
-  - uid: 'word!OfficeExtension.ClientRequestContext:class'
+  - uid: 'office!OfficeExtension.ClientRequestContext:class'
     name: OfficeExtension.ClientRequestContext
   - uid: 'word!Word.Interfaces.SearchOptionsUpdateData:interface'
     name: Interfaces.SearchOptionsUpdateData
-  - uid: 'word!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'word!Word.Interfaces.SearchOptionsData:interface'
     name: Word.Interfaces.SearchOptionsData

--- a/docs/docs-ref-autogen/word_1_3/word/word.section.yml
+++ b/docs/docs-ref-autogen/word_1_3/word/word.section.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.Section#body:member'
@@ -406,7 +406,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'word!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'word!Word.Section#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -479,7 +479,7 @@ items:
           - 'word!Word.Section:class'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.Body:class'
     name: Word.Body
@@ -493,7 +493,7 @@ references:
     name: Word.Interfaces.SectionLoadOptions
   - uid: 'word!Word.Interfaces.SectionUpdateData:interface'
     name: Interfaces.SectionUpdateData
-  - uid: 'word!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'word!Word.Interfaces.SectionData:interface'
     name: Word.Interfaces.SectionData

--- a/docs/docs-ref-autogen/word_1_3/word/word.sectioncollection.yml
+++ b/docs/docs-ref-autogen/word_1_3/word/word.sectioncollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.SectionCollection#context:member'
@@ -158,7 +158,7 @@ items:
         - id: option
           description: ''
           type:
-            - 'word!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'word!Word.SectionCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -213,7 +213,7 @@ items:
           - 'word!Word.SectionCollection:class'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.RequestContext:class'
     name: RequestContext
@@ -242,7 +242,7 @@ references:
       - uid: 'word!Word.Interfaces.CollectionLoadOptions:interface'
         name: Word.Interfaces.CollectionLoadOptions
         fullName: Word.Interfaces.CollectionLoadOptions
-  - uid: 'word!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'word!Word.Interfaces.SectionCollectionData:interface'
     name: Word.Interfaces.SectionCollectionData

--- a/docs/docs-ref-autogen/word_1_3/word/word.table.yml
+++ b/docs/docs-ref-autogen/word_1_3/word/word.table.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.Table#addColumns:member(1)'
@@ -1195,7 +1195,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'word!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'word!Word.Table#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -1533,7 +1533,7 @@ items:
         type:
           - number
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.InsertLocation:enum'
     name: Word.InsertLocation
@@ -1562,7 +1562,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'word!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -1573,7 +1573,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'word!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -1652,7 +1652,7 @@ references:
     name: Word.SelectionMode
   - uid: 'word!Word.Interfaces.TableUpdateData:interface'
     name: Interfaces.TableUpdateData
-  - uid: 'word!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'word!Word.Table#styleBuiltIn~0:complex'
     name: >-

--- a/docs/docs-ref-autogen/word_1_3/word/word.tableborder.yml
+++ b/docs/docs-ref-autogen/word_1_3/word/word.tableborder.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.TableBorder#color:member'
@@ -164,7 +164,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'word!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'word!Word.TableBorder#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -273,7 +273,7 @@ items:
         type:
           - number
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.RequestContext:class'
     name: RequestContext
@@ -283,7 +283,7 @@ references:
     name: Word.Interfaces.TableBorderLoadOptions
   - uid: 'word!Word.Interfaces.TableBorderUpdateData:interface'
     name: Interfaces.TableBorderUpdateData
-  - uid: 'word!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'word!Word.Interfaces.TableBorderData:interface'
     name: Word.Interfaces.TableBorderData

--- a/docs/docs-ref-autogen/word_1_3/word/word.tablecell.yml
+++ b/docs/docs-ref-autogen/word_1_3/word/word.tablecell.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.TableCell#body:member'
@@ -556,7 +556,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'word!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'word!Word.TableCell#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -739,7 +739,7 @@ items:
         type:
           - number
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.Body:class'
     name: Word.Body
@@ -753,7 +753,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'word!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -764,7 +764,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'word!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -792,7 +792,7 @@ references:
     name: Word.Table
   - uid: 'word!Word.Interfaces.TableCellUpdateData:interface'
     name: Interfaces.TableCellUpdateData
-  - uid: 'word!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'word!Word.Interfaces.TableCellData:interface'
     name: Word.Interfaces.TableCellData

--- a/docs/docs-ref-autogen/word_1_3/word/word.tablecellcollection.yml
+++ b/docs/docs-ref-autogen/word_1_3/word/word.tablecellcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.TableCellCollection#context:member'
@@ -158,7 +158,7 @@ items:
         - id: option
           description: ''
           type:
-            - 'word!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'word!Word.TableCellCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -213,7 +213,7 @@ items:
           - 'word!Word.TableCellCollection:class'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.RequestContext:class'
     name: RequestContext
@@ -242,7 +242,7 @@ references:
       - uid: 'word!Word.Interfaces.CollectionLoadOptions:interface'
         name: Word.Interfaces.CollectionLoadOptions
         fullName: Word.Interfaces.CollectionLoadOptions
-  - uid: 'word!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'word!Word.Interfaces.TableCellCollectionData:interface'
     name: Word.Interfaces.TableCellCollectionData

--- a/docs/docs-ref-autogen/word_1_3/word/word.tablecollection.yml
+++ b/docs/docs-ref-autogen/word_1_3/word/word.tablecollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.TableCollection#context:member'
@@ -158,7 +158,7 @@ items:
         - id: option
           description: ''
           type:
-            - 'word!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'word!Word.TableCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -213,7 +213,7 @@ items:
           - 'word!Word.TableCollection:class'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.RequestContext:class'
     name: RequestContext
@@ -242,7 +242,7 @@ references:
       - uid: 'word!Word.Interfaces.CollectionLoadOptions:interface'
         name: Word.Interfaces.CollectionLoadOptions
         fullName: Word.Interfaces.CollectionLoadOptions
-  - uid: 'word!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'word!Word.Interfaces.TableCollectionData:interface'
     name: Word.Interfaces.TableCollectionData

--- a/docs/docs-ref-autogen/word_1_3/word/word.tablerow.yml
+++ b/docs/docs-ref-autogen/word_1_3/word/word.tablerow.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.TableRow#cellCount:member'
@@ -590,7 +590,7 @@ items:
         - id: options
           description: Provides an option to suppress errors if the properties object tries to set any read-only properties.
           type:
-            - 'word!OfficeExtension.UpdateOptions:interface'
+            - 'office!OfficeExtension.UpdateOptions:interface'
   - uid: 'word!Word.TableRow#set:member(2)'
     summary: 'Sets multiple properties on the object at the same time, based on an existing loaded object.'
     name: set(properties)
@@ -758,7 +758,7 @@ items:
         type:
           - 'word!Word.TableRow#verticalAlignment~0:complex'
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.TableCellCollection:class'
     name: Word.TableCellCollection
@@ -774,7 +774,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'word!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -785,7 +785,7 @@ references:
     name: OfficeExtension.ClientResult<number>
     fullName: OfficeExtension.ClientResult<number>
     spec.typeScript:
-      - uid: 'word!OfficeExtension.ClientResult:class'
+      - uid: 'office!OfficeExtension.ClientResult:class'
         name: OfficeExtension.ClientResult
         fullName: OfficeExtension.ClientResult
       - name: <number>
@@ -860,7 +860,7 @@ references:
     name: Word.SelectionMode
   - uid: 'word!Word.Interfaces.TableRowUpdateData:interface'
     name: Interfaces.TableRowUpdateData
-  - uid: 'word!OfficeExtension.UpdateOptions:interface'
+  - uid: 'office!OfficeExtension.UpdateOptions:interface'
     name: OfficeExtension.UpdateOptions
   - uid: 'word!Word.Interfaces.TableRowData:interface'
     name: Word.Interfaces.TableRowData

--- a/docs/docs-ref-autogen/word_1_3/word/word.tablerowcollection.yml
+++ b/docs/docs-ref-autogen/word_1_3/word/word.tablerowcollection.yml
@@ -11,7 +11,7 @@ items:
       - typeScript
     type: class
     extends:
-      - 'word!OfficeExtension.ClientObject:class'
+      - 'office!OfficeExtension.ClientObject:class'
     package: word!
     children:
       - 'word!Word.TableRowCollection#context:member'
@@ -158,7 +158,7 @@ items:
         - id: option
           description: ''
           type:
-            - 'word!OfficeExtension.LoadOption:interface'
+            - 'office!OfficeExtension.LoadOption:interface'
   - uid: 'word!Word.TableRowCollection#toJSON:member(1)'
     summary: >-
       Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to
@@ -213,7 +213,7 @@ items:
           - 'word!Word.TableRowCollection:class'
         description: ''
 references:
-  - uid: 'word!OfficeExtension.ClientObject:class'
+  - uid: 'office!OfficeExtension.ClientObject:class'
     name: OfficeExtension.ClientObject
   - uid: 'word!Word.RequestContext:class'
     name: RequestContext
@@ -242,7 +242,7 @@ references:
       - uid: 'word!Word.Interfaces.CollectionLoadOptions:interface'
         name: Word.Interfaces.CollectionLoadOptions
         fullName: Word.Interfaces.CollectionLoadOptions
-  - uid: 'word!OfficeExtension.LoadOption:interface'
+  - uid: 'office!OfficeExtension.LoadOption:interface'
     name: OfficeExtension.LoadOption
   - uid: 'word!Word.Interfaces.TableRowCollectionData:interface'
     name: Word.Interfaces.TableRowCollectionData

--- a/generate-docs/json/excel_1_1/excel.api.json
+++ b/generate-docs/json/excel_1_1/excel.api.json
@@ -40,7 +40,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "excel!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -354,7 +354,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "excel!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -487,7 +487,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "excel!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -594,7 +594,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "excel!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -856,7 +856,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "excel!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -1152,7 +1152,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.LoadOption",
-                      "canonicalReference": "excel!OfficeExtension.LoadOption:interface"
+                      "canonicalReference": "office!OfficeExtension.LoadOption:interface"
                     },
                     {
                       "kind": "Content",
@@ -1933,7 +1933,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "excel!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -2368,7 +2368,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "excel!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -2770,7 +2770,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "excel!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -3018,7 +3018,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "excel!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -3151,7 +3151,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "excel!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -3399,7 +3399,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "excel!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -3559,7 +3559,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "excel!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -3938,7 +3938,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "excel!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -4098,7 +4098,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "excel!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -4346,7 +4346,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "excel!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -4479,7 +4479,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "excel!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -4700,7 +4700,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "excel!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -4885,7 +4885,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "excel!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -5106,7 +5106,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "excel!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -5239,7 +5239,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "excel!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -5689,7 +5689,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.LoadOption",
-                      "canonicalReference": "excel!OfficeExtension.LoadOption:interface"
+                      "canonicalReference": "office!OfficeExtension.LoadOption:interface"
                     },
                     {
                       "kind": "Content",
@@ -5771,7 +5771,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "excel!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -6019,7 +6019,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "excel!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -6419,7 +6419,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "excel!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -6697,7 +6697,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "excel!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -6986,7 +6986,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "excel!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -7142,7 +7142,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "excel!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -7440,7 +7440,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "excel!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -7630,7 +7630,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "excel!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -7851,7 +7851,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "excel!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -8010,7 +8010,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "excel!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -8231,7 +8231,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "excel!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -8364,7 +8364,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "excel!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -8642,7 +8642,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "excel!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -8801,7 +8801,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "excel!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -9049,7 +9049,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "excel!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -9344,7 +9344,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "excel!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -9592,7 +9592,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "excel!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -9725,7 +9725,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "excel!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -9946,7 +9946,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "excel!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -10105,7 +10105,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "excel!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -10326,7 +10326,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "excel!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -10459,7 +10459,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "excel!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -10710,7 +10710,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.LoadOption",
-                      "canonicalReference": "excel!OfficeExtension.LoadOption:interface"
+                      "canonicalReference": "office!OfficeExtension.LoadOption:interface"
                     },
                     {
                       "kind": "Content",
@@ -10792,7 +10792,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "excel!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -11066,7 +11066,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "excel!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -11277,7 +11277,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "excel!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -11528,7 +11528,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.LoadOption",
-                      "canonicalReference": "excel!OfficeExtension.LoadOption:interface"
+                      "canonicalReference": "office!OfficeExtension.LoadOption:interface"
                     },
                     {
                       "kind": "Content",
@@ -11610,7 +11610,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "excel!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -11858,7 +11858,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "excel!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -11991,7 +11991,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "excel!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -12238,7 +12238,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "excel!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -12423,7 +12423,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "excel!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -12671,7 +12671,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "excel!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -34730,7 +34730,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "excel!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -34979,7 +34979,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "excel!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -35195,7 +35195,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "excel!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -35420,7 +35420,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.LoadOption",
-                      "canonicalReference": "excel!OfficeExtension.LoadOption:interface"
+                      "canonicalReference": "office!OfficeExtension.LoadOption:interface"
                     },
                     {
                       "kind": "Content",
@@ -35707,7 +35707,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "excel!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -36989,7 +36989,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "excel!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -37290,7 +37290,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "excel!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -37510,7 +37510,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "excel!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -37736,7 +37736,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "excel!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -38078,7 +38078,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.LoadOption",
-                      "canonicalReference": "excel!OfficeExtension.LoadOption:interface"
+                      "canonicalReference": "office!OfficeExtension.LoadOption:interface"
                     },
                     {
                       "kind": "Content",
@@ -38160,7 +38160,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "excel!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -38408,7 +38408,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "excel!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -38541,7 +38541,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "excel!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -38839,7 +38839,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "excel!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -39029,7 +39029,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "excel!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -39379,7 +39379,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "excel!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -39872,7 +39872,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientRequestContext",
-                  "canonicalReference": "excel!OfficeExtension.ClientRequestContext:class"
+                  "canonicalReference": "office!OfficeExtension.ClientRequestContext:class"
                 },
                 {
                   "kind": "Content",
@@ -40069,7 +40069,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "excel!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -40164,7 +40164,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "excel!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -40358,7 +40358,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientRequestContext",
-                  "canonicalReference": "excel!OfficeExtension.ClientRequestContext:class"
+                  "canonicalReference": "office!OfficeExtension.ClientRequestContext:class"
                 },
                 {
                   "kind": "Content",
@@ -40453,7 +40453,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.RunOptions",
-                  "canonicalReference": "excel!OfficeExtension.RunOptions:interface"
+                  "canonicalReference": "office!OfficeExtension.RunOptions:interface"
                 },
                 {
                   "kind": "Content",
@@ -40704,7 +40704,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "excel!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -41148,7 +41148,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "excel!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -41359,7 +41359,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "excel!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -41720,7 +41720,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.LoadOption",
-                      "canonicalReference": "excel!OfficeExtension.LoadOption:interface"
+                      "canonicalReference": "office!OfficeExtension.LoadOption:interface"
                     },
                     {
                       "kind": "Content",
@@ -41802,7 +41802,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "excel!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -42218,7 +42218,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "excel!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -42377,7 +42377,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "excel!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -42762,7 +42762,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.LoadOption",
-                      "canonicalReference": "excel!OfficeExtension.LoadOption:interface"
+                      "canonicalReference": "office!OfficeExtension.LoadOption:interface"
                     },
                     {
                       "kind": "Content",
@@ -42844,7 +42844,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "excel!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -43121,7 +43121,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "excel!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -43280,7 +43280,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "excel!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -43605,7 +43605,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.LoadOption",
-                      "canonicalReference": "excel!OfficeExtension.LoadOption:interface"
+                      "canonicalReference": "office!OfficeExtension.LoadOption:interface"
                     },
                     {
                       "kind": "Content",
@@ -43807,7 +43807,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "excel!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -44111,7 +44111,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "excel!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -44298,7 +44298,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "excel!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -44758,7 +44758,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "excel!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -44949,7 +44949,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "excel!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -45248,7 +45248,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.LoadOption",
-                      "canonicalReference": "excel!OfficeExtension.LoadOption:interface"
+                      "canonicalReference": "office!OfficeExtension.LoadOption:interface"
                     },
                     {
                       "kind": "Content",

--- a/generate-docs/json/onenote/onenote.api.json
+++ b/generate-docs/json/onenote/onenote.api.json
@@ -40,7 +40,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "onenote!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -379,7 +379,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "onenote!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -456,7 +456,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "onenote!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -814,7 +814,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "onenote!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -1173,7 +1173,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "onenote!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -1248,7 +1248,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "onenote!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -1585,7 +1585,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "onenote!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -1868,7 +1868,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "onenote!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -2115,7 +2115,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "onenote!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -2306,7 +2306,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "onenote!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -2553,7 +2553,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "onenote!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -2771,7 +2771,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "onenote!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -3067,7 +3067,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.LoadOption",
-                      "canonicalReference": "onenote!OfficeExtension.LoadOption:interface"
+                      "canonicalReference": "office!OfficeExtension.LoadOption:interface"
                     },
                     {
                       "kind": "Content",
@@ -3207,7 +3207,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "onenote!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -3481,7 +3481,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "onenote!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -3672,7 +3672,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "onenote!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -3968,7 +3968,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.LoadOption",
-                      "canonicalReference": "onenote!OfficeExtension.LoadOption:interface"
+                      "canonicalReference": "office!OfficeExtension.LoadOption:interface"
                     },
                     {
                       "kind": "Content",
@@ -4108,7 +4108,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "onenote!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -4381,7 +4381,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "onenote!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -4629,7 +4629,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "onenote!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -4925,7 +4925,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.LoadOption",
-                      "canonicalReference": "onenote!OfficeExtension.LoadOption:interface"
+                      "canonicalReference": "office!OfficeExtension.LoadOption:interface"
                     },
                     {
                       "kind": "Content",
@@ -5065,7 +5065,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "onenote!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -5397,7 +5397,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "onenote!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -5693,7 +5693,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.LoadOption",
-                      "canonicalReference": "onenote!OfficeExtension.LoadOption:interface"
+                      "canonicalReference": "office!OfficeExtension.LoadOption:interface"
                     },
                     {
                       "kind": "Content",
@@ -5899,7 +5899,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "onenote!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -6283,7 +6283,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "onenote!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -6579,7 +6579,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.LoadOption",
-                      "canonicalReference": "onenote!OfficeExtension.LoadOption:interface"
+                      "canonicalReference": "office!OfficeExtension.LoadOption:interface"
                     },
                     {
                       "kind": "Content",
@@ -17786,7 +17786,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "onenote!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -17977,7 +17977,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "onenote!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -18372,7 +18372,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "onenote!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -18713,7 +18713,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.LoadOption",
-                      "canonicalReference": "onenote!OfficeExtension.LoadOption:interface"
+                      "canonicalReference": "office!OfficeExtension.LoadOption:interface"
                     },
                     {
                       "kind": "Content",
@@ -18853,7 +18853,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "onenote!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -20966,7 +20966,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "onenote!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -21280,7 +21280,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "onenote!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -21597,7 +21597,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "onenote!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -21694,7 +21694,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "onenote!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -21969,7 +21969,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "onenote!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -22002,7 +22002,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "onenote!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -22407,7 +22407,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "onenote!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -22650,7 +22650,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "onenote!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -22991,7 +22991,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.LoadOption",
-                      "canonicalReference": "onenote!OfficeExtension.LoadOption:interface"
+                      "canonicalReference": "office!OfficeExtension.LoadOption:interface"
                     },
                     {
                       "kind": "Content",
@@ -23131,7 +23131,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "onenote!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -23513,7 +23513,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "onenote!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -23761,7 +23761,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "onenote!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -24057,7 +24057,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.LoadOption",
-                      "canonicalReference": "onenote!OfficeExtension.LoadOption:interface"
+                      "canonicalReference": "office!OfficeExtension.LoadOption:interface"
                     },
                     {
                       "kind": "Content",
@@ -24296,7 +24296,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "onenote!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -24495,7 +24495,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "onenote!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -25553,7 +25553,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "onenote!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -25802,7 +25802,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "onenote!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -26098,7 +26098,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.LoadOption",
-                      "canonicalReference": "onenote!OfficeExtension.LoadOption:interface"
+                      "canonicalReference": "office!OfficeExtension.LoadOption:interface"
                     },
                     {
                       "kind": "Content",
@@ -26484,7 +26484,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientRequestContext",
-                  "canonicalReference": "onenote!OfficeExtension.ClientRequestContext:class"
+                  "canonicalReference": "office!OfficeExtension.ClientRequestContext:class"
                 },
                 {
                   "kind": "Content",
@@ -26570,7 +26570,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "onenote!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -26619,7 +26619,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "onenote!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -27066,7 +27066,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "onenote!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -27161,7 +27161,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "onenote!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -27260,7 +27260,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "onenote!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -27472,7 +27472,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "onenote!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -28094,7 +28094,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "onenote!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -28435,7 +28435,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.LoadOption",
-                      "canonicalReference": "onenote!OfficeExtension.LoadOption:interface"
+                      "canonicalReference": "office!OfficeExtension.LoadOption:interface"
                     },
                     {
                       "kind": "Content",
@@ -28575,7 +28575,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "onenote!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -28740,7 +28740,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "onenote!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -29190,7 +29190,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "onenote!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -29531,7 +29531,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.LoadOption",
-                      "canonicalReference": "onenote!OfficeExtension.LoadOption:interface"
+                      "canonicalReference": "office!OfficeExtension.LoadOption:interface"
                     },
                     {
                       "kind": "Content",
@@ -29671,7 +29671,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "onenote!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -30319,7 +30319,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "onenote!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -30554,7 +30554,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "onenote!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -31147,7 +31147,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "onenote!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -31364,7 +31364,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "onenote!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -31660,7 +31660,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.LoadOption",
-                      "canonicalReference": "onenote!OfficeExtension.LoadOption:interface"
+                      "canonicalReference": "office!OfficeExtension.LoadOption:interface"
                     },
                     {
                       "kind": "Content",
@@ -31800,7 +31800,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "onenote!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -32404,7 +32404,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "onenote!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -32700,7 +32700,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.LoadOption",
-                      "canonicalReference": "onenote!OfficeExtension.LoadOption:interface"
+                      "canonicalReference": "office!OfficeExtension.LoadOption:interface"
                     },
                     {
                       "kind": "Content",

--- a/generate-docs/json/visio/visio.api.json
+++ b/generate-docs/json/visio/visio.api.json
@@ -40,7 +40,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "visio!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -234,7 +234,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "visio!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -654,7 +654,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "visio!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -900,7 +900,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "visio!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -1059,7 +1059,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "visio!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -1108,7 +1108,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "visio!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -1317,7 +1317,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.LoadOption",
-                      "canonicalReference": "visio!OfficeExtension.LoadOption:interface"
+                      "canonicalReference": "office!OfficeExtension.LoadOption:interface"
                     },
                     {
                       "kind": "Content",
@@ -1466,7 +1466,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "visio!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -1707,7 +1707,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.EventHandlers",
-                      "canonicalReference": "visio!OfficeExtension.EventHandlers:class"
+                      "canonicalReference": "office!OfficeExtension.EventHandlers:class"
                     },
                     {
                       "kind": "Content",
@@ -1747,7 +1747,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.EventHandlers",
-                      "canonicalReference": "visio!OfficeExtension.EventHandlers:class"
+                      "canonicalReference": "office!OfficeExtension.EventHandlers:class"
                     },
                     {
                       "kind": "Content",
@@ -1787,7 +1787,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.EventHandlers",
-                      "canonicalReference": "visio!OfficeExtension.EventHandlers:class"
+                      "canonicalReference": "office!OfficeExtension.EventHandlers:class"
                     },
                     {
                       "kind": "Content",
@@ -1827,7 +1827,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.EventHandlers",
-                      "canonicalReference": "visio!OfficeExtension.EventHandlers:class"
+                      "canonicalReference": "office!OfficeExtension.EventHandlers:class"
                     },
                     {
                       "kind": "Content",
@@ -1867,7 +1867,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.EventHandlers",
-                      "canonicalReference": "visio!OfficeExtension.EventHandlers:class"
+                      "canonicalReference": "office!OfficeExtension.EventHandlers:class"
                     },
                     {
                       "kind": "Content",
@@ -1907,7 +1907,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.EventHandlers",
-                      "canonicalReference": "visio!OfficeExtension.EventHandlers:class"
+                      "canonicalReference": "office!OfficeExtension.EventHandlers:class"
                     },
                     {
                       "kind": "Content",
@@ -1983,7 +1983,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "visio!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -2256,7 +2256,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "visio!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -2580,7 +2580,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "visio!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -2920,7 +2920,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "visio!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -3245,7 +3245,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "visio!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -3294,7 +3294,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "visio!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -3503,7 +3503,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.LoadOption",
-                      "canonicalReference": "visio!OfficeExtension.LoadOption:interface"
+                      "canonicalReference": "office!OfficeExtension.LoadOption:interface"
                     },
                     {
                       "kind": "Content",
@@ -8190,7 +8190,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "visio!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -8570,7 +8570,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "visio!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -8783,7 +8783,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "visio!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -8832,7 +8832,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "visio!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -9041,7 +9041,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.LoadOption",
-                      "canonicalReference": "visio!OfficeExtension.LoadOption:interface"
+                      "canonicalReference": "office!OfficeExtension.LoadOption:interface"
                     },
                     {
                       "kind": "Content",
@@ -9255,7 +9255,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "visio!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -9376,7 +9376,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "visio!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -9456,7 +9456,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "visio!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -9642,7 +9642,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "visio!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -9912,7 +9912,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientRequestContext",
-                  "canonicalReference": "visio!OfficeExtension.ClientRequestContext:class"
+                  "canonicalReference": "office!OfficeExtension.ClientRequestContext:class"
                 },
                 {
                   "kind": "Content",
@@ -9938,7 +9938,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.EmbeddedSession",
-                      "canonicalReference": "visio!OfficeExtension.EmbeddedSession:class"
+                      "canonicalReference": "office!OfficeExtension.EmbeddedSession:class"
                     },
                     {
                       "kind": "Content",
@@ -10082,7 +10082,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "visio!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -10091,7 +10091,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.EmbeddedSession",
-                  "canonicalReference": "visio!OfficeExtension.EmbeddedSession:class"
+                  "canonicalReference": "office!OfficeExtension.EmbeddedSession:class"
                 },
                 {
                   "kind": "Content",
@@ -10186,7 +10186,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "visio!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -10285,7 +10285,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientRequestContext",
-                  "canonicalReference": "visio!OfficeExtension.ClientRequestContext:class"
+                  "canonicalReference": "office!OfficeExtension.ClientRequestContext:class"
                 },
                 {
                   "kind": "Content",
@@ -10380,7 +10380,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "visio!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -10648,7 +10648,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "visio!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -10724,7 +10724,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "visio!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -11016,7 +11016,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "visio!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -11256,7 +11256,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "visio!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -11305,7 +11305,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "visio!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -11514,7 +11514,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.LoadOption",
-                      "canonicalReference": "visio!OfficeExtension.LoadOption:interface"
+                      "canonicalReference": "office!OfficeExtension.LoadOption:interface"
                     },
                     {
                       "kind": "Content",
@@ -11596,7 +11596,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "visio!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -11921,7 +11921,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "visio!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -11970,7 +11970,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "visio!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -12179,7 +12179,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.LoadOption",
-                      "canonicalReference": "visio!OfficeExtension.LoadOption:interface"
+                      "canonicalReference": "office!OfficeExtension.LoadOption:interface"
                     },
                     {
                       "kind": "Content",
@@ -12393,7 +12393,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "visio!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -12466,7 +12466,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "visio!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -12590,7 +12590,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "visio!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -12909,7 +12909,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "visio!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",

--- a/generate-docs/json/word/word.api.json
+++ b/generate-docs/json/word/word.api.json
@@ -181,7 +181,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -275,7 +275,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientRequestContext",
-                      "canonicalReference": "word!OfficeExtension.ClientRequestContext:class"
+                      "canonicalReference": "office!OfficeExtension.ClientRequestContext:class"
                     },
                     {
                       "kind": "Content",
@@ -356,7 +356,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -487,7 +487,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "word!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -520,7 +520,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "word!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -2242,7 +2242,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "word!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -3699,7 +3699,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -3983,7 +3983,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "word!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -4016,7 +4016,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "word!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -5443,7 +5443,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.EventHandlers",
-                      "canonicalReference": "word!OfficeExtension.EventHandlers:class"
+                      "canonicalReference": "office!OfficeExtension.EventHandlers:class"
                     },
                     {
                       "kind": "Content",
@@ -5483,7 +5483,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.EventHandlers",
-                      "canonicalReference": "word!OfficeExtension.EventHandlers:class"
+                      "canonicalReference": "office!OfficeExtension.EventHandlers:class"
                     },
                     {
                       "kind": "Content",
@@ -5523,7 +5523,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.EventHandlers",
-                      "canonicalReference": "word!OfficeExtension.EventHandlers:class"
+                      "canonicalReference": "office!OfficeExtension.EventHandlers:class"
                     },
                     {
                       "kind": "Content",
@@ -5994,7 +5994,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "word!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -6577,7 +6577,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -7090,7 +7090,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.LoadOption",
-                      "canonicalReference": "word!OfficeExtension.LoadOption:interface"
+                      "canonicalReference": "office!OfficeExtension.LoadOption:interface"
                     },
                     {
                       "kind": "Content",
@@ -7674,7 +7674,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -7922,7 +7922,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "word!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -8170,7 +8170,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -8307,7 +8307,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "word!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -8561,7 +8561,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.LoadOption",
-                      "canonicalReference": "word!OfficeExtension.LoadOption:interface"
+                      "canonicalReference": "office!OfficeExtension.LoadOption:interface"
                     },
                     {
                       "kind": "Content",
@@ -8701,7 +8701,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -8911,7 +8911,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "word!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -9326,7 +9326,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "word!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -9675,7 +9675,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -9814,7 +9814,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "word!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -10068,7 +10068,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.LoadOption",
-                      "canonicalReference": "word!OfficeExtension.LoadOption:interface"
+                      "canonicalReference": "office!OfficeExtension.LoadOption:interface"
                     },
                     {
                       "kind": "Content",
@@ -10208,7 +10208,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -10257,7 +10257,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "word!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -10569,7 +10569,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.LoadOption",
-                      "canonicalReference": "word!OfficeExtension.LoadOption:interface"
+                      "canonicalReference": "office!OfficeExtension.LoadOption:interface"
                     },
                     {
                       "kind": "Content",
@@ -10709,7 +10709,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -11138,7 +11138,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.EventHandlers",
-                      "canonicalReference": "word!OfficeExtension.EventHandlers:class"
+                      "canonicalReference": "office!OfficeExtension.EventHandlers:class"
                     },
                     {
                       "kind": "Content",
@@ -11295,7 +11295,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "word!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -11513,7 +11513,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -12058,7 +12058,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "word!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -12276,7 +12276,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -12864,7 +12864,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "word!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -13592,7 +13592,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -13942,7 +13942,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "word!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -14655,7 +14655,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -14784,7 +14784,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "word!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -16373,7 +16373,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "word!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -16590,7 +16590,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -16828,7 +16828,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.LoadOption",
-                      "canonicalReference": "word!OfficeExtension.LoadOption:interface"
+                      "canonicalReference": "office!OfficeExtension.LoadOption:interface"
                     },
                     {
                       "kind": "Content",
@@ -35881,7 +35881,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -36028,7 +36028,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "word!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -36077,7 +36077,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "word!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -37449,7 +37449,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -37822,7 +37822,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.LoadOption",
-                      "canonicalReference": "word!OfficeExtension.LoadOption:interface"
+                      "canonicalReference": "office!OfficeExtension.LoadOption:interface"
                     },
                     {
                       "kind": "Content",
@@ -37962,7 +37962,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -38343,7 +38343,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "word!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -39088,7 +39088,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -39392,7 +39392,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "word!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -39483,7 +39483,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "word!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -41612,7 +41612,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "word!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -42068,7 +42068,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -42364,7 +42364,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.LoadOption",
-                      "canonicalReference": "word!OfficeExtension.LoadOption:interface"
+                      "canonicalReference": "office!OfficeExtension.LoadOption:interface"
                     },
                     {
                       "kind": "Content",
@@ -42504,7 +42504,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -42563,7 +42563,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "word!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -42830,7 +42830,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "word!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -42878,7 +42878,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "word!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -43060,7 +43060,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "word!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -45057,7 +45057,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "word!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -45448,7 +45448,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -45686,7 +45686,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.LoadOption",
-                      "canonicalReference": "word!OfficeExtension.LoadOption:interface"
+                      "canonicalReference": "office!OfficeExtension.LoadOption:interface"
                     },
                     {
                       "kind": "Content",
@@ -45967,7 +45967,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientRequestContext",
-                  "canonicalReference": "word!OfficeExtension.ClientRequestContext:class"
+                  "canonicalReference": "office!OfficeExtension.ClientRequestContext:class"
                 },
                 {
                   "kind": "Content",
@@ -46080,7 +46080,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -46179,7 +46179,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -46353,7 +46353,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -46746,7 +46746,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientRequestContext",
-                      "canonicalReference": "word!OfficeExtension.ClientRequestContext:class"
+                      "canonicalReference": "office!OfficeExtension.ClientRequestContext:class"
                     },
                     {
                       "kind": "Content",
@@ -46801,7 +46801,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "word!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -46934,7 +46934,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -47395,7 +47395,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "word!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -47586,7 +47586,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -47824,7 +47824,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.LoadOption",
-                      "canonicalReference": "word!OfficeExtension.LoadOption:interface"
+                      "canonicalReference": "office!OfficeExtension.LoadOption:interface"
                     },
                     {
                       "kind": "Content",
@@ -48042,7 +48042,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -48334,7 +48334,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "word!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -48551,7 +48551,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -48688,7 +48688,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "word!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -48942,7 +48942,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.LoadOption",
-                      "canonicalReference": "word!OfficeExtension.LoadOption:interface"
+                      "canonicalReference": "office!OfficeExtension.LoadOption:interface"
                     },
                     {
                       "kind": "Content",
@@ -52205,7 +52205,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -53062,7 +53062,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "word!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -53111,7 +53111,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "word!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -54488,7 +54488,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "word!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -55121,7 +55121,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -55341,7 +55341,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "word!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -55589,7 +55589,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -55873,7 +55873,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "word!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -55922,7 +55922,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "word!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -56577,7 +56577,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "word!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -57055,7 +57055,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -57293,7 +57293,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.LoadOption",
-                      "canonicalReference": "word!OfficeExtension.LoadOption:interface"
+                      "canonicalReference": "office!OfficeExtension.LoadOption:interface"
                     },
                     {
                       "kind": "Content",
@@ -57433,7 +57433,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -57671,7 +57671,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.LoadOption",
-                      "canonicalReference": "word!OfficeExtension.LoadOption:interface"
+                      "canonicalReference": "office!OfficeExtension.LoadOption:interface"
                     },
                     {
                       "kind": "Content",
@@ -57811,7 +57811,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -58096,7 +58096,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "word!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -58145,7 +58145,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "word!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -58888,7 +58888,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "word!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -59281,7 +59281,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -59519,7 +59519,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.LoadOption",
-                      "canonicalReference": "word!OfficeExtension.LoadOption:interface"
+                      "canonicalReference": "office!OfficeExtension.LoadOption:interface"
                     },
                     {
                       "kind": "Content",

--- a/generate-docs/json/word_1_1/word.api.json
+++ b/generate-docs/json/word_1_1/word.api.json
@@ -181,7 +181,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -312,7 +312,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "word!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -345,7 +345,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "word!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -1512,7 +1512,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "word!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -2880,7 +2880,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -3164,7 +3164,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "word!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -3197,7 +3197,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "word!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -4413,7 +4413,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "word!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -4817,7 +4817,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -5177,7 +5177,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.LoadOption",
-                      "canonicalReference": "word!OfficeExtension.LoadOption:interface"
+                      "canonicalReference": "office!OfficeExtension.LoadOption:interface"
                     },
                     {
                       "kind": "Content",
@@ -5689,7 +5689,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -6047,7 +6047,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "word!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -6697,7 +6697,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -7047,7 +7047,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "word!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -7760,7 +7760,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -7861,7 +7861,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "word!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -8173,7 +8173,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "word!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -8390,7 +8390,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -8570,7 +8570,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.LoadOption",
-                      "canonicalReference": "word!OfficeExtension.LoadOption:interface"
+                      "canonicalReference": "office!OfficeExtension.LoadOption:interface"
                     },
                     {
                       "kind": "Content",
@@ -17565,7 +17565,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -17781,7 +17781,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "word!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -17814,7 +17814,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "word!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -19231,7 +19231,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "word!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -19526,7 +19526,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -19706,7 +19706,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.LoadOption",
-                      "canonicalReference": "word!OfficeExtension.LoadOption:interface"
+                      "canonicalReference": "office!OfficeExtension.LoadOption:interface"
                     },
                     {
                       "kind": "Content",
@@ -19846,7 +19846,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -20005,7 +20005,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "word!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -20038,7 +20038,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "word!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -21178,7 +21178,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "word!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -21421,7 +21421,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -21601,7 +21601,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.LoadOption",
-                      "canonicalReference": "word!OfficeExtension.LoadOption:interface"
+                      "canonicalReference": "office!OfficeExtension.LoadOption:interface"
                     },
                     {
                       "kind": "Content",
@@ -21882,7 +21882,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientRequestContext",
-                  "canonicalReference": "word!OfficeExtension.ClientRequestContext:class"
+                  "canonicalReference": "office!OfficeExtension.ClientRequestContext:class"
                 },
                 {
                   "kind": "Content",
@@ -21968,7 +21968,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -22067,7 +22067,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -22241,7 +22241,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -22634,7 +22634,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientRequestContext",
-                      "canonicalReference": "word!OfficeExtension.ClientRequestContext:class"
+                      "canonicalReference": "office!OfficeExtension.ClientRequestContext:class"
                     },
                     {
                       "kind": "Content",
@@ -22689,7 +22689,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "word!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -22822,7 +22822,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -23225,7 +23225,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "word!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -23416,7 +23416,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -23596,7 +23596,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.LoadOption",
-                      "canonicalReference": "word!OfficeExtension.LoadOption:interface"
+                      "canonicalReference": "office!OfficeExtension.LoadOption:interface"
                     },
                     {
                       "kind": "Content",

--- a/generate-docs/json/word_1_2/word.api.json
+++ b/generate-docs/json/word_1_2/word.api.json
@@ -181,7 +181,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -312,7 +312,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "word!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -345,7 +345,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "word!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -1633,7 +1633,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "word!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -3001,7 +3001,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -3285,7 +3285,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "word!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -3318,7 +3318,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "word!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -4655,7 +4655,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "word!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -5059,7 +5059,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -5419,7 +5419,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.LoadOption",
-                      "canonicalReference": "word!OfficeExtension.LoadOption:interface"
+                      "canonicalReference": "office!OfficeExtension.LoadOption:interface"
                     },
                     {
                       "kind": "Content",
@@ -5931,7 +5931,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -6289,7 +6289,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "word!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -6939,7 +6939,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -7289,7 +7289,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "word!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -8002,7 +8002,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -8131,7 +8131,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "word!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -9405,7 +9405,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "word!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -9622,7 +9622,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -9802,7 +9802,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.LoadOption",
-                      "canonicalReference": "word!OfficeExtension.LoadOption:interface"
+                      "canonicalReference": "office!OfficeExtension.LoadOption:interface"
                     },
                     {
                       "kind": "Content",
@@ -18879,7 +18879,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -19095,7 +19095,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "word!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -19128,7 +19128,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "word!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -20545,7 +20545,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "word!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -20840,7 +20840,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -21020,7 +21020,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.LoadOption",
-                      "canonicalReference": "word!OfficeExtension.LoadOption:interface"
+                      "canonicalReference": "office!OfficeExtension.LoadOption:interface"
                     },
                     {
                       "kind": "Content",
@@ -21160,7 +21160,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -21319,7 +21319,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "word!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -21352,7 +21352,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "word!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -22640,7 +22640,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "word!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -22883,7 +22883,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -23063,7 +23063,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.LoadOption",
-                      "canonicalReference": "word!OfficeExtension.LoadOption:interface"
+                      "canonicalReference": "office!OfficeExtension.LoadOption:interface"
                     },
                     {
                       "kind": "Content",
@@ -23344,7 +23344,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientRequestContext",
-                  "canonicalReference": "word!OfficeExtension.ClientRequestContext:class"
+                  "canonicalReference": "office!OfficeExtension.ClientRequestContext:class"
                 },
                 {
                   "kind": "Content",
@@ -23430,7 +23430,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -23529,7 +23529,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -23703,7 +23703,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -24096,7 +24096,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientRequestContext",
-                      "canonicalReference": "word!OfficeExtension.ClientRequestContext:class"
+                      "canonicalReference": "office!OfficeExtension.ClientRequestContext:class"
                     },
                     {
                       "kind": "Content",
@@ -24151,7 +24151,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "word!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -24284,7 +24284,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -24687,7 +24687,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "word!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -24878,7 +24878,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -25058,7 +25058,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.LoadOption",
-                      "canonicalReference": "word!OfficeExtension.LoadOption:interface"
+                      "canonicalReference": "office!OfficeExtension.LoadOption:interface"
                     },
                     {
                       "kind": "Content",

--- a/generate-docs/json/word_1_3/word.api.json
+++ b/generate-docs/json/word_1_3/word.api.json
@@ -181,7 +181,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -275,7 +275,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientRequestContext",
-                      "canonicalReference": "word!OfficeExtension.ClientRequestContext:class"
+                      "canonicalReference": "office!OfficeExtension.ClientRequestContext:class"
                     },
                     {
                       "kind": "Content",
@@ -356,7 +356,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -487,7 +487,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "word!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -520,7 +520,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "word!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -2242,7 +2242,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "word!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -3699,7 +3699,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -3983,7 +3983,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "word!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -4016,7 +4016,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "word!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -5874,7 +5874,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "word!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -6457,7 +6457,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -6970,7 +6970,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.LoadOption",
-                      "canonicalReference": "word!OfficeExtension.LoadOption:interface"
+                      "canonicalReference": "office!OfficeExtension.LoadOption:interface"
                     },
                     {
                       "kind": "Content",
@@ -7482,7 +7482,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -7730,7 +7730,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "word!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -7978,7 +7978,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -8115,7 +8115,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "word!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -8369,7 +8369,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.LoadOption",
-                      "canonicalReference": "word!OfficeExtension.LoadOption:interface"
+                      "canonicalReference": "office!OfficeExtension.LoadOption:interface"
                     },
                     {
                       "kind": "Content",
@@ -8509,7 +8509,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -8894,7 +8894,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "word!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -9085,7 +9085,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -9469,7 +9469,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "word!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -9660,7 +9660,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -10248,7 +10248,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "word!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -10976,7 +10976,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -11326,7 +11326,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "word!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -12039,7 +12039,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -12168,7 +12168,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "word!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -13726,7 +13726,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "word!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -13943,7 +13943,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -14181,7 +14181,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.LoadOption",
-                      "canonicalReference": "word!OfficeExtension.LoadOption:interface"
+                      "canonicalReference": "office!OfficeExtension.LoadOption:interface"
                     },
                     {
                       "kind": "Content",
@@ -32130,7 +32130,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -32232,7 +32232,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "word!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -33486,7 +33486,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -33859,7 +33859,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.LoadOption",
-                      "canonicalReference": "word!OfficeExtension.LoadOption:interface"
+                      "canonicalReference": "office!OfficeExtension.LoadOption:interface"
                     },
                     {
                       "kind": "Content",
@@ -33999,7 +33999,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -34380,7 +34380,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "word!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -35125,7 +35125,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -35429,7 +35429,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "word!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -35520,7 +35520,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "word!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -37649,7 +37649,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "word!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -38105,7 +38105,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -38401,7 +38401,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.LoadOption",
-                      "canonicalReference": "word!OfficeExtension.LoadOption:interface"
+                      "canonicalReference": "office!OfficeExtension.LoadOption:interface"
                     },
                     {
                       "kind": "Content",
@@ -38541,7 +38541,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -38600,7 +38600,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "word!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -38851,7 +38851,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "word!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -39033,7 +39033,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "word!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -40986,7 +40986,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "word!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -41377,7 +41377,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -41615,7 +41615,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.LoadOption",
-                      "canonicalReference": "word!OfficeExtension.LoadOption:interface"
+                      "canonicalReference": "office!OfficeExtension.LoadOption:interface"
                     },
                     {
                       "kind": "Content",
@@ -41896,7 +41896,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientRequestContext",
-                  "canonicalReference": "word!OfficeExtension.ClientRequestContext:class"
+                  "canonicalReference": "office!OfficeExtension.ClientRequestContext:class"
                 },
                 {
                   "kind": "Content",
@@ -42009,7 +42009,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -42108,7 +42108,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -42282,7 +42282,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -42675,7 +42675,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientRequestContext",
-                      "canonicalReference": "word!OfficeExtension.ClientRequestContext:class"
+                      "canonicalReference": "office!OfficeExtension.ClientRequestContext:class"
                     },
                     {
                       "kind": "Content",
@@ -42730,7 +42730,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "word!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -42863,7 +42863,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -43324,7 +43324,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "word!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -43515,7 +43515,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -43753,7 +43753,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.LoadOption",
-                      "canonicalReference": "word!OfficeExtension.LoadOption:interface"
+                      "canonicalReference": "office!OfficeExtension.LoadOption:interface"
                     },
                     {
                       "kind": "Content",
@@ -47094,7 +47094,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -47951,7 +47951,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "word!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -48000,7 +48000,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "word!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -49287,7 +49287,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "word!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -49920,7 +49920,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -50140,7 +50140,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "word!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -50388,7 +50388,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -50672,7 +50672,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "word!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -50721,7 +50721,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "word!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -51376,7 +51376,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "word!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -51795,7 +51795,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -52033,7 +52033,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.LoadOption",
-                      "canonicalReference": "word!OfficeExtension.LoadOption:interface"
+                      "canonicalReference": "office!OfficeExtension.LoadOption:interface"
                     },
                     {
                       "kind": "Content",
@@ -52173,7 +52173,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -52411,7 +52411,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.LoadOption",
-                      "canonicalReference": "word!OfficeExtension.LoadOption:interface"
+                      "canonicalReference": "office!OfficeExtension.LoadOption:interface"
                     },
                     {
                       "kind": "Content",
@@ -52551,7 +52551,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -52836,7 +52836,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "word!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -52885,7 +52885,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.ClientResult",
-                      "canonicalReference": "word!OfficeExtension.ClientResult:class"
+                      "canonicalReference": "office!OfficeExtension.ClientResult:class"
                     },
                     {
                       "kind": "Content",
@@ -53570,7 +53570,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.UpdateOptions",
-                      "canonicalReference": "word!OfficeExtension.UpdateOptions:interface"
+                      "canonicalReference": "office!OfficeExtension.UpdateOptions:interface"
                     },
                     {
                       "kind": "Content",
@@ -53963,7 +53963,7 @@
                 {
                   "kind": "Reference",
                   "text": "OfficeExtension.ClientObject",
-                  "canonicalReference": "word!OfficeExtension.ClientObject:class"
+                  "canonicalReference": "office!OfficeExtension.ClientObject:class"
                 },
                 {
                   "kind": "Content",
@@ -54201,7 +54201,7 @@
                     {
                       "kind": "Reference",
                       "text": "OfficeExtension.LoadOption",
-                      "canonicalReference": "word!OfficeExtension.LoadOption:interface"
+                      "canonicalReference": "office!OfficeExtension.LoadOption:interface"
                     },
                     {
                       "kind": "Content",

--- a/generate-docs/scripts/midprocessor.ts
+++ b/generate-docs/scripts/midprocessor.ts
@@ -38,6 +38,26 @@ tryCatch(async () => {
 
     console.log("\nCompleted Outlook json cross-referencing cleanup");
 
+    console.log("\nCleaning up Excel json cross-referencing...");
+
+    const excelJsonPath = path.resolve("../json/excel");
+    const excelFilename = "excel.api.json";
+    console.log("\nStarting excel...");
+    let excelJson = fsx.readFileSync(`${excelJsonPath}/${excelFilename}`).toString();
+    fsx.writeFileSync(`${excelJsonPath}/${excelFilename}`, cleanUpExcelJson(excelJson));
+    excelJson = fsx.readFileSync(`${excelJsonPath}_online/${excelFilename}`).toString();
+    fsx.writeFileSync(`${excelJsonPath}_online/${excelFilename}`, cleanUpExcelJson(excelJson));
+    console.log("\Completed excel");
+    for (let i = CURRENT_OUTLOOK_RELEASE; i > 0; i--) {
+        console.log(`\nStarting excel${i}...`);
+        excelJson = fsx.readFileSync(`${excelJsonPath}_1_${i}/${excelFilename}`).toString();
+        fsx.writeFileSync(`${excelJsonPath}_1_${i}/${excelFilename}`, cleanUpExcelJson(excelJson));
+        console.log(`\Completed excel${i}`);
+    }
+
+    console.log("\nCompleted Excel json cross-referencing cleanup");
+
+
     // ----
     // Process Snippets
     // ----
@@ -211,6 +231,10 @@ function cleanUpOutlookJson(jsonString : string) {
         startSearchIndex = jsonString.indexOf(commonApiSearchString, outlookIndex + 8);
     } while (startSearchIndex >= 0);
     return jsonString;
+}
+
+function cleanUpExcelJson(jsonString : string) {
+    return jsonString.replace(/excel\!OfficeExtension/g, "office!OfficeExtension");
 }
 
 async function tryCatch(call: () => Promise<void>) {

--- a/generate-docs/scripts/midprocessor.ts
+++ b/generate-docs/scripts/midprocessor.ts
@@ -33,7 +33,7 @@ tryCatch(async () => {
         console.log(`\nStarting outlook_1_${i}...`);
         outlookJson = fsx.readFileSync(`${outlookJsonPath}_1_${i}/${outlookFilename}`).toString();
         fsx.writeFileSync(`${outlookJsonPath}_1_${i}/${outlookFilename}`, cleanUpOutlookJson(outlookJson));
-        console.log(`\Completed outlook_1_${i}`);
+        console.log(`Completed outlook_1_${i}`);
     }
 
     console.log("\nCompleted Outlook json cross-referencing cleanup");
@@ -44,19 +44,56 @@ tryCatch(async () => {
     const excelFilename = "excel.api.json";
     console.log("\nStarting excel...");
     let excelJson = fsx.readFileSync(`${excelJsonPath}/${excelFilename}`).toString();
-    fsx.writeFileSync(`${excelJsonPath}/${excelFilename}`, cleanUpExcelJson(excelJson));
+    fsx.writeFileSync(`${excelJsonPath}/${excelFilename}`, cleanUpRichApiJson(excelJson));
     excelJson = fsx.readFileSync(`${excelJsonPath}_online/${excelFilename}`).toString();
-    fsx.writeFileSync(`${excelJsonPath}_online/${excelFilename}`, cleanUpExcelJson(excelJson));
-    console.log("\Completed excel");
-    for (let i = CURRENT_OUTLOOK_RELEASE; i > 0; i--) {
+    fsx.writeFileSync(`${excelJsonPath}_online/${excelFilename}`, cleanUpRichApiJson(excelJson));
+    console.log("Completed excel");
+    for (let i = CURRENT_EXCEL_RELEASE; i > 0; i--) {
         console.log(`\nStarting excel${i}...`);
         excelJson = fsx.readFileSync(`${excelJsonPath}_1_${i}/${excelFilename}`).toString();
-        fsx.writeFileSync(`${excelJsonPath}_1_${i}/${excelFilename}`, cleanUpExcelJson(excelJson));
-        console.log(`\Completed excel${i}`);
+        fsx.writeFileSync(`${excelJsonPath}_1_${i}/${excelFilename}`, cleanUpRichApiJson(excelJson));
+        console.log(`Completed excel${i}`);
     }
 
     console.log("\nCompleted Excel json cross-referencing cleanup");
 
+    console.log("\nCleaning up Word json cross-referencing...");
+
+    const wordJsonPath = path.resolve("../json/word");
+    const wordFilename = "word.api.json";
+    console.log("\nStarting word...");
+    let wordJson = fsx.readFileSync(`${wordJsonPath}/${wordFilename}`).toString();
+    fsx.writeFileSync(`${wordJsonPath}/${wordFilename}`, cleanUpRichApiJson(wordJson));
+    console.log("Completed word");
+    for (let i = CURRENT_WORD_RELEASE; i > 0; i--) {
+        console.log(`\nStarting word_1_${i}...`);
+        wordJson = fsx.readFileSync(`${wordJsonPath}_1_${i}/${wordFilename}`).toString();
+        fsx.writeFileSync(`${wordJsonPath}_1_${i}/${wordFilename}`, cleanUpRichApiJson(wordJson));
+        console.log(`Completed word_1_${i}`);
+    }
+
+    console.log("\nCompleted Word json cross-referencing cleanup");
+
+    console.log("\nCleaning up Visio json cross-referencing...");
+
+    const visioJsonPath = path.resolve("../json/visio");
+    const visioFilename = "visio.api.json";
+    console.log("\nStarting visio...");
+    let visioJson = fsx.readFileSync(`${visioJsonPath}/${visioFilename}`).toString();
+    fsx.writeFileSync(`${visioJsonPath}/${visioFilename}`, cleanUpRichApiJson(visioJson));
+    console.log("Completed visio");
+
+    console.log("\nCompleted Visio json cross-referencing cleanup");
+
+    console.log("\nCleaning up OneNote json cross-referencing...");
+
+    const onenoteJsonPath = path.resolve("../json/onenote");
+    const onenoteFilename = "onenote.api.json";
+    console.log("\nStarting onenote...");
+    let onenoteJson = fsx.readFileSync(`${onenoteJsonPath}/${onenoteFilename}`).toString();
+    fsx.writeFileSync(`${onenoteJsonPath}/${onenoteFilename}`, cleanUpRichApiJson(onenoteJson));
+    console.log("Completed onenote");
+    console.log("\nCompleted OneNote json cross-referencing cleanup");
 
     // ----
     // Process Snippets
@@ -233,8 +270,8 @@ function cleanUpOutlookJson(jsonString : string) {
     return jsonString;
 }
 
-function cleanUpExcelJson(jsonString : string) {
-    return jsonString.replace(/excel\!OfficeExtension/g, "office!OfficeExtension");
+function cleanUpRichApiJson(jsonString : string) {
+    return jsonString.replace(/(excel|word|visio|onenote)\!OfficeExtension/g, "office!OfficeExtension");
 }
 
 async function tryCatch(call: () => Promise<void>) {


### PR DESCRIPTION
This edits the midprocessor to edit the universal references for `OfficeExtension` classes so they point to the Office package, instead of the ones for individual hosts. It mirrors the recent work done for Outlook by @ElizabethSamuel-MSFT. 

Here's the staging link for spot checking, once the build is complete: https://review.docs.microsoft.com/en-us/javascript/api/excel/excel.range?view=excel-js-preview&branch=AlexJ-Links