### PR TITLE
Postprocessing the API requirement set links for CFs and PPT

### DIFF
--- a/docs/docs-ref-autogen/excel/custom-functions-runtime/customfunctions.cancelableinvocation.yml
+++ b/docs/docs-ref-autogen/excel/custom-functions-runtime/customfunctions.cancelableinvocation.yml
@@ -24,7 +24,7 @@ items:
   - uid: 'custom-functions-runtime!CustomFunctions.CancelableInvocation#onCanceled:member'
     summary: >-
       Event handler called when the custom function is canceled. \[ [API set: CustomFunctionsRuntime
-      1.1](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      1.1](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: onCanceled
     fullName: onCanceled
     langs:

--- a/docs/docs-ref-autogen/excel/custom-functions-runtime/customfunctions.error.yml
+++ b/docs/docs-ref-autogen/excel/custom-functions-runtime/customfunctions.error.yml
@@ -3,7 +3,7 @@ items:
   - uid: 'custom-functions-runtime!CustomFunctions.Error:class'
     summary: >-
       Use this class to handle errors and write custom error messages. \[ [API set: CustomFunctionsRuntime
-      1.2](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      1.2](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: CustomFunctions.Error
     fullName: CustomFunctions.Error
     langs:
@@ -35,7 +35,7 @@ items:
   - uid: 'custom-functions-runtime!CustomFunctions.Error#errorCode:member'
     summary: >-
       The error code returned by your custom function. \[ [API set: CustomFunctionsRuntime
-      1.2](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      1.2](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: errorCode
     fullName: errorCode
     langs:
@@ -50,7 +50,7 @@ items:
     summary: >-
       Your custom error message, such as "This stock price is unavailable". Custom messages are only available with
       certain error codes. \[ [API set: CustomFunctionsRuntime
-      1.2](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      1.2](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: errorMessage
     fullName: errorMessage
     langs:

--- a/docs/docs-ref-autogen/excel/custom-functions-runtime/customfunctions.errorcode.yml
+++ b/docs/docs-ref-autogen/excel/custom-functions-runtime/customfunctions.errorcode.yml
@@ -5,8 +5,8 @@ items:
       Error codes for custom functions. The error codes will appear in the cell that invoked the function.
 
 
-      Custom error messages will appear in addition to these error codes. Custom messages will display in the error
-      indicator menu, which is accessed by clicking the error flag on each cell with an error.
+      Custom error messages appear in addition to these error codes. Custom messages display in the error indicator
+      menu, which is accessed by hovering over the error flag on each cell with an error.
     name: CustomFunctions.ErrorCode
     fullName: CustomFunctions.ErrorCode
     langs:
@@ -23,9 +23,10 @@ items:
       - 'custom-functions-runtime!CustomFunctions.ErrorCode.nullReference:member'
   - uid: 'custom-functions-runtime!CustomFunctions.ErrorCode.divisionByZero:member'
     summary: >-
-      This error code indicates that the function used is dividing by zero or empty cells. A custom error message can't
-      be used. \[ [API set: CustomFunctionsRuntime
-      1.3](/office/dev/add-ins/reference/overview/visio-javascript-reference-overview) \]
+      This error code indicates that the function used is dividing by zero or empty cells. Be aware that JavaScript
+      allows division by zero, so you need to write an error handler carefully to detect this condition. A custom error
+      message can't be used. \[ [API set: CustomFunctionsRuntime
+      1.3](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: divisionByZero
     fullName: divisionByZero
     langs:
@@ -34,8 +35,9 @@ items:
     numericValue: '"#DIV/0!"'
   - uid: 'custom-functions-runtime!CustomFunctions.ErrorCode.invalidName:member'
     summary: >-
-      This error code indicates that there is a typo in the function name. A custom error message can't be used. \[ [API
-      set: CustomFunctionsRuntime 1.3](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      This error code indicates that there is a typo in the function name. Note that this error code is supported as a
+      custom function input error, but not as a custom function output error. A custom error message can't be used. \[
+      [API set: CustomFunctionsRuntime 1.3](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: invalidName
     fullName: invalidName
     langs:
@@ -44,8 +46,8 @@ items:
     numericValue: '"#NAME?"'
   - uid: 'custom-functions-runtime!CustomFunctions.ErrorCode.invalidNumber:member'
     summary: >-
-      This error code indicates that there is a problem with a number used in the function. A custom error message can't
-      be used. \[ [API set: CustomFunctionsRuntime 1.3](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      This error code indicates that there is a problem with a number in the function. A custom error message can't be
+      used. \[ [API set: CustomFunctionsRuntime 1.3](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: invalidNumber
     fullName: invalidNumber
     langs:
@@ -54,8 +56,9 @@ items:
     numericValue: '"#NUM!"'
   - uid: 'custom-functions-runtime!CustomFunctions.ErrorCode.invalidReference:member'
     summary: >-
-      This error code indicates that the function refers to an invalid cell. A custom error message can't be used. \[
-      [API set: CustomFunctionsRuntime 1.3](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      This error code indicates that the function refers to an invalid cell. Note that this error code is supported as a
+      custom function input error, but not as a custom function output error. A custom error message can't be used. \[
+      [API set: CustomFunctionsRuntime 1.3](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: invalidReference
     fullName: invalidReference
     langs:
@@ -64,9 +67,9 @@ items:
     numericValue: '"#REF!"'
   - uid: 'custom-functions-runtime!CustomFunctions.ErrorCode.invalidValue:member'
     summary: >-
-      This error code indicates that a value used in the function is of the wrong data type. A custom error message can
-      be used in addition to the error code, if desired. \[ [API set: CustomFunctionsRuntime
-      1.3](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      This error code indicates that a value in the function is of the wrong data type. A custom error message can be
+      used in addition to the error code, if desired. \[ [API set: CustomFunctionsRuntime
+      1.3](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: invalidValue
     fullName: invalidValue
     langs:
@@ -77,7 +80,7 @@ items:
     summary: >-
       This error code indicates that the function or service isn't available. A custom error message can be used in
       addition to the error code, if desired. \[ [API set: CustomFunctionsRuntime
-      1.3](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      1.3](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: notAvailable
     fullName: notAvailable
     langs:
@@ -87,7 +90,7 @@ items:
   - uid: 'custom-functions-runtime!CustomFunctions.ErrorCode.nullReference:member'
     summary: >-
       This error code indicates that the ranges in the function don't intersect. A custom error message can't be used.
-      \[ [API set: CustomFunctionsRuntime 1.3](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      \[ [API set: CustomFunctionsRuntime 1.3](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: nullReference
     fullName: nullReference
     langs:

--- a/docs/docs-ref-autogen/excel/custom-functions-runtime/customfunctions.invocation.yml
+++ b/docs/docs-ref-autogen/excel/custom-functions-runtime/customfunctions.invocation.yml
@@ -21,7 +21,7 @@ items:
 
 
       If the metadata JSON file is being generated from JSDoc comments, include the tag `@requiresAddress`<!-- -->. \[
-      [API set: CustomFunctionsRuntime 1.1](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      [API set: CustomFunctionsRuntime 1.1](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: address
     fullName: address
     langs:
@@ -43,7 +43,7 @@ items:
 
       If the metadata JSON file is being generated from JSDoc comments, include the tag
       `@requiresParameterAddresses`<!-- -->. \[ [API set: CustomFunctionsRuntime
-      1.3](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      1.3](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: parameterAddresses
     fullName: parameterAddresses
     langs:

--- a/docs/docs-ref-autogen/excel/custom-functions-runtime/customfunctions.streaminginvocation.yml
+++ b/docs/docs-ref-autogen/excel/custom-functions-runtime/customfunctions.streaminginvocation.yml
@@ -23,7 +23,7 @@ items:
   - uid: 'custom-functions-runtime!CustomFunctions.StreamingInvocation#setResult:member'
     summary: >-
       Set the result for the custom function. May be called more than once. \[ [API set: CustomFunctionsRuntime
-      1.1](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      1.1](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: setResult
     fullName: setResult
     langs:

--- a/docs/docs-ref-autogen/excel_1_10/custom-functions-runtime/customfunctions.cancelableinvocation.yml
+++ b/docs/docs-ref-autogen/excel_1_10/custom-functions-runtime/customfunctions.cancelableinvocation.yml
@@ -24,7 +24,7 @@ items:
   - uid: 'custom-functions-runtime!CustomFunctions.CancelableInvocation#onCanceled:member'
     summary: >-
       Event handler called when the custom function is canceled. \[ [API set: CustomFunctionsRuntime
-      1.1](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      1.1](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: onCanceled
     fullName: onCanceled
     langs:

--- a/docs/docs-ref-autogen/excel_1_10/custom-functions-runtime/customfunctions.error.yml
+++ b/docs/docs-ref-autogen/excel_1_10/custom-functions-runtime/customfunctions.error.yml
@@ -3,7 +3,7 @@ items:
   - uid: 'custom-functions-runtime!CustomFunctions.Error:class'
     summary: >-
       Use this class to handle errors and write custom error messages. \[ [API set: CustomFunctionsRuntime
-      1.2](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      1.2](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: CustomFunctions.Error
     fullName: CustomFunctions.Error
     langs:
@@ -35,7 +35,7 @@ items:
   - uid: 'custom-functions-runtime!CustomFunctions.Error#errorCode:member'
     summary: >-
       The error code returned by your custom function. \[ [API set: CustomFunctionsRuntime
-      1.2](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      1.2](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: errorCode
     fullName: errorCode
     langs:
@@ -50,7 +50,7 @@ items:
     summary: >-
       Your custom error message, such as "This stock price is unavailable". Custom messages are only available with
       certain error codes. \[ [API set: CustomFunctionsRuntime
-      1.2](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      1.2](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: errorMessage
     fullName: errorMessage
     langs:

--- a/docs/docs-ref-autogen/excel_1_10/custom-functions-runtime/customfunctions.errorcode.yml
+++ b/docs/docs-ref-autogen/excel_1_10/custom-functions-runtime/customfunctions.errorcode.yml
@@ -5,8 +5,8 @@ items:
       Error codes for custom functions. The error codes will appear in the cell that invoked the function.
 
 
-      Custom error messages will appear in addition to these error codes. Custom messages will display in the error
-      indicator menu, which is accessed by clicking the error flag on each cell with an error.
+      Custom error messages appear in addition to these error codes. Custom messages display in the error indicator
+      menu, which is accessed by hovering over the error flag on each cell with an error.
     name: CustomFunctions.ErrorCode
     fullName: CustomFunctions.ErrorCode
     langs:
@@ -23,9 +23,10 @@ items:
       - 'custom-functions-runtime!CustomFunctions.ErrorCode.nullReference:member'
   - uid: 'custom-functions-runtime!CustomFunctions.ErrorCode.divisionByZero:member'
     summary: >-
-      This error code indicates that the function used is dividing by zero or empty cells. A custom error message can't
-      be used. \[ [API set: CustomFunctionsRuntime
-      1.3](/office/dev/add-ins/reference/overview/visio-javascript-reference-overview) \]
+      This error code indicates that the function used is dividing by zero or empty cells. Be aware that JavaScript
+      allows division by zero, so you need to write an error handler carefully to detect this condition. A custom error
+      message can't be used. \[ [API set: CustomFunctionsRuntime
+      1.3](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: divisionByZero
     fullName: divisionByZero
     langs:
@@ -34,8 +35,9 @@ items:
     numericValue: '"#DIV/0!"'
   - uid: 'custom-functions-runtime!CustomFunctions.ErrorCode.invalidName:member'
     summary: >-
-      This error code indicates that there is a typo in the function name. A custom error message can't be used. \[ [API
-      set: CustomFunctionsRuntime 1.3](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      This error code indicates that there is a typo in the function name. Note that this error code is supported as a
+      custom function input error, but not as a custom function output error. A custom error message can't be used. \[
+      [API set: CustomFunctionsRuntime 1.3](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: invalidName
     fullName: invalidName
     langs:
@@ -44,8 +46,8 @@ items:
     numericValue: '"#NAME?"'
   - uid: 'custom-functions-runtime!CustomFunctions.ErrorCode.invalidNumber:member'
     summary: >-
-      This error code indicates that there is a problem with a number used in the function. A custom error message can't
-      be used. \[ [API set: CustomFunctionsRuntime 1.3](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      This error code indicates that there is a problem with a number in the function. A custom error message can't be
+      used. \[ [API set: CustomFunctionsRuntime 1.3](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: invalidNumber
     fullName: invalidNumber
     langs:
@@ -54,8 +56,9 @@ items:
     numericValue: '"#NUM!"'
   - uid: 'custom-functions-runtime!CustomFunctions.ErrorCode.invalidReference:member'
     summary: >-
-      This error code indicates that the function refers to an invalid cell. A custom error message can't be used. \[
-      [API set: CustomFunctionsRuntime 1.3](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      This error code indicates that the function refers to an invalid cell. Note that this error code is supported as a
+      custom function input error, but not as a custom function output error. A custom error message can't be used. \[
+      [API set: CustomFunctionsRuntime 1.3](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: invalidReference
     fullName: invalidReference
     langs:
@@ -64,9 +67,9 @@ items:
     numericValue: '"#REF!"'
   - uid: 'custom-functions-runtime!CustomFunctions.ErrorCode.invalidValue:member'
     summary: >-
-      This error code indicates that a value used in the function is of the wrong data type. A custom error message can
-      be used in addition to the error code, if desired. \[ [API set: CustomFunctionsRuntime
-      1.3](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      This error code indicates that a value in the function is of the wrong data type. A custom error message can be
+      used in addition to the error code, if desired. \[ [API set: CustomFunctionsRuntime
+      1.3](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: invalidValue
     fullName: invalidValue
     langs:
@@ -77,7 +80,7 @@ items:
     summary: >-
       This error code indicates that the function or service isn't available. A custom error message can be used in
       addition to the error code, if desired. \[ [API set: CustomFunctionsRuntime
-      1.3](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      1.3](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: notAvailable
     fullName: notAvailable
     langs:
@@ -87,7 +90,7 @@ items:
   - uid: 'custom-functions-runtime!CustomFunctions.ErrorCode.nullReference:member'
     summary: >-
       This error code indicates that the ranges in the function don't intersect. A custom error message can't be used.
-      \[ [API set: CustomFunctionsRuntime 1.3](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      \[ [API set: CustomFunctionsRuntime 1.3](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: nullReference
     fullName: nullReference
     langs:

--- a/docs/docs-ref-autogen/excel_1_10/custom-functions-runtime/customfunctions.invocation.yml
+++ b/docs/docs-ref-autogen/excel_1_10/custom-functions-runtime/customfunctions.invocation.yml
@@ -21,7 +21,7 @@ items:
 
 
       If the metadata JSON file is being generated from JSDoc comments, include the tag `@requiresAddress`<!-- -->. \[
-      [API set: CustomFunctionsRuntime 1.1](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      [API set: CustomFunctionsRuntime 1.1](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: address
     fullName: address
     langs:
@@ -43,7 +43,7 @@ items:
 
       If the metadata JSON file is being generated from JSDoc comments, include the tag
       `@requiresParameterAddresses`<!-- -->. \[ [API set: CustomFunctionsRuntime
-      1.3](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      1.3](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: parameterAddresses
     fullName: parameterAddresses
     langs:

--- a/docs/docs-ref-autogen/excel_1_10/custom-functions-runtime/customfunctions.streaminginvocation.yml
+++ b/docs/docs-ref-autogen/excel_1_10/custom-functions-runtime/customfunctions.streaminginvocation.yml
@@ -23,7 +23,7 @@ items:
   - uid: 'custom-functions-runtime!CustomFunctions.StreamingInvocation#setResult:member'
     summary: >-
       Set the result for the custom function. May be called more than once. \[ [API set: CustomFunctionsRuntime
-      1.1](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      1.1](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: setResult
     fullName: setResult
     langs:

--- a/docs/docs-ref-autogen/excel_1_11/custom-functions-runtime/customfunctions.cancelableinvocation.yml
+++ b/docs/docs-ref-autogen/excel_1_11/custom-functions-runtime/customfunctions.cancelableinvocation.yml
@@ -24,7 +24,7 @@ items:
   - uid: 'custom-functions-runtime!CustomFunctions.CancelableInvocation#onCanceled:member'
     summary: >-
       Event handler called when the custom function is canceled. \[ [API set: CustomFunctionsRuntime
-      1.1](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      1.1](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: onCanceled
     fullName: onCanceled
     langs:

--- a/docs/docs-ref-autogen/excel_1_11/custom-functions-runtime/customfunctions.error.yml
+++ b/docs/docs-ref-autogen/excel_1_11/custom-functions-runtime/customfunctions.error.yml
@@ -3,7 +3,7 @@ items:
   - uid: 'custom-functions-runtime!CustomFunctions.Error:class'
     summary: >-
       Use this class to handle errors and write custom error messages. \[ [API set: CustomFunctionsRuntime
-      1.2](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      1.2](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: CustomFunctions.Error
     fullName: CustomFunctions.Error
     langs:
@@ -35,7 +35,7 @@ items:
   - uid: 'custom-functions-runtime!CustomFunctions.Error#errorCode:member'
     summary: >-
       The error code returned by your custom function. \[ [API set: CustomFunctionsRuntime
-      1.2](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      1.2](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: errorCode
     fullName: errorCode
     langs:
@@ -50,7 +50,7 @@ items:
     summary: >-
       Your custom error message, such as "This stock price is unavailable". Custom messages are only available with
       certain error codes. \[ [API set: CustomFunctionsRuntime
-      1.2](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      1.2](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: errorMessage
     fullName: errorMessage
     langs:

--- a/docs/docs-ref-autogen/excel_1_11/custom-functions-runtime/customfunctions.errorcode.yml
+++ b/docs/docs-ref-autogen/excel_1_11/custom-functions-runtime/customfunctions.errorcode.yml
@@ -5,8 +5,8 @@ items:
       Error codes for custom functions. The error codes will appear in the cell that invoked the function.
 
 
-      Custom error messages will appear in addition to these error codes. Custom messages will display in the error
-      indicator menu, which is accessed by clicking the error flag on each cell with an error.
+      Custom error messages appear in addition to these error codes. Custom messages display in the error indicator
+      menu, which is accessed by hovering over the error flag on each cell with an error.
     name: CustomFunctions.ErrorCode
     fullName: CustomFunctions.ErrorCode
     langs:
@@ -23,9 +23,10 @@ items:
       - 'custom-functions-runtime!CustomFunctions.ErrorCode.nullReference:member'
   - uid: 'custom-functions-runtime!CustomFunctions.ErrorCode.divisionByZero:member'
     summary: >-
-      This error code indicates that the function used is dividing by zero or empty cells. A custom error message can't
-      be used. \[ [API set: CustomFunctionsRuntime
-      1.3](/office/dev/add-ins/reference/overview/visio-javascript-reference-overview) \]
+      This error code indicates that the function used is dividing by zero or empty cells. Be aware that JavaScript
+      allows division by zero, so you need to write an error handler carefully to detect this condition. A custom error
+      message can't be used. \[ [API set: CustomFunctionsRuntime
+      1.3](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: divisionByZero
     fullName: divisionByZero
     langs:
@@ -34,8 +35,9 @@ items:
     numericValue: '"#DIV/0!"'
   - uid: 'custom-functions-runtime!CustomFunctions.ErrorCode.invalidName:member'
     summary: >-
-      This error code indicates that there is a typo in the function name. A custom error message can't be used. \[ [API
-      set: CustomFunctionsRuntime 1.3](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      This error code indicates that there is a typo in the function name. Note that this error code is supported as a
+      custom function input error, but not as a custom function output error. A custom error message can't be used. \[
+      [API set: CustomFunctionsRuntime 1.3](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: invalidName
     fullName: invalidName
     langs:
@@ -44,8 +46,8 @@ items:
     numericValue: '"#NAME?"'
   - uid: 'custom-functions-runtime!CustomFunctions.ErrorCode.invalidNumber:member'
     summary: >-
-      This error code indicates that there is a problem with a number used in the function. A custom error message can't
-      be used. \[ [API set: CustomFunctionsRuntime 1.3](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      This error code indicates that there is a problem with a number in the function. A custom error message can't be
+      used. \[ [API set: CustomFunctionsRuntime 1.3](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: invalidNumber
     fullName: invalidNumber
     langs:
@@ -54,8 +56,9 @@ items:
     numericValue: '"#NUM!"'
   - uid: 'custom-functions-runtime!CustomFunctions.ErrorCode.invalidReference:member'
     summary: >-
-      This error code indicates that the function refers to an invalid cell. A custom error message can't be used. \[
-      [API set: CustomFunctionsRuntime 1.3](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      This error code indicates that the function refers to an invalid cell. Note that this error code is supported as a
+      custom function input error, but not as a custom function output error. A custom error message can't be used. \[
+      [API set: CustomFunctionsRuntime 1.3](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: invalidReference
     fullName: invalidReference
     langs:
@@ -64,9 +67,9 @@ items:
     numericValue: '"#REF!"'
   - uid: 'custom-functions-runtime!CustomFunctions.ErrorCode.invalidValue:member'
     summary: >-
-      This error code indicates that a value used in the function is of the wrong data type. A custom error message can
-      be used in addition to the error code, if desired. \[ [API set: CustomFunctionsRuntime
-      1.3](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      This error code indicates that a value in the function is of the wrong data type. A custom error message can be
+      used in addition to the error code, if desired. \[ [API set: CustomFunctionsRuntime
+      1.3](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: invalidValue
     fullName: invalidValue
     langs:
@@ -77,7 +80,7 @@ items:
     summary: >-
       This error code indicates that the function or service isn't available. A custom error message can be used in
       addition to the error code, if desired. \[ [API set: CustomFunctionsRuntime
-      1.3](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      1.3](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: notAvailable
     fullName: notAvailable
     langs:
@@ -87,7 +90,7 @@ items:
   - uid: 'custom-functions-runtime!CustomFunctions.ErrorCode.nullReference:member'
     summary: >-
       This error code indicates that the ranges in the function don't intersect. A custom error message can't be used.
-      \[ [API set: CustomFunctionsRuntime 1.3](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      \[ [API set: CustomFunctionsRuntime 1.3](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: nullReference
     fullName: nullReference
     langs:

--- a/docs/docs-ref-autogen/excel_1_11/custom-functions-runtime/customfunctions.invocation.yml
+++ b/docs/docs-ref-autogen/excel_1_11/custom-functions-runtime/customfunctions.invocation.yml
@@ -21,7 +21,7 @@ items:
 
 
       If the metadata JSON file is being generated from JSDoc comments, include the tag `@requiresAddress`<!-- -->. \[
-      [API set: CustomFunctionsRuntime 1.1](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      [API set: CustomFunctionsRuntime 1.1](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: address
     fullName: address
     langs:
@@ -43,7 +43,7 @@ items:
 
       If the metadata JSON file is being generated from JSDoc comments, include the tag
       `@requiresParameterAddresses`<!-- -->. \[ [API set: CustomFunctionsRuntime
-      1.3](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      1.3](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: parameterAddresses
     fullName: parameterAddresses
     langs:

--- a/docs/docs-ref-autogen/excel_1_11/custom-functions-runtime/customfunctions.streaminginvocation.yml
+++ b/docs/docs-ref-autogen/excel_1_11/custom-functions-runtime/customfunctions.streaminginvocation.yml
@@ -23,7 +23,7 @@ items:
   - uid: 'custom-functions-runtime!CustomFunctions.StreamingInvocation#setResult:member'
     summary: >-
       Set the result for the custom function. May be called more than once. \[ [API set: CustomFunctionsRuntime
-      1.1](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      1.1](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: setResult
     fullName: setResult
     langs:

--- a/docs/docs-ref-autogen/excel_1_12/custom-functions-runtime/customfunctions.cancelableinvocation.yml
+++ b/docs/docs-ref-autogen/excel_1_12/custom-functions-runtime/customfunctions.cancelableinvocation.yml
@@ -24,7 +24,7 @@ items:
   - uid: 'custom-functions-runtime!CustomFunctions.CancelableInvocation#onCanceled:member'
     summary: >-
       Event handler called when the custom function is canceled. \[ [API set: CustomFunctionsRuntime
-      1.1](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      1.1](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: onCanceled
     fullName: onCanceled
     langs:

--- a/docs/docs-ref-autogen/excel_1_12/custom-functions-runtime/customfunctions.error.yml
+++ b/docs/docs-ref-autogen/excel_1_12/custom-functions-runtime/customfunctions.error.yml
@@ -3,7 +3,7 @@ items:
   - uid: 'custom-functions-runtime!CustomFunctions.Error:class'
     summary: >-
       Use this class to handle errors and write custom error messages. \[ [API set: CustomFunctionsRuntime
-      1.2](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      1.2](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: CustomFunctions.Error
     fullName: CustomFunctions.Error
     langs:
@@ -35,7 +35,7 @@ items:
   - uid: 'custom-functions-runtime!CustomFunctions.Error#errorCode:member'
     summary: >-
       The error code returned by your custom function. \[ [API set: CustomFunctionsRuntime
-      1.2](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      1.2](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: errorCode
     fullName: errorCode
     langs:
@@ -50,7 +50,7 @@ items:
     summary: >-
       Your custom error message, such as "This stock price is unavailable". Custom messages are only available with
       certain error codes. \[ [API set: CustomFunctionsRuntime
-      1.2](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      1.2](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: errorMessage
     fullName: errorMessage
     langs:

--- a/docs/docs-ref-autogen/excel_1_12/custom-functions-runtime/customfunctions.errorcode.yml
+++ b/docs/docs-ref-autogen/excel_1_12/custom-functions-runtime/customfunctions.errorcode.yml
@@ -5,8 +5,8 @@ items:
       Error codes for custom functions. The error codes will appear in the cell that invoked the function.
 
 
-      Custom error messages will appear in addition to these error codes. Custom messages will display in the error
-      indicator menu, which is accessed by clicking the error flag on each cell with an error.
+      Custom error messages appear in addition to these error codes. Custom messages display in the error indicator
+      menu, which is accessed by hovering over the error flag on each cell with an error.
     name: CustomFunctions.ErrorCode
     fullName: CustomFunctions.ErrorCode
     langs:
@@ -23,9 +23,10 @@ items:
       - 'custom-functions-runtime!CustomFunctions.ErrorCode.nullReference:member'
   - uid: 'custom-functions-runtime!CustomFunctions.ErrorCode.divisionByZero:member'
     summary: >-
-      This error code indicates that the function used is dividing by zero or empty cells. A custom error message can't
-      be used. \[ [API set: CustomFunctionsRuntime
-      1.3](/office/dev/add-ins/reference/overview/visio-javascript-reference-overview) \]
+      This error code indicates that the function used is dividing by zero or empty cells. Be aware that JavaScript
+      allows division by zero, so you need to write an error handler carefully to detect this condition. A custom error
+      message can't be used. \[ [API set: CustomFunctionsRuntime
+      1.3](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: divisionByZero
     fullName: divisionByZero
     langs:
@@ -34,8 +35,9 @@ items:
     numericValue: '"#DIV/0!"'
   - uid: 'custom-functions-runtime!CustomFunctions.ErrorCode.invalidName:member'
     summary: >-
-      This error code indicates that there is a typo in the function name. A custom error message can't be used. \[ [API
-      set: CustomFunctionsRuntime 1.3](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      This error code indicates that there is a typo in the function name. Note that this error code is supported as a
+      custom function input error, but not as a custom function output error. A custom error message can't be used. \[
+      [API set: CustomFunctionsRuntime 1.3](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: invalidName
     fullName: invalidName
     langs:
@@ -44,8 +46,8 @@ items:
     numericValue: '"#NAME?"'
   - uid: 'custom-functions-runtime!CustomFunctions.ErrorCode.invalidNumber:member'
     summary: >-
-      This error code indicates that there is a problem with a number used in the function. A custom error message can't
-      be used. \[ [API set: CustomFunctionsRuntime 1.3](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      This error code indicates that there is a problem with a number in the function. A custom error message can't be
+      used. \[ [API set: CustomFunctionsRuntime 1.3](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: invalidNumber
     fullName: invalidNumber
     langs:
@@ -54,8 +56,9 @@ items:
     numericValue: '"#NUM!"'
   - uid: 'custom-functions-runtime!CustomFunctions.ErrorCode.invalidReference:member'
     summary: >-
-      This error code indicates that the function refers to an invalid cell. A custom error message can't be used. \[
-      [API set: CustomFunctionsRuntime 1.3](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      This error code indicates that the function refers to an invalid cell. Note that this error code is supported as a
+      custom function input error, but not as a custom function output error. A custom error message can't be used. \[
+      [API set: CustomFunctionsRuntime 1.3](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: invalidReference
     fullName: invalidReference
     langs:
@@ -64,9 +67,9 @@ items:
     numericValue: '"#REF!"'
   - uid: 'custom-functions-runtime!CustomFunctions.ErrorCode.invalidValue:member'
     summary: >-
-      This error code indicates that a value used in the function is of the wrong data type. A custom error message can
-      be used in addition to the error code, if desired. \[ [API set: CustomFunctionsRuntime
-      1.3](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      This error code indicates that a value in the function is of the wrong data type. A custom error message can be
+      used in addition to the error code, if desired. \[ [API set: CustomFunctionsRuntime
+      1.3](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: invalidValue
     fullName: invalidValue
     langs:
@@ -77,7 +80,7 @@ items:
     summary: >-
       This error code indicates that the function or service isn't available. A custom error message can be used in
       addition to the error code, if desired. \[ [API set: CustomFunctionsRuntime
-      1.3](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      1.3](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: notAvailable
     fullName: notAvailable
     langs:
@@ -87,7 +90,7 @@ items:
   - uid: 'custom-functions-runtime!CustomFunctions.ErrorCode.nullReference:member'
     summary: >-
       This error code indicates that the ranges in the function don't intersect. A custom error message can't be used.
-      \[ [API set: CustomFunctionsRuntime 1.3](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      \[ [API set: CustomFunctionsRuntime 1.3](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: nullReference
     fullName: nullReference
     langs:

--- a/docs/docs-ref-autogen/excel_1_12/custom-functions-runtime/customfunctions.invocation.yml
+++ b/docs/docs-ref-autogen/excel_1_12/custom-functions-runtime/customfunctions.invocation.yml
@@ -21,7 +21,7 @@ items:
 
 
       If the metadata JSON file is being generated from JSDoc comments, include the tag `@requiresAddress`<!-- -->. \[
-      [API set: CustomFunctionsRuntime 1.1](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      [API set: CustomFunctionsRuntime 1.1](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: address
     fullName: address
     langs:
@@ -43,7 +43,7 @@ items:
 
       If the metadata JSON file is being generated from JSDoc comments, include the tag
       `@requiresParameterAddresses`<!-- -->. \[ [API set: CustomFunctionsRuntime
-      1.3](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      1.3](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: parameterAddresses
     fullName: parameterAddresses
     langs:

--- a/docs/docs-ref-autogen/excel_1_12/custom-functions-runtime/customfunctions.streaminginvocation.yml
+++ b/docs/docs-ref-autogen/excel_1_12/custom-functions-runtime/customfunctions.streaminginvocation.yml
@@ -23,7 +23,7 @@ items:
   - uid: 'custom-functions-runtime!CustomFunctions.StreamingInvocation#setResult:member'
     summary: >-
       Set the result for the custom function. May be called more than once. \[ [API set: CustomFunctionsRuntime
-      1.1](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      1.1](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: setResult
     fullName: setResult
     langs:

--- a/docs/docs-ref-autogen/excel_1_9/custom-functions-runtime/customfunctions.cancelableinvocation.yml
+++ b/docs/docs-ref-autogen/excel_1_9/custom-functions-runtime/customfunctions.cancelableinvocation.yml
@@ -24,7 +24,7 @@ items:
   - uid: 'custom-functions-runtime!CustomFunctions.CancelableInvocation#onCanceled:member'
     summary: >-
       Event handler called when the custom function is canceled. \[ [API set: CustomFunctionsRuntime
-      1.1](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      1.1](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: onCanceled
     fullName: onCanceled
     langs:

--- a/docs/docs-ref-autogen/excel_1_9/custom-functions-runtime/customfunctions.error.yml
+++ b/docs/docs-ref-autogen/excel_1_9/custom-functions-runtime/customfunctions.error.yml
@@ -3,7 +3,7 @@ items:
   - uid: 'custom-functions-runtime!CustomFunctions.Error:class'
     summary: >-
       Use this class to handle errors and write custom error messages. \[ [API set: CustomFunctionsRuntime
-      1.2](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      1.2](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: CustomFunctions.Error
     fullName: CustomFunctions.Error
     langs:
@@ -35,7 +35,7 @@ items:
   - uid: 'custom-functions-runtime!CustomFunctions.Error#errorCode:member'
     summary: >-
       The error code returned by your custom function. \[ [API set: CustomFunctionsRuntime
-      1.2](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      1.2](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: errorCode
     fullName: errorCode
     langs:
@@ -50,7 +50,7 @@ items:
     summary: >-
       Your custom error message, such as "This stock price is unavailable". Custom messages are only available with
       certain error codes. \[ [API set: CustomFunctionsRuntime
-      1.2](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      1.2](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: errorMessage
     fullName: errorMessage
     langs:

--- a/docs/docs-ref-autogen/excel_1_9/custom-functions-runtime/customfunctions.errorcode.yml
+++ b/docs/docs-ref-autogen/excel_1_9/custom-functions-runtime/customfunctions.errorcode.yml
@@ -5,8 +5,8 @@ items:
       Error codes for custom functions. The error codes will appear in the cell that invoked the function.
 
 
-      Custom error messages will appear in addition to these error codes. Custom messages will display in the error
-      indicator menu, which is accessed by clicking the error flag on each cell with an error.
+      Custom error messages appear in addition to these error codes. Custom messages display in the error indicator
+      menu, which is accessed by hovering over the error flag on each cell with an error.
     name: CustomFunctions.ErrorCode
     fullName: CustomFunctions.ErrorCode
     langs:
@@ -23,9 +23,10 @@ items:
       - 'custom-functions-runtime!CustomFunctions.ErrorCode.nullReference:member'
   - uid: 'custom-functions-runtime!CustomFunctions.ErrorCode.divisionByZero:member'
     summary: >-
-      This error code indicates that the function used is dividing by zero or empty cells. A custom error message can't
-      be used. \[ [API set: CustomFunctionsRuntime
-      1.3](/office/dev/add-ins/reference/overview/visio-javascript-reference-overview) \]
+      This error code indicates that the function used is dividing by zero or empty cells. Be aware that JavaScript
+      allows division by zero, so you need to write an error handler carefully to detect this condition. A custom error
+      message can't be used. \[ [API set: CustomFunctionsRuntime
+      1.3](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: divisionByZero
     fullName: divisionByZero
     langs:
@@ -34,8 +35,9 @@ items:
     numericValue: '"#DIV/0!"'
   - uid: 'custom-functions-runtime!CustomFunctions.ErrorCode.invalidName:member'
     summary: >-
-      This error code indicates that there is a typo in the function name. A custom error message can't be used. \[ [API
-      set: CustomFunctionsRuntime 1.3](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      This error code indicates that there is a typo in the function name. Note that this error code is supported as a
+      custom function input error, but not as a custom function output error. A custom error message can't be used. \[
+      [API set: CustomFunctionsRuntime 1.3](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: invalidName
     fullName: invalidName
     langs:
@@ -44,8 +46,8 @@ items:
     numericValue: '"#NAME?"'
   - uid: 'custom-functions-runtime!CustomFunctions.ErrorCode.invalidNumber:member'
     summary: >-
-      This error code indicates that there is a problem with a number used in the function. A custom error message can't
-      be used. \[ [API set: CustomFunctionsRuntime 1.3](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      This error code indicates that there is a problem with a number in the function. A custom error message can't be
+      used. \[ [API set: CustomFunctionsRuntime 1.3](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: invalidNumber
     fullName: invalidNumber
     langs:
@@ -54,8 +56,9 @@ items:
     numericValue: '"#NUM!"'
   - uid: 'custom-functions-runtime!CustomFunctions.ErrorCode.invalidReference:member'
     summary: >-
-      This error code indicates that the function refers to an invalid cell. A custom error message can't be used. \[
-      [API set: CustomFunctionsRuntime 1.3](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      This error code indicates that the function refers to an invalid cell. Note that this error code is supported as a
+      custom function input error, but not as a custom function output error. A custom error message can't be used. \[
+      [API set: CustomFunctionsRuntime 1.3](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: invalidReference
     fullName: invalidReference
     langs:
@@ -64,9 +67,9 @@ items:
     numericValue: '"#REF!"'
   - uid: 'custom-functions-runtime!CustomFunctions.ErrorCode.invalidValue:member'
     summary: >-
-      This error code indicates that a value used in the function is of the wrong data type. A custom error message can
-      be used in addition to the error code, if desired. \[ [API set: CustomFunctionsRuntime
-      1.3](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      This error code indicates that a value in the function is of the wrong data type. A custom error message can be
+      used in addition to the error code, if desired. \[ [API set: CustomFunctionsRuntime
+      1.3](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: invalidValue
     fullName: invalidValue
     langs:
@@ -77,7 +80,7 @@ items:
     summary: >-
       This error code indicates that the function or service isn't available. A custom error message can be used in
       addition to the error code, if desired. \[ [API set: CustomFunctionsRuntime
-      1.3](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      1.3](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: notAvailable
     fullName: notAvailable
     langs:
@@ -87,7 +90,7 @@ items:
   - uid: 'custom-functions-runtime!CustomFunctions.ErrorCode.nullReference:member'
     summary: >-
       This error code indicates that the ranges in the function don't intersect. A custom error message can't be used.
-      \[ [API set: CustomFunctionsRuntime 1.3](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      \[ [API set: CustomFunctionsRuntime 1.3](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: nullReference
     fullName: nullReference
     langs:

--- a/docs/docs-ref-autogen/excel_1_9/custom-functions-runtime/customfunctions.invocation.yml
+++ b/docs/docs-ref-autogen/excel_1_9/custom-functions-runtime/customfunctions.invocation.yml
@@ -21,7 +21,7 @@ items:
 
 
       If the metadata JSON file is being generated from JSDoc comments, include the tag `@requiresAddress`<!-- -->. \[
-      [API set: CustomFunctionsRuntime 1.1](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      [API set: CustomFunctionsRuntime 1.1](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: address
     fullName: address
     langs:
@@ -43,7 +43,7 @@ items:
 
       If the metadata JSON file is being generated from JSDoc comments, include the tag
       `@requiresParameterAddresses`<!-- -->. \[ [API set: CustomFunctionsRuntime
-      1.3](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      1.3](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: parameterAddresses
     fullName: parameterAddresses
     langs:

--- a/docs/docs-ref-autogen/excel_1_9/custom-functions-runtime/customfunctions.streaminginvocation.yml
+++ b/docs/docs-ref-autogen/excel_1_9/custom-functions-runtime/customfunctions.streaminginvocation.yml
@@ -23,7 +23,7 @@ items:
   - uid: 'custom-functions-runtime!CustomFunctions.StreamingInvocation#setResult:member'
     summary: >-
       Set the result for the custom function. May be called more than once. \[ [API set: CustomFunctionsRuntime
-      1.1](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      1.1](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: setResult
     fullName: setResult
     langs:

--- a/docs/docs-ref-autogen/excel_online/custom-functions-runtime/customfunctions.cancelableinvocation.yml
+++ b/docs/docs-ref-autogen/excel_online/custom-functions-runtime/customfunctions.cancelableinvocation.yml
@@ -24,7 +24,7 @@ items:
   - uid: 'custom-functions-runtime!CustomFunctions.CancelableInvocation#onCanceled:member'
     summary: >-
       Event handler called when the custom function is canceled. \[ [API set: CustomFunctionsRuntime
-      1.1](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      1.1](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: onCanceled
     fullName: onCanceled
     langs:

--- a/docs/docs-ref-autogen/excel_online/custom-functions-runtime/customfunctions.error.yml
+++ b/docs/docs-ref-autogen/excel_online/custom-functions-runtime/customfunctions.error.yml
@@ -3,7 +3,7 @@ items:
   - uid: 'custom-functions-runtime!CustomFunctions.Error:class'
     summary: >-
       Use this class to handle errors and write custom error messages. \[ [API set: CustomFunctionsRuntime
-      1.2](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      1.2](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: CustomFunctions.Error
     fullName: CustomFunctions.Error
     langs:
@@ -35,7 +35,7 @@ items:
   - uid: 'custom-functions-runtime!CustomFunctions.Error#errorCode:member'
     summary: >-
       The error code returned by your custom function. \[ [API set: CustomFunctionsRuntime
-      1.2](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      1.2](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: errorCode
     fullName: errorCode
     langs:
@@ -50,7 +50,7 @@ items:
     summary: >-
       Your custom error message, such as "This stock price is unavailable". Custom messages are only available with
       certain error codes. \[ [API set: CustomFunctionsRuntime
-      1.2](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      1.2](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: errorMessage
     fullName: errorMessage
     langs:

--- a/docs/docs-ref-autogen/excel_online/custom-functions-runtime/customfunctions.errorcode.yml
+++ b/docs/docs-ref-autogen/excel_online/custom-functions-runtime/customfunctions.errorcode.yml
@@ -5,8 +5,8 @@ items:
       Error codes for custom functions. The error codes will appear in the cell that invoked the function.
 
 
-      Custom error messages will appear in addition to these error codes. Custom messages will display in the error
-      indicator menu, which is accessed by clicking the error flag on each cell with an error.
+      Custom error messages appear in addition to these error codes. Custom messages display in the error indicator
+      menu, which is accessed by hovering over the error flag on each cell with an error.
     name: CustomFunctions.ErrorCode
     fullName: CustomFunctions.ErrorCode
     langs:
@@ -23,9 +23,10 @@ items:
       - 'custom-functions-runtime!CustomFunctions.ErrorCode.nullReference:member'
   - uid: 'custom-functions-runtime!CustomFunctions.ErrorCode.divisionByZero:member'
     summary: >-
-      This error code indicates that the function used is dividing by zero or empty cells. A custom error message can't
-      be used. \[ [API set: CustomFunctionsRuntime
-      1.3](/office/dev/add-ins/reference/overview/visio-javascript-reference-overview) \]
+      This error code indicates that the function used is dividing by zero or empty cells. Be aware that JavaScript
+      allows division by zero, so you need to write an error handler carefully to detect this condition. A custom error
+      message can't be used. \[ [API set: CustomFunctionsRuntime
+      1.3](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: divisionByZero
     fullName: divisionByZero
     langs:
@@ -34,8 +35,9 @@ items:
     numericValue: '"#DIV/0!"'
   - uid: 'custom-functions-runtime!CustomFunctions.ErrorCode.invalidName:member'
     summary: >-
-      This error code indicates that there is a typo in the function name. A custom error message can't be used. \[ [API
-      set: CustomFunctionsRuntime 1.3](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      This error code indicates that there is a typo in the function name. Note that this error code is supported as a
+      custom function input error, but not as a custom function output error. A custom error message can't be used. \[
+      [API set: CustomFunctionsRuntime 1.3](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: invalidName
     fullName: invalidName
     langs:
@@ -44,8 +46,8 @@ items:
     numericValue: '"#NAME?"'
   - uid: 'custom-functions-runtime!CustomFunctions.ErrorCode.invalidNumber:member'
     summary: >-
-      This error code indicates that there is a problem with a number used in the function. A custom error message can't
-      be used. \[ [API set: CustomFunctionsRuntime 1.3](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      This error code indicates that there is a problem with a number in the function. A custom error message can't be
+      used. \[ [API set: CustomFunctionsRuntime 1.3](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: invalidNumber
     fullName: invalidNumber
     langs:
@@ -54,8 +56,9 @@ items:
     numericValue: '"#NUM!"'
   - uid: 'custom-functions-runtime!CustomFunctions.ErrorCode.invalidReference:member'
     summary: >-
-      This error code indicates that the function refers to an invalid cell. A custom error message can't be used. \[
-      [API set: CustomFunctionsRuntime 1.3](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      This error code indicates that the function refers to an invalid cell. Note that this error code is supported as a
+      custom function input error, but not as a custom function output error. A custom error message can't be used. \[
+      [API set: CustomFunctionsRuntime 1.3](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: invalidReference
     fullName: invalidReference
     langs:
@@ -64,9 +67,9 @@ items:
     numericValue: '"#REF!"'
   - uid: 'custom-functions-runtime!CustomFunctions.ErrorCode.invalidValue:member'
     summary: >-
-      This error code indicates that a value used in the function is of the wrong data type. A custom error message can
-      be used in addition to the error code, if desired. \[ [API set: CustomFunctionsRuntime
-      1.3](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      This error code indicates that a value in the function is of the wrong data type. A custom error message can be
+      used in addition to the error code, if desired. \[ [API set: CustomFunctionsRuntime
+      1.3](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: invalidValue
     fullName: invalidValue
     langs:
@@ -77,7 +80,7 @@ items:
     summary: >-
       This error code indicates that the function or service isn't available. A custom error message can be used in
       addition to the error code, if desired. \[ [API set: CustomFunctionsRuntime
-      1.3](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      1.3](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: notAvailable
     fullName: notAvailable
     langs:
@@ -87,7 +90,7 @@ items:
   - uid: 'custom-functions-runtime!CustomFunctions.ErrorCode.nullReference:member'
     summary: >-
       This error code indicates that the ranges in the function don't intersect. A custom error message can't be used.
-      \[ [API set: CustomFunctionsRuntime 1.3](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      \[ [API set: CustomFunctionsRuntime 1.3](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: nullReference
     fullName: nullReference
     langs:

--- a/docs/docs-ref-autogen/excel_online/custom-functions-runtime/customfunctions.invocation.yml
+++ b/docs/docs-ref-autogen/excel_online/custom-functions-runtime/customfunctions.invocation.yml
@@ -21,7 +21,7 @@ items:
 
 
       If the metadata JSON file is being generated from JSDoc comments, include the tag `@requiresAddress`<!-- -->. \[
-      [API set: CustomFunctionsRuntime 1.1](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      [API set: CustomFunctionsRuntime 1.1](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: address
     fullName: address
     langs:
@@ -43,7 +43,7 @@ items:
 
       If the metadata JSON file is being generated from JSDoc comments, include the tag
       `@requiresParameterAddresses`<!-- -->. \[ [API set: CustomFunctionsRuntime
-      1.3](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      1.3](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: parameterAddresses
     fullName: parameterAddresses
     langs:

--- a/docs/docs-ref-autogen/excel_online/custom-functions-runtime/customfunctions.streaminginvocation.yml
+++ b/docs/docs-ref-autogen/excel_online/custom-functions-runtime/customfunctions.streaminginvocation.yml
@@ -23,7 +23,7 @@ items:
   - uid: 'custom-functions-runtime!CustomFunctions.StreamingInvocation#setResult:member'
     summary: >-
       Set the result for the custom function. May be called more than once. \[ [API set: CustomFunctionsRuntime
-      1.1](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      1.1](/office/dev/add-ins/excel/custom-functions-requirement-sets) \]
     name: setResult
     fullName: setResult
     langs:

--- a/docs/docs-ref-autogen/powerpoint/powerpoint.yml
+++ b/docs/docs-ref-autogen/powerpoint/powerpoint.yml
@@ -14,7 +14,7 @@ items:
       .pptx file.
 
 
-      \[ [API set: PowerPointApi 1.1](/office/dev/add-ins/reference/javascript-api-for-office) \]
+      \[ [API set: PowerPointApi 1.1](/office/dev/add-ins/reference/requirement-sets/powerpoint-api-requirement-sets) \]
     name: PowerPoint.createPresentation(base64File)
     fullName: PowerPoint.createPresentation(base64File)
     langs:

--- a/generate-docs/api-extractor-inputs-custom-functions-runtime/custom-functions-runtime.d.ts
+++ b/generate-docs/api-extractor-inputs-custom-functions-runtime/custom-functions-runtime.d.ts
@@ -105,13 +105,13 @@ export declare namespace CustomFunctions {
     /**
      * Error codes for custom functions. The error codes will appear in the cell that invoked the function.
      *
-     * Custom error messages will appear in addition to these error codes. Custom messages will display in the error
-     * indicator menu, which is accessed by clicking the error flag on each cell with an error.
+     * Custom error messages appear in addition to these error codes. Custom messages display in the error
+     * indicator menu, which is accessed by hovering over the error flag on each cell with an error.
      */
     enum ErrorCode {
         /**
          *
-         * This error code indicates that a value used in the function is of the wrong data type.
+         * This error code indicates that a value in the function is of the wrong data type.
          * A custom error message can be used in addition to the error code, if desired.
          * [Api set: CustomFunctionsRuntime 1.3]
          */
@@ -126,13 +126,14 @@ export declare namespace CustomFunctions {
         /**
          *
          * This error code indicates that the function used is dividing by zero or empty cells.
+         * Be aware that JavaScript allows division by zero, so you need to write an error handler carefully to detect this condition.
          * A custom error message can't be used.
          * [Api set: CustomFunctionsRuntime 1.3]
          */
         divisionByZero = "#DIV/0!",
         /**
          *
-         * This error code indicates that there is a problem with a number used in the function.
+         * This error code indicates that there is a problem with a number in the function.
          * A custom error message can't be used.
          * [Api set: CustomFunctionsRuntime 1.3]
          */
@@ -147,6 +148,7 @@ export declare namespace CustomFunctions {
         /**
          *
          * This error code indicates that there is a typo in the function name.
+         * Note that this error code is supported as a custom function input error, but not as a custom function output error.
          * A custom error message can't be used.
          * [Api set: CustomFunctionsRuntime 1.3]
          */
@@ -154,6 +156,7 @@ export declare namespace CustomFunctions {
         /**
          *
          * This error code indicates that the function refers to an invalid cell.
+         * Note that this error code is supported as a custom function input error, but not as a custom function output error.
          * A custom error message can't be used.
          * [Api set: CustomFunctionsRuntime 1.3]
          */

--- a/generate-docs/json/custom-functions-runtime.api.json
+++ b/generate-docs/json/custom-functions-runtime.api.json
@@ -312,7 +312,7 @@
             {
               "kind": "Enum",
               "canonicalReference": "custom-functions-runtime!CustomFunctions.ErrorCode:enum",
-              "docComment": "/**\n * Error codes for custom functions. The error codes will appear in the cell that invoked the function.\n *\n * Custom error messages will appear in addition to these error codes. Custom messages will display in the error indicator menu, which is accessed by clicking the error flag on each cell with an error.\n */\n",
+              "docComment": "/**\n * Error codes for custom functions. The error codes will appear in the cell that invoked the function.\n *\n * Custom error messages appear in addition to these error codes. Custom messages display in the error indicator menu, which is accessed by hovering over the error flag on each cell with an error.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -325,7 +325,7 @@
                 {
                   "kind": "EnumMember",
                   "canonicalReference": "custom-functions-runtime!CustomFunctions.ErrorCode.divisionByZero:member",
-                  "docComment": "/**\n * This error code indicates that the function used is dividing by zero or empty cells. A custom error message can't be used. [Api set: CustomFunctionsRuntime 1.3]\n */\n",
+                  "docComment": "/**\n * This error code indicates that the function used is dividing by zero or empty cells. Be aware that JavaScript allows division by zero, so you need to write an error handler carefully to detect this condition. A custom error message can't be used. [Api set: CustomFunctionsRuntime 1.3]\n */\n",
                   "excerptTokens": [
                     {
                       "kind": "Content",
@@ -346,7 +346,7 @@
                 {
                   "kind": "EnumMember",
                   "canonicalReference": "custom-functions-runtime!CustomFunctions.ErrorCode.invalidName:member",
-                  "docComment": "/**\n * This error code indicates that there is a typo in the function name. A custom error message can't be used. [Api set: CustomFunctionsRuntime 1.3]\n */\n",
+                  "docComment": "/**\n * This error code indicates that there is a typo in the function name. Note that this error code is supported as a custom function input error, but not as a custom function output error. A custom error message can't be used. [Api set: CustomFunctionsRuntime 1.3]\n */\n",
                   "excerptTokens": [
                     {
                       "kind": "Content",
@@ -367,7 +367,7 @@
                 {
                   "kind": "EnumMember",
                   "canonicalReference": "custom-functions-runtime!CustomFunctions.ErrorCode.invalidNumber:member",
-                  "docComment": "/**\n * This error code indicates that there is a problem with a number used in the function. A custom error message can't be used. [Api set: CustomFunctionsRuntime 1.3]\n */\n",
+                  "docComment": "/**\n * This error code indicates that there is a problem with a number in the function. A custom error message can't be used. [Api set: CustomFunctionsRuntime 1.3]\n */\n",
                   "excerptTokens": [
                     {
                       "kind": "Content",
@@ -388,7 +388,7 @@
                 {
                   "kind": "EnumMember",
                   "canonicalReference": "custom-functions-runtime!CustomFunctions.ErrorCode.invalidReference:member",
-                  "docComment": "/**\n * This error code indicates that the function refers to an invalid cell. A custom error message can't be used. [Api set: CustomFunctionsRuntime 1.3]\n */\n",
+                  "docComment": "/**\n * This error code indicates that the function refers to an invalid cell. Note that this error code is supported as a custom function input error, but not as a custom function output error. A custom error message can't be used. [Api set: CustomFunctionsRuntime 1.3]\n */\n",
                   "excerptTokens": [
                     {
                       "kind": "Content",
@@ -409,7 +409,7 @@
                 {
                   "kind": "EnumMember",
                   "canonicalReference": "custom-functions-runtime!CustomFunctions.ErrorCode.invalidValue:member",
-                  "docComment": "/**\n * This error code indicates that a value used in the function is of the wrong data type. A custom error message can be used in addition to the error code, if desired. [Api set: CustomFunctionsRuntime 1.3]\n */\n",
+                  "docComment": "/**\n * This error code indicates that a value in the function is of the wrong data type. A custom error message can be used in addition to the error code, if desired. [Api set: CustomFunctionsRuntime 1.3]\n */\n",
                   "excerptTokens": [
                     {
                       "kind": "Content",

--- a/generate-docs/json/excel/custom-functions-runtime.api.json
+++ b/generate-docs/json/excel/custom-functions-runtime.api.json
@@ -312,7 +312,7 @@
             {
               "kind": "Enum",
               "canonicalReference": "custom-functions-runtime!CustomFunctions.ErrorCode:enum",
-              "docComment": "/**\n * Error codes for custom functions. The error codes will appear in the cell that invoked the function.\n *\n * Custom error messages will appear in addition to these error codes. Custom messages will display in the error indicator menu, which is accessed by clicking the error flag on each cell with an error.\n */\n",
+              "docComment": "/**\n * Error codes for custom functions. The error codes will appear in the cell that invoked the function.\n *\n * Custom error messages appear in addition to these error codes. Custom messages display in the error indicator menu, which is accessed by hovering over the error flag on each cell with an error.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -325,7 +325,7 @@
                 {
                   "kind": "EnumMember",
                   "canonicalReference": "custom-functions-runtime!CustomFunctions.ErrorCode.divisionByZero:member",
-                  "docComment": "/**\n * This error code indicates that the function used is dividing by zero or empty cells. A custom error message can't be used. [Api set: CustomFunctionsRuntime 1.3]\n */\n",
+                  "docComment": "/**\n * This error code indicates that the function used is dividing by zero or empty cells. Be aware that JavaScript allows division by zero, so you need to write an error handler carefully to detect this condition. A custom error message can't be used. [Api set: CustomFunctionsRuntime 1.3]\n */\n",
                   "excerptTokens": [
                     {
                       "kind": "Content",
@@ -346,7 +346,7 @@
                 {
                   "kind": "EnumMember",
                   "canonicalReference": "custom-functions-runtime!CustomFunctions.ErrorCode.invalidName:member",
-                  "docComment": "/**\n * This error code indicates that there is a typo in the function name. A custom error message can't be used. [Api set: CustomFunctionsRuntime 1.3]\n */\n",
+                  "docComment": "/**\n * This error code indicates that there is a typo in the function name. Note that this error code is supported as a custom function input error, but not as a custom function output error. A custom error message can't be used. [Api set: CustomFunctionsRuntime 1.3]\n */\n",
                   "excerptTokens": [
                     {
                       "kind": "Content",
@@ -367,7 +367,7 @@
                 {
                   "kind": "EnumMember",
                   "canonicalReference": "custom-functions-runtime!CustomFunctions.ErrorCode.invalidNumber:member",
-                  "docComment": "/**\n * This error code indicates that there is a problem with a number used in the function. A custom error message can't be used. [Api set: CustomFunctionsRuntime 1.3]\n */\n",
+                  "docComment": "/**\n * This error code indicates that there is a problem with a number in the function. A custom error message can't be used. [Api set: CustomFunctionsRuntime 1.3]\n */\n",
                   "excerptTokens": [
                     {
                       "kind": "Content",
@@ -388,7 +388,7 @@
                 {
                   "kind": "EnumMember",
                   "canonicalReference": "custom-functions-runtime!CustomFunctions.ErrorCode.invalidReference:member",
-                  "docComment": "/**\n * This error code indicates that the function refers to an invalid cell. A custom error message can't be used. [Api set: CustomFunctionsRuntime 1.3]\n */\n",
+                  "docComment": "/**\n * This error code indicates that the function refers to an invalid cell. Note that this error code is supported as a custom function input error, but not as a custom function output error. A custom error message can't be used. [Api set: CustomFunctionsRuntime 1.3]\n */\n",
                   "excerptTokens": [
                     {
                       "kind": "Content",
@@ -409,7 +409,7 @@
                 {
                   "kind": "EnumMember",
                   "canonicalReference": "custom-functions-runtime!CustomFunctions.ErrorCode.invalidValue:member",
-                  "docComment": "/**\n * This error code indicates that a value used in the function is of the wrong data type. A custom error message can be used in addition to the error code, if desired. [Api set: CustomFunctionsRuntime 1.3]\n */\n",
+                  "docComment": "/**\n * This error code indicates that a value in the function is of the wrong data type. A custom error message can be used in addition to the error code, if desired. [Api set: CustomFunctionsRuntime 1.3]\n */\n",
                   "excerptTokens": [
                     {
                       "kind": "Content",

--- a/generate-docs/json/excel_1_10/custom-functions-runtime.api.json
+++ b/generate-docs/json/excel_1_10/custom-functions-runtime.api.json
@@ -312,7 +312,7 @@
             {
               "kind": "Enum",
               "canonicalReference": "custom-functions-runtime!CustomFunctions.ErrorCode:enum",
-              "docComment": "/**\n * Error codes for custom functions. The error codes will appear in the cell that invoked the function.\n *\n * Custom error messages will appear in addition to these error codes. Custom messages will display in the error indicator menu, which is accessed by clicking the error flag on each cell with an error.\n */\n",
+              "docComment": "/**\n * Error codes for custom functions. The error codes will appear in the cell that invoked the function.\n *\n * Custom error messages appear in addition to these error codes. Custom messages display in the error indicator menu, which is accessed by hovering over the error flag on each cell with an error.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -325,7 +325,7 @@
                 {
                   "kind": "EnumMember",
                   "canonicalReference": "custom-functions-runtime!CustomFunctions.ErrorCode.divisionByZero:member",
-                  "docComment": "/**\n * This error code indicates that the function used is dividing by zero or empty cells. A custom error message can't be used. [Api set: CustomFunctionsRuntime 1.3]\n */\n",
+                  "docComment": "/**\n * This error code indicates that the function used is dividing by zero or empty cells. Be aware that JavaScript allows division by zero, so you need to write an error handler carefully to detect this condition. A custom error message can't be used. [Api set: CustomFunctionsRuntime 1.3]\n */\n",
                   "excerptTokens": [
                     {
                       "kind": "Content",
@@ -346,7 +346,7 @@
                 {
                   "kind": "EnumMember",
                   "canonicalReference": "custom-functions-runtime!CustomFunctions.ErrorCode.invalidName:member",
-                  "docComment": "/**\n * This error code indicates that there is a typo in the function name. A custom error message can't be used. [Api set: CustomFunctionsRuntime 1.3]\n */\n",
+                  "docComment": "/**\n * This error code indicates that there is a typo in the function name. Note that this error code is supported as a custom function input error, but not as a custom function output error. A custom error message can't be used. [Api set: CustomFunctionsRuntime 1.3]\n */\n",
                   "excerptTokens": [
                     {
                       "kind": "Content",
@@ -367,7 +367,7 @@
                 {
                   "kind": "EnumMember",
                   "canonicalReference": "custom-functions-runtime!CustomFunctions.ErrorCode.invalidNumber:member",
-                  "docComment": "/**\n * This error code indicates that there is a problem with a number used in the function. A custom error message can't be used. [Api set: CustomFunctionsRuntime 1.3]\n */\n",
+                  "docComment": "/**\n * This error code indicates that there is a problem with a number in the function. A custom error message can't be used. [Api set: CustomFunctionsRuntime 1.3]\n */\n",
                   "excerptTokens": [
                     {
                       "kind": "Content",
@@ -388,7 +388,7 @@
                 {
                   "kind": "EnumMember",
                   "canonicalReference": "custom-functions-runtime!CustomFunctions.ErrorCode.invalidReference:member",
-                  "docComment": "/**\n * This error code indicates that the function refers to an invalid cell. A custom error message can't be used. [Api set: CustomFunctionsRuntime 1.3]\n */\n",
+                  "docComment": "/**\n * This error code indicates that the function refers to an invalid cell. Note that this error code is supported as a custom function input error, but not as a custom function output error. A custom error message can't be used. [Api set: CustomFunctionsRuntime 1.3]\n */\n",
                   "excerptTokens": [
                     {
                       "kind": "Content",
@@ -409,7 +409,7 @@
                 {
                   "kind": "EnumMember",
                   "canonicalReference": "custom-functions-runtime!CustomFunctions.ErrorCode.invalidValue:member",
-                  "docComment": "/**\n * This error code indicates that a value used in the function is of the wrong data type. A custom error message can be used in addition to the error code, if desired. [Api set: CustomFunctionsRuntime 1.3]\n */\n",
+                  "docComment": "/**\n * This error code indicates that a value in the function is of the wrong data type. A custom error message can be used in addition to the error code, if desired. [Api set: CustomFunctionsRuntime 1.3]\n */\n",
                   "excerptTokens": [
                     {
                       "kind": "Content",

--- a/generate-docs/json/excel_1_11/custom-functions-runtime.api.json
+++ b/generate-docs/json/excel_1_11/custom-functions-runtime.api.json
@@ -312,7 +312,7 @@
             {
               "kind": "Enum",
               "canonicalReference": "custom-functions-runtime!CustomFunctions.ErrorCode:enum",
-              "docComment": "/**\n * Error codes for custom functions. The error codes will appear in the cell that invoked the function.\n *\n * Custom error messages will appear in addition to these error codes. Custom messages will display in the error indicator menu, which is accessed by clicking the error flag on each cell with an error.\n */\n",
+              "docComment": "/**\n * Error codes for custom functions. The error codes will appear in the cell that invoked the function.\n *\n * Custom error messages appear in addition to these error codes. Custom messages display in the error indicator menu, which is accessed by hovering over the error flag on each cell with an error.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -325,7 +325,7 @@
                 {
                   "kind": "EnumMember",
                   "canonicalReference": "custom-functions-runtime!CustomFunctions.ErrorCode.divisionByZero:member",
-                  "docComment": "/**\n * This error code indicates that the function used is dividing by zero or empty cells. A custom error message can't be used. [Api set: CustomFunctionsRuntime 1.3]\n */\n",
+                  "docComment": "/**\n * This error code indicates that the function used is dividing by zero or empty cells. Be aware that JavaScript allows division by zero, so you need to write an error handler carefully to detect this condition. A custom error message can't be used. [Api set: CustomFunctionsRuntime 1.3]\n */\n",
                   "excerptTokens": [
                     {
                       "kind": "Content",
@@ -346,7 +346,7 @@
                 {
                   "kind": "EnumMember",
                   "canonicalReference": "custom-functions-runtime!CustomFunctions.ErrorCode.invalidName:member",
-                  "docComment": "/**\n * This error code indicates that there is a typo in the function name. A custom error message can't be used. [Api set: CustomFunctionsRuntime 1.3]\n */\n",
+                  "docComment": "/**\n * This error code indicates that there is a typo in the function name. Note that this error code is supported as a custom function input error, but not as a custom function output error. A custom error message can't be used. [Api set: CustomFunctionsRuntime 1.3]\n */\n",
                   "excerptTokens": [
                     {
                       "kind": "Content",
@@ -367,7 +367,7 @@
                 {
                   "kind": "EnumMember",
                   "canonicalReference": "custom-functions-runtime!CustomFunctions.ErrorCode.invalidNumber:member",
-                  "docComment": "/**\n * This error code indicates that there is a problem with a number used in the function. A custom error message can't be used. [Api set: CustomFunctionsRuntime 1.3]\n */\n",
+                  "docComment": "/**\n * This error code indicates that there is a problem with a number in the function. A custom error message can't be used. [Api set: CustomFunctionsRuntime 1.3]\n */\n",
                   "excerptTokens": [
                     {
                       "kind": "Content",
@@ -388,7 +388,7 @@
                 {
                   "kind": "EnumMember",
                   "canonicalReference": "custom-functions-runtime!CustomFunctions.ErrorCode.invalidReference:member",
-                  "docComment": "/**\n * This error code indicates that the function refers to an invalid cell. A custom error message can't be used. [Api set: CustomFunctionsRuntime 1.3]\n */\n",
+                  "docComment": "/**\n * This error code indicates that the function refers to an invalid cell. Note that this error code is supported as a custom function input error, but not as a custom function output error. A custom error message can't be used. [Api set: CustomFunctionsRuntime 1.3]\n */\n",
                   "excerptTokens": [
                     {
                       "kind": "Content",
@@ -409,7 +409,7 @@
                 {
                   "kind": "EnumMember",
                   "canonicalReference": "custom-functions-runtime!CustomFunctions.ErrorCode.invalidValue:member",
-                  "docComment": "/**\n * This error code indicates that a value used in the function is of the wrong data type. A custom error message can be used in addition to the error code, if desired. [Api set: CustomFunctionsRuntime 1.3]\n */\n",
+                  "docComment": "/**\n * This error code indicates that a value in the function is of the wrong data type. A custom error message can be used in addition to the error code, if desired. [Api set: CustomFunctionsRuntime 1.3]\n */\n",
                   "excerptTokens": [
                     {
                       "kind": "Content",

--- a/generate-docs/json/excel_1_12/custom-functions-runtime.api.json
+++ b/generate-docs/json/excel_1_12/custom-functions-runtime.api.json
@@ -312,7 +312,7 @@
             {
               "kind": "Enum",
               "canonicalReference": "custom-functions-runtime!CustomFunctions.ErrorCode:enum",
-              "docComment": "/**\n * Error codes for custom functions. The error codes will appear in the cell that invoked the function.\n *\n * Custom error messages will appear in addition to these error codes. Custom messages will display in the error indicator menu, which is accessed by clicking the error flag on each cell with an error.\n */\n",
+              "docComment": "/**\n * Error codes for custom functions. The error codes will appear in the cell that invoked the function.\n *\n * Custom error messages appear in addition to these error codes. Custom messages display in the error indicator menu, which is accessed by hovering over the error flag on each cell with an error.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -325,7 +325,7 @@
                 {
                   "kind": "EnumMember",
                   "canonicalReference": "custom-functions-runtime!CustomFunctions.ErrorCode.divisionByZero:member",
-                  "docComment": "/**\n * This error code indicates that the function used is dividing by zero or empty cells. A custom error message can't be used. [Api set: CustomFunctionsRuntime 1.3]\n */\n",
+                  "docComment": "/**\n * This error code indicates that the function used is dividing by zero or empty cells. Be aware that JavaScript allows division by zero, so you need to write an error handler carefully to detect this condition. A custom error message can't be used. [Api set: CustomFunctionsRuntime 1.3]\n */\n",
                   "excerptTokens": [
                     {
                       "kind": "Content",
@@ -346,7 +346,7 @@
                 {
                   "kind": "EnumMember",
                   "canonicalReference": "custom-functions-runtime!CustomFunctions.ErrorCode.invalidName:member",
-                  "docComment": "/**\n * This error code indicates that there is a typo in the function name. A custom error message can't be used. [Api set: CustomFunctionsRuntime 1.3]\n */\n",
+                  "docComment": "/**\n * This error code indicates that there is a typo in the function name. Note that this error code is supported as a custom function input error, but not as a custom function output error. A custom error message can't be used. [Api set: CustomFunctionsRuntime 1.3]\n */\n",
                   "excerptTokens": [
                     {
                       "kind": "Content",
@@ -367,7 +367,7 @@
                 {
                   "kind": "EnumMember",
                   "canonicalReference": "custom-functions-runtime!CustomFunctions.ErrorCode.invalidNumber:member",
-                  "docComment": "/**\n * This error code indicates that there is a problem with a number used in the function. A custom error message can't be used. [Api set: CustomFunctionsRuntime 1.3]\n */\n",
+                  "docComment": "/**\n * This error code indicates that there is a problem with a number in the function. A custom error message can't be used. [Api set: CustomFunctionsRuntime 1.3]\n */\n",
                   "excerptTokens": [
                     {
                       "kind": "Content",
@@ -388,7 +388,7 @@
                 {
                   "kind": "EnumMember",
                   "canonicalReference": "custom-functions-runtime!CustomFunctions.ErrorCode.invalidReference:member",
-                  "docComment": "/**\n * This error code indicates that the function refers to an invalid cell. A custom error message can't be used. [Api set: CustomFunctionsRuntime 1.3]\n */\n",
+                  "docComment": "/**\n * This error code indicates that the function refers to an invalid cell. Note that this error code is supported as a custom function input error, but not as a custom function output error. A custom error message can't be used. [Api set: CustomFunctionsRuntime 1.3]\n */\n",
                   "excerptTokens": [
                     {
                       "kind": "Content",
@@ -409,7 +409,7 @@
                 {
                   "kind": "EnumMember",
                   "canonicalReference": "custom-functions-runtime!CustomFunctions.ErrorCode.invalidValue:member",
-                  "docComment": "/**\n * This error code indicates that a value used in the function is of the wrong data type. A custom error message can be used in addition to the error code, if desired. [Api set: CustomFunctionsRuntime 1.3]\n */\n",
+                  "docComment": "/**\n * This error code indicates that a value in the function is of the wrong data type. A custom error message can be used in addition to the error code, if desired. [Api set: CustomFunctionsRuntime 1.3]\n */\n",
                   "excerptTokens": [
                     {
                       "kind": "Content",

--- a/generate-docs/json/excel_1_9/custom-functions-runtime.api.json
+++ b/generate-docs/json/excel_1_9/custom-functions-runtime.api.json
@@ -312,7 +312,7 @@
             {
               "kind": "Enum",
               "canonicalReference": "custom-functions-runtime!CustomFunctions.ErrorCode:enum",
-              "docComment": "/**\n * Error codes for custom functions. The error codes will appear in the cell that invoked the function.\n *\n * Custom error messages will appear in addition to these error codes. Custom messages will display in the error indicator menu, which is accessed by clicking the error flag on each cell with an error.\n */\n",
+              "docComment": "/**\n * Error codes for custom functions. The error codes will appear in the cell that invoked the function.\n *\n * Custom error messages appear in addition to these error codes. Custom messages display in the error indicator menu, which is accessed by hovering over the error flag on each cell with an error.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -325,7 +325,7 @@
                 {
                   "kind": "EnumMember",
                   "canonicalReference": "custom-functions-runtime!CustomFunctions.ErrorCode.divisionByZero:member",
-                  "docComment": "/**\n * This error code indicates that the function used is dividing by zero or empty cells. A custom error message can't be used. [Api set: CustomFunctionsRuntime 1.3]\n */\n",
+                  "docComment": "/**\n * This error code indicates that the function used is dividing by zero or empty cells. Be aware that JavaScript allows division by zero, so you need to write an error handler carefully to detect this condition. A custom error message can't be used. [Api set: CustomFunctionsRuntime 1.3]\n */\n",
                   "excerptTokens": [
                     {
                       "kind": "Content",
@@ -346,7 +346,7 @@
                 {
                   "kind": "EnumMember",
                   "canonicalReference": "custom-functions-runtime!CustomFunctions.ErrorCode.invalidName:member",
-                  "docComment": "/**\n * This error code indicates that there is a typo in the function name. A custom error message can't be used. [Api set: CustomFunctionsRuntime 1.3]\n */\n",
+                  "docComment": "/**\n * This error code indicates that there is a typo in the function name. Note that this error code is supported as a custom function input error, but not as a custom function output error. A custom error message can't be used. [Api set: CustomFunctionsRuntime 1.3]\n */\n",
                   "excerptTokens": [
                     {
                       "kind": "Content",
@@ -367,7 +367,7 @@
                 {
                   "kind": "EnumMember",
                   "canonicalReference": "custom-functions-runtime!CustomFunctions.ErrorCode.invalidNumber:member",
-                  "docComment": "/**\n * This error code indicates that there is a problem with a number used in the function. A custom error message can't be used. [Api set: CustomFunctionsRuntime 1.3]\n */\n",
+                  "docComment": "/**\n * This error code indicates that there is a problem with a number in the function. A custom error message can't be used. [Api set: CustomFunctionsRuntime 1.3]\n */\n",
                   "excerptTokens": [
                     {
                       "kind": "Content",
@@ -388,7 +388,7 @@
                 {
                   "kind": "EnumMember",
                   "canonicalReference": "custom-functions-runtime!CustomFunctions.ErrorCode.invalidReference:member",
-                  "docComment": "/**\n * This error code indicates that the function refers to an invalid cell. A custom error message can't be used. [Api set: CustomFunctionsRuntime 1.3]\n */\n",
+                  "docComment": "/**\n * This error code indicates that the function refers to an invalid cell. Note that this error code is supported as a custom function input error, but not as a custom function output error. A custom error message can't be used. [Api set: CustomFunctionsRuntime 1.3]\n */\n",
                   "excerptTokens": [
                     {
                       "kind": "Content",
@@ -409,7 +409,7 @@
                 {
                   "kind": "EnumMember",
                   "canonicalReference": "custom-functions-runtime!CustomFunctions.ErrorCode.invalidValue:member",
-                  "docComment": "/**\n * This error code indicates that a value used in the function is of the wrong data type. A custom error message can be used in addition to the error code, if desired. [Api set: CustomFunctionsRuntime 1.3]\n */\n",
+                  "docComment": "/**\n * This error code indicates that a value in the function is of the wrong data type. A custom error message can be used in addition to the error code, if desired. [Api set: CustomFunctionsRuntime 1.3]\n */\n",
                   "excerptTokens": [
                     {
                       "kind": "Content",

--- a/generate-docs/json/excel_online/custom-functions-runtime.api.json
+++ b/generate-docs/json/excel_online/custom-functions-runtime.api.json
@@ -312,7 +312,7 @@
             {
               "kind": "Enum",
               "canonicalReference": "custom-functions-runtime!CustomFunctions.ErrorCode:enum",
-              "docComment": "/**\n * Error codes for custom functions. The error codes will appear in the cell that invoked the function.\n *\n * Custom error messages will appear in addition to these error codes. Custom messages will display in the error indicator menu, which is accessed by clicking the error flag on each cell with an error.\n */\n",
+              "docComment": "/**\n * Error codes for custom functions. The error codes will appear in the cell that invoked the function.\n *\n * Custom error messages appear in addition to these error codes. Custom messages display in the error indicator menu, which is accessed by hovering over the error flag on each cell with an error.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -325,7 +325,7 @@
                 {
                   "kind": "EnumMember",
                   "canonicalReference": "custom-functions-runtime!CustomFunctions.ErrorCode.divisionByZero:member",
-                  "docComment": "/**\n * This error code indicates that the function used is dividing by zero or empty cells. A custom error message can't be used. [Api set: CustomFunctionsRuntime 1.3]\n */\n",
+                  "docComment": "/**\n * This error code indicates that the function used is dividing by zero or empty cells. Be aware that JavaScript allows division by zero, so you need to write an error handler carefully to detect this condition. A custom error message can't be used. [Api set: CustomFunctionsRuntime 1.3]\n */\n",
                   "excerptTokens": [
                     {
                       "kind": "Content",
@@ -346,7 +346,7 @@
                 {
                   "kind": "EnumMember",
                   "canonicalReference": "custom-functions-runtime!CustomFunctions.ErrorCode.invalidName:member",
-                  "docComment": "/**\n * This error code indicates that there is a typo in the function name. A custom error message can't be used. [Api set: CustomFunctionsRuntime 1.3]\n */\n",
+                  "docComment": "/**\n * This error code indicates that there is a typo in the function name. Note that this error code is supported as a custom function input error, but not as a custom function output error. A custom error message can't be used. [Api set: CustomFunctionsRuntime 1.3]\n */\n",
                   "excerptTokens": [
                     {
                       "kind": "Content",
@@ -367,7 +367,7 @@
                 {
                   "kind": "EnumMember",
                   "canonicalReference": "custom-functions-runtime!CustomFunctions.ErrorCode.invalidNumber:member",
-                  "docComment": "/**\n * This error code indicates that there is a problem with a number used in the function. A custom error message can't be used. [Api set: CustomFunctionsRuntime 1.3]\n */\n",
+                  "docComment": "/**\n * This error code indicates that there is a problem with a number in the function. A custom error message can't be used. [Api set: CustomFunctionsRuntime 1.3]\n */\n",
                   "excerptTokens": [
                     {
                       "kind": "Content",
@@ -388,7 +388,7 @@
                 {
                   "kind": "EnumMember",
                   "canonicalReference": "custom-functions-runtime!CustomFunctions.ErrorCode.invalidReference:member",
-                  "docComment": "/**\n * This error code indicates that the function refers to an invalid cell. A custom error message can't be used. [Api set: CustomFunctionsRuntime 1.3]\n */\n",
+                  "docComment": "/**\n * This error code indicates that the function refers to an invalid cell. Note that this error code is supported as a custom function input error, but not as a custom function output error. A custom error message can't be used. [Api set: CustomFunctionsRuntime 1.3]\n */\n",
                   "excerptTokens": [
                     {
                       "kind": "Content",
@@ -409,7 +409,7 @@
                 {
                   "kind": "EnumMember",
                   "canonicalReference": "custom-functions-runtime!CustomFunctions.ErrorCode.invalidValue:member",
-                  "docComment": "/**\n * This error code indicates that a value used in the function is of the wrong data type. A custom error message can be used in addition to the error code, if desired. [Api set: CustomFunctionsRuntime 1.3]\n */\n",
+                  "docComment": "/**\n * This error code indicates that a value in the function is of the wrong data type. A custom error message can be used in addition to the error code, if desired. [Api set: CustomFunctionsRuntime 1.3]\n */\n",
                   "excerptTokens": [
                     {
                       "kind": "Content",

--- a/generate-docs/script-inputs/custom-functions-runtime.d.ts
+++ b/generate-docs/script-inputs/custom-functions-runtime.d.ts
@@ -105,13 +105,13 @@ declare namespace CustomFunctions {
     /**
      * Error codes for custom functions. The error codes will appear in the cell that invoked the function.
      *
-     * Custom error messages will appear in addition to these error codes. Custom messages will display in the error
-     * indicator menu, which is accessed by clicking the error flag on each cell with an error.
+     * Custom error messages appear in addition to these error codes. Custom messages display in the error
+     * indicator menu, which is accessed by hovering over the error flag on each cell with an error.
      */
     enum ErrorCode {
         /**
          *
-         * This error code indicates that a value used in the function is of the wrong data type.
+         * This error code indicates that a value in the function is of the wrong data type.
          * A custom error message can be used in addition to the error code, if desired.
          * [Api set: CustomFunctionsRuntime 1.3]
          */
@@ -126,13 +126,14 @@ declare namespace CustomFunctions {
         /**
          *
          * This error code indicates that the function used is dividing by zero or empty cells.
+         * Be aware that JavaScript allows division by zero, so you need to write an error handler carefully to detect this condition.
          * A custom error message can't be used.
          * [Api set: CustomFunctionsRuntime 1.3]
          */
         divisionByZero = "#DIV/0!",
         /**
          *
-         * This error code indicates that there is a problem with a number used in the function.
+         * This error code indicates that there is a problem with a number in the function.
          * A custom error message can't be used.
          * [Api set: CustomFunctionsRuntime 1.3]
          */
@@ -147,6 +148,7 @@ declare namespace CustomFunctions {
         /**
          *
          * This error code indicates that there is a typo in the function name.
+         * Note that this error code is supported as a custom function input error, but not as a custom function output error.
          * A custom error message can't be used.
          * [Api set: CustomFunctionsRuntime 1.3]
          */
@@ -154,6 +156,7 @@ declare namespace CustomFunctions {
         /**
          *
          * This error code indicates that the function refers to an invalid cell.
+         * Note that this error code is supported as a custom function input error, but not as a custom function output error.
          * A custom error message can't be used.
          * [Api set: CustomFunctionsRuntime 1.3]
          */

--- a/generate-docs/scripts/postprocessor.ts
+++ b/generate-docs/scripts/postprocessor.ts
@@ -116,6 +116,40 @@ tryCatch(async () => {
             fsx.writeFileSync(officeFolder + '/' + filename, fsx.readFileSync(officeFolder + '/' + filename).toString().replace(/Outlook\.Mailbox/g, "Office.Mailbox").replace(/Outlook\.RoamingSettings/g, "Office.RoamingSettings"));
         });
 
+    console.log(`Custom Functions API requirement set link pass`);
+    fsx.readdirSync(docsDestination)
+        .filter(filename => filename.indexOf("excel") >= 0 && filename.indexOf(".yml") < 0)
+        .forEach(filename => {
+            let subfolder = docsDestination + '/' + filename + "/custom-functions-runtime";
+            if (fsx.existsSync(subfolder)) {
+                fsx.readdirSync(subfolder)
+                    .forEach(subfilename => {
+                        fsx.writeFileSync(subfolder + '/' + subfilename,
+                            fsx.readFileSync(subfolder + '/' + subfilename).toString()
+                                .replace(/\/office\/dev\/add-ins\/reference\/javascript-api-for-office/g, "/office/dev/add-ins/excel/custom-functions-requirement-sets")
+                                .replace(/\/office\/dev\/add-ins\/reference\/overview\/visio-javascript-reference-overview/g, "/office/dev/add-ins/excel/custom-functions-requirement-sets"));
+                    });
+            }
+        });
+
+    console.log(`PowerPoint API requirement set link pass`);
+    fsx.readdirSync(docsDestination)
+        .filter(filename => filename.indexOf("powerpoint") >= 0 && filename.indexOf(".yml") < 0)
+        .forEach(filename => {
+            let subfolder = docsDestination + '/' + filename + "/powerpoint";
+            if (fsx.existsSync(subfolder)) {
+                fsx.readdirSync(subfolder)
+                    .forEach(subfilename => {
+                        fsx.writeFileSync(subfolder + '/' + subfilename,
+                            fsx.readFileSync(subfolder + '/' + subfilename).toString()
+                                .replace(/\/office\/dev\/add-ins\/reference\/javascript-api-for-office/g, "/office/dev/add-ins/reference/requirement-sets/powerpoint-api-requirement-sets"));
+                    });
+            }
+            let baseYml = docsDestination + '/powerpoint/powerpoint.yml';
+            fsx.writeFileSync(baseYml, fsx.readFileSync(baseYml).toString()
+                .replace(/\/office\/dev\/add-ins\/reference\/javascript-api-for-office/g, "/office/dev/add-ins/reference/requirement-sets/powerpoint-api-requirement-sets"));
+        });
+
     console.log(`Fixing top href`);
     fsx.readdirSync(docsDestination)
         .filter(filename => filename.indexOf(".yml") < 0)


### PR DESCRIPTION
This PR fixes the incorrect requirement set links across Custom Functions and PowerPoint. The post-processor corrects the links inserted by the RushStack tooling. There's room to make the post-processor more efficient, but this fix mitigates the immediate problem.

This also adds some DT changes made to the CF docs.